### PR TITLE
[REVIEW] Added a function to initialize gdf columns in cugraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - PR #354 Fixed bug in building a debug version
 - PR #360 Fixed bug in snmg coo2csr causing intermittent test failures.
 - PR #364 Fixed bug building or installing cugraph when conda isn't installed
+- PR #375 Added a function to initialize gdf columns in cugraph #375
+
 
 
 # cuGraph 0.8.0 (Date TBD)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -271,6 +271,7 @@ add_library(cugraph SHARED
     src/snmg/blas/spmv.cu
     src/snmg/link_analysis/pagerank.cu
     src/utilities/cusparse_helper.cu
+    src/utilities/graph_utils.cu
     src/snmg/utils.cu
     src/components/connectivity.cu
     src/snmg/degree/degree.cu

--- a/cpp/src/snmg/COO2CSR/COO2CSR.cu
+++ b/cpp/src/snmg/COO2CSR/COO2CSR.cu
@@ -422,13 +422,17 @@ gdf_error snmg_coo2csr_impl(size_t* part_offsets,
   ALLOC_FREE_TRY(runcount, nullptr);
 
   // Each thread sets up the results into the provided gdf_columns
+  cugraph::gdf_col_set_defaults(csrOff);
   csrOff->dtype = cooRow->dtype;
   csrOff->size = localMaxId + 2;
   csrOff->data = offsets;
+
+  cugraph::gdf_col_set_defaults(csrInd);
   csrInd->dtype = cooRow->dtype;
   csrInd->size = myEdgeCount;
   csrInd->data = cooColNew;
   if (cooValNew != nullptr) {
+    cugraph::gdf_col_set_defaults(cooVal);
     csrVal->dtype = cooVal->dtype;
     csrVal->size = myEdgeCount;
     csrVal->data = cooValNew;

--- a/cpp/src/snmg/link_analysis/pagerank.cu
+++ b/cpp/src/snmg/link_analysis/pagerank.cu
@@ -241,17 +241,15 @@ gdf_error gdf_snmg_pagerank_impl(
     // set the result in the gdf column
     #pragma omp master
     {
+      //default gdf values
+      cugraph::gdf_col_set_defaults(pr_col);
+
+      //fill relevant fields
       ALLOC_TRY ((void**)&pr_col->data,   sizeof(val_t) * part_offset[p], nullptr);
       cudaMemcpy(pr_col->data, pagerank[i], sizeof(val_t) * part_offset[p], cudaMemcpyDeviceToDevice);
       cudaCheckError();
-      //default gfd values
       pr_col->size = part_offset[p];
-      pr_col->valid = nullptr;
-      pr_col->null_count = 0;
       pr_col->dtype = GDF_FLOAT32;
-      gdf_dtype_extra_info extra_info;
-      extra_info.time_unit = TIME_UNIT_NONE;
-      pr_col->dtype_info = extra_info;
     }
     // Power iteration time
     #ifdef SNMG_PR_T

--- a/cpp/src/utilities/graph_utils.cu
+++ b/cpp/src/utilities/graph_utils.cu
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * NVIDIA CORPORATION and its licensors retain all intellectual property
+ * and proprietary rights in and to this software, related documentation
+ * and any modifications thereto.  Any use, reproduction, disclosure or
+ * distribution of this software and related documentation without an express
+ * license agreement from NVIDIA CORPORATION is strictly prohibited.
+ *
+ */
+
+// Interanl helper functions 
+#include "utilities/graph_utils.cuh"
+
+namespace cugraph
+{
+    
+void gdf_col_set_defaults(gdf_column* col) {
+  col->dtype = GDF_invalid;
+  col->size = 0;
+  col->data = nullptr;
+  col->valid = nullptr;
+  col->null_count = 0;
+  gdf_dtype_extra_info extra_info;
+  extra_info.time_unit = TIME_UNIT_NONE;
+  col->dtype_info = extra_info;  
+}
+
+} //namespace cugraph

--- a/cpp/src/utilities/graph_utils.cuh
+++ b/cpp/src/utilities/graph_utils.cuh
@@ -558,4 +558,8 @@ namespace cugraph
 		    return (result < 0);
 #endif
 	    }
+
+// Initialize a gdf_column with default (0 / null) values
+void gdf_col_set_defaults(gdf_column* col);
+
 } //namespace cugraph


### PR DESCRIPTION
This fixes 
```ERROR: RMM runtime call  RMM_FREE( (col->valid), (stream) )invalid device pointer```
Initiated by dask-cugraph https://github.com/rapidsai/dask-cugraph/issues/23 after the first fix https://github.com/rapidsai/dask-cugraph/pull/24