### PR TITLE
[BUG] Added RMM init check so RMM free APIs are not called if not initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - PR #468 Remove unnecessary print statement
 - PR #464 Limit initial RMM pool allocator size to 128mb so pytest can run in parallel
 - PR #474 Add csv file writing, lazy compute - snmg pagerank
-- PR #481 Run bfs on unweighted graphs when calling sssp 
+- PR #481 Run bfs on unweighted graphs when calling sssp
 - PR #491 Use YYMMDD tag in nightly build
 - PR #487 Add woverlap test, add namespace in snmg COO2CSR
 - PR #531 Use new rmm python package
@@ -42,6 +42,7 @@
 - PR #525 Update build scripts and YYMMDD tagging for nightly builds
 - PR #548 Added missing cores documentation
 - PR #556 Fixed recursive remote options for submodules
+- PR #559 Added RMM init check so RMM free APIs are not called if not initialized
 
 
 # cuGraph 0.9.0 (21 Aug 2019)

--- a/cpp/include/rmm_utils.h
+++ b/cpp/include/rmm_utils.h
@@ -37,6 +37,11 @@
   RMM_TRY_THROW( RMM_REALLOC((ptr), (sz), (stream)) ) \
 }
 
+// TODO: temporarily wrapping RMM_FREE in a rmmIsInitialized() check to work
+// around the RMM session being finalized prior to this call. A larger
+// refactoring will need to be done to eliminate the need to do this, and
+// calling RMM APIs directly should likely also be removed in favor of working
+// with a higher-level abstraction that manages RMM properly (eg. cuDF?)
 #define ALLOC_FREE_TRY(ptr, stream){              \
   if(rmmIsInitialized((rmmOptions_t*) NULL)) {    \
     RMM_TRY_THROW( RMM_FREE( (ptr), (stream) ) )  \

--- a/cpp/include/rmm_utils.h
+++ b/cpp/include/rmm_utils.h
@@ -18,7 +18,7 @@
 #include <sstream>
 #include <stdexcept>
 
-#define RMM_TRY_THROW( call )  if ((call)!=RMM_SUCCESS) \
+#define RMM_TRY_THROW_IFINIT( call )  if (rmmIsInitialized((rmmOptions_t*) NULL) && (call)!=RMM_SUCCESS) \
     {                                                   \
       std::stringstream ss;                             \
       ss << "ERROR: RMM runtime call  " << #call        \
@@ -30,13 +30,13 @@
 #include <rmm/thrust_rmm_allocator.h>
 
 #define ALLOC_TRY( ptr, sz, stream ){               \
-  RMM_TRY_THROW( RMM_ALLOC((ptr), (sz), (stream)) ) \
+  RMM_TRY_THROW_IFINIT( RMM_ALLOC((ptr), (sz), (stream)) ) \
 }
 
 #define REALLOC_TRY(ptr, new_sz, stream){             \
-  RMM_TRY_THROW( RMM_REALLOC((ptr), (sz), (stream)) ) \
+  RMM_TRY_THROW_IFINIT( RMM_REALLOC((ptr), (sz), (stream)) ) \
 }
 
 #define ALLOC_FREE_TRY(ptr, stream){            \
-  RMM_TRY_THROW( RMM_FREE( (ptr), (stream) ) )  \
+  RMM_TRY_THROW_IFINIT( RMM_FREE( (ptr), (stream) ) )  \
 }

--- a/cpp/include/rmm_utils.h
+++ b/cpp/include/rmm_utils.h
@@ -18,7 +18,7 @@
 #include <sstream>
 #include <stdexcept>
 
-#define RMM_TRY_THROW_IFINIT( call )  if (rmmIsInitialized((rmmOptions_t*) NULL) && (call)!=RMM_SUCCESS) \
+#define RMM_TRY_THROW( call )  if ((call)!=RMM_SUCCESS) \
     {                                                   \
       std::stringstream ss;                             \
       ss << "ERROR: RMM runtime call  " << #call        \
@@ -30,13 +30,15 @@
 #include <rmm/thrust_rmm_allocator.h>
 
 #define ALLOC_TRY( ptr, sz, stream ){               \
-  RMM_TRY_THROW_IFINIT( RMM_ALLOC((ptr), (sz), (stream)) ) \
+  RMM_TRY_THROW( RMM_ALLOC((ptr), (sz), (stream)) ) \
 }
 
 #define REALLOC_TRY(ptr, new_sz, stream){             \
-  RMM_TRY_THROW_IFINIT( RMM_REALLOC((ptr), (sz), (stream)) ) \
+  RMM_TRY_THROW( RMM_REALLOC((ptr), (sz), (stream)) ) \
 }
 
-#define ALLOC_FREE_TRY(ptr, stream){            \
-  RMM_TRY_THROW_IFINIT( RMM_FREE( (ptr), (stream) ) )  \
+#define ALLOC_FREE_TRY(ptr, stream){              \
+  if(rmmIsInitialized((rmmOptions_t*) NULL)) {    \
+    RMM_TRY_THROW( RMM_FREE( (ptr), (stream) ) )  \
+  }                                               \
 }


### PR DESCRIPTION
Only call RMM free if the RMM session has been initialized.

This resolves almost all the cugraph notebook test failures (still an issue with `Renumbering-test`, may have to handle separately).

I'm not sure if this is the right approach as a client of RMM, hoping @kkraus14 has some thoughts.  Also unsure if this is the best place to add this check, hoping @afender and @seunghwak have feedback.