### PR TITLE
Spectral clustering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - PR #47 BSF bindings
 - PR #53 New Repo structure
 - PR #67 RMM Integration with rmm as as submodule
+- PR #82 Spectral Clustering bindings
+- PR #82 Clustering metrics binding
 
 ## Improvements
 

--- a/cpp/include/nvgraph_gdf.h
+++ b/cpp/include/nvgraph_gdf.h
@@ -50,12 +50,12 @@ gdf_error gdf_sssp_nvgraph(gdf_graph *gdf_G, const int *source_vert, gdf_column 
  * Wrapper function for Nvgraph balanced cut clustering
  * @param gdf_G Pointer to GDF graph object
  * @param num_clusters The desired number of clusters
- * @param num_eigen_vects The number of eigen-vectors to use
- * @param evs_type The type of the eigen-value solver to use
- * @param evs_tolerance The tolerance to use for the eigen-value solver
- * @param evs_max_iter The maximum number of iterations of the eigen-value solver
+ * @param num_eigen_vects The number of eigenvectors to use
+ * @param evs_type The type of the eigenvalue solver to use
+ * @param evs_tolerance The tolerance to use for the eigenvalue solver
+ * @param evs_max_iter The maximum number of iterations of the eigenvalue solver
  * @param kmean_tolerance The tolerance to use for the kmeans solver
- * @param kmean_max_iter The maximum number of iteration of the kmeans solver
+ * @param kmean_max_iter The maximum number of iteration of the k-means solver
  * @param clustering Pointer to a GDF column in which the resulting clustering will be stored
  * @param eig_vals Pointer to a GDF column in which the resulting eigenvalues will be stored
  * @param eig_vects Pointer to a GDF column in which the resulting eigenvectors will be stored
@@ -72,3 +72,28 @@ gdf_error gdf_balancedCutClustering_nvgraph(gdf_graph* gdf_G,
 																						gdf_column* clustering,
 																						gdf_column* eig_vals,
 																						gdf_column* eig_vects);
+
+/**
+ * Wrapper function for Nvgraph spectral modularity maximization algorithm
+ * @param gdf_G Pointer to GDF graph object
+ * @param n_clusters The desired number of clusters
+ * @param n_eig_vects The number of eigenvectors to use
+ * @param evs_tolerance The tolerance to use for the eigenvalue solver
+ * @param evs_max_iter The maximum number of iterations of the eigenvalue solver
+ * @param kmean_tolerance The tolerance to use for the k-means solver
+ * @param kmean_max_iter The maximum number of iterations of the k-means solver
+ * @param clustering Pointer to a GDF column in which the resulting clustering will be stored
+ * @param eig_vals Pointer to a GDF column in which the resulting eigenvalues will be stored
+ * @param eig_vects Pointer to a GDF column in which the resulting eigenvectors will be stored
+ * @return
+ */
+gdf_error gdf_spectralModularityMaximization_nvgraph(	gdf_graph* gdf_G,
+																											const int n_clusters,
+																											const int n_eig_vects,
+																											const float evs_tolerance,
+																											const int evs_max_iter,
+																											const float kmean_tolerance,
+																											const int kmean_max_iter,
+																											gdf_column* clustering,
+																											gdf_column* eig_vals,
+																											gdf_column* eig_vects);

--- a/cpp/include/nvgraph_gdf.h
+++ b/cpp/include/nvgraph_gdf.h
@@ -64,7 +64,6 @@ gdf_error gdf_sssp_nvgraph(gdf_graph *gdf_G, const int *source_vert, gdf_column 
 gdf_error gdf_balancedCutClustering_nvgraph(gdf_graph* gdf_G,
 																						const int num_clusters,
 																						const int num_eigen_vects,
-																						const int evs_type,
 																						const float evs_tolerance,
 																						const int evs_max_iter,
 																						const float kmean_tolerance,
@@ -97,3 +96,42 @@ gdf_error gdf_spectralModularityMaximization_nvgraph(	gdf_graph* gdf_G,
 																											gdf_column* clustering,
 																											gdf_column* eig_vals,
 																											gdf_column* eig_vects);
+
+/**
+ * Wrapper function for Nvgraph clustering modularity metric
+ * @param gdf_G Pointer to GDF graph object
+ * @param n_clusters Number of clusters in the clustering
+ * @param clustering Pointer to GDF column containing the clustering to analyze
+ * @param score Pointer to a float in which the result will be written
+ * @return Error code
+ */
+gdf_error gdf_AnalyzeClustering_modularity_nvgraph(gdf_graph* gdf_G,
+                                                   const int n_clusters,
+                                                   gdf_column* clustering,
+                                                   float* score);
+
+/**
+ * Wrapper function for Nvgraph clustering edge cut metric
+ * @param gdf_G Pointer to GDF graph object
+ * @param n_clusters Number of clusters in the clustering
+ * @param clustering Pointer to GDF column containing the clustering to analyze
+ * @param score Pointer to a float in which the result will be written
+ * @return Error code
+ */
+gdf_error gdf_AnalyzeClustering_edge_cut_nvgraph(gdf_graph* gdf_G,
+                                                   const int n_clusters,
+                                                   gdf_column* clustering,
+                                                   float* score);
+
+/**
+ * Wrapper function for Nvgraph clustering ratio cut metric
+ * @param gdf_G Pointer to GDF graph object
+ * @param n_clusters Number of clusters in the clustering
+ * @param clustering Pointer to GDF column containing the clustering to analyze
+ * @param score Pointer to a float in which the result will be written
+ * @return Error code
+ */
+gdf_error gdf_AnalyzeClustering_ratio_cut_nvgraph(gdf_graph* gdf_G,
+                                                   const int n_clusters,
+                                                   gdf_column* clustering,
+                                                   float* score);

--- a/cpp/include/nvgraph_gdf.h
+++ b/cpp/include/nvgraph_gdf.h
@@ -1,7 +1,74 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** ---------------------------------------------------------------------------*
+ * @brief Wrapper functions for Nvgraph
+ *
+ * @file nvgraph_gdf.h
+ * ---------------------------------------------------------------------------**/
+
 #pragma once
 
 #include <nvgraph/nvgraph.h>
 #include <cugraph.h>
 
-gdf_error gdf_createGraph_nvgraph(nvgraphHandle_t nvg_handle, gdf_graph* gdf_G, nvgraphGraphDescr_t * nvgraph_G, bool use_transposed = false);
+/**
+ * Takes a GDF graph and wraps its data with an Nvgraph graph object.
+ * @param nvg_handle The Nvgraph handle
+ * @param gdf_G Pointer to GDF graph object
+ * @param nvgraph_G Pointer to the Nvgraph graph descriptor
+ * @param use_transposed True if we are transposing the input graph while wrapping
+ * @return Error code
+ */
+gdf_error gdf_createGraph_nvgraph(nvgraphHandle_t nvg_handle,
+																	gdf_graph* gdf_G,
+																	nvgraphGraphDescr_t * nvgraph_G,
+																	bool use_transposed = false);
+
+/**
+ * Wrapper function for Nvgraph SSSP algorithm
+ * @param gdf_G Pointer to GDF graph object
+ * @param source_vert Value for the starting vertex
+ * @param sssp_distances Pointer to a GDF column in which the resulting distances will be stored
+ * @return Error code
+ */
 gdf_error gdf_sssp_nvgraph(gdf_graph *gdf_G, const int *source_vert, gdf_column *sssp_distances);
+
+/**
+ * Wrapper function for Nvgraph balanced cut clustering
+ * @param gdf_G Pointer to GDF graph object
+ * @param num_clusters The desired number of clusters
+ * @param num_eigen_vects The number of eigen-vectors to use
+ * @param evs_type The type of the eigen-value solver to use
+ * @param evs_tolerance The tolerance to use for the eigen-value solver
+ * @param evs_max_iter The maximum number of iterations of the eigen-value solver
+ * @param kmean_tolerance The tolerance to use for the kmeans solver
+ * @param kmean_max_iter The maximum number of iteration of the kmeans solver
+ * @param clustering Pointer to a GDF column in which the resulting clustering will be stored
+ * @param eig_vals Pointer to a GDF column in which the resulting eigenvalues will be stored
+ * @param eig_vects Pointer to a GDF column in which the resulting eigenvectors will be stored
+ * @return Error code
+ */
+gdf_error gdf_balancedCutClustering_nvgraph(gdf_graph* gdf_G,
+																						const int num_clusters,
+																						const int num_eigen_vects,
+																						const int evs_type,
+																						const float evs_tolerance,
+																						const int evs_max_iter,
+																						const float kmean_tolerance,
+																						const int kmean_max_iter,
+																						gdf_column* clustering,
+																						gdf_column* eig_vals,
+																						gdf_column* eig_vects);

--- a/cpp/include/nvgraph_gdf.h
+++ b/cpp/include/nvgraph_gdf.h
@@ -68,9 +68,7 @@ gdf_error gdf_balancedCutClustering_nvgraph(gdf_graph* gdf_G,
 																						const int evs_max_iter,
 																						const float kmean_tolerance,
 																						const int kmean_max_iter,
-																						gdf_column* clustering,
-																						gdf_column* eig_vals,
-																						gdf_column* eig_vects);
+																						gdf_column* clustering);
 
 /**
  * Wrapper function for Nvgraph spectral modularity maximization algorithm
@@ -93,9 +91,7 @@ gdf_error gdf_spectralModularityMaximization_nvgraph(	gdf_graph* gdf_G,
 																											const int evs_max_iter,
 																											const float kmean_tolerance,
 																											const int kmean_max_iter,
-																											gdf_column* clustering,
-																											gdf_column* eig_vals,
-																											gdf_column* eig_vects);
+																											gdf_column* clustering);
 
 /**
  * Wrapper function for Nvgraph clustering modularity metric

--- a/cpp/src/nvgraph_gdf.cu
+++ b/cpp/src/nvgraph_gdf.cu
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** ---------------------------------------------------------------------------*
+ * @brief Wrapper functions for Nvgraph
+ *
+ * @file nvgraph_gdf.cu
+ * ---------------------------------------------------------------------------**/
+
 #include <nvgraph_gdf.h>
 #include <thrust/device_vector.h>
 #include <ctime>
@@ -5,58 +26,68 @@
 
 //RMM:
 //
-	
+
 #include <rmm_utils.h>
-		
+
 template<typename T>
 using Vector = thrust::device_vector<T, rmm_allocator<T>>;
 
 gdf_error nvgraph2gdf_error(nvgraphStatus_t nvg_stat)
-{
-  switch (nvg_stat) {
-    case NVGRAPH_STATUS_SUCCESS:
-      return GDF_SUCCESS;
-    case NVGRAPH_STATUS_NOT_INITIALIZED:
-      return GDF_INVALID_API_CALL;
-    case NVGRAPH_STATUS_INVALID_VALUE:
-      return GDF_INVALID_API_CALL;
-    case NVGRAPH_STATUS_TYPE_NOT_SUPPORTED:
-      return GDF_UNSUPPORTED_DTYPE;
-    case NVGRAPH_STATUS_GRAPH_TYPE_NOT_SUPPORTED:
-      return GDF_INVALID_API_CALL;
-    default:
-      return GDF_CUDA_ERROR;
-  }
+														{
+	switch (nvg_stat) {
+		case NVGRAPH_STATUS_SUCCESS:
+			return GDF_SUCCESS;
+		case NVGRAPH_STATUS_NOT_INITIALIZED:
+			return GDF_INVALID_API_CALL;
+		case NVGRAPH_STATUS_INVALID_VALUE:
+			return GDF_INVALID_API_CALL;
+		case NVGRAPH_STATUS_TYPE_NOT_SUPPORTED:
+			return GDF_UNSUPPORTED_DTYPE;
+		case NVGRAPH_STATUS_GRAPH_TYPE_NOT_SUPPORTED:
+			return GDF_INVALID_API_CALL;
+		default:
+			return GDF_CUDA_ERROR;
+	}
 }
 
 gdf_error nvgraph2gdf_error_verbose(nvgraphStatus_t nvg_stat)
-{
-  switch (nvg_stat) {
-    case NVGRAPH_STATUS_NOT_INITIALIZED:
-      std::cerr << "nvGRAPH not initialized"; return GDF_CUDA_ERROR;
-    case NVGRAPH_STATUS_ALLOC_FAILED:
-      std::cerr << "nvGRAPH alloc failed"; return GDF_CUDA_ERROR;
-    case NVGRAPH_STATUS_INVALID_VALUE:
-      std::cerr << "nvGRAPH invalid value"; return GDF_CUDA_ERROR;
-    case NVGRAPH_STATUS_ARCH_MISMATCH:
-      std::cerr << "nvGRAPH arch mismatch"; return GDF_CUDA_ERROR;
-    case NVGRAPH_STATUS_MAPPING_ERROR:
-      std::cerr << "nvGRAPH mapping error"; return GDF_CUDA_ERROR;
-    case NVGRAPH_STATUS_EXECUTION_FAILED:
-      std::cerr << "nvGRAPH execution failed"; return GDF_CUDA_ERROR;
-    case NVGRAPH_STATUS_INTERNAL_ERROR:
-      std::cerr << "nvGRAPH internal error"; return GDF_CUDA_ERROR;
-    case NVGRAPH_STATUS_TYPE_NOT_SUPPORTED:
-      std::cerr << "nvGRAPH type not supported"; return GDF_CUDA_ERROR;
-    case NVGRAPH_STATUS_NOT_CONVERGED:
-      std::cerr << "nvGRAPH algorithm failed to converge"; return GDF_CUDA_ERROR;
-    case NVGRAPH_STATUS_GRAPH_TYPE_NOT_SUPPORTED:
-      std::cerr << "nvGRAPH graph type not supported"; return GDF_CUDA_ERROR;
-    default:
-      std::cerr << "Unknown nvGRAPH Status"; return GDF_CUDA_ERROR;
-  }
+																		{
+	switch (nvg_stat) {
+		case NVGRAPH_STATUS_NOT_INITIALIZED:
+			std::cerr << "nvGRAPH not initialized";
+			return GDF_CUDA_ERROR;
+		case NVGRAPH_STATUS_ALLOC_FAILED:
+			std::cerr << "nvGRAPH alloc failed";
+			return GDF_CUDA_ERROR;
+		case NVGRAPH_STATUS_INVALID_VALUE:
+			std::cerr << "nvGRAPH invalid value";
+			return GDF_CUDA_ERROR;
+		case NVGRAPH_STATUS_ARCH_MISMATCH:
+			std::cerr << "nvGRAPH arch mismatch";
+			return GDF_CUDA_ERROR;
+		case NVGRAPH_STATUS_MAPPING_ERROR:
+			std::cerr << "nvGRAPH mapping error";
+			return GDF_CUDA_ERROR;
+		case NVGRAPH_STATUS_EXECUTION_FAILED:
+			std::cerr << "nvGRAPH execution failed";
+			return GDF_CUDA_ERROR;
+		case NVGRAPH_STATUS_INTERNAL_ERROR:
+			std::cerr << "nvGRAPH internal error";
+			return GDF_CUDA_ERROR;
+		case NVGRAPH_STATUS_TYPE_NOT_SUPPORTED:
+			std::cerr << "nvGRAPH type not supported";
+			return GDF_CUDA_ERROR;
+		case NVGRAPH_STATUS_NOT_CONVERGED:
+			std::cerr << "nvGRAPH algorithm failed to converge";
+			return GDF_CUDA_ERROR;
+		case NVGRAPH_STATUS_GRAPH_TYPE_NOT_SUPPORTED:
+			std::cerr << "nvGRAPH graph type not supported";
+			return GDF_CUDA_ERROR;
+		default:
+			std::cerr << "Unknown nvGRAPH Status";
+			return GDF_CUDA_ERROR;
+	}
 }
-
 
 #ifdef VERBOSE
 #define NVG_TRY(call)                     \
@@ -72,138 +103,221 @@ gdf_error nvgraph2gdf_error_verbose(nvgraphStatus_t nvg_stat)
 }
 #endif
 
-gdf_error gdf_createGraph_nvgraph(nvgraphHandle_t nvg_handle, gdf_graph* gdf_G, nvgraphGraphDescr_t* nvgraph_G, bool use_transposed) {
+gdf_error gdf_createGraph_nvgraph(nvgraphHandle_t nvg_handle,
+																	gdf_graph* gdf_G,
+																	nvgraphGraphDescr_t* nvgraph_G,
+																	bool use_transposed) {
 
-  // check input
-  GDF_REQUIRE(!((gdf_G->edgeList == nullptr) &&
-               (gdf_G->adjList == nullptr) && 
-               (gdf_G->transposedAdjList == nullptr)), 
-                GDF_INVALID_API_CALL);
-  nvgraphTopologyType_t TT; ;
-  cudaDataType_t settype;
-  // create an nvgraph graph handle
-  NVG_TRY(nvgraphCreateGraphDescr(nvg_handle, nvgraph_G));
-  // setup nvgraph variables
-  if (use_transposed) {
-     // convert edgeList to transposedAdjList
-    if (gdf_G->transposedAdjList == nullptr) {
-      GDF_TRY(gdf_add_transpose(gdf_G));
-    }
-    // using exiting transposedAdjList if it exisits and if adjList is missing 
-    TT = NVGRAPH_CSC_32;
-    nvgraphCSCTopology32I_st topoData;
-    topoData.nvertices = gdf_G->transposedAdjList->offsets->size -1;
-    topoData.nedges = gdf_G->transposedAdjList->indices->size;
-    topoData.destination_offsets = (int *) gdf_G->transposedAdjList->offsets->data;
-    topoData.source_indices = (int *) gdf_G->transposedAdjList->indices->data;
-    // attach the transposed adj list
-    NVG_TRY(nvgraphAttachGraphStructure(nvg_handle, *nvgraph_G, (void *)&topoData, TT));
-      //attach edge values
-    if (gdf_G->transposedAdjList->edge_data) {
-      switch (gdf_G->transposedAdjList->edge_data->dtype) {
-        case GDF_FLOAT32:   
-          settype = CUDA_R_32F;
-          NVG_TRY(nvgraphAttachEdgeData(nvg_handle, *nvgraph_G, 0, settype, (float *) gdf_G->transposedAdjList->edge_data->data));
-        case GDF_FLOAT64:   
-          settype = CUDA_R_64F;
-          NVG_TRY(nvgraphAttachEdgeData(nvg_handle, *nvgraph_G, 0, settype, (double *) gdf_G->transposedAdjList->edge_data->data));
-        default: return GDF_UNSUPPORTED_DTYPE;
-      }
-    }
-  }
-  else {
-    // convert edgeList to adjList
-    if (gdf_G->adjList == nullptr) {
-      GDF_TRY(gdf_add_adj_list(gdf_G));
-    }
-    TT = NVGRAPH_CSR_32;
-    nvgraphCSRTopology32I_st topoData;
-    topoData.nvertices = gdf_G->adjList->offsets->size -1;
-    topoData.nedges = gdf_G->adjList->indices->size;
-    topoData.source_offsets = (int *) gdf_G->adjList->offsets->data;
-    topoData.destination_indices = (int *) gdf_G->adjList->indices->data;
-    
-    // attach adj list
-    NVG_TRY(nvgraphAttachGraphStructure(nvg_handle, *nvgraph_G, (void *)&topoData, TT));
-      //attach edge values
-    if (gdf_G->adjList->edge_data) {
-      switch (gdf_G->adjList->edge_data->dtype) {
-        case GDF_FLOAT32:   
-          settype = CUDA_R_32F;
-          NVG_TRY(nvgraphAttachEdgeData(nvg_handle, *nvgraph_G, 0, settype, (float *) gdf_G->adjList->edge_data->data));
-        case GDF_FLOAT64:   
-          settype = CUDA_R_64F;
-          NVG_TRY(nvgraphAttachEdgeData(nvg_handle, *nvgraph_G, 0, settype, (double *) gdf_G->adjList->edge_data->data));
-        default: return GDF_UNSUPPORTED_DTYPE;
-      }
-    }
-  }
-  return GDF_SUCCESS;
+	// check input
+	GDF_REQUIRE(!((gdf_G->edgeList == nullptr) &&
+									(gdf_G->adjList == nullptr) &&
+									(gdf_G->transposedAdjList == nullptr)),
+							GDF_INVALID_API_CALL);
+	nvgraphTopologyType_t TT;
+	;
+	cudaDataType_t settype;
+	// create an nvgraph graph handle
+	NVG_TRY(nvgraphCreateGraphDescr(nvg_handle, nvgraph_G));
+	// setup nvgraph variables
+	if (use_transposed) {
+		// convert edgeList to transposedAdjList
+		if (gdf_G->transposedAdjList == nullptr) {
+			GDF_TRY(gdf_add_transpose(gdf_G));
+		}
+		// using exiting transposedAdjList if it exisits and if adjList is missing
+		TT = NVGRAPH_CSC_32;
+		nvgraphCSCTopology32I_st topoData;
+		topoData.nvertices = gdf_G->transposedAdjList->offsets->size - 1;
+		topoData.nedges = gdf_G->transposedAdjList->indices->size;
+		topoData.destination_offsets = (int *) gdf_G->transposedAdjList->offsets->data;
+		topoData.source_indices = (int *) gdf_G->transposedAdjList->indices->data;
+		// attach the transposed adj list
+		NVG_TRY(nvgraphAttachGraphStructure(nvg_handle, *nvgraph_G, (void * )&topoData, TT));
+		//attach edge values
+		if (gdf_G->transposedAdjList->edge_data) {
+			switch (gdf_G->transposedAdjList->edge_data->dtype) {
+				case GDF_FLOAT32:
+					settype = CUDA_R_32F;
+					NVG_TRY(nvgraphAttachEdgeData(nvg_handle,
+																				*nvgraph_G,
+																				0,
+																				settype,
+																				(float * ) gdf_G->transposedAdjList->edge_data->data))
+					;
+				case GDF_FLOAT64:
+					settype = CUDA_R_64F;
+					NVG_TRY(nvgraphAttachEdgeData(nvg_handle,
+																				*nvgraph_G,
+																				0,
+																				settype,
+																				(double * ) gdf_G->transposedAdjList->edge_data->data))
+					;
+				default:
+					return GDF_UNSUPPORTED_DTYPE;
+			}
+		}
+	}
+	else {
+		// convert edgeList to adjList
+		if (gdf_G->adjList == nullptr) {
+			GDF_TRY(gdf_add_adj_list(gdf_G));
+		}
+		TT = NVGRAPH_CSR_32;
+		nvgraphCSRTopology32I_st topoData;
+		topoData.nvertices = gdf_G->adjList->offsets->size - 1;
+		topoData.nedges = gdf_G->adjList->indices->size;
+		topoData.source_offsets = (int *) gdf_G->adjList->offsets->data;
+		topoData.destination_indices = (int *) gdf_G->adjList->indices->data;
+
+		// attach adj list
+		NVG_TRY(nvgraphAttachGraphStructure(nvg_handle, *nvgraph_G, (void * )&topoData, TT));
+		//attach edge values
+		if (gdf_G->adjList->edge_data) {
+			switch (gdf_G->adjList->edge_data->dtype) {
+				case GDF_FLOAT32:
+					settype = CUDA_R_32F;
+					NVG_TRY(nvgraphAttachEdgeData(nvg_handle,
+																				*nvgraph_G,
+																				0,
+																				settype,
+																				(float * ) gdf_G->adjList->edge_data->data))
+					;
+				case GDF_FLOAT64:
+					settype = CUDA_R_64F;
+					NVG_TRY(nvgraphAttachEdgeData(nvg_handle,
+																				*nvgraph_G,
+																				0,
+																				settype,
+																				(double * ) gdf_G->adjList->edge_data->data))
+					;
+				default:
+					return GDF_UNSUPPORTED_DTYPE;
+			}
+		}
+	}
+	return GDF_SUCCESS;
 }
 
-gdf_error gdf_sssp_nvgraph(gdf_graph *gdf_G, 
-                 const int *source_vert,
-                 gdf_column *sssp_distances) {
+gdf_error gdf_sssp_nvgraph(gdf_graph *gdf_G,
+														const int *source_vert,
+														gdf_column *sssp_distances) {
 
+	std::clock_t start;
+	GDF_REQUIRE(gdf_G != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(*source_vert >= 0, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(*source_vert < sssp_distances->size, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(sssp_distances != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(sssp_distances->data != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(!sssp_distances->valid, GDF_VALIDITY_UNSUPPORTED);
+	GDF_REQUIRE(sssp_distances->size > 0, GDF_INVALID_API_CALL);
 
-  std::clock_t start;
-  GDF_REQUIRE( gdf_G != nullptr , GDF_INVALID_API_CALL ); 
-  GDF_REQUIRE( *source_vert >= 0 , GDF_INVALID_API_CALL ); 
-  GDF_REQUIRE( *source_vert < sssp_distances->size , GDF_INVALID_API_CALL ); 
-  GDF_REQUIRE( sssp_distances != nullptr , GDF_INVALID_API_CALL ); 
-  GDF_REQUIRE( sssp_distances->data != nullptr , GDF_INVALID_API_CALL ); 
-  GDF_REQUIRE( !sssp_distances->valid , GDF_VALIDITY_UNSUPPORTED );          
-  GDF_REQUIRE( sssp_distances->size > 0 , GDF_INVALID_API_CALL ); 
+	// init nvgraph
+	// TODO : time this call
+	nvgraphHandle_t nvg_handle = 0;
+	nvgraphGraphDescr_t nvgraph_G = 0;
+	cudaDataType_t settype;
 
-  // init nvgraph
-  // TODO : time this call
-  nvgraphHandle_t nvg_handle = 0;
-  nvgraphGraphDescr_t nvgraph_G = 0;
-  cudaDataType_t settype;
+	start = std::clock();
+	NVG_TRY(nvgraphCreate(&nvg_handle));
+	GDF_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvgraph_G, true));
+	std::cout << (std::clock() - start) / (double) (CLOCKS_PER_SEC / 1000) << ","; // in ms
 
-  start = std::clock();
-  NVG_TRY(nvgraphCreate(&nvg_handle));
-  GDF_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvgraph_G, true));
-  std::cout << (std::clock() - start) / (double)(CLOCKS_PER_SEC / 1000) << ","; // in ms
+	int sssp_index = 0;
+	int weight_index = 0;
+	Vector<float> d_val;
 
-  int sssp_index = 0;
-  int weight_index = 0;
-  Vector<float> d_val;
-		
-  //RMM:
-  //
-  cudaStream_t stream{nullptr};
-  rmm_temp_allocator allocator(stream);
-  start = std::clock();
-  if (gdf_G->transposedAdjList->edge_data == nullptr) {
-    // use a fp32 vector  [1,...,1]
-    settype = CUDA_R_32F;
-    d_val.resize(gdf_G->transposedAdjList->indices->size);
-    thrust::fill(thrust::cuda::par(allocator).on(stream), d_val.begin(), d_val.end(), 1.0);
-    NVG_TRY(nvgraphAttachEdgeData(nvg_handle, nvgraph_G, weight_index, settype, (void *) thrust::raw_pointer_cast(d_val.data())));
-  }
-  else {
-    switch (gdf_G->transposedAdjList->edge_data->dtype) {
-     case GDF_FLOAT32:   
-       settype = CUDA_R_32F;
-     case GDF_FLOAT64:   
-       settype = CUDA_R_64F;
-     default: return GDF_UNSUPPORTED_DTYPE;
-    } 
-  }
+	//RMM:
+	//
+	cudaStream_t stream { nullptr };
+	rmm_temp_allocator allocator(stream);
+	start = std::clock();
+	if (gdf_G->transposedAdjList->edge_data == nullptr) {
+		// use a fp32 vector  [1,...,1]
+		settype = CUDA_R_32F;
+		d_val.resize(gdf_G->transposedAdjList->indices->size);
+		thrust::fill(thrust::cuda::par(allocator).on(stream), d_val.begin(), d_val.end(), 1.0);
+		NVG_TRY(nvgraphAttachEdgeData(nvg_handle,
+																	nvgraph_G,
+																	weight_index,
+																	settype,
+																	(void * ) thrust::raw_pointer_cast(d_val.data())));
+	}
+	else {
+		switch (gdf_G->transposedAdjList->edge_data->dtype) {
+			case GDF_FLOAT32:
+				settype = CUDA_R_32F;
+			case GDF_FLOAT64:
+				settype = CUDA_R_64F;
+			default:
+				return GDF_UNSUPPORTED_DTYPE;
+		}
+	}
 
-  NVG_TRY(nvgraphAttachVertexData(nvg_handle, nvgraph_G, 0, settype, sssp_distances->data ));
-  std::cout << (std::clock() - start) / (double)(CLOCKS_PER_SEC / 1000) << ","; // in ms
-  start = std::clock();
+	NVG_TRY(nvgraphAttachVertexData(nvg_handle, nvgraph_G, 0, settype, sssp_distances->data));
+	std::cout << (std::clock() - start) / (double) (CLOCKS_PER_SEC / 1000) << ","; // in ms
+	start = std::clock();
 
-  NVG_TRY(nvgraphSssp(nvg_handle, nvgraph_G, weight_index, source_vert, sssp_index));
-  std::cout << (std::clock() - start) / (double)(CLOCKS_PER_SEC / 1000) << ","; // in ms
-  start = std::clock();
+	NVG_TRY(nvgraphSssp(nvg_handle, nvgraph_G, weight_index, source_vert, sssp_index));
+	std::cout << (std::clock() - start) / (double) (CLOCKS_PER_SEC / 1000) << ","; // in ms
+	start = std::clock();
 
-  NVG_TRY(nvgraphDestroyGraphDescr(nvg_handle, nvgraph_G));
-  NVG_TRY(nvgraphDestroy(nvg_handle));
-  std::cout << (std::clock() - start) / (double)(CLOCKS_PER_SEC / 1000) <<std::endl; // in ms
+	NVG_TRY(nvgraphDestroyGraphDescr(nvg_handle, nvgraph_G));
+	NVG_TRY(nvgraphDestroy(nvg_handle));
+	std::cout << (std::clock() - start) / (double) (CLOCKS_PER_SEC / 1000) << std::endl; // in ms
 
-
-  return GDF_SUCCESS;
+	return GDF_SUCCESS;
 }
+
+gdf_error gdf_balancedCutClustering_nvgraph(gdf_graph* gdf_G,
+																						const int num_clusters,
+																						const int num_eigen_vects,
+																						const int evs_type,
+																						const float evs_tolerance,
+																						const int evs_max_iter,
+																						const float kmean_tolerance,
+																						const int kmean_max_iter,
+																						gdf_column* clustering,
+																						gdf_column* eig_vals,
+																						gdf_column* eig_vects) {
+	GDF_REQUIRE(gdf_G != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE((gdf_G->adjList != nullptr) || (gdf_G->edgeList != nullptr), GDF_INVALID_API_CALL);
+	GDF_REQUIRE(clustering != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(clustering->data != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(!clustering->valid, GDF_VALIDITY_UNSUPPORTED);
+	GDF_REQUIRE(eig_vals != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(eig_vals->data != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(!eig_vals->valid, GDF_VALIDITY_UNSUPPORTED);
+	GDF_REQUIRE(eig_vects != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(eig_vects->data != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(!eig_vects->valid, GDF_VALIDITY_UNSUPPORTED);
+
+	// Ensure that the input graph has values
+	GDF_TRY(gdf_add_adj_list(gdf_G));
+	GDF_REQUIRE(gdf_G->adjList->edge_data != nullptr, GDF_INVALID_API_CALL);
+
+	// Initialize Nvgraph and wrap the graph
+	nvgraphHandle_t nvg_handle = nullptr;
+	nvgraphGraphDescr_t nvgraph_G = nullptr;
+	NVG_TRY(nvgraphCreate(&nvg_handle));
+	GDF_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvgraph_G, false));
+	int weight_index = 0;
+
+	// Make call to Nvgraph balancedCutClustering
+	NVG_TRY(nvgraphBalancedCutClustering(	nvg_handle,
+																				nvgraph_G,
+																				weight_index,
+																				num_clusters,
+																				num_eigen_vects,
+																				evs_type,
+																				evs_tolerance,
+																				evs_max_iter,
+																				kmean_tolerance,
+																				kmean_max_iter,
+																				clustering->data,
+																				eig_vals->data,
+																				eig_vects->data));
+	NVG_TRY(nvgraphDestroyGraphDescr(nvg_handle, nvgraph_G));
+	NVG_TRY(nvgraphDestroy(nvg_handle));
+	return GDF_SUCCESS;
+}
+

--- a/cpp/src/nvgraph_gdf.cu
+++ b/cpp/src/nvgraph_gdf.cu
@@ -303,7 +303,7 @@ gdf_error gdf_balancedCutClustering_nvgraph(gdf_graph* gdf_G,
 	int weight_index = 0;
 
 	// Make call to Nvgraph balancedCutClustering
-	NVG_TRY(nvgraphBalancedCutClustering(	nvg_handle,
+	NVG_TRY(nvgraphBalancedCutClustering(nvg_handle,
 																				nvgraph_G,
 																				weight_index,
 																				num_clusters,
@@ -316,6 +316,57 @@ gdf_error gdf_balancedCutClustering_nvgraph(gdf_graph* gdf_G,
 																				clustering->data,
 																				eig_vals->data,
 																				eig_vects->data));
+	NVG_TRY(nvgraphDestroyGraphDescr(nvg_handle, nvgraph_G));
+	NVG_TRY(nvgraphDestroy(nvg_handle));
+	return GDF_SUCCESS;
+}
+
+gdf_error gdf_spectralModularityMaximization_nvgraph(gdf_graph* gdf_G,
+																											const int n_clusters,
+																											const int n_eig_vects,
+																											const float evs_tolerance,
+																											const int evs_max_iter,
+																											const float kmean_tolerance,
+																											const int kmean_max_iter,
+																											gdf_column* clustering,
+																											gdf_column* eig_vals,
+																											gdf_column* eig_vects) {
+	GDF_REQUIRE(gdf_G != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE((gdf_G->adjList != nullptr) || (gdf_G->edgeList != nullptr), GDF_INVALID_API_CALL);
+	GDF_REQUIRE(clustering != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(clustering->data != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(!clustering->valid, GDF_VALIDITY_UNSUPPORTED);
+	GDF_REQUIRE(eig_vals != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(eig_vals->data != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(!eig_vals->valid, GDF_VALIDITY_UNSUPPORTED);
+	GDF_REQUIRE(eig_vects != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(eig_vects->data != nullptr, GDF_INVALID_API_CALL);
+	GDF_REQUIRE(!eig_vects->valid, GDF_VALIDITY_UNSUPPORTED);
+
+	// Ensure that the input graph has values
+	GDF_TRY(gdf_add_adj_list(gdf_G));
+	GDF_REQUIRE(gdf_G->adjList->edge_data != nullptr, GDF_INVALID_API_CALL);
+
+	// Initialize Nvgraph and wrap the graph
+	nvgraphHandle_t nvg_handle = nullptr;
+	nvgraphGraphDescr_t nvgraph_G = nullptr;
+	NVG_TRY(nvgraphCreate(&nvg_handle));
+	GDF_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvgraph_G, false));
+	int weight_index = 0;
+
+	// Make call to Nvgraph balancedCutClustering
+	NVG_TRY(nvgraphSpectralModularityMaximization(nvg_handle,
+																								nvgraph_G,
+																								weight_index,
+																								n_clusters,
+																								n_eig_vects,
+																								evs_tolerance,
+																								evs_max_iter,
+																								kmean_tolerance,
+																								kmean_max_iter,
+																								clustering->data,
+																								eig_vals->data,
+																								eig_vects->data));
 	NVG_TRY(nvgraphDestroyGraphDescr(nvg_handle, nvgraph_G));
 	NVG_TRY(nvgraphDestroy(nvg_handle));
 	return GDF_SUCCESS;

--- a/cpp/src/utilities/error_utils.h
+++ b/cpp/src/utilities/error_utils.h
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** ---------------------------------------------------------------------------*
+ * @brief Error utilities
+ *
+ * @file error_utils.h
+ * ---------------------------------------------------------------------------**/
+
 #ifndef GDF_ERRORUTILS_H
 #define GDF_ERRORUTILS_H
 
@@ -25,7 +46,12 @@
 
 #define CUDA_CHECK_LAST() CUDA_TRY(cudaPeekAtLastError())
 
-#define GDF_TRY(x) if ((x)!=GDF_SUCCESS) return GDF_CUDA_ERROR;
+#define GDF_TRY(x) 														\
+{																							\
+gdf_error err_code = (x);											\
+if (err_code != GDF_SUCCESS) 									\
+	return err_code;														\
+}
 
 #define GDF_REQUIRE(F, S) if (!(F)) return (S);
 

--- a/python/cugraph/cugraph.pyx
+++ b/python/cugraph/cugraph.pyx
@@ -1,3 +1,16 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 include "graph/c_graph.pyx"
 include "nvgraph/c_nvgraph.pyx"
 include "pagerank/pagerank_wrapper.pyx"
@@ -7,3 +20,4 @@ include "jaccard/wjaccard_wrapper.pyx"
 include "grmat/grmat_wrapper.pyx"
 include "louvain/louvain_wrapper.pyx"
 include "bfs/bfs_wrapper.pyx"
+include "spectral_clustering/spectral_clustering.pyx"

--- a/python/cugraph/graph/c_graph.pyx
+++ b/python/cugraph/graph/c_graph.pyx
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from c_graph cimport *
+from c_graph cimport * 
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport calloc, malloc, free
@@ -23,20 +23,20 @@ dtypes = {np.int32: GDF_INT32, np.int64: GDF_INT64, np.float32: GDF_FLOAT32, np.
 
 cdef create_column(col):
     
-    x= <gdf_column*>malloc(sizeof(gdf_column))
-    cdef gdf_column* c_col = <gdf_column*>malloc(sizeof(gdf_column))
+    x = < gdf_column *> malloc(sizeof(gdf_column))
+    cdef gdf_column * c_col = < gdf_column *> malloc(sizeof(gdf_column))
     cdef uintptr_t data_ptr = cudf.bindings.cudf_cpp.get_column_data_ptr(col._column)
-    #cdef uintptr_t valid_ptr = cudf.bindings.cudf_cpp.get_column_valid_ptr(col._column)
+    # cdef uintptr_t valid_ptr = cudf.bindings.cudf_cpp.get_column_valid_ptr(col._column)
 
-    err = gdf_column_view_augmented(<gdf_column*>c_col,
-                                    <void*> data_ptr,
-                                    <gdf_valid_type*> 0,
-                                    <gdf_size_type>len(col),
+    err = gdf_column_view_augmented(< gdf_column *> c_col,
+                                    < void *> data_ptr,
+                                    < gdf_valid_type *> 0,
+                                    < gdf_size_type > len(col),
                                     dtypes[col.dtype.type],
-                                    <gdf_size_type>col.null_count)
+                                    < gdf_size_type > col.null_count)
     cudf.bindings.cudf_cpp.check_gdf_error(err)
 
-    cdef uintptr_t col_ptr = <uintptr_t>c_col
+    cdef uintptr_t col_ptr = < uintptr_t > c_col
     return col_ptr
 
 class Graph:
@@ -53,12 +53,11 @@ class Graph:
         >>> import cuGraph
         >>> G = cuGraph.Graph()
         """
-        cdef gdf_graph* graph
-        graph = <gdf_graph*>calloc(1,sizeof(gdf_graph))
+        cdef gdf_graph * graph
+        graph = < gdf_graph *> calloc(1, sizeof(gdf_graph))
 
-        cdef uintptr_t graph_ptr = <uintptr_t>graph
+        cdef uintptr_t graph_ptr = < uintptr_t > graph
         self.graph_ptr = graph_ptr
-
 
     def add_edge_list(self, source_col, dest_col, value_col=None):
         """
@@ -91,35 +90,43 @@ class Graph:
         >>> destinations = cudf.Series(M.col)
         >>> G = cuGraph.Graph()
         >>> G.add_edge_list(sources,destinations,none)
-        
         """
-
         cdef uintptr_t graph = self.graph_ptr
-        cdef uintptr_t source=create_column(source_col)
-        cdef uintptr_t dest=create_column(dest_col)
+        cdef uintptr_t source = create_column(source_col)
+        cdef uintptr_t dest = create_column(dest_col)
         cdef uintptr_t value
         if value_col is None:
             value = 0
         else:
-            value=create_column(value_col)
+            value = create_column(value_col)
 
-        err = gdf_edge_list_view(<gdf_graph*>graph,
-                                 <gdf_column*>source,
-                                 <gdf_column*>dest,
-                                 <gdf_column*>value)
-        cudf.bindings.cudf_cpp.check_gdf_error(err)    
+        err = gdf_edge_list_view(< gdf_graph *> graph,
+                                 < gdf_column *> source,
+                                 < gdf_column *> dest,
+                                 < gdf_column *> value)
+        cudf.bindings.cudf_cpp.check_gdf_error(err) 
+        
+    def num_vertices(self):
+        """
+        Get the number of vertices in the graph
+        """
+        cdef uintptr_t graph = self.graph_ptr
+        cdef gdf_graph* g = <gdf_graph*>graph
+        err = gdf_add_adj_list(g)
+        cudf.bindings.cudf_cpp.check_gdf_error(err)
+        return g.adjList.offsets.size - 1   
 
     def view_edge_list(self):
         """
         Display the edge list. Compute it if needed.
         """
         cdef uintptr_t graph = self.graph_ptr
-        cdef gdf_graph* g = <gdf_graph*>graph
+        cdef gdf_graph * g = < gdf_graph *> graph
         gdf_add_edge_list(g)
         col_size = g.edgeList.src_indices.size
 
-        cdef uintptr_t src_col_data = <uintptr_t>g.edgeList.src_indices.data
-        cdef uintptr_t dest_col_data = <uintptr_t>g.edgeList.dest_indices.data
+        cdef uintptr_t src_col_data = < uintptr_t > g.edgeList.src_indices.data
+        cdef uintptr_t dest_col_data = < uintptr_t > g.edgeList.dest_indices.data
 
         src_data = rmm.device_array_from_ptr(src_col_data,
                                      nelem=col_size,
@@ -137,22 +144,22 @@ class Graph:
         Compute the edge list from adjacency list and return sources and destinations as cudf Series.
         """
         cdef uintptr_t graph = self.graph_ptr
-        err = gdf_add_edge_list(<gdf_graph*>graph)
+        err = gdf_add_edge_list(< gdf_graph *> graph)
         cudf.bindings.cudf_cpp.check_gdf_error(err)
 
-        cdef gdf_graph* g = <gdf_graph*>graph
+        cdef gdf_graph * g = < gdf_graph *> graph
         col_size = g.edgeList.src_indices.size
-        cdef uintptr_t src_col_data = <uintptr_t>g.edgeList.src_indices.data
-        cdef uintptr_t dest_col_data = <uintptr_t>g.edgeList.dest_indices.data
+        cdef uintptr_t src_col_data = < uintptr_t > g.edgeList.src_indices.data
+        cdef uintptr_t dest_col_data = < uintptr_t > g.edgeList.dest_indices.data
 
         src_data = rmm.device_array_from_ptr(src_col_data,
                                      nelem=col_size,
-                                     dtype=np.int32)#,
-                                     #finalizer=rmm._make_finalizer(src_col_data, 0))
+                                     dtype=np.int32)  # ,
+                                     # finalizer=rmm._make_finalizer(src_col_data, 0))
         dest_data = rmm.device_array_from_ptr(dest_col_data,
                                      nelem=col_size,
-                                     dtype=np.int32)#,
-                                     #finalizer=rmm._make_finalizer(dest_col_data, 0))
+                                     dtype=np.int32)  # ,
+                                     # finalizer=rmm._make_finalizer(dest_col_data, 0))
 
         return cudf.Series(src_data), cudf.Series(dest_data)
 
@@ -161,7 +168,7 @@ class Graph:
         Delete the edge list.
         """
         cdef uintptr_t graph = self.graph_ptr
-        err = gdf_delete_edge_list(<gdf_graph*>graph)
+        err = gdf_delete_edge_list(< gdf_graph *> graph)
         cudf.bindings.cudf_cpp.check_gdf_error(err)
 
     def add_adj_list(self, offsets_col, indices_col, value_col):
@@ -169,18 +176,18 @@ class Graph:
         Warp existing gdf columns representing an adjacency list in a gdf_graph.
         """
         cdef uintptr_t graph = self.graph_ptr
-        cdef uintptr_t offsets=create_column(offsets_col)
-        cdef uintptr_t indices=create_column(indices_col)
+        cdef uintptr_t offsets = create_column(offsets_col)
+        cdef uintptr_t indices = create_column(indices_col)
         cdef uintptr_t value
         if value_col is None:
             value = 0
         else:
-            value=create_column(value_col)
+            value = create_column(value_col)
     
-        err = gdf_adj_list_view(<gdf_graph*>graph,
-                                <gdf_column*>offsets,
-                                <gdf_column*>indices,
-                                <gdf_column*>value)
+        err = gdf_adj_list_view(< gdf_graph *> graph,
+                                < gdf_column *> offsets,
+                                < gdf_column *> indices,
+                                < gdf_column *> value)
         cudf.bindings.cudf_cpp.check_gdf_error(err)
         
     def view_adj_list(self):
@@ -188,15 +195,15 @@ class Graph:
         Compute the adjacency list from edge list and return offsets and indices as cudf Series.
         """
         cdef uintptr_t graph = self.graph_ptr
-        err = gdf_add_adj_list(<gdf_graph*>graph)
+        err = gdf_add_adj_list(< gdf_graph *> graph)
         cudf.bindings.cudf_cpp.check_gdf_error(err)
         
-        cdef gdf_graph* g = <gdf_graph*>graph
+        cdef gdf_graph * g = < gdf_graph *> graph
         col_size_off = g.adjList.offsets.size
         col_size_ind = g.adjList.indices.size
 
-        cdef uintptr_t offsets_col_data = <uintptr_t>g.adjList.offsets.data
-        cdef uintptr_t indices_col_data = <uintptr_t>g.adjList.indices.data
+        cdef uintptr_t offsets_col_data = < uintptr_t > g.adjList.offsets.data
+        cdef uintptr_t indices_col_data = < uintptr_t > g.adjList.indices.data
 
         offsets_data = rmm.device_array_from_ptr(offsets_col_data,
                                      nelem=col_size_off,
@@ -215,15 +222,15 @@ class Graph:
         exist.
         """
         cdef uintptr_t graph = self.graph_ptr
-        cdef gdf_graph* g = <gdf_graph*>graph
+        cdef gdf_graph * g = < gdf_graph *> graph
         err = gdf_add_transpose(g)
         cudf.bindings.cudf_cpp.check_gdf_error(err)
         
         off_size = g.transposedAdjList.offsets.size
         ind_size = g.transposedAdjList.indices.size
         
-        cdef uintptr_t offsets_col_data = <uintptr_t>g.transposedAdjList.offsets.data
-        cdef uintptr_t indices_col_data = <uintptr_t>g.transposedAdjList.indices.data
+        cdef uintptr_t offsets_col_data = < uintptr_t > g.transposedAdjList.offsets.data
+        cdef uintptr_t indices_col_data = < uintptr_t > g.transposedAdjList.indices.data
         
         offsets_data = rmm.device_array_from_ptr(offsets_col_data,
                                      nelem=off_size,
@@ -242,7 +249,7 @@ class Graph:
         Delete the adjacency list.
         """
         cdef uintptr_t graph = self.graph_ptr
-        err = gdf_delete_adj_list(<gdf_graph*>graph)
+        err = gdf_delete_adj_list(< gdf_graph *> graph)
         cudf.bindings.cudf_cpp.check_gdf_error(err)
 
     def add_transpose(self):
@@ -250,7 +257,7 @@ class Graph:
         Compute the transposed adjacency list from the edge list and add it to the existing graph.
         """
         cdef uintptr_t graph = self.graph_ptr
-        err = gdf_add_transpose(<gdf_graph*>graph)
+        err = gdf_add_transpose(< gdf_graph *> graph)
         cudf.bindings.cudf_cpp.check_gdf_error(err)
 
     def delete_transpose(self):
@@ -258,7 +265,7 @@ class Graph:
         Delete the transposed adjacency list.
         """
         cdef uintptr_t graph = self.graph_ptr
-        err = gdf_delete_transpose(<gdf_graph*>graph)
+        err = gdf_delete_transpose(< gdf_graph *> graph)
         cudf.bindings.cudf_cpp.check_gdf_error(err)
 
 

--- a/python/cugraph/louvain/test_louvain.py
+++ b/python/cugraph/louvain/test_louvain.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import cugraph
 import cudf
 import numpy as np

--- a/python/cugraph/nvgraph/c_nvgraph.pxd
+++ b/python/cugraph/nvgraph/c_nvgraph.pxd
@@ -27,9 +27,7 @@ cdef extern from "nvgraph_gdf.h":
                                                      const int evs_max_iter,
                                                      const float kmean_tolerance,
                                                      const int kmean_max_iter,
-                                                     gdf_column* clustering,
-                                                     gdf_column* eig_vals,
-                                                     gdf_column* eig_vects)
+                                                     gdf_column* clustering)
     
     cdef gdf_error gdf_spectralModularityMaximization_nvgraph(gdf_graph* gdf_G,
                                                               const int n_clusters,
@@ -38,9 +36,7 @@ cdef extern from "nvgraph_gdf.h":
                                                               const int evs_max_iter,
                                                               const float kmean_tolerance,
                                                               const int kmean_max_iter,
-                                                              gdf_column* clustering,
-                                                              gdf_column* eig_vals,
-                                                              gdf_column* eig_vects) 
+                                                              gdf_column* clustering) 
     
     cdef gdf_error gdf_AnalyzeClustering_modularity_nvgraph(gdf_graph* gdf_G,
                                                             const int n_clusters,

--- a/python/cugraph/nvgraph/c_nvgraph.pxd
+++ b/python/cugraph/nvgraph/c_nvgraph.pxd
@@ -1,3 +1,16 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from c_graph cimport *
 from libcpp cimport bool
 
@@ -7,3 +20,39 @@ cdef extern from "nvgraph_gdf.h":
                                     const int *source_vert,
                                     gdf_column *sssp_distances)
 
+    cdef gdf_error gdf_balancedCutClustering_nvgraph(gdf_graph *gdf_G,
+                                                     const int num_clusters,
+                                                     const int num_eigen_vects,
+                                                     const float evs_tolerance,
+                                                     const int evs_max_iter,
+                                                     const float kmean_tolerance,
+                                                     const int kmean_max_iter,
+                                                     gdf_column* clustering,
+                                                     gdf_column* eig_vals,
+                                                     gdf_column* eig_vects)
+    
+    cdef gdf_error gdf_spectralModularityMaximization_nvgraph(gdf_graph* gdf_G,
+                                                              const int n_clusters,
+                                                              const int n_eig_vects,
+                                                              const float evs_tolerance,
+                                                              const int evs_max_iter,
+                                                              const float kmean_tolerance,
+                                                              const int kmean_max_iter,
+                                                              gdf_column* clustering,
+                                                              gdf_column* eig_vals,
+                                                              gdf_column* eig_vects) 
+    
+    cdef gdf_error gdf_AnalyzeClustering_modularity_nvgraph(gdf_graph* gdf_G,
+                                                            const int n_clusters,
+                                                            gdf_column* clustering,
+                                                            float* score)    
+    
+    cdef gdf_error gdf_AnalyzeClustering_edge_cut_nvgraph(gdf_graph* gdf_G,
+                                                            const int n_clusters,
+                                                            gdf_column* clustering,
+                                                            float* score)
+    
+    cdef gdf_error gdf_AnalyzeClustering_ratio_cut_nvgraph(gdf_graph* gdf_G,
+                                                            const int n_clusters,
+                                                            gdf_column* clustering,
+                                                            float* score)                               

--- a/python/cugraph/nvgraph/c_nvgraph.pyx
+++ b/python/cugraph/nvgraph/c_nvgraph.pyx
@@ -1,1 +1,14 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from c_nvgraph cimport *

--- a/python/cugraph/spectral_clustering/spectral_clustering.pyx
+++ b/python/cugraph/spectral_clustering/spectral_clustering.pyx
@@ -1,0 +1,287 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from c_nvgraph cimport * 
+from c_graph cimport * 
+from libcpp cimport bool
+from libc.stdint cimport uintptr_t
+from libc.stdlib cimport calloc, malloc, free
+from libc.float cimport FLT_MAX_EXP
+import cudf
+from librmm_cffi import librmm as rmm
+import numpy as np
+
+cpdef spectralBalancedCutClustering(G,
+                                    num_clusters,
+                                    num_eigen_vects=1,
+                                    evs_tolerance=.00001,
+                                    evs_max_iter=100,
+                                    kmean_tolerance=.00001,
+                                    kmean_max_iter=100):
+    """
+    Compute a clustering/partitioning of the given graph using the spectral balanced
+    cut method.
+    
+    Parameters
+    ----------
+    G : cuGraph.Graph                  
+       cuGraph graph descriptor
+    num_clusters : integer
+        Specifies the number of clusters to find
+    num_eigen_vects : integer
+        Specifies the number of eigenvectors to use 
+    evs_tolerance: float
+        Specifies the tolerance to use in the eigensolver
+    evs_max_iter: integer
+        Specifies the maximum number of iterations for the eigensolver
+    kmean_tolerance: float
+        Specifies the tolerance to use in the k-means solver
+    kmean_max_iter: integer
+        Specifies the maximum number of iterations for the k-means solver
+    
+    Returns
+    -------
+    DF : GPU data frame containing two cudf.Series of size V: the vertex identifiers and the corresponding SSSP distances.
+        DF['vertex'] contains the vertex identifiers
+        DF['cluster'] contains the cluster assignments
+        DF['eigenvalues'] contains the computed eigenvalues
+        DF['eigenvectors'] contains the computed eigenvectors
+        
+    Example:
+    --------
+    >>> M = ReadMtxFile(graph_file)
+    >>> sources = cudf.Series(M.row)
+    >>> destinations = cudf.Series(M.col)
+    >>> G = cuGraph.Graph()
+    >>> G.add_edge_list(sources,destinations,None)
+    >>> DF = cuGraph.spectralBalancedCutClustering(G, 5)
+    """
+
+    cdef uintptr_t graph = G.graph_ptr
+    cdef gdf_graph * g = < gdf_graph *> graph
+
+    num_vert = g.adjList.offsets.size - 1
+
+    # Create the output dataframe
+    df = cudf.DataFrame()
+    df['vertex'] = cudf.Series(np.zeros(num_vert, dtype=np.int32))
+    cdef uintptr_t identifier_ptr = create_column(df['vertex'])
+    df['cluster'] = cudf.Series(np.zeros(num_vert, dtype=np.int32))
+    cdef uintptr_t cluster_ptr = create_column(df['cluster'])
+    df['eigenvalues'] = cudf.Series(np.zeros(num_eigen_vects, dtype=np.float32))
+    cdef uintptr_t eigenvalues_ptr = create_column(df['eigenvalues'])
+    df['eigenvectors'] = cudf.Series(np.zeros(num_eigen_vects * num_vert, dtype=np.float32))
+    cdef uintptr_t eigenvectors_ptr = create_column(df['eigenvectors'])
+    
+    # Set the vertex identifiers
+    err = g.adjList.get_vertex_identifiers(< gdf_column *> identifier_ptr)
+    cudf.bindings.cudf_cpp.check_gdf_error(err)
+
+    err = gdf_balancedCutClustering_nvgraph(g,
+                                            num_clusters,
+                                            num_eigen_vects,
+                                            evs_tolerance,
+                                            evs_max_iter,
+                                            kmean_tolerance,
+                                            kmean_max_iter,
+                                            < gdf_column *> cluster_ptr,
+                                            < gdf_column *> eigenvalues_ptr,
+                                            < gdf_column *> eigenvectors_ptr)
+    cudf.bindings.cudf_cpp.check_gdf_error(err)
+
+    return df
+
+cpdef spectralModularityMaximizationClustering(G,
+                                               num_clusters,
+                                               num_eigen_vects=1,
+                                               evs_tolerance=.00001,
+                                               evs_max_iter=100,
+                                               kmean_tolerance=.00001,
+                                               kmean_max_iter=100):
+    """
+    Compute a clustering/partitioning of the given graph using the spectral modularity
+    maximization method.
+    
+    Parameters
+    ----------
+    G : cuGraph.Graph                  
+       cuGraph graph descriptor
+    num_clusters : integer
+        Specifies the number of clusters to find
+    num_eigen_vects : integer
+        Specifies the number of eigenvectors to use 
+    evs_tolerance: float
+        Specifies the tolerance to use in the eigensolver
+    evs_max_iter: integer
+        Specifies the maximum number of iterations for the eigensolver
+    kmean_tolerance: float
+        Specifies the tolerance to use in the k-means solver
+    kmean_max_iter: integer
+        Specifies the maximum number of iterations for the k-means solver
+    
+    Returns
+    -------
+    DF : GPU data frame containing two cudf.Series of size V: the vertex identifiers and the corresponding SSSP distances.
+        DF['vertex'] contains the vertex identifiers
+        DF['cluster'] contains the cluster assignments
+        DF['eigenvalues'] contains the computed eigenvalues
+        DF['eigenvectors'] contains the computed eigenvectors
+        
+    Example:
+    --------
+    >>> M = ReadMtxFile(graph_file)
+    >>> sources = cudf.Series(M.row)
+    >>> destinations = cudf.Series(M.col)
+    >>> G = cuGraph.Graph()
+    >>> G.add_edge_list(sources,destinations,None)
+    >>> DF = cuGraph.spectralBalancedCutClustering(G, 5)
+    """
+
+    cdef uintptr_t graph = G.graph_ptr
+    cdef gdf_graph * g = < gdf_graph *> graph
+
+    num_vert = g.adjList.offsets.size - 1
+
+    # Create the output dataframe
+    df = cudf.DataFrame()
+    df['vertex'] = cudf.Series(np.zeros(num_vert, dtype=np.int32))
+    cdef uintptr_t identifier_ptr = create_column(df['vertex'])
+    df['cluster'] = cudf.Series(np.zeros(num_vert, dtype=np.int32))
+    cdef uintptr_t cluster_ptr = create_column(df['cluster'])
+    df['eigenvalues'] = cudf.Series(np.zeros(num_eigen_vects, dtype=np.float32))
+    cdef uintptr_t eigenvalues_ptr = create_column(df['eigenvalues'])
+    df['eigenvectors'] = cudf.Series(np.zeros(num_eigen_vects * num_vert, dtype=np.float32))
+    cdef uintptr_t eigenvectors_ptr = create_column(df['eigenvectors'])
+    
+    # Set the vertex identifiers
+    err = g.adjList.get_vertex_identifiers(< gdf_column *> identifier_ptr)
+    cudf.bindings.cudf_cpp.check_gdf_error(err)
+
+    err = gdf_spectralModularityMaximization_nvgraph(g,
+                                                     num_clusters,
+                                                     num_eigen_vects,
+                                                     evs_tolerance,
+                                                     evs_max_iter,
+                                                     kmean_tolerance,
+                                                     kmean_max_iter,
+                                                     < gdf_column *> cluster_ptr,
+                                                     < gdf_column *> eigenvalues_ptr,
+                                                     < gdf_column *> eigenvectors_ptr)
+    cudf.bindings.cudf_cpp.check_gdf_error(err)
+
+    return df
+
+cpdef analyzeClustering_modularity(G, n_clusters, clustering):
+    """
+    Compute the modularity score for a partitioning/clustering
+    
+    Parameters
+    ----------
+    G : cuGraph.Graph                  
+       cuGraph graph descriptor
+    n_clusters : integer
+        Specifies the number of clusters in the given clustering
+    clustering : cudf.Series
+        The cluster assignment to analyze.
+    Returns
+    -------
+    score : float
+        The computed modularity score
+        
+    Example:
+    --------
+    >>> M = ReadMtxFile(graph_file)
+    >>> sources = cudf.Series(M.row)
+    >>> destinations = cudf.Series(M.col)
+    >>> G = cuGraph.Graph()
+    >>> G.add_edge_list(sources,destinations,None)
+    >>> DF = cuGraph.spectralBalancedCutClustering(G, 5)
+    >>> score = cuGraph.analyzeClustering_modularity(G, 5, DF['cluster'])
+    """
+    cdef uintptr_t graph = G.graph_ptr
+    cdef gdf_graph * g = < gdf_graph *> graph
+    cdef uintptr_t clustering_ptr = create_column(clustering)
+    cdef float score
+    err = gdf_AnalyzeClustering_modularity_nvgraph(g, n_clusters, <gdf_column*>clustering_ptr, &score)
+    cudf.bindings.cudf_cpp.check_gdf_error(err)
+    return score
+
+cpdef analyzeClustering_edge_cut(G, n_clusters, clustering):
+    """
+    Compute the edge cut score for a partitioning/clustering
+    
+    Parameters
+    ----------
+    G : cuGraph.Graph                  
+       cuGraph graph descriptor
+    n_clusters : integer
+        Specifies the number of clusters in the given clustering
+    clustering : cudf.Series
+        The cluster assignment to analyze.
+    Returns
+    -------
+    score : float
+        The computed edge cut score
+        
+    Example:
+    --------
+    >>> M = ReadMtxFile(graph_file)
+    >>> sources = cudf.Series(M.row)
+    >>> destinations = cudf.Series(M.col)
+    >>> G = cuGraph.Graph()
+    >>> G.add_edge_list(sources,destinations,None)
+    >>> DF = cuGraph.spectralBalancedCutClustering(G, 5)
+    >>> score = cuGraph.analyzeClustering_modularity(G, 5, DF['cluster'])
+    """
+    cdef uintptr_t graph = G.graph_ptr
+    cdef gdf_graph * g = < gdf_graph *> graph
+    cdef uintptr_t clustering_ptr = create_column(clustering)
+    cdef float score
+    err = gdf_AnalyzeClustering_edge_cut_nvgraph(g, n_clusters, <gdf_column*>clustering_ptr, &score)
+    cudf.bindings.cudf_cpp.check_gdf_error(err)
+    return score
+
+cpdef analyzeClustering_ratio_cut(G, n_clusters, clustering):
+    """
+    Compute the ratio cut score for a partitioning/clustering
+    
+    Parameters
+    ----------
+    G : cuGraph.Graph                  
+       cuGraph graph descriptor
+    n_clusters : integer
+        Specifies the number of clusters in the given clustering
+    clustering : cudf.Series
+        The cluster assignment to analyze.
+    Returns
+    -------
+    score : float
+        The computed ratio cut score
+        
+    Example:
+    --------
+    >>> M = ReadMtxFile(graph_file)
+    >>> sources = cudf.Series(M.row)
+    >>> destinations = cudf.Series(M.col)
+    >>> G = cuGraph.Graph()
+    >>> G.add_edge_list(sources,destinations,None)
+    >>> DF = cuGraph.spectralBalancedCutClustering(G, 5)
+    >>> score = cuGraph.analyzeClustering_modularity(G, 5, DF['cluster'])
+    """
+    cdef uintptr_t graph = G.graph_ptr
+    cdef gdf_graph * g = < gdf_graph *> graph
+    cdef uintptr_t clustering_ptr = create_column(clustering)
+    cdef float score
+    err = gdf_AnalyzeClustering_ratio_cut_nvgraph(g, n_clusters, <gdf_column*>clustering_ptr, &score)
+    cudf.bindings.cudf_cpp.check_gdf_error(err)
+    return score

--- a/python/cugraph/spectral_clustering/spectral_clustering.pyx
+++ b/python/cugraph/spectral_clustering/spectral_clustering.pyx
@@ -78,10 +78,6 @@ cpdef spectralBalancedCutClustering(G,
     cdef uintptr_t identifier_ptr = create_column(df['vertex'])
     df['cluster'] = cudf.Series(np.zeros(num_vert, dtype=np.int32))
     cdef uintptr_t cluster_ptr = create_column(df['cluster'])
-    df['eigenvalues'] = cudf.Series(np.zeros(num_eigen_vects, dtype=np.float32))
-    cdef uintptr_t eigenvalues_ptr = create_column(df['eigenvalues'])
-    df['eigenvectors'] = cudf.Series(np.zeros(num_eigen_vects * num_vert, dtype=np.float32))
-    cdef uintptr_t eigenvectors_ptr = create_column(df['eigenvectors'])
     
     # Set the vertex identifiers
     err = g.adjList.get_vertex_identifiers(< gdf_column *> identifier_ptr)
@@ -94,9 +90,7 @@ cpdef spectralBalancedCutClustering(G,
                                             evs_max_iter,
                                             kmean_tolerance,
                                             kmean_max_iter,
-                                            < gdf_column *> cluster_ptr,
-                                            < gdf_column *> eigenvalues_ptr,
-                                            < gdf_column *> eigenvectors_ptr)
+                                            < gdf_column *> cluster_ptr)
     cudf.bindings.cudf_cpp.check_gdf_error(err)
 
     return df
@@ -144,7 +138,7 @@ cpdef spectralModularityMaximizationClustering(G,
     >>> destinations = cudf.Series(M.col)
     >>> G = cuGraph.Graph()
     >>> G.add_edge_list(sources,destinations,None)
-    >>> DF = cuGraph.spectralBalancedCutClustering(G, 5)
+    >>> DF = cuGraph.spectralModularityMaximizationClustering(G, 5)
     """
 
     cdef uintptr_t graph = G.graph_ptr
@@ -158,10 +152,6 @@ cpdef spectralModularityMaximizationClustering(G,
     cdef uintptr_t identifier_ptr = create_column(df['vertex'])
     df['cluster'] = cudf.Series(np.zeros(num_vert, dtype=np.int32))
     cdef uintptr_t cluster_ptr = create_column(df['cluster'])
-    df['eigenvalues'] = cudf.Series(np.zeros(num_eigen_vects, dtype=np.float32))
-    cdef uintptr_t eigenvalues_ptr = create_column(df['eigenvalues'])
-    df['eigenvectors'] = cudf.Series(np.zeros(num_eigen_vects * num_vert, dtype=np.float32))
-    cdef uintptr_t eigenvectors_ptr = create_column(df['eigenvectors'])
     
     # Set the vertex identifiers
     err = g.adjList.get_vertex_identifiers(< gdf_column *> identifier_ptr)
@@ -174,9 +164,7 @@ cpdef spectralModularityMaximizationClustering(G,
                                                      evs_max_iter,
                                                      kmean_tolerance,
                                                      kmean_max_iter,
-                                                     < gdf_column *> cluster_ptr,
-                                                     < gdf_column *> eigenvalues_ptr,
-                                                     < gdf_column *> eigenvectors_ptr)
+                                                     < gdf_column *> cluster_ptr)
     cudf.bindings.cudf_cpp.check_gdf_error(err)
 
     return df
@@ -241,7 +229,7 @@ cpdef analyzeClustering_edge_cut(G, n_clusters, clustering):
     >>> G = cuGraph.Graph()
     >>> G.add_edge_list(sources,destinations,None)
     >>> DF = cuGraph.spectralBalancedCutClustering(G, 5)
-    >>> score = cuGraph.analyzeClustering_modularity(G, 5, DF['cluster'])
+    >>> score = cuGraph.analyzeClustering_edge_cut(G, 5, DF['cluster'])
     """
     cdef uintptr_t graph = G.graph_ptr
     cdef gdf_graph * g = < gdf_graph *> graph
@@ -276,7 +264,7 @@ cpdef analyzeClustering_ratio_cut(G, n_clusters, clustering):
     >>> G = cuGraph.Graph()
     >>> G.add_edge_list(sources,destinations,None)
     >>> DF = cuGraph.spectralBalancedCutClustering(G, 5)
-    >>> score = cuGraph.analyzeClustering_modularity(G, 5, DF['cluster'])
+    >>> score = cuGraph.analyzeClustering_ratio_cut(G, 5, DF['cluster'])
     """
     cdef uintptr_t graph = G.graph_ptr
     cdef gdf_graph * g = < gdf_graph *> graph

--- a/python/cugraph/spectral_clustering/spectral_clustering.pyx
+++ b/python/cugraph/spectral_clustering/spectral_clustering.pyx
@@ -39,7 +39,7 @@ cpdef spectralBalancedCutClustering(G,
     num_clusters : integer
         Specifies the number of clusters to find
     num_eigen_vects : integer
-        Specifies the number of eigenvectors to use 
+        Specifies the number of eigenvectors to use. Must be lower or equal to num_clusters.
     evs_tolerance: float
         Specifies the tolerance to use in the eigensolver
     evs_max_iter: integer
@@ -111,7 +111,7 @@ cpdef spectralModularityMaximizationClustering(G,
     num_clusters : integer
         Specifies the number of clusters to find
     num_eigen_vects : integer
-        Specifies the number of eigenvectors to use 
+        Specifies the number of eigenvectors to use. Must be lower or equal to num_clusters
     evs_tolerance: float
         Specifies the tolerance to use in the eigensolver
     evs_max_iter: integer

--- a/python/cugraph/spectral_clustering/spectral_clustering.pyx
+++ b/python/cugraph/spectral_clustering/spectral_clustering.pyx
@@ -23,7 +23,7 @@ import numpy as np
 
 cpdef spectralBalancedCutClustering(G,
                                     num_clusters,
-                                    num_eigen_vects=1,
+                                    num_eigen_vects=2,
                                     evs_tolerance=.00001,
                                     evs_max_iter=100,
                                     kmean_tolerance=.00001,
@@ -95,7 +95,7 @@ cpdef spectralBalancedCutClustering(G,
 
 cpdef spectralModularityMaximizationClustering(G,
                                                num_clusters,
-                                               num_eigen_vects=1,
+                                               num_eigen_vects=2,
                                                evs_tolerance=.00001,
                                                evs_max_iter=100,
                                                kmean_tolerance=.00001,

--- a/python/cugraph/spectral_clustering/spectral_clustering.pyx
+++ b/python/cugraph/spectral_clustering/spectral_clustering.pyx
@@ -54,8 +54,6 @@ cpdef spectralBalancedCutClustering(G,
     DF : GPU data frame containing two cudf.Series of size V: the vertex identifiers and the corresponding SSSP distances.
         DF['vertex'] contains the vertex identifiers
         DF['cluster'] contains the cluster assignments
-        DF['eigenvalues'] contains the computed eigenvalues
-        DF['eigenvectors'] contains the computed eigenvectors
         
     Example:
     --------
@@ -128,8 +126,6 @@ cpdef spectralModularityMaximizationClustering(G,
     DF : GPU data frame containing two cudf.Series of size V: the vertex identifiers and the corresponding SSSP distances.
         DF['vertex'] contains the vertex identifiers
         DF['cluster'] contains the cluster assignments
-        DF['eigenvalues'] contains the computed eigenvalues
-        DF['eigenvectors'] contains the computed eigenvectors
         
     Example:
     --------

--- a/python/cugraph/spectral_clustering/test_balanced_cut.py
+++ b/python/cugraph/spectral_clustering/test_balanced_cut.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cugraph
+import cudf
+import numpy as np
+import sys
+import time
+from scipy.io import mmread
+import community
+import os
+import pytest
+import random
+
+def ReadMtxFile(mmFile):
+    print('Reading ' + str(mmFile) + '...')
+    return mmread(mmFile).asfptype()
+
+    
+def cuGraph_Call(G, partitions):
+    df = cugraph.spectralBalancedCutClustering(G, partitions, num_eigen_vects=partitions)
+    score = cugraph.analyzeClustering_edge_cut(G, partitions, df['cluster'])
+    return score
+
+def random_Call(G, partitions):
+    num_verts = G.num_vertices()
+    assignment = []
+    for i in range(num_verts):
+        assignment.append(random.randint(0,partitions-1))
+    assignment_cu = cudf.Series(assignment)
+    score = cugraph.analyzeClustering_edge_cut(G, partitions, assignment_cu)
+    return score
+   
+
+datasets = ['/datasets/networks/karate.mtx', '/datasets/networks/dolphins.mtx', '/datasets/golden_data/graphs/dblp.mtx']
+partitions = [2, 4, 8]
+@pytest.mark.parametrize('graph_file', datasets)
+@pytest.mark.parametrize('partitions', partitions)
+def test_modularityClustering(graph_file, partitions):
+    # Read in the graph and get a cugraph object
+    M = ReadMtxFile(graph_file).tocsr()
+    row_offsets = cudf.Series(M.indptr)
+    col_indices = cudf.Series(M.indices)
+    values = cudf.Series(M.data)
+    G = cugraph.Graph()
+    G.add_adj_list(row_offsets, col_indices, values)
+    
+    # Get the modularity score for partitioning versus random assignment
+    cu_score = cuGraph_Call(G, partitions)
+    rand_score = random_Call(G, partitions)
+    
+    # Assert that the partitioning has better modularity than the random assignment
+    assert cu_score < rand_score

--- a/python/cugraph/spectral_clustering/test_modularity.py
+++ b/python/cugraph/spectral_clustering/test_modularity.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cugraph
+import cudf
+import numpy as np
+import sys
+import time
+from scipy.io import mmread
+import community
+import os
+import pytest
+import random
+
+def ReadMtxFile(mmFile):
+    print('Reading ' + str(mmFile) + '...')
+    return mmread(mmFile).asfptype()
+
+    
+def cuGraph_Call(G, partitions):
+    df = cugraph.spectralModularityMaximizationClustering(G, partitions, num_eigen_vects=(partitions - 1))
+    score = cugraph.analyzeClustering_modularity(G, partitions, df['cluster'])
+    return score
+
+def random_Call(G, partitions):
+    num_verts = G.num_vertices()
+    assignment = []
+    for i in range(num_verts):
+        assignment.append(random.randint(0,partitions-1))
+    assignment_cu = cudf.Series(assignment)
+    score = cugraph.analyzeClustering_modularity(G, partitions, assignment_cu)
+    return score
+   
+
+datasets = ['/datasets/networks/karate.mtx', '/datasets/networks/dolphins.mtx', '/datasets/golden_data/graphs/dblp.mtx']
+partitions = [2, 4, 8]
+@pytest.mark.parametrize('graph_file', datasets)
+@pytest.mark.parametrize('partitions', partitions)
+def test_modularityClustering(graph_file, partitions):
+    # Read in the graph and get a cugraph object
+    M = ReadMtxFile(graph_file).tocsr()
+    row_offsets = cudf.Series(M.indptr)
+    col_indices = cudf.Series(M.indices)
+    values = cudf.Series(M.data)
+    G = cugraph.Graph()
+    G.add_adj_list(row_offsets, col_indices, values)
+    
+    # Get the modularity score for partitioning versus random assignment
+    cu_score = cuGraph_Call(G, partitions)
+    rand_score = random_Call(G, partitions)
+    
+    # Assert that the partitioning has better modularity than the random assignment
+    assert cu_score > rand_score


### PR DESCRIPTION
Added bindings for spectral clustering and clustering analyzing metrics. Added Graph.num_vertices() method to python Graph object to facilitate tests. Added tests for spectral clustering similar to those in Nvgraph (check modularity or edge cut scores versus a random assignment). Close #62 