### PR TITLE
[REVIEW] Fix Skip Test Functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - PR #412 Fixed formatting issues in cuGraph documentation.
 - PR #413 Updated python build instructions.
 - PR #414 Add weights to wjaccrd.py
+- PR #436 Fix Skip Test Functionality
 
 
 # cuGraph 0.8.0 (27 June 2019)

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -69,16 +69,16 @@ $WORKSPACE/build.sh clean libcugraph cugraph
 
 if hasArg --skip-tests; then
     logger "Skipping Tests..."
-    exit 0
+else
+    logger "Check GPU usage..."
+    nvidia-smi
+
+    logger "GoogleTest for libcugraph..."
+    cd $WORKSPACE/cpp/build
+    GTEST_OUTPUT="xml:${WORKSPACE}/test-results/" gtests/GDFGRAPH_TEST
+
+    logger "Python py.test for cuGraph..."
+    cd $WORKSPACE/python
+    py.test --cache-clear --junitxml=${WORKSPACE}/junit-cugraph.xml -v
 fi
 
-logger "Check GPU usage..."
-nvidia-smi
-
-logger "GoogleTest for libcugraph..."
-cd $WORKSPACE/cpp/build
-GTEST_OUTPUT="xml:${WORKSPACE}/test-results/" gtests/GDFGRAPH_TEST
-
-logger "Python py.test for cuGraph..."
-cd $WORKSPACE/python
-py.test --cache-clear --junitxml=${WORKSPACE}/junit-cugraph.xml -v


### PR DESCRIPTION
Removing `exit 0` in favor of an else statement which is more friendly when calling the script via the `source` command.