### PR TITLE
[REVIEW] [BUG] Handle negative vertex ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #471 Remove nvidia driver installation from ci/cpu/build.sh
 - PR #473 Re-sync cugraph with cudf (cudf renamed the bindings directory to _lib).
 - PR #478 Remove requirements and setup for pi
+- PR #489 Handle negative vertex ids in renumber
 
 
 # cuGraph 0.9.0 (Date TBD)

--- a/cpp/src/converters/renumber.cuh
+++ b/cpp/src/converters/renumber.cuh
@@ -53,7 +53,7 @@ namespace cugraph {
     template <typename VertexIdType>
     __device__ __inline__
     detail::hash_type operator()(const VertexIdType &vertex_id) const {
-      return (vertex_id % hash_size_);
+      return ((vertex_id % hash_size_) + hash_size_) % hash_size_;
     }
 
     detail::hash_type getHashSize() const {

--- a/python/cugraph/tests/test_graph.py
+++ b/python/cugraph/tests/test_graph.py
@@ -613,6 +613,26 @@ def test_renumber():
         assert dest_as_int[i] == numbering[dst[i]]
 '''
 
+def test_renumber_negative():
+    source_list = [4, 6, 8, -20, 1]
+    dest_list = [1, 29, 35, 0, 77]
+
+    df = pd.DataFrame({
+        'source_list': source_list,
+        'dest_list': dest_list,
+    })
+
+    G = cugraph.Graph()
+
+    gdf = cudf.DataFrame.from_pandas(df[['source_list', 'dest_list']])
+
+    src, dst, numbering = cugraph.renumber(gdf['source_list'],
+                                           gdf['dest_list'])
+
+    for i in range(len(source_list)):
+        assert source_list[i] == numbering[src[i]]
+        assert dest_list[i] == numbering[dst[i]]
+
 
 # Test all combinations of default/managed and pooled/non-pooled allocation
 @pytest.mark.parametrize('managed, pool',

--- a/python/cugraph/tests/test_graph.py
+++ b/python/cugraph/tests/test_graph.py
@@ -613,6 +613,7 @@ def test_renumber():
         assert dest_as_int[i] == numbering[dst[i]]
 '''
 
+
 def test_renumber_negative():
     source_list = [4, 6, 8, -20, 1]
     dest_list = [1, 29, 35, 0, 77]
@@ -621,8 +622,6 @@ def test_renumber_negative():
         'source_list': source_list,
         'dest_list': dest_list,
     })
-
-    G = cugraph.Graph()
 
     gdf = cudf.DataFrame.from_pandas(df[['source_list', 'dest_list']])
 


### PR DESCRIPTION
Hash function assumed unsigned integers in the computation.  Modulus of a
negative integer is negative - which caused an out of bounds index.

Added a unit test to include a negative index example.

To keep from overflowing, compute modulus, then add modulus and mod again
to force number to be in range of [0, mod).

closes #488 