### PR TITLE
Add default definition for conda_lib_dir in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Bug Fixes
 - PR #354 Fixed bug in building a debug version
 - PR #360 Fixed bug in snmg coo2csr causing intermittent test failures.
+- PR #364 Fixed bug building or installing cugraph when conda isn't installed
 
 
 # cuGraph 0.8.0 (Date TBD)

--- a/python/setup.py
+++ b/python/setup.py
@@ -19,6 +19,7 @@ try:
 except AttributeError:
     NUMPY_INCLUDE = numpy.get_numpy_include()
 
+conda_lib_dir = os.path.normpath(sys.prefix) + '/lib'
 conda_include_dir = os.path.normpath(sys.prefix) + '/include'
 CYTHON_FILES = ['cugraph/*.pyx']
 


### PR DESCRIPTION
Adds a missing variable definition that causes setup.py to fail if conda isn't installed.