### PR TITLE
[REVIEW] Add cudatoolkit dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - PR #233 Added csv datasets and edited test to use cudf for reading graphs
 - PR #247 Added some documentation for renumbering
 - PR #252 cpp test upgrades for more convenient testing on large input
+- PR #264 Add cudatoolkit conda dependency
 
 ## Bug Fixes
 - PR #256 Add pip to the install, clean up conda instructions

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Install and update cuGraph using the conda command:
 
 ```bash
 # CUDA 9.2
-conda install -c nvidia -c rapidsai -c numba -c conda-forge -c defaults cugraph
+conda install -c nvidia -c rapidsai -c numba -c conda-forge -c defaults cugraph cudatoolkit=9.2
 
 # CUDA 10.0
-conda install -c nvidia/label/cuda10.0 -c rapidsai/label/cuda10.0 -c numba -c conda-forge -c defaults cugraph
+conda install -c nvidia -c rapidsai -c numba -c conda-forge -c defaults cugraph cudatoolkit=10.0
 ```
 
 Note: This conda installation only applies to Linux and Python versions 3.6/3.7.

--- a/ci/cpu/libcugraph/upload-anaconda.sh
+++ b/ci/cpu/libcugraph/upload-anaconda.sh
@@ -15,14 +15,7 @@ if [ "$UPLOAD_LIBCUGRAPH" == "1" ]; then
 
   SOURCE_BRANCH=master
 
-  if [ "$LABEL_MAIN" == "1" ]; then
-    LABEL_OPTION="--label main --label cuda${CUDA_REL}"
-  elif [ "$LABEL_MAIN" == "0" ]; then
-    LABEL_OPTION="--label dev --label cuda${CUDA_REL}"
-  else
-    echo "Unknown label configuration LABEL_MAIN='$LABEL_MAIN'"
-    exit 1
-  fi
+  LABEL_OPTION="--label main --label cuda${CUDA_REL}"
   echo "LABEL_OPTION=${LABEL_OPTION}"
 
   test -e ${UPLOADFILE}

--- a/conda/environments/cugraph_dev.yml
+++ b/conda/environments/cugraph_dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - networkx
 - python-louvain
 - nccl
-- cudatoolkit
+- cudatoolkit=9.2
 - cmake>=3.12
 - python>=3.6,<3.8
 - numba>=0.41

--- a/conda/environments/cugraph_dev_cuda10.yml
+++ b/conda/environments/cugraph_dev_cuda10.yml
@@ -12,7 +12,7 @@ dependencies:
 - networkx
 - python-louvain
 - nccl
-- cudatoolkit
+- cudatoolkit=10.0
 - cmake>=3.12
 - python>=3.6,<3.8
 - numba>=0.41

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -4,7 +4,7 @@
 #   conda build -c nvidia -c rapidsai -c conda-forge -c defaults .
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') %}
 {% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
-{% set cuda_version='.'.join(environ.get('CUDA', 'unknown').split('.')[:2]) %}
+{% set cuda_version='.'.join(environ.get('CUDA', '9.2').split('.')[:2]) %}
 package:
   name: libcugraph
   version: {{ version }}
@@ -29,11 +29,13 @@ requirements:
     - networkx
     - cython
     - nvgraph
+    - cudatoolkit {{ cuda_version }}.*
   run:
     - libcudf=0.7*
     - networkx
     - cython
     - nvgraph
+    - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 
 #test:
 #  commands:


### PR DESCRIPTION
Refs conda-forge/conda-forge.github.io#687

This is to bring our conda packages in line with the community effort above and remove our current use of labels.