### PR TITLE
Removed networkx conda dependency for both build and runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - PR #214 Removed throw exception from dtor in TC
 - PR #211 Remove hardcoded dataset paths, replace with build var that can be overridden with an env var
 - PR #206 Updated versions in conda envs
-- PR #218 Update c_graph.pyx 
+- PR #218 Update c_graph.pyx
 - PR #224 Update erroneous comments in overlap_wrapper.pyx, woverlap_wrapper.pyx, test_louvain.py, and spectral_clustering.pyx
 - PR #220 Fixed bugs in Nvgraph triangle counting
 - PR #232 Fixed memory leaks in managing cudf columns.
@@ -44,6 +44,7 @@
 - PR #239 Added a check to prevent a cugraph object to store two different graphs.
 - PR #244 Fixed issue with nvgraph's subgraph extraction if the first vertex in the vertex list is not incident on an edge in the extracted graph
 - PR #249 Fix oudated cuDF version in gpu/build.sh
+- PR #262 Removed networkx conda dependency for both build and runtime
 
 
 # cuGraph 0.6.0 (22 Mar 2019)
@@ -69,7 +70,7 @@
 - PR #95 Code clean up
 - PR #96 Relocated mmio.c and mmio.h (external files) to thirdparty/mmio
 - PR #97 Updated python tests to speed them up
-- PR #100 Added testing for returned vertex and edge identifiers  
+- PR #100 Added testing for returned vertex and edge identifiers
 - PR #105 Updated python code to follow PEP8 (fixed flake8 complaints)
 - PR #121 Cleaned up READEME file
 - PR #130 Update conda build recipes

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -26,12 +26,10 @@ requirements:
   build:
     - cmake>=3.12.4
     - libcudf=0.7*
-    - networkx
     - cython
     - nvgraph
   run:
     - libcudf=0.7*
-    - networkx
     - cython
     - nvgraph
 


### PR DESCRIPTION
Removed networkx conda dependency for both build and runtime since it is only needed for tests validating correctness against NetworkX, and not an actual build or runtime dependency.