### PR TITLE
[REVIEW] updated CMakeLists to apply RUNPATH to transitive dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@
 - PR #314 Added datasets to gitignore
 - PR #322 Updates to accommodate new cudf include file locations
 - PR #324 Fixed crash in WeakCC for larger graph and added adj matrix symmetry check
-- PR #327 Implemented a tempory fix for the build failure due to gunrock updates.
+- PR #327 Implemented a temporary fix for the build failure due to gunrock updates.
+- PR #345 Updated CMakeLists.txt to apply RUNPATH to transitive dependencies.
 
 # cuGraph 0.7.0 (10 May 2019)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -92,6 +92,9 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G -Xcompiler -rdynamic")
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
+# To apply RUNPATH to transitive dependencies (this is a temporary solution)
+set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--disable-new-dtags")
+
 option(BUILD_TESTS "Configure CMake to build tests"
        ON)
 


### PR DESCRIPTION
When running C++ tests (make test) within the build directory we see

`error while loading shared libraries: libNVCategory.so: cannot open shared object file: No such file or directory`

This may be related to OS/compiler changes (https://stackoverflow.com/questions/52018092/how-to-set-rpath-and-runpath-with-gcc-ld?rq=1)

Added set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--disable-new-dtags") to enforce the old behavior to avoid this error.