### PR TITLE
[gpuCI] Auto-merge branch-0.6 to branch-0.7 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-# cuGraph 0.6.0 (Date TBD)
+# cuGraph 0.6.0 (22 Mar 2019)
 
 ## New Features
 

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -53,3 +53,7 @@ sed_runner 's/'"cuGraph VERSION .* LANGUAGES C CXX CUDA)"'/'"cuGraph VERSION ${N
 # Conda recipe updates
 sed_runner 's/cudf=.*/cudf='"${NEXT_SHORT_TAG}*"'/g' conda/recipes/cugraph/meta.yaml
 sed_runner 's/libcudf=.*/libcudf='"${NEXT_SHORT_TAG}*"'/g' conda/recipes/libcugraph/meta.yaml
+
+# RTD update
+sed_runner 's/version = .*/version = '"'${NEXT_SHORT_TAG}'"'/g' docs/source/conf.py
+sed_runner 's/release = .*/release = '"'${NEXT_FULL_TAG}'"'/g' docs/source/conf.py


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.6` that creates a PR to keep `branch-0.7` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.