### PR TITLE
[REVIEW] Consider limiting tests' initial pool size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Improvements
 - PR #466 Add file splitting test; Update to reduce dask overhead
 - PR #468 Remove unnecessary print statement
+- PR #464 Limit initial RMM pool allocator size to 128mb so pytest can run in parallel
 
 ## Bug Fixes
 - PR #458 Fix potential race condition in SSSP

--- a/python/cugraph/tests/test_balanced_cut.py
+++ b/python/cugraph/tests/test_balanced_cut.py
@@ -60,7 +60,7 @@ def test_modularity_clustering(managed, pool, graph_file, partitions):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_balanced_cut.py
+++ b/python/cugraph/tests/test_balanced_cut.py
@@ -60,6 +60,7 @@ def test_modularity_clustering(managed, pool, graph_file, partitions):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_bfs.py
+++ b/python/cugraph/tests/test_bfs.py
@@ -87,7 +87,7 @@ def test_bfs(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_bfs.py
+++ b/python/cugraph/tests/test_bfs.py
@@ -87,6 +87,7 @@ def test_bfs(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_connectivity.py
+++ b/python/cugraph/tests/test_connectivity.py
@@ -156,6 +156,7 @@ def test_weak_cc(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -195,6 +196,7 @@ def test_strong_cc(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_connectivity.py
+++ b/python/cugraph/tests/test_connectivity.py
@@ -156,7 +156,7 @@ def test_weak_cc(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -196,7 +196,7 @@ def test_strong_cc(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_filter_unreachable.py
+++ b/python/cugraph/tests/test_filter_unreachable.py
@@ -53,7 +53,7 @@ def test_filter_unreachable(managed, pool, graph_file, source):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_filter_unreachable.py
+++ b/python/cugraph/tests/test_filter_unreachable.py
@@ -53,6 +53,7 @@ def test_filter_unreachable(managed, pool, graph_file, source):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_graph.py
+++ b/python/cugraph/tests/test_graph.py
@@ -173,6 +173,7 @@ def test_add_edge_list_to_adj_list(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -209,6 +210,7 @@ def test_add_adj_list_to_edge_list(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -247,6 +249,7 @@ def test_transpose_from_adj_list(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -274,6 +277,7 @@ def test_view_edge_list_from_adj_list(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -302,6 +306,7 @@ def test_delete_edge_list_delete_adj_list(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -345,6 +350,7 @@ def test_add_edge_or_adj_list_after_add_edge_or_adj_list(
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -399,6 +405,7 @@ def test_networkx_compatibility(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -457,6 +464,7 @@ def test_two_hop_neighbors(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -485,6 +493,7 @@ def test_degree_functionality(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -533,6 +542,7 @@ def test_degrees_functionality(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -613,6 +623,7 @@ def test_renumber_files(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -643,6 +654,7 @@ def test_number_of_vertices(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_graph.py
+++ b/python/cugraph/tests/test_graph.py
@@ -173,7 +173,7 @@ def test_add_edge_list_to_adj_list(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -210,7 +210,7 @@ def test_add_adj_list_to_edge_list(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -249,7 +249,7 @@ def test_transpose_from_adj_list(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -277,7 +277,7 @@ def test_view_edge_list_from_adj_list(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -306,7 +306,7 @@ def test_delete_edge_list_delete_adj_list(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -350,7 +350,7 @@ def test_add_edge_or_adj_list_after_add_edge_or_adj_list(
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -405,7 +405,7 @@ def test_networkx_compatibility(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -464,7 +464,7 @@ def test_two_hop_neighbors(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -493,7 +493,7 @@ def test_degree_functionality(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -542,7 +542,7 @@ def test_degrees_functionality(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -623,7 +623,7 @@ def test_renumber_files(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -654,7 +654,7 @@ def test_number_of_vertices(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_grmat.py
+++ b/python/cugraph/tests/test_grmat.py
@@ -29,7 +29,7 @@ def test_grmat_gen(managed, pool):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_grmat.py
+++ b/python/cugraph/tests/test_grmat.py
@@ -29,6 +29,7 @@ def test_grmat_gen(managed, pool):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_jaccard.py
+++ b/python/cugraph/tests/test_jaccard.py
@@ -114,7 +114,7 @@ def test_jaccard(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -148,7 +148,7 @@ def test_jaccard_edgevals(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -182,7 +182,7 @@ def test_jaccard_two_hop(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -219,7 +219,7 @@ def test_jaccard_two_hop_edge_vals(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_jaccard.py
+++ b/python/cugraph/tests/test_jaccard.py
@@ -114,6 +114,7 @@ def test_jaccard(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -147,6 +148,7 @@ def test_jaccard_edgevals(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -180,6 +182,7 @@ def test_jaccard_two_hop(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -216,6 +219,7 @@ def test_jaccard_two_hop_edge_vals(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_louvain.py
+++ b/python/cugraph/tests/test_louvain.py
@@ -89,7 +89,7 @@ def test_louvain_with_edgevals(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -129,7 +129,7 @@ def test_louvain(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_louvain.py
+++ b/python/cugraph/tests/test_louvain.py
@@ -89,6 +89,7 @@ def test_louvain_with_edgevals(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -128,6 +129,7 @@ def test_louvain(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_modularity.py
+++ b/python/cugraph/tests/test_modularity.py
@@ -60,7 +60,7 @@ def test_modularity_clustering(managed, pool, graph_file, partitions):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_modularity.py
+++ b/python/cugraph/tests/test_modularity.py
@@ -60,6 +60,7 @@ def test_modularity_clustering(managed, pool, graph_file, partitions):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_overlap.py
+++ b/python/cugraph/tests/test_overlap.py
@@ -91,6 +91,7 @@ def test_overlap(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -123,6 +124,7 @@ def test_overlap_edge_vals(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_overlap.py
+++ b/python/cugraph/tests/test_overlap.py
@@ -91,7 +91,7 @@ def test_overlap(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -124,7 +124,7 @@ def test_overlap_edge_vals(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_pagerank.py
+++ b/python/cugraph/tests/test_pagerank.py
@@ -155,7 +155,7 @@ def test_pagerank(managed, pool, graph_file, max_iter, tol, alpha,
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_pagerank.py
+++ b/python/cugraph/tests/test_pagerank.py
@@ -155,6 +155,7 @@ def test_pagerank(managed, pool, graph_file, max_iter, tol, alpha,
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_sssp.py
+++ b/python/cugraph/tests/test_sssp.py
@@ -115,7 +115,7 @@ def test_sssp(managed, pool, graph_file, source):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -156,7 +156,7 @@ def test_sssp_edgevals(managed, pool, graph_file, source):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_sssp.py
+++ b/python/cugraph/tests/test_sssp.py
@@ -115,6 +115,7 @@ def test_sssp(managed, pool, graph_file, source):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -155,6 +156,7 @@ def test_sssp_edgevals(managed, pool, graph_file, source):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_subgraph_extraction.py
+++ b/python/cugraph/tests/test_subgraph_extraction.py
@@ -72,6 +72,7 @@ def test_subgraph_extraction(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_subgraph_extraction.py
+++ b/python/cugraph/tests/test_subgraph_extraction.py
@@ -72,7 +72,7 @@ def test_subgraph_extraction(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_triangle_count.py
+++ b/python/cugraph/tests/test_triangle_count.py
@@ -70,6 +70,7 @@ def test_triangles(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -90,6 +91,7 @@ def test_triangles_edge_vals(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_triangle_count.py
+++ b/python/cugraph/tests/test_triangle_count.py
@@ -70,7 +70,7 @@ def test_triangles(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())
@@ -91,7 +91,7 @@ def test_triangles_edge_vals(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_wjaccard.py
+++ b/python/cugraph/tests/test_wjaccard.py
@@ -103,6 +103,7 @@ def test_wjaccard(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    rmm_cfg.initial_pool_size = 2<<30
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/python/cugraph/tests/test_wjaccard.py
+++ b/python/cugraph/tests/test_wjaccard.py
@@ -103,7 +103,7 @@ def test_wjaccard(managed, pool, graph_file):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
-    rmm_cfg.initial_pool_size = 2<<30
+    rmm_cfg.initial_pool_size = 2 << 27
     rmm.initialize()
 
     assert(rmm.is_initialized())


### PR DESCRIPTION
Since RMM allocates half the available GPU memory by default, the pytests are forced to run sequentially. I'm opening this PR to discuss capping RMM's initial pool size in each test, so they can be run in parallel with `pytest-xdist`.

Here's the execution time pytest reports with and without `pytest-xdist`:
```shell
$ pytest .
== 460 passed, 1 warnings in 426.15 seconds ==

$ pytest -n auto .
== 460 passed, 2 warnings in 82.64 seconds ==
```

I'm not familiar enough with the tests to know whether the 2GB cap in this PR is too high or low. The tests also passed when I set it to 8, 128, and 512mb.