### PR TITLE
[REVIEW] [BUG] ABI fixes

### DIFF
--- a/cmake/Modules/ConfigureGoogleTest.cmake
+++ b/cmake/Modules/ConfigureGoogleTest.cmake
@@ -16,18 +16,18 @@
 #=============================================================================
 # Download and unpack googletest at configure time
 
-#set(GTEST_CMAKE_ARGS " -Dgtest_build_samples=ON"	
-#	                     " -DCMAKE_VERBOSE_MAKEFILE=ON")
+set(GTEST_CMAKE_ARGS " -Dgtest_build_samples=ON"	
+	                     " -DCMAKE_VERBOSE_MAKEFILE=ON")
 	
-#if(NOT CMAKE_CXX11_ABI)
-#    message(STATUS "GTEST: Disabling the GLIBCXX11 ABI")
-#    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
-#    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
-#elseif(CMAKE_CXX11_ABI)
-#    message(STATUS "GTEST: Enabling the GLIBCXX11 ABI")
-#    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
-#    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
-#endif(NOT CMAKE_CXX11_ABI)
+if(NOT CMAKE_CXX11_ABI)
+    message(STATUS "GTEST: Disabling the GLIBCXX11 ABI")
+    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
+    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
+elseif(CMAKE_CXX11_ABI)
+    message(STATUS "GTEST: Enabling the GLIBCXX11 ABI")
+    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
+    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
+endif(NOT CMAKE_CXX11_ABI)
 
 configure_file(${CMAKE_SOURCE_DIR}/cmake/Templates/GoogleTest.CMakeLists.txt.cmake ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/thirdparty/googletest-download/CMakeLists.txt)
 

--- a/cmake/Templates/GoogleTest.CMakeLists.txt.cmake
+++ b/cmake/Templates/GoogleTest.CMakeLists.txt.cmake
@@ -28,5 +28,5 @@ ExternalProject_Add(googletest
     SOURCE_DIR        "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/thirdparty/googletest-src"
     BINARY_DIR        "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/thirdparty/googletest-build"
     INSTALL_DIR       "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/thirdparty/googletest-install"
-    CMAKE_ARGS        -Dgtest_build_samples=ON -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/thirdparty/googletest-install
+    CMAKE_ARGS        ${GTEST_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/thirdparty/googletest-install
 )

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -9,6 +9,16 @@ project(CUGRAPH_TESTS LANGUAGES C CXX CUDA)
 
 set(CMAKE_CUDA_FLAGS "-shared -cudart shared")
 
+if(CMAKE_CXX11_ABI)
+    message(STATUS "cuGraph test: Enabling the GLIBCXX11 ABI")
+else()
+    message(STATUS "cuGraph test: Disabling the GLIBCXX11 ABI")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -D_GLIBCXX_USE_CXX11_ABI=0")
+endif(CMAKE_CXX11_ABI)
+
+
 ###################################################################################################
 # - add nvgraph -----------------------------------------------------------------------------------
 #if(NOT TARGET NVGRAPH AND NVG_PLUGIN)

--- a/src/tests/grmat/grmat_test.cu
+++ b/src/tests/grmat/grmat_test.cu
@@ -113,7 +113,7 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
      int rmat_scale = 0, edge_factor = 0, undirected = false;
      char* argv[32] = {0};
      int argc = 0;
-     std::string tmp_argv = param.argv;
+     std::string tmp_argv(param.argv.c_str());
      get_array_of_strings (argv, (char *)tmp_argv.c_str(), argc);
      rmat_scale = atoi(strrchr(argv[1], '=')+1);
      edge_factor = atoi(strrchr(argv[2], '=')+1);
@@ -167,7 +167,8 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
     int rmat_scale = 0, edge_factor = 0, undirected = false;;
     char* argv[32] = {0};
     int argc = 0;
-    std::string tmp_argv = param.argv;
+    std::string tmp_argv(param.argv.c_str());
+
     get_array_of_strings (argv, (char *)tmp_argv.c_str(), argc);
     
     rmat_scale = atoi(strrchr(argv[1], '=')+1);


### PR DESCRIPTION
Couldn't build master due to ABI issues.  This PR adds back some cmake entries that had previously been removed to allow for the user to turn the CXX11 ABI changes on or off universally for everything built with cugraph.

Had to make a change to one of the unit tests which failed when built using the old ABI.