### PR TITLE
[BUG] Added additional link directory to support building on CentOS-7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - PR #120 Bug fix for segfault calling spectral clustering with only edge list
 - PR #123 Fixed weighted Jaccard to assume the input weights are given as a cudf.Series
 - PR #152 Fix conda package version string
+- PR #160 Added additional link directory to support building on CentOS-7
 
 
 # cuGraph 0.5.0 (28 Jan 2019)

--- a/cpp/cmake/Modules/ConfigureGoogleTest.cmake
+++ b/cpp/cmake/Modules/ConfigureGoogleTest.cmake
@@ -64,3 +64,5 @@ set(GTEST_ROOT ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/thirdparty/googletest
 message(STATUS "GTEST_ROOT: " ${GTEST_ROOT})
 
 link_directories(${GTEST_ROOT}/lib/)
+# FIXME: lib64 also needs to be added for CentOS-7. This might be a code smell - investigate.
+link_directories(${GTEST_ROOT}/lib64/)


### PR DESCRIPTION
This is possibly a symptom of a bigger issue which should be addressed in a later change.

closes #159 
