### PR TITLE
Updates to remove libboost_system as a runtime dependency on libcugraph.so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - PR #327 Implemented a temporary fix for the build failure due to gunrock updates.
 - PR #345 Updated CMakeLists.txt to apply RUNPATH to transitive dependencies.
 - PR #350 Configure Sphinx to render params correctly
+- PR #359 Updates to remove libboost_system as a runtime dependency on libcugraph.so
 
 
 # cuGraph 0.7.0 (10 May 2019)

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -28,12 +28,11 @@ requirements:
     - libcudf=0.8*
     - cython
     - cudatoolkit {{ cuda_version }}.*
-    - boost
+    - boost-cpp>=1.66
   run:
     - libcudf=0.8*
     - cython
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
-    - boost
 
 #test:
 #  commands:

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -335,7 +335,7 @@ target_include_directories(cugraph
 # - link libraries --------------------------------------------------------------------------------
 
 target_link_libraries(cugraph PRIVATE
-    ${CUDF_LIBRARY} ${RMM_LIBRARY} ${NVSTRINGS_LIBRARY} cublas cusparse curand cusolver cudart cuda ${Boost_LIBRARIES})
+    ${CUDF_LIBRARY} ${RMM_LIBRARY} ${NVSTRINGS_LIBRARY} cublas cusparse curand cusolver cudart cuda)
 if(OpenMP_CXX_FOUND)
 target_link_libraries(cugraph PRIVATE
 ###################################################################################################


### PR DESCRIPTION
Updates to remove libboost_system as a runtime dependency on libcugraph.so, since only boost headers are needed at build-time.