### PR TITLE
[REVIEW] Remove boost from meta.yaml & linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# cuGraph 0.8.1 (28 June 2019)
+
+## Bug Fixes
+- PR #358 Remove boost linking dependency
+
+
 # cuGraph 0.8.0 (27 June 2019)
 
 ## New Features

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -28,12 +28,10 @@ requirements:
     - libcudf=0.8*
     - cython
     - cudatoolkit {{ cuda_version }}.*
-    - boost
   run:
     - libcudf=0.8*
     - cython
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
-    - boost
 
 #test:
 #  commands:

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -28,10 +28,12 @@ requirements:
     - libcudf=0.8*
     - cython
     - cudatoolkit {{ cuda_version }}.*
+    - boost
   run:
     - libcudf=0.8*
     - cython
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
+    - boost
 
 #test:
 #  commands:

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -335,7 +335,7 @@ target_include_directories(cugraph
 # - link libraries --------------------------------------------------------------------------------
 
 target_link_libraries(cugraph PRIVATE
-    ${CUDF_LIBRARY} ${RMM_LIBRARY} ${NVSTRINGS_LIBRARY} cublas cusparse curand cusolver cudart cuda ${Boost_LIBRARIES})
+    ${CUDF_LIBRARY} ${RMM_LIBRARY} ${NVSTRINGS_LIBRARY} cublas cusparse curand cusolver cudart cuda)
 if(OpenMP_CXX_FOUND)
 target_link_libraries(cugraph PRIVATE
 ###################################################################################################

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -126,8 +126,8 @@ endif()
 
 ###################################################################################################
 # - find boost ------------------------------------------------------------------------------------
-set(BOOST_ROOT $ENV{CONDA_PREFIX})
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED HINTS "$ENV{BOOST_ROOT}"
+                                  "$ENV{CONDA_PREFIX}" )
 if(Boost_FOUND)
     message(STATUS "Boost found in ${Boost_INCLUDE_DIRS}")
 else()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 
 ###################################################################################################
 # - find boost ------------------------------------------------------------------------------------
-
+set(BOOST_ROOT $ENV{CONDA_PREFIX})
 find_package(Boost REQUIRED)
 if(Boost_FOUND)
     message(STATUS "Boost found in ${Boost_INCLUDE_DIRS}")


### PR DESCRIPTION
cuGraph does not need to link against boost. Doing so has caused some strange build issues in the conda packages.