### PR TITLE
[REVIEW] Remove nvgraph conda dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,9 @@
 - PR #236 Fixed issue with v0.7 nightly yml environment file.  Also updated the README to remove pip
 - PR #239 Added a check to prevent a cugraph object to store two different graphs.
 - PR #244 Fixed issue with nvgraph's subgraph extraction if the first vertex in the vertex list is not incident on an edge in the extracted graph
-- PR #249 Fix oudated cuDF version in gpu/build.sh
+- PR #249 Fix oudated cuDF version in gpu/build.shi
 - PR #262 Removed networkx conda dependency for both build and runtime
+- PR #271 Removed nvgraph conda dependency
 
 
 # cuGraph 0.6.0 (22 Mar 2019)

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -33,7 +33,7 @@ nvidia-smi
 logger "Activate conda env..."
 source activate gdf
 conda install -c nvidia/label/cuda$CUDA_REL -c rapidsai/label/cuda$CUDA_REL -c rapidsai-nightly/label/cuda$CUDA_REL -c numba -c conda-forge \
-    cudf=$CUDF_VERSION rmm=$RMM_VERSION nvgraph networkx python-louvain
+    cudf=$CUDF_VERSION rmm=$RMM_VERSION networkx python-louvain cudatoolkit=$CUDA_REL
 
 logger "Check versions..."
 python --version

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -27,12 +27,10 @@ requirements:
     - cmake>=3.12.4
     - libcudf=0.7*
     - cython
-    - nvgraph
     - cudatoolkit {{ cuda_version }}.*
   run:
     - libcudf=0.7*
     - cython
-    - nvgraph
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 
 #test:


### PR DESCRIPTION
Remove the conda dependency on nvgraph since it is already included in `libcugraph`.

Ref: https://github.com/rapidsai/cugraph/issues/266#issuecomment-488843365

Closes #266 