### PR TITLE
[WIP] - Add Dockerfile for containerized dev & testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM cudf
+
+ADD src /cugraph/src
+ADD include /cugraph/include
+ADD cmake /cugraph/cmake
+ADD CMakeLists.txt /cugraph/CMakeLists.txt
+ADD python /cugraph/python
+ADD setup.py /cugraph/setup.py
+ADD docs /cugraph/docs
+
+WORKDIR /cugraph/build
+RUN source activate cudf && \
+    cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DNVG_PLUGIN=FALSE && \
+    make install && \
+    cd .. && \
+    python setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# built from https://github.com/rapidsai/cudf/blob/master/Dockerfile
 FROM cudf
 
 ADD src /cugraph/src


### PR DESCRIPTION
fixes #2 

Currently getting an error with cugraph_generated_grmat.cu.o.cmake:
```
[100%] Completed 'googletest'
[100%] Built target googletest
-- GTEST_ROOT: /cugraph/build/CMakeFiles/thirdparty/googletest-install/
-- Found CUDA: /usr/local/cuda (found version "9.2") 
-- CUDA 9.2 found in /usr/local/cuda
-- CUDA_NVCC_FLAGS: -std=c++11;--expt-extended-lambda;-Xcompiler;-rdynamic;-lineinfo;-Wno-deprecated-declarations;-Xptxas;--disable-warnings;-Werror;cross-execution-space-call;-Xcompiler;-Wall,-Wno-error=sign-compare
-- Boost version: 1.58.0
-- Found the following Boost libraries:
--   system
Cloning into '/cugraph/../gunrock'...
Submodule 'externals/cub' (https://github.com/NVlabs/cub.git) registered for path 'externals/cub'
Submodule 'externals/moderngpu' (https://github.com/NVlabs/moderngpu.git) registered for path 'externals/moderngpu'
Cloning into 'externals/cub'...
Submodule path 'externals/cub': checked out 'c3cceac115c072fb63df1836ff46d8c60d9eb304'
Cloning into 'externals/moderngpu'...
Submodule path 'externals/moderngpu': checked out '9b1c96a5e5ee06e963b4099a948b9d8a2a649627'
-- Found OpenMP_C: -fopenmp (found version "4.0") 
-- Found OpenMP_CXX: -fopenmp (found version "4.0") 
-- Found OpenMP: TRUE (found version "4.0")  
-- GDF found in /conda/envs/cudf/lib/libcudf.so
-- Nvgraph plugin : FALSE
-- Google C++ Testing Framework (Google Test) found in /cugraph/build/CMakeFiles/thirdparty/googletest-install/
-- ******** Configuring tests ********
-- ******** Tests are ready ********
-- The following OPTIONAL packages have been found:

 * Boost (required version >= 1.45.0)
 * Git
 * OpenMP
 * Threads
 * GTest, <https://github.com/google/googletest>
   Google C++ Testing Framework (Google Test).

-- The following REQUIRED packages have been found:

 * CUDA, <https://developer.nvidia.com/cuda-zone>
   NVIDIA CUDA® parallel computing platform and programming model.

-- Configuring done
-- Generating done
-- Build files have been written to: /cugraph/build
[  5%] Building NVCC (Device) object CMakeFiles/cugraph.dir/__/gunrock/externals/moderngpu/src/cugraph_generated_mgpucontext.cu.o
/cugraph/../gunrock/externals/moderngpu/src/mgpucontext.cu: In constructor 'mgpu::CudaContext::CudaContext(mgpu::CudaDevice&, bool, bool)':
/cugraph/../gunrock/externals/moderngpu/src/mgpucontext.cu:232:13: warning: variable 'error' set but not used [-Wunused-but-set-variable]
  cudaError_t error = cudaMallocHost((void**)&_pageLocked, 4096);
             ^
[ 11%] Building NVCC (Device) object CMakeFiles/cugraph.dir/src/cugraph_generated_grmat.cu.o
/cugraph/src/grmat.cu:35:21: fatal error: gdf/gdf.h: No such file or directory
compilation terminated.
CMake Error at cugraph_generated_grmat.cu.o.cmake:219 (message):
  Error generating
  /cugraph/build/CMakeFiles/cugraph.dir/src/./cugraph_generated_grmat.cu.o


CMakeFiles/cugraph.dir/build.make:63: recipe for target 'CMakeFiles/cugraph.dir/src/cugraph_generated_grmat.cu.o' failed
make[2]: *** [CMakeFiles/cugraph.dir/src/cugraph_generated_grmat.cu.o] Error 1
CMakeFiles/Makefile2:72: recipe for target 'CMakeFiles/cugraph.dir/all' failed
make[1]: *** [CMakeFiles/cugraph.dir/all] Error 2
Makefile:140: recipe for target 'all' failed
make: *** [all] Error 2
The command '/bin/bash -c source activate cudf &&     cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DNVG_PLUGIN=FALSE &&     make install &&     cd .. &&     python setup.py install' returned a non-zero code: 2
```