### PR TITLE
[REVIEW] Fix nvgraph bug in subgraph extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - PR #232 Fixed memory leaks in managing cudf columns.
 - PR #236 Fixed issue with v0.7 nightly yml environment file.  Also updated the README to remove pip
 - PR #239 Added a check to prevent a cugraph object to store two different graphs.
+- PR #244 Fixed issue with nvgraph's subgraph extraction if the first vertex in the vertex list is not incident on an edge in the extracted graph
 
 
 # cuGraph 0.6.0 (22 Mar 2019)


### PR DESCRIPTION
Created a unit test that demonstrates the problem that @jwyles discovered in subgraph extraction.

Subgraph extraction takes a list of vertices, identifies the subset of edges that connect these vertices, renumbers the vertices and then generates a new CSR graph that only uses the provided vertices.  The problem James discovered occurs when vertex 0 (the first element in the extraction list) is not incident on any edges.

Fixed the implementation to address this.