### PR TITLE
Fixed error_utils.h dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ endif()
 # - include paths ---------------------------------------------------------------------------------
 include_directories(
     "${CMAKE_CURRENT_SOURCE_DIR}/include" 
+    "${CMAKE_CURRENT_SOURCE_DIR}/src"
     "${CUDA_INCLUDE_DIRS}" 
     "${CUDF_INCLUDE}"
     "${CMAKE_CURRENT_BINARY_DIR}/gunrock/"

--- a/include/cugraph.h
+++ b/include/cugraph.h
@@ -4,7 +4,6 @@
 #include <cstdint>
 
 #include <cudf.h>
-#include <utilities/error_utils.h>
 
 #include "types.h"
 

--- a/src/COOtoCSR.cuh
+++ b/src/COOtoCSR.cuh
@@ -17,7 +17,7 @@
 #include <cub/device/device_radix_sort.cuh>
 #include <cub/device/device_run_length_encode.cuh>
 
-#include <utilities/error_utils.h>
+#include "utilities/error_utils.h"
 
 template <typename T>
 struct CSR_Result {

--- a/src/cugraph.cu
+++ b/src/cugraph.cu
@@ -16,6 +16,8 @@
 #include "graph_utils.cuh"
 #include "pagerank.cuh"
 #include "COOtoCSR.cuh"
+#include "utilities/error_utils.h"
+
 //#include <functions.h>
 
 void gdf_col_delete(gdf_column* col) {

--- a/src/grmat.cu
+++ b/src/grmat.cu
@@ -33,8 +33,8 @@
 #include <gunrock/util/shared_utils.cuh>
 
 #include <cudf.h>
-#include <utilities/error_utils.h>
 #include <thrust/extrema.h>
+#include "utilities/error_utils.h"
 #include "graph_utils.cuh"
 
 using namespace gunrock;


### PR DESCRIPTION
Issue #22

Fixed `Cmakelist.txt` to find `error_utils.h`.
Removed `error_utils.h` from `cugraph.h` so that `error_utils.h` does not need to be installed