### PR TITLE
[REVIEW] Use latest tag in update-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - PR #247 Added some documentation for renumbering
 - PR #252 cpp test upgrades for more convenient testing on large input
 - PR #264 Add cudatoolkit conda dependency
+- PR #267 Use latest release version in update-version CI script
 
 ## Bug Fixes
 - PR #256 Add pip to the install, clean up conda instructions

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -13,7 +13,7 @@ set -e
 RELEASE_TYPE=$1
 
 # Get current version and calculate next versions
-CURRENT_TAG=`git describe --abbrev=0 --tags | tr -d 'v'`
+CURRENT_TAG=`git tag | grep -xE 'v[0-9\.]+' | sort --version-sort | tail -n 1 | tr -d 'v'`
 CURRENT_MAJOR=`echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}'`
 CURRENT_MINOR=`echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}'`
 CURRENT_PATCH=`echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}'`
@@ -38,8 +38,6 @@ else
   exit 1
 fi
 
-# Move to root of repo
-cd ../..
 echo "Preparing '$RELEASE_TYPE' release [$CURRENT_TAG -> $NEXT_FULL_TAG]"
 
 # Inplace sed replace; workaround for Linux and Mac
@@ -49,10 +47,7 @@ function sed_runner() {
 
 # CMakeLists update
 sed_runner 's/'"cuGraph VERSION .* LANGUAGES C CXX CUDA)"'/'"cuGraph VERSION ${NEXT_FULL_TAG} LANGUAGES C CXX CUDA)"'/g' cpp/CMakeLists.txt
-
-# Conda recipe updates
-sed_runner 's/cudf=.*/cudf='"${NEXT_SHORT_TAG}*"'/g' conda/recipes/cugraph/meta.yaml
-sed_runner 's/libcudf=.*/libcudf='"${NEXT_SHORT_TAG}*"'/g' conda/recipes/libcugraph/meta.yaml
+sed_runner 's/'"NV_GRAPH VERSION .* LANGUAGES C CXX CUDA)"'/'"NV_GRAPH VERSION ${NEXT_FULL_TAG} LANGUAGES C CXX CUDA)"'/g' cpp/nvgraph/cpp/CMakeLists.txt
 
 # RTD update
 sed_runner 's/version = .*/version = '"'${NEXT_SHORT_TAG}'"'/g' docs/source/conf.py


### PR DESCRIPTION
Change update-version script to ignore dev/alpha/rc versions and use only the latest version

Also updated where changes are made