### PR TITLE
[REVIEW] Remove numba dependency so we use the one from cudf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - PR #446 Fix permission for source (-x) and script (+x) files.
 - PR #448 Import filter_unreachable
 - PR #453 Re-sync cugraph with cudf (dependencies, type conversion & scatter functions).
+- PR #463 Remove numba dependency and use the one from cudf
 
 # cuGraph 0.8.0 (27 June 2019)
 

--- a/conda/environments/cugraph_dev_cuda10.yml
+++ b/conda/environments/cugraph_dev_cuda10.yml
@@ -19,7 +19,6 @@ dependencies:
 - cudatoolkit=10.0
 - cmake>=3.12
 - python>=3.6,<3.8
-- numba>=0.41,<0.45
 - pandas>=0.24.2,<0.25
 - pyarrow=0.14.1
 - notebook>=0.5.0

--- a/conda/environments/cugraph_dev_cuda92.yml
+++ b/conda/environments/cugraph_dev_cuda92.yml
@@ -19,7 +19,6 @@ dependencies:
 - cudatoolkit=9.2
 - cmake>=3.12
 - python>=3.6,<3.8
-- numba>=0.41,<0.45
 - pandas>=0.24.2,<0.25
 - pyarrow=0.14.1
 - notebook>=0.5.0


### PR DESCRIPTION
cudf [bumped](https://github.com/rapidsai/cudf/pull/2573) its numba dependency to 0.45.1, which will cause problems with cugraph's numba dependency. @kkraus14 said it's probably best to remove this entirely and rely on cudf's numba install.