### PR TITLE
Make everything build with the new abi - remove backward compatibility

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -28,7 +28,10 @@ include(CTest)
 ###################################################################################################
 # - compiler options ------------------------------------------------------------------------------
 
-#option(CMAKE_CXX11_ABI "Enable the GLIBCXX11 ABI" OFF)
+### NOTE:  This flag is set to ensure the RMM is compiled with the ABI on.
+###   if/when RMM is updated to default to using the CXX11 ABI we can remove
+###   this line.
+option(CMAKE_CXX11_ABI "Enable the GLIBCXX11 ABI" ON)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_C_COMPILER $ENV{CC})
@@ -38,15 +41,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CUDA_STANDARD 14)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 
-#if(NOT CMAKE_CXX11_ABI)
-#		message(STATUS "CUDF: Disabling the GLIBCXX11 ABI")
-#		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
-#		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
-#		set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -D_GLIBCXX_USE_CXX11_ABI=0")
-#elseif(CMAKE_CXX11_ABI)
-#		message(STATUS "CUDF: Enabling the GLIBCXX11 ABI")
-#endif(NOT CMAKE_CXX11_ABI)
-	
 #set(CUDA_USE_STATIC_CUDA_RUNTIME OFF CACHE INTERNAL "")
 
 #find_package(CUDA)
@@ -90,15 +84,6 @@ message(STATUS "CMAKE_MODULE_PATH:" "${CMAKE_MODULE_PATH}")
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-    option(CMAKE_CXX11_ABI "Enable the GLIBCXX11 ABI" OFF)
-    if(CMAKE_CXX11_ABI)
-        message(STATUS "cuGraph: Enabling the GLIBCXX11 ABI")
-    else()
-        message(STATUS "cuGraph: Disabling the GLIBCXX11 ABI")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
-        set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -D_GLIBCXX_USE_CXX11_ABI=0")
-    endif(CMAKE_CXX11_ABI)
 endif(CMAKE_COMPILER_IS_GNUCXX)
 	
 # Keith testing space

--- a/cpp/cmake/Modules/ConfigureArrow.cmake
+++ b/cpp/cmake/Modules/ConfigureArrow.cmake
@@ -36,14 +36,6 @@ set(ARROW_DOWNLOAD_BINARY_DIR ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/thirdp
 #	                     " -DARROW_PYTHON=OFF"
 #	                     " -DCMAKE_VERBOSE_MAKEFILE=ON")
 	
-#	if(NOT CMAKE_CXX11_ABI)
-#	    message(STATUS "ARROW: Disabling the GLIBCXX11 ABI")
-#	    list(APPEND ARROW_CMAKE_ARGS " -DARROW_TENSORFLOW=ON")
-#	elseif(CMAKE_CXX11_ABI)
-#	    message(STATUS "ARROW: Enabling the GLIBCXX11 ABI")
-#	    list(APPEND ARROW_CMAKE_ARGS " -DARROW_TENSORFLOW=OFF")
-#	endif(NOT CMAKE_CXX11_ABI)
-
 # Download and unpack arrow at configure time
 configure_file(${CMAKE_SOURCE_DIR}/cmake/Templates/Arrow.CMakeLists.txt.cmake ${ARROW_DOWNLOAD_BINARY_DIR}/CMakeLists.txt COPYONLY)
 

--- a/cpp/cmake/Modules/ConfigureGoogleTest.cmake
+++ b/cpp/cmake/Modules/ConfigureGoogleTest.cmake
@@ -19,16 +19,6 @@
 set(GTEST_CMAKE_ARGS " -Dgtest_build_samples=ON"	
 	                     " -DCMAKE_VERBOSE_MAKEFILE=ON")
 	
-if(NOT CMAKE_CXX11_ABI)
-    message(STATUS "GTEST: Disabling the GLIBCXX11 ABI")
-    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
-    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
-elseif(CMAKE_CXX11_ABI)
-    message(STATUS "GTEST: Enabling the GLIBCXX11 ABI")
-    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
-    list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
-endif(NOT CMAKE_CXX11_ABI)
-
 configure_file(${CMAKE_SOURCE_DIR}/cmake/Templates/GoogleTest.CMakeLists.txt.cmake ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/thirdparty/googletest-download/CMakeLists.txt)
 
 execute_process(


### PR DESCRIPTION
This PR removes code in the CMake files for supporting backward compatibility of the C++ ABI change.

At this point, all of the conda dependencies are built with the new ABI, there is no reason to maintain backward compatibility with version 0.6.

This PR will eliminate the need to explicitly compile with the new ABI, the default build will use the new ABI.