### PR TITLE
[gpuCI] Auto-merge branch-0.10 to branch-0.11 [skip ci]

### DIFF
--- a/datasets/get_test_data.sh
+++ b/datasets/get_test_data.sh
@@ -3,12 +3,12 @@
 echo Downloading ...
 mkdir tmp
 cd tmp
-wget https://s3.us-east-2.amazonaws.com/rapidsai-data/cugraph/test/datasets.tgz
-wget https://s3.us-east-2.amazonaws.com/rapidsai-data/cugraph/test/ref/pagerank.tgz
-wget https://s3.us-east-2.amazonaws.com/rapidsai-data/cugraph/test/ref/sssp.tgz
-wget https://s3.us-east-2.amazonaws.com/rapidsai-data/cugraph/benchmark/hibench/hibench_1_huge.tgz
-wget https://s3.us-east-2.amazonaws.com/rapidsai-data/cugraph/benchmark/hibench/hibench_1_large.tgz
-wget https://s3.us-east-2.amazonaws.com/rapidsai-data/cugraph/benchmark/hibench/hibench_1_small.tgz
+wget --progress=dot:mega https://s3.us-east-2.amazonaws.com/rapidsai-data/cugraph/test/datasets.tgz
+wget --progress=dot:mega https://s3.us-east-2.amazonaws.com/rapidsai-data/cugraph/test/ref/pagerank.tgz
+wget --progress=dot:mega https://s3.us-east-2.amazonaws.com/rapidsai-data/cugraph/test/ref/sssp.tgz
+wget --progress=dot:mega https://s3.us-east-2.amazonaws.com/rapidsai-data/cugraph/benchmark/hibench/hibench_1_huge.tgz
+wget --progress=dot:mega https://s3.us-east-2.amazonaws.com/rapidsai-data/cugraph/benchmark/hibench/hibench_1_large.tgz
+wget --progress=dot:mega https://s3.us-east-2.amazonaws.com/rapidsai-data/cugraph/benchmark/hibench/hibench_1_small.tgz
 cd ..
 
 mkdir test


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.10` that creates a PR to keep `branch-0.11` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.