### PR TITLE
[gpuCI] Auto-merge branch-0.6 to branch-0.7 [skip ci]

### DIFF
--- a/ci/cpu/libcugraph/upload-anaconda.sh
+++ b/ci/cpu/libcugraph/upload-anaconda.sh
@@ -5,6 +5,12 @@
 set -e
 
 if [ "$BUILD_LIBCUGRAPH" == "1" ]; then
+  CUDA_REL=${CUDA:0:3}
+  if [ "${CUDA:0:2}" == '10' ]; then
+    # CUDA 10 release
+    CUDA_REL=${CUDA:0:4}
+  fi
+  
   if [ "$BUILD_ABI" == "1" ]; then
     export UPLOADFILE=`conda build conda/recipes/libcugraph -c rapidsai -c nvidia -c numba -c conda-forge -c defaults --python=$PYTHON --output`
   else
@@ -13,15 +19,14 @@ if [ "$BUILD_LIBCUGRAPH" == "1" ]; then
 
   SOURCE_BRANCH=master
 
-  # Have to label all CUDA versions due to the compatibility to work with any CUDA
   if [ "$LABEL_MAIN" == "1" -a "$BUILD_ABI" == "1" ]; then
-    LABEL_OPTION="--label main --label cuda9.2 --label cuda10.0"
+    LABEL_OPTION="--label main --label cuda${CUDA_REL}"
   elif [ "$LABEL_MAIN" == "0" -a "$BUILD_ABI" == "1" ]; then
-    LABEL_OPTION="--label dev --label cuda9.2 --label cuda10.0"
+    LABEL_OPTION="--label dev --label cuda${CUDA_REL}"
   elif [ "$LABEL_MAIN" == "1" -a "$BUILD_ABI" == "0" ]; then
-    LABEL_OPTION="--label cf201901 --label cf201901-cuda9.2 --label cf201901-cuda10.0"
+    LABEL_OPTION="--label cf201901 --label cf201901-cuda${CUDA_REL}"
   elif [ "$LABEL_MAIN" == "0" -a "$BUILD_ABI" == "0" ]; then
-    LABEL_OPTION="--label cf201901-dev --label cf201901-cuda9.2 --label cf201901-cuda10.0"
+    LABEL_OPTION="--label cf201901-dev --label cf201901-cuda${CUDA_REL}"
   else
     echo "Unknown label configuration LABEL_MAIN='$LABEL_MAIN' BUILD_ABI='$BUILD_ABI'"
     exit 1


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.6` that creates a PR to keep `branch-0.7` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.