### PR TITLE
Issue #352 Fixing warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - PR #442 Updated versions in conda environments.
 - PR #442 Added except + to cython bindings to C(++) functions.
 - PR #443 Fix accuracy loss issue for snmg pagerank
-- PR #352 Fix warnings in strongly connected components
+- PR #444 Fix warnings in strongly connected components
 
 # cuGraph 0.8.0 (27 June 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - PR #442 Updated versions in conda environments.
 - PR #442 Added except + to cython bindings to C(++) functions.
 - PR #443 Fix accuracy loss issue for snmg pagerank
-
+- PR #352 Fix warnings in strongly connected components
 
 # cuGraph 0.8.0 (27 June 2019)
 

--- a/cpp/src/components/connectivity.cu
+++ b/cpp/src/components/connectivity.cu
@@ -170,8 +170,7 @@ gdf_connected_components_impl(gdf_graph *graph,
           return GDF_MEMORYMANAGER_ERROR;
         }
       SCC_Data<ByteT, IndexT> sccd(nrows, p_d_row_offsets, p_d_col_ind);
-      size_t count = 0;
-      count = sccd.run_scc(p_d_labels);
+      sccd.run_scc(p_d_labels);
       
     }
 

--- a/cpp/src/tests/components/scc_test.cu
+++ b/cpp/src/tests/components/scc_test.cu
@@ -136,7 +136,7 @@ struct Tests_Strongly_CC : ::testing::TestWithParam<Usecase>
     double time_tmp;
 
     FILE* fpin = fopen(param.get_matrix_file().c_str(),"r");
-    ASSERT_TRUE( fpin != nullptr );
+    ASSERT_NE(fpin, nullptr) << "fopen (" << param.get_matrix_file().c_str() << ") failure.";
 
     ASSERT_EQ(mm_properties<IndexT>(fpin, 1, &mc, &m, &k, &nnz),0) << "could not read Matrix Market file properties"<< "\n";
     ASSERT_TRUE(mm_is_matrix(mc));


### PR DESCRIPTION
Fixed the warnings for unused variables and updated the tester file's dealing of null ptr to file name.