### PR TITLE
[REVIEW] Exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Improvements
+- PR #569 Exceptions
 
 ## Bug Fixes
 

--- a/cpp/src/centrality/katz_centrality.cu
+++ b/cpp/src/centrality/katz_centrality.cu
@@ -33,14 +33,14 @@ gdf_error gdf_katz_centrality(gdf_graph *graph,
                               double tol,
                               bool has_guess,
                               bool normalized) {
-  GDF_REQUIRE(graph->adjList != nullptr || graph->edgeList != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(graph->adjList != nullptr || graph->edgeList != nullptr, "Invalid API parameter");
   gdf_error err = gdf_add_adj_list(graph);
   if (err != GDF_SUCCESS)
     return err;
-  GDF_REQUIRE(graph->adjList->offsets->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(graph->adjList->indices->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(katz_centrality->dtype == GDF_FLOAT64, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(katz_centrality->size == graph->numberOfVertices, GDF_COLUMN_SIZE_MISMATCH);
+  CUGRAPH_EXPECTS(graph->adjList->offsets->dtype == GDF_INT32, "Unsupported data type");
+  CUGRAPH_EXPECTS(graph->adjList->indices->dtype == GDF_INT32, "Unsupported data type");
+  CUGRAPH_EXPECTS(katz_centrality->dtype == GDF_FLOAT64, "Unsupported data type");
+  CUGRAPH_EXPECTS(katz_centrality->size == graph->numberOfVertices, "Column size mismatch");
 
   const bool isStatic = true;
   using HornetGraph = hornet::gpu::HornetStatic<int>;

--- a/cpp/src/community/nvgraph_gdf.cu
+++ b/cpp/src/community/nvgraph_gdf.cu
@@ -42,15 +42,15 @@ gdf_error gdf_balancedCutClustering_nvgraph(gdf_graph* gdf_G,
                                             const float kmean_tolerance,
                                             const int kmean_max_iter,
                                             gdf_column* clustering) {
-  GDF_REQUIRE(gdf_G != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE((gdf_G->adjList != nullptr) || (gdf_G->edgeList != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE(clustering != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(clustering->data != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(!clustering->valid, GDF_VALIDITY_UNSUPPORTED);
+  CUGRAPH_EXPECTS(gdf_G != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS((gdf_G->adjList != nullptr) || (gdf_G->edgeList != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS(clustering != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(clustering->data != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(!clustering->valid, "Column must be valid");
 
   // Ensure that the input graph has values
-  GDF_TRY(gdf_add_adj_list(gdf_G));
-  //GDF_REQUIRE(gdf_G->adjList->edge_data != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_TRY(gdf_add_adj_list(gdf_G));
+  //CUGRAPH_EXPECTS(gdf_G->adjList->edge_data != nullptr, "Invalid API parameter");
 
   // Initialize Nvgraph and wrap the graph
   nvgraphHandle_t nvg_handle = nullptr;
@@ -59,7 +59,7 @@ gdf_error gdf_balancedCutClustering_nvgraph(gdf_graph* gdf_G,
         rmm::device_vector<double> d_val;
 
   NVG_TRY(nvgraphCreate(&nvg_handle));
-  GDF_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvgraph_G, false));
+  CUGRAPH_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvgraph_G, false));
   int weight_index = 0;
 
   cudaStream_t stream{nullptr};
@@ -125,21 +125,21 @@ gdf_error gdf_spectralModularityMaximization_nvgraph(gdf_graph* gdf_G,
                                                       const float kmean_tolerance,
                                                       const int kmean_max_iter,
                                                       gdf_column* clustering) {
-  GDF_REQUIRE(gdf_G != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE((gdf_G->adjList != nullptr) || (gdf_G->edgeList != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE(clustering != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(clustering->data != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(!clustering->valid, GDF_VALIDITY_UNSUPPORTED);
+  CUGRAPH_EXPECTS(gdf_G != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS((gdf_G->adjList != nullptr) || (gdf_G->edgeList != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS(clustering != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(clustering->data != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(!clustering->valid, "Column must be valid");
 
   // Ensure that the input graph has values
-  GDF_TRY(gdf_add_adj_list(gdf_G));
-  GDF_REQUIRE(gdf_G->adjList->edge_data != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_TRY(gdf_add_adj_list(gdf_G));
+  CUGRAPH_EXPECTS(gdf_G->adjList->edge_data != nullptr, "Invalid API parameter");
 
   // Initialize Nvgraph and wrap the graph
   nvgraphHandle_t nvg_handle = nullptr;
   nvgraphGraphDescr_t nvgraph_G = nullptr;
   NVG_TRY(nvgraphCreate(&nvg_handle));
-  GDF_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvgraph_G, false));
+  CUGRAPH_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvgraph_G, false));
   int weight_index = 0;
 
   // Pack parameters for call to Nvgraph
@@ -174,19 +174,19 @@ gdf_error gdf_AnalyzeClustering_modularity_nvgraph(gdf_graph* gdf_G,
                                                     const int n_clusters,
                                                     gdf_column* clustering,
                                                     float* score) {
-  GDF_REQUIRE(gdf_G != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE((gdf_G->adjList != nullptr) || (gdf_G->edgeList != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE((gdf_G->adjList == nullptr) || (gdf_G->adjList->edge_data != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE((gdf_G->edgeList == nullptr) || (gdf_G->edgeList->edge_data != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE(clustering != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(clustering->data != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(!clustering->valid, GDF_VALIDITY_UNSUPPORTED);
+  CUGRAPH_EXPECTS(gdf_G != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS((gdf_G->adjList != nullptr) || (gdf_G->edgeList != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS((gdf_G->adjList == nullptr) || (gdf_G->adjList->edge_data != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS((gdf_G->edgeList == nullptr) || (gdf_G->edgeList->edge_data != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS(clustering != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(clustering->data != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(!clustering->valid, "Column must be valid");
 
   // Initialize Nvgraph and wrap the graph
   nvgraphHandle_t nvg_handle = nullptr;
   nvgraphGraphDescr_t nvgraph_G = nullptr;
   NVG_TRY(nvgraphCreate(&nvg_handle));
-  GDF_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvgraph_G, false));
+  CUGRAPH_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvgraph_G, false));
   int weight_index = 0;
 
   // Make Nvgraph call
@@ -205,11 +205,11 @@ gdf_error gdf_AnalyzeClustering_edge_cut_nvgraph(gdf_graph* gdf_G,
                                                   const int n_clusters,
                                                   gdf_column* clustering,
                                                   float* score) {
-  GDF_REQUIRE(gdf_G != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE((gdf_G->adjList != nullptr) || (gdf_G->edgeList != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE(clustering != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(clustering->data != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(!clustering->valid, GDF_VALIDITY_UNSUPPORTED);
+  CUGRAPH_EXPECTS(gdf_G != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS((gdf_G->adjList != nullptr) || (gdf_G->edgeList != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS(clustering != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(clustering->data != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(!clustering->valid, "Column must be valid");
 
   // Initialize Nvgraph and wrap the graph
   nvgraphHandle_t nvg_handle = nullptr;
@@ -218,7 +218,7 @@ gdf_error gdf_AnalyzeClustering_edge_cut_nvgraph(gdf_graph* gdf_G,
         rmm::device_vector<double> d_val;
 
   NVG_TRY(nvgraphCreate(&nvg_handle));
-  GDF_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvgraph_G, false));
+  CUGRAPH_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvgraph_G, false));
   int weight_index = 0;
 
   cudaStream_t stream{nullptr};
@@ -263,19 +263,19 @@ gdf_error gdf_AnalyzeClustering_ratio_cut_nvgraph(gdf_graph* gdf_G,
                                                   const int n_clusters,
                                                   gdf_column* clustering,
                                                   float* score) {
-  GDF_REQUIRE(gdf_G != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE((gdf_G->adjList != nullptr) || (gdf_G->edgeList != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE((gdf_G->adjList == nullptr) || (gdf_G->adjList->edge_data != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE((gdf_G->edgeList == nullptr) || (gdf_G->edgeList->edge_data != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE(clustering != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(clustering->data != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(!clustering->valid, GDF_VALIDITY_UNSUPPORTED);
+  CUGRAPH_EXPECTS(gdf_G != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS((gdf_G->adjList != nullptr) || (gdf_G->edgeList != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS((gdf_G->adjList == nullptr) || (gdf_G->adjList->edge_data != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS((gdf_G->edgeList == nullptr) || (gdf_G->edgeList->edge_data != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS(clustering != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(clustering->data != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(!clustering->valid, "Column must be valid");
 
   // Initialize Nvgraph and wrap the graph
   nvgraphHandle_t nvg_handle = nullptr;
   nvgraphGraphDescr_t nvgraph_G = nullptr;
   NVG_TRY(nvgraphCreate(&nvg_handle));
-  GDF_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvgraph_G, false));
+  CUGRAPH_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvgraph_G, false));
   int weight_index = 0;
 
   // Make Nvgraph call
@@ -294,17 +294,17 @@ gdf_error gdf_AnalyzeClustering_ratio_cut_nvgraph(gdf_graph* gdf_G,
 gdf_error gdf_extract_subgraph_vertex_nvgraph(gdf_graph* gdf_G,
                                               gdf_column* vertices,
                                               gdf_graph* result) {
-  GDF_REQUIRE(gdf_G != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE((gdf_G->adjList != nullptr) || (gdf_G->edgeList != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE(vertices != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(vertices->data != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(!vertices->valid, GDF_VALIDITY_UNSUPPORTED);
+  CUGRAPH_EXPECTS(gdf_G != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS((gdf_G->adjList != nullptr) || (gdf_G->edgeList != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS(vertices != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(vertices->data != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(!vertices->valid, "Column must be valid");
 
   // Initialize Nvgraph and wrap the graph
   nvgraphHandle_t nvg_handle = nullptr;
   nvgraphGraphDescr_t nvg_G = nullptr;
   NVG_TRY(nvgraphCreate(&nvg_handle));
-  GDF_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvg_G, false));
+  CUGRAPH_TRY(gdf_createGraph_nvgraph(nvg_handle, gdf_G, &nvg_G, false));
 
   // Create an Nvgraph graph descriptor for the result and initialize
   nvgraphGraphDescr_t nvg_result = nullptr;
@@ -358,16 +358,16 @@ gdf_error gdf_extract_subgraph_vertex_nvgraph(gdf_graph* gdf_G,
 }
 
 gdf_error gdf_triangle_count_nvgraph(gdf_graph* G, uint64_t* result) {
-  GDF_REQUIRE(G != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE((G->adjList != nullptr) || (G->edgeList != nullptr), GDF_INVALID_API_CALL);
-  GDF_TRY(gdf_add_adj_list(G));
-  GDF_REQUIRE(G->adjList != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(G != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS((G->adjList != nullptr) || (G->edgeList != nullptr), "Invalid API parameter");
+  CUGRAPH_TRY(gdf_add_adj_list(G));
+  CUGRAPH_EXPECTS(G->adjList != nullptr, "Invalid API parameter");
 
   // Initialize Nvgraph and wrap the graph
   nvgraphHandle_t nvg_handle = nullptr;
   nvgraphGraphDescr_t nvg_G = nullptr;
   NVG_TRY(nvgraphCreate(&nvg_handle));
-  GDF_TRY(gdf_createGraph_nvgraph(nvg_handle, G, &nvg_G, false));
+  CUGRAPH_TRY(gdf_createGraph_nvgraph(nvg_handle, G, &nvg_G, false));
 
   // Make Nvgraph call
   NVG_TRY(nvgraphTriangleCount(nvg_handle, nvg_G, result));
@@ -375,7 +375,7 @@ gdf_error gdf_triangle_count_nvgraph(gdf_graph* G, uint64_t* result) {
 }
 
 gdf_error gdf_louvain(gdf_graph *graph, void *final_modularity, void *num_level, gdf_column *louvain_parts) {
-  GDF_REQUIRE(graph->adjList != nullptr || graph->edgeList != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(graph->adjList != nullptr || graph->edgeList != nullptr, "Invalid API parameter");
   gdf_error err = gdf_add_adj_list(graph);
   if (err != GDF_SUCCESS)
     return err;

--- a/cpp/src/components/connectivity.cu
+++ b/cpp/src/components/connectivity.cu
@@ -70,26 +70,26 @@ gdf_connected_components_impl(gdf_graph *graph,
   gdf_column* labels = table->get_column(0);
   gdf_column* verts = table->get_column(1);
 
-  GDF_REQUIRE(graph != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(graph != nullptr, "Invalid API parameter");
     
-  GDF_REQUIRE(graph->adjList != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(graph->adjList != nullptr, "Invalid API parameter");
     
-  GDF_REQUIRE(row_offsets_(graph) != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(row_offsets_(graph) != nullptr, "Invalid API parameter");
 
-  GDF_REQUIRE(col_indices_(graph) != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(col_indices_(graph) != nullptr, "Invalid API parameter");
   
-  GDF_REQUIRE(labels->data != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(labels->data != nullptr, "Invalid API parameter");
 
-  GDF_REQUIRE(verts->data != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(verts->data != nullptr, "Invalid API parameter");
   
   auto type_id = graph->adjList->offsets->dtype;
-  GDF_REQUIRE( type_id == GDF_INT32 || type_id == GDF_INT64, GDF_UNSUPPORTED_DTYPE);
+  CUGRAPH_EXPECTS( type_id == GDF_INT32 || type_id == GDF_INT64, "Unsupported data type");
   
-  GDF_REQUIRE( type_id == graph->adjList->indices->dtype, GDF_UNSUPPORTED_DTYPE);
+  CUGRAPH_EXPECTS( type_id == graph->adjList->indices->dtype, "Unsupported data type");
   
   //TODO: relax this requirement:
   //
-  GDF_REQUIRE( type_id == labels->dtype, GDF_UNSUPPORTED_DTYPE);
+  CUGRAPH_EXPECTS( type_id == labels->dtype, "Unsupported data type");
 
   IndexT* p_d_labels = static_cast<IndexT*>(labels->data);
   IndexT* p_d_verts = static_cast<IndexT*>(verts->data);
@@ -135,7 +135,7 @@ gdf_connected_components_impl(gdf_graph *graph,
                <<"\n";
 #endif
       
-      GDF_REQUIRE( is_symmetric, GDF_INVALID_API_CALL);
+      CUGRAPH_EXPECTS( is_symmetric, "Invalid API parameter");
       MLCommon::Sparse::weak_cc_entry<IndexT, TPB_X>(p_d_labels,
                                                      p_d_row_offsets,
                                                      p_d_col_ind,
@@ -208,17 +208,17 @@ gdf_connected_components_impl(gdf_graph *graph,
 {
   cudaStream_t stream{nullptr};
 
-  GDF_REQUIRE(table != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(table->num_columns() > 1, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(table != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(table->num_columns() > 1, "Invalid API parameter");
   
   gdf_column* labels = table->get_column(0);
   gdf_column* verts = table->get_column(1);
 
-  GDF_REQUIRE(labels != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(verts != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(labels != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(verts != nullptr, "Invalid API parameter");
 
   auto dtype = labels->dtype;
-  GDF_REQUIRE( dtype == verts->dtype, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS( dtype == verts->dtype, "Invalid API parameter");
   
   switch( dtype )//currently graph's row offsets, col_indices and labels are same type; that may change in the future
     {

--- a/cpp/src/converters/nvgraph.cu
+++ b/cpp/src/converters/nvgraph.cu
@@ -33,7 +33,7 @@ gdf_error gdf_createGraph_nvgraph(nvgraphHandle_t nvg_handle,
   CUGRAPH_EXPECTS(!((gdf_G->edgeList == nullptr) &&
                   (gdf_G->adjList == nullptr) &&
                   (gdf_G->transposedAdjList == nullptr)),
-              GDF_INVALID_API_CALL);
+              "Invalid API parameter");
   nvgraphTopologyType_t TT;
   cudaDataType_t settype;
   // create an nvgraph graph handle

--- a/cpp/src/converters/nvgraph.cu
+++ b/cpp/src/converters/nvgraph.cu
@@ -30,7 +30,7 @@ gdf_error gdf_createGraph_nvgraph(nvgraphHandle_t nvg_handle,
                                   bool use_transposed) {
 
   // check input
-  GDF_REQUIRE(!((gdf_G->edgeList == nullptr) &&
+  CUGRAPH_EXPECTS(!((gdf_G->edgeList == nullptr) &&
                   (gdf_G->adjList == nullptr) &&
                   (gdf_G->transposedAdjList == nullptr)),
               GDF_INVALID_API_CALL);
@@ -42,7 +42,7 @@ gdf_error gdf_createGraph_nvgraph(nvgraphHandle_t nvg_handle,
   if (use_transposed) {
     // convert edgeList to transposedAdjList
     if (gdf_G->transposedAdjList == nullptr) {
-      GDF_TRY(gdf_add_transposed_adj_list(gdf_G));
+      CUGRAPH_TRY(gdf_add_transposed_adj_list(gdf_G));
     }
     // using exiting transposedAdjList if it exisits and if adjList is missing
     TT = NVGRAPH_CSC_32;
@@ -81,7 +81,7 @@ gdf_error gdf_createGraph_nvgraph(nvgraphHandle_t nvg_handle,
   else {
     // convert edgeList to adjList
     if (gdf_G->adjList == nullptr) {
-      GDF_TRY(gdf_add_adj_list(gdf_G));
+      CUGRAPH_TRY(gdf_add_adj_list(gdf_G));
     }
     TT = NVGRAPH_CSR_32;
     nvgraphCSRTopology32I_st topoData;

--- a/cpp/src/converters/renumber.cu
+++ b/cpp/src/converters/renumber.cu
@@ -24,8 +24,8 @@
 gdf_error gdf_renumber_vertices(const gdf_column *src, const gdf_column *dst,
                                 gdf_column *src_renumbered, gdf_column *dst_renumbered,
                                 gdf_column *numbering_map) {
-  GDF_REQUIRE( src->size == dst->size, GDF_COLUMN_SIZE_MISMATCH );
-  GDF_REQUIRE( src->dtype == dst->dtype, GDF_UNSUPPORTED_DTYPE );
+  CUGRAPH_EXPECTS( src->size == dst->size, "Column size mismatch" );
+  CUGRAPH_EXPECTS( src->dtype == dst->dtype, "Unsupported data type" );
 
   //
   //  Added this back in.  Below I added support for strings, however the 
@@ -34,8 +34,8 @@ gdf_error gdf_renumber_vertices(const gdf_column *src, const gdf_column *dst,
   //  will prevent code from being executed.  Once cudf fully support string
   //  columns we can eliminate this check and debug the GDF_STRING case below.
   //
-  GDF_REQUIRE( ((src->dtype == GDF_INT32) || (src->dtype == GDF_INT64)), GDF_UNSUPPORTED_DTYPE );
-  GDF_REQUIRE( src->size > 0, GDF_DATASET_EMPTY );
+  CUGRAPH_EXPECTS( ((src->dtype == GDF_INT32) || (src->dtype == GDF_INT64)), "Unsupported data type" );
+  CUGRAPH_EXPECTS( src->size > 0, "Column is empty");
 
   //
   //  TODO: we're currently renumbering without using valid.  We need to

--- a/cpp/src/cores/core_number.cu
+++ b/cpp/src/cores/core_number.cu
@@ -47,14 +47,14 @@ gdf_error core_number_impl(gdf_graph *graph,
 
 gdf_error gdf_core_number(gdf_graph *graph,
                           gdf_column *core_number) {
-  GDF_REQUIRE(graph->adjList != nullptr || graph->edgeList != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(graph->adjList != nullptr || graph->edgeList != nullptr, "Invalid API parameter");
   gdf_error err = gdf_add_adj_list(graph);
   if (err != GDF_SUCCESS)
     return err;
-  GDF_REQUIRE(graph->adjList->offsets->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(graph->adjList->indices->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(core_number->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(core_number->size == graph->numberOfVertices, GDF_COLUMN_SIZE_MISMATCH);
+  CUGRAPH_EXPECTS(graph->adjList->offsets->dtype == GDF_INT32, "Unsupported data type");
+  CUGRAPH_EXPECTS(graph->adjList->indices->dtype == GDF_INT32, "Unsupported data type");
+  CUGRAPH_EXPECTS(core_number->dtype == GDF_INT32, "Unsupported data type");
+  CUGRAPH_EXPECTS(core_number->size == graph->numberOfVertices, "Column size mismatch");
 
   return core_number_impl(graph, static_cast<int*>(core_number->data));
 }
@@ -207,20 +207,20 @@ gdf_error gdf_k_core(gdf_graph *in_graph,
                      gdf_column *vertex_id,
                      gdf_column *core_number,
                      gdf_graph *out_graph) {
-  GDF_REQUIRE(out_graph != nullptr && in_graph != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(out_graph != nullptr && in_graph != nullptr, "Invalid API parameter");
   gdf_error err = gdf_add_adj_list(in_graph);
   gdf_size_type nV = in_graph->numberOfVertices;
 
   if (err != GDF_SUCCESS)
     return err;
-  GDF_REQUIRE(in_graph->adjList->offsets->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(in_graph->adjList->indices->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE((vertex_id != nullptr) && (core_number != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE(vertex_id->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(core_number->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(core_number->size == vertex_id->size, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(core_number->size == nV, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(k >= 0, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(in_graph->adjList->offsets->dtype == GDF_INT32, "Unsupported data type");
+  CUGRAPH_EXPECTS(in_graph->adjList->indices->dtype == GDF_INT32, "Unsupported data type");
+  CUGRAPH_EXPECTS((vertex_id != nullptr) && (core_number != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS(vertex_id->dtype == GDF_INT32, "Unsupported data type");
+  CUGRAPH_EXPECTS(core_number->dtype == GDF_INT32, "Unsupported data type");
+  CUGRAPH_EXPECTS(core_number->size == vertex_id->size, "Invalid API parameter");
+  CUGRAPH_EXPECTS(core_number->size == nV, "Invalid API parameter");
+  CUGRAPH_EXPECTS(k >= 0, "Invalid API parameter");
 
   int * vertex_identifier_ptr = static_cast<int*>(vertex_id->data);
   int * core_number_ptr = static_cast<int*>(core_number->data);
@@ -229,7 +229,7 @@ gdf_error gdf_k_core(gdf_graph *in_graph,
   err = extract_subgraph(in_graph, out_graph,
       vertex_identifier_ptr, core_number_ptr,
       k, vLen, nV);
-  GDF_REQUIRE(err, GDF_SUCCESS);
+  CUGRAPH_EXPECTS(err, "cuGraph execution failed");
 
   return GDF_SUCCESS;
 }

--- a/cpp/src/cores/core_number.cu
+++ b/cpp/src/cores/core_number.cu
@@ -208,11 +208,8 @@ gdf_error gdf_k_core(gdf_graph *in_graph,
                      gdf_column *core_number,
                      gdf_graph *out_graph) {
   CUGRAPH_EXPECTS(out_graph != nullptr && in_graph != nullptr, "Invalid API parameter");
-  gdf_error err = gdf_add_adj_list(in_graph);
+  CUGRAPH_TRY(gdf_add_adj_list(in_graph));
   gdf_size_type nV = in_graph->numberOfVertices;
-
-  if (err != GDF_SUCCESS)
-    return err;
   CUGRAPH_EXPECTS(in_graph->adjList->offsets->dtype == GDF_INT32, "Unsupported data type");
   CUGRAPH_EXPECTS(in_graph->adjList->indices->dtype == GDF_INT32, "Unsupported data type");
   CUGRAPH_EXPECTS((vertex_id != nullptr) && (core_number != nullptr), "Invalid API parameter");
@@ -226,10 +223,8 @@ gdf_error gdf_k_core(gdf_graph *in_graph,
   int * core_number_ptr = static_cast<int*>(core_number->data);
   gdf_size_type vLen = vertex_id->size;
 
-  err = extract_subgraph(in_graph, out_graph,
+  CUGRAPH_TRY(extract_subgraph(in_graph, out_graph,
       vertex_identifier_ptr, core_number_ptr,
-      k, vLen, nV);
-  CUGRAPH_EXPECTS(err, "cuGraph execution failed");
-
+      k, vLen, nV));
   return GDF_SUCCESS;
 }

--- a/cpp/src/db/db_object.cu
+++ b/cpp/src/db/db_object.cu
@@ -396,7 +396,7 @@ namespace cugraph {
       int threadsPerBlock = 1024;
       int numBlocks = (runCount_h + threadsPerBlock - 1) / threadsPerBlock;
       offsetsKernel<<<numBlocks, threadsPerBlock>>>(runCount_h, unique, counts, offsets);
-      cudaCheckError();
+      CUDA_CHECK_LAST();
 
       // Taking the exclusive scan of the run lengths to get the final offsets.
       thrust::exclusive_scan(rmm::exec_policy(nullptr)->on(nullptr),

--- a/cpp/src/link_analysis/pagerank.cu
+++ b/cpp/src/link_analysis/pagerank.cu
@@ -196,27 +196,27 @@ gdf_error gdf_pagerank_impl (gdf_graph *graph,
   int *prsVtx = nullptr;
   WT  *prsVal = nullptr;
   int prsLen = 0;
-  GDF_REQUIRE((personalization_subset == nullptr) == (personalization_values == nullptr), GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS((personalization_subset == nullptr) == (personalization_values == nullptr), "Invalid API parameter");
   if (personalization_subset != nullptr) {
     has_personalization = true;
     prsVtx = reinterpret_cast<int*>(personalization_subset->data);
     prsVal = reinterpret_cast<WT* >(personalization_values->data);
     prsLen = reinterpret_cast<int >(personalization_subset->size);
-    GDF_REQUIRE(pagerank->dtype == personalization_values->dtype, GDF_DTYPE_MISMATCH);
-    GDF_REQUIRE(personalization_subset->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-    GDF_REQUIRE(personalization_subset->size == personalization_values->size, GDF_COLUMN_SIZE_MISMATCH);
-    GDF_REQUIRE(personalization_subset->null_count == 0 , GDF_VALIDITY_UNSUPPORTED );
-    GDF_REQUIRE(personalization_values->null_count == 0 , GDF_VALIDITY_UNSUPPORTED );
+    CUGRAPH_EXPECTS(pagerank->dtype == personalization_values->dtype, "Invalid API parameter");
+    CUGRAPH_EXPECTS(personalization_subset->dtype == GDF_INT32, "Unsupported data type");
+    CUGRAPH_EXPECTS(personalization_subset->size == personalization_values->size, "Column size mismatch");
+    CUGRAPH_EXPECTS(personalization_subset->null_count == 0 , "Input column has non-zero null count");
+    CUGRAPH_EXPECTS(personalization_values->null_count == 0 , "Input column has non-zero null count");
   }
-  GDF_REQUIRE( graph->edgeList != nullptr, GDF_VALIDITY_UNSUPPORTED );
-  GDF_REQUIRE( graph->edgeList->src_indices->size == graph->edgeList->dest_indices->size, GDF_COLUMN_SIZE_MISMATCH );
-  GDF_REQUIRE( graph->edgeList->src_indices->dtype == graph->edgeList->dest_indices->dtype, GDF_UNSUPPORTED_DTYPE );
-  GDF_REQUIRE( graph->edgeList->src_indices->null_count == 0 , GDF_VALIDITY_UNSUPPORTED );
-  GDF_REQUIRE( graph->edgeList->dest_indices->null_count == 0 , GDF_VALIDITY_UNSUPPORTED );
-  GDF_REQUIRE( pagerank != nullptr , GDF_INVALID_API_CALL );
-  GDF_REQUIRE( pagerank->data != nullptr , GDF_INVALID_API_CALL );
-  GDF_REQUIRE( pagerank->null_count == 0 , GDF_VALIDITY_UNSUPPORTED );
-  GDF_REQUIRE( pagerank->size > 0 , GDF_INVALID_API_CALL );
+  CUGRAPH_EXPECTS( graph->edgeList != nullptr, "Invalid API parameter" );
+  CUGRAPH_EXPECTS( graph->edgeList->src_indices->size == graph->edgeList->dest_indices->size, "Column size mismatch" );
+  CUGRAPH_EXPECTS( graph->edgeList->src_indices->dtype == graph->edgeList->dest_indices->dtype, "Unsupported data type" );
+  CUGRAPH_EXPECTS( graph->edgeList->src_indices->null_count == 0 , "Input column has non-zero null count");
+  CUGRAPH_EXPECTS( graph->edgeList->dest_indices->null_count == 0 , "Input column has non-zero null count");
+  CUGRAPH_EXPECTS( pagerank != nullptr , "Invalid API parameter" );
+  CUGRAPH_EXPECTS( pagerank->data != nullptr , "Invalid API parameter" );
+  CUGRAPH_EXPECTS( pagerank->null_count == 0 , "Input column has non-zero null count");
+  CUGRAPH_EXPECTS( pagerank->size > 0 , "Invalid API parameter" );
 
   int m=pagerank->size, nnz = graph->edgeList->src_indices->size, status = 0;
   WT *d_pr, *d_val = nullptr, *d_leaf_vector = nullptr;
@@ -240,7 +240,7 @@ gdf_error gdf_pagerank_impl (gdf_graph *graph,
 
   if (has_guess)
   {
-    GDF_REQUIRE( pagerank->data != nullptr, GDF_VALIDITY_UNSUPPORTED );
+    CUGRAPH_EXPECTS( pagerank->data != nullptr, "Column must be valid" );
     cugraph::copy<WT>(m, (WT*)pagerank->data, d_pr);
   }
 
@@ -276,13 +276,13 @@ gdf_error gdf_pagerank(gdf_graph *graph, gdf_column *pagerank,
   //
   //  If csr doesn't exist, create it.  Then check type to make sure it is 32-bit.
   //
-  GDF_REQUIRE(graph->adjList != nullptr || graph->edgeList != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(graph->adjList != nullptr || graph->edgeList != nullptr, "Invalid API parameter");
   gdf_error err = gdf_add_adj_list(graph);
   if (err != GDF_SUCCESS)
     return err;
 
-  GDF_REQUIRE(graph->adjList->offsets->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(graph->adjList->indices->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
+  CUGRAPH_EXPECTS(graph->adjList->offsets->dtype == GDF_INT32, "Unsupported data type");
+  CUGRAPH_EXPECTS(graph->adjList->indices->dtype == GDF_INT32, "Unsupported data type");
 
   switch (pagerank->dtype) {
     case GDF_FLOAT32:   return gdf_pagerank_impl<float>(graph, pagerank,

--- a/cpp/src/link_analysis/pagerank.cu
+++ b/cpp/src/link_analysis/pagerank.cu
@@ -105,7 +105,7 @@ int pagerank(IndexType n, IndexType e, IndexType *cscPtr, IndexType *cscInd, Val
 #else
   ALLOC_TRY((void**)&tmp, sizeof(ValueType) * n, stream);
 #endif
-  cudaCheckError();
+  CUDA_CHECK_LAST();
 
   if (!has_guess) {
        fill(n, pagerank_vector, randomProbability);
@@ -133,7 +133,7 @@ int pagerank(IndexType n, IndexType e, IndexType *cscPtr, IndexType *cscInd, Val
                                   cscPtr, cscInd, tmp, pagerank_vector, n, n, e));
    // Allocate temporary storage
   ALLOC_TRY ((void**)&cub_d_temp_storage, cub_temp_storage_bytes, stream);
-  cudaCheckError()
+  CUDA_CHECK_LAST()
 #ifdef PR_VERBOSE
   std::stringstream ss;
   ss.str(std::string());

--- a/cpp/src/link_prediction/jaccard.cu
+++ b/cpp/src/link_prediction/jaccard.cu
@@ -346,14 +346,14 @@ namespace cugraph {
 } // End cugraph namespace
 
 gdf_error gdf_jaccard(gdf_graph *graph, gdf_column *weights, gdf_column *result) {
-  GDF_REQUIRE(graph != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE((graph->adjList != nullptr) || (graph->edgeList != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE(result != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(result->data != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(!result->valid, GDF_VALIDITY_UNSUPPORTED);
+  CUGRAPH_EXPECTS(graph != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS((graph->adjList != nullptr) || (graph->edgeList != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS(result != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(result->data != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(!result->valid, "Column must be valid");
 
-  GDF_TRY(gdf_add_adj_list(graph));
-  GDF_REQUIRE(graph->adjList != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_TRY(gdf_add_adj_list(graph));
+  CUGRAPH_EXPECTS(graph->adjList != nullptr, "Invalid API parameter");
 
   bool weighted = (weights != nullptr);
 
@@ -512,29 +512,29 @@ gdf_error gdf_jaccard_list(gdf_graph* graph,
                            gdf_column* first,
                            gdf_column* second,
                            gdf_column* result) {
-  GDF_REQUIRE(graph != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE((graph->adjList != nullptr) || (graph->edgeList != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE(result != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(result->data != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(!result->valid, GDF_VALIDITY_UNSUPPORTED);
+  CUGRAPH_EXPECTS(graph != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS((graph->adjList != nullptr) || (graph->edgeList != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS(result != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(result->data != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(!result->valid, "Column must be valid");
 
-  GDF_REQUIRE(first != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(first->data != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(!first->valid, GDF_VALIDITY_UNSUPPORTED);
+  CUGRAPH_EXPECTS(first != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(first->data != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(!first->valid, "Column must be valid");
 
-  GDF_REQUIRE(second != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(second->data != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(!second->valid, GDF_VALIDITY_UNSUPPORTED);
+  CUGRAPH_EXPECTS(second != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(second->data != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(!second->valid, "Column must be valid");
 
-  GDF_TRY(gdf_add_adj_list(graph));
-  GDF_REQUIRE(graph->adjList != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_TRY(gdf_add_adj_list(graph));
+  CUGRAPH_EXPECTS(graph->adjList != nullptr, "Invalid API parameter");
 
   bool weighted = (weights != nullptr);
 
   gdf_dtype ValueType = result->dtype;
   gdf_dtype IndexType = graph->adjList->offsets->dtype;
-  GDF_REQUIRE(first->dtype == IndexType, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(second->dtype == IndexType, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(first->dtype == IndexType, "Invalid API parameter");
+  CUGRAPH_EXPECTS(second->dtype == IndexType, "Invalid API parameter");
 
   void *first_pair = first->data;
   void *second_pair = second->data;

--- a/cpp/src/link_prediction/overlap.cu
+++ b/cpp/src/link_prediction/overlap.cu
@@ -345,14 +345,14 @@ namespace cugraph {
 } // End cugraph namespace
 
 gdf_error gdf_overlap(gdf_graph *graph, gdf_column *weights, gdf_column *result) {
-  GDF_REQUIRE(graph != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE((graph->adjList != nullptr) || (graph->edgeList != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE(result != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(result->data != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(!result->valid, GDF_VALIDITY_UNSUPPORTED);
+  CUGRAPH_EXPECTS(graph != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS((graph->adjList != nullptr) || (graph->edgeList != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS(result != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(result->data != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(!result->valid, "Column must be valid");
 
-  GDF_TRY(gdf_add_adj_list(graph));
-  GDF_REQUIRE(graph->adjList != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_TRY(gdf_add_adj_list(graph));
+  CUGRAPH_EXPECTS(graph->adjList != nullptr, "Invalid API parameter");
 
   bool weighted = (weights != nullptr);
 
@@ -511,29 +511,29 @@ gdf_error gdf_overlap_list(gdf_graph* graph,
                            gdf_column* first,
                            gdf_column* second,
                            gdf_column* result) {
-  GDF_REQUIRE(graph != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE((graph->adjList != nullptr) || (graph->edgeList != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE(result != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(result->data != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(!result->valid, GDF_VALIDITY_UNSUPPORTED);
+  CUGRAPH_EXPECTS(graph != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS((graph->adjList != nullptr) || (graph->edgeList != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS(result != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(result->data != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(!result->valid, "Column must be valid");
 
-  GDF_REQUIRE(first != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(first->data != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(!first->valid, GDF_VALIDITY_UNSUPPORTED);
+  CUGRAPH_EXPECTS(first != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(first->data != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(!first->valid, "Column must be valid");
 
-  GDF_REQUIRE(second != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(second->data != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(!second->valid, GDF_VALIDITY_UNSUPPORTED);
+  CUGRAPH_EXPECTS(second != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(second->data != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(!second->valid, "Column must be valid");
 
-  GDF_TRY(gdf_add_adj_list(graph));
-  GDF_REQUIRE(graph->adjList != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_TRY(gdf_add_adj_list(graph));
+  CUGRAPH_EXPECTS(graph->adjList != nullptr, "Invalid API parameter");
 
   bool weighted = (weights != nullptr);
 
   gdf_dtype ValueType = result->dtype;
   gdf_dtype IndexType = graph->adjList->offsets->dtype;
-  GDF_REQUIRE(first->dtype == IndexType, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(second->dtype == IndexType, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(first->dtype == IndexType, "Invalid API parameter");
+  CUGRAPH_EXPECTS(second->dtype == IndexType, "Invalid API parameter");
 
   void *first_pair = first->data;
   void *second_pair = second->data;

--- a/cpp/src/matching/subg_match.cu
+++ b/cpp/src/matching/subg_match.cu
@@ -61,18 +61,18 @@ gdf_error gdf_subgraph_matching_impl(gdf_graph *graph_src,
   //
   for(auto&& graph: arr_graph)
     {
-      GDF_REQUIRE(graph != nullptr, GDF_INVALID_API_CALL);
+      CUGRAPH_EXPECTS(graph != nullptr, "Invalid API parameter");
     
-      GDF_REQUIRE(graph->adjList != nullptr, GDF_INVALID_API_CALL);
+      CUGRAPH_EXPECTS(graph->adjList != nullptr, "Invalid API parameter");
     
-      GDF_REQUIRE(row_offsets_(graph) != nullptr, GDF_INVALID_API_CALL);
+      CUGRAPH_EXPECTS(row_offsets_(graph) != nullptr, "Invalid API parameter");
 
-      GDF_REQUIRE(col_indices_(graph) != nullptr, GDF_INVALID_API_CALL);
+      CUGRAPH_EXPECTS(col_indices_(graph) != nullptr, "Invalid API parameter");
     
       auto type_id = graph->adjList->offsets->dtype;
-      GDF_REQUIRE( type_id == GDF_INT32 || type_id == GDF_INT64, GDF_UNSUPPORTED_DTYPE);
+      CUGRAPH_EXPECTS( type_id == GDF_INT32 || type_id == GDF_INT64, "Unsupported data type");
   
-      GDF_REQUIRE( type_id == graph->adjList->indices->dtype, GDF_UNSUPPORTED_DTYPE);
+      CUGRAPH_EXPECTS( type_id == graph->adjList->indices->dtype, "Unsupported data type");
   
       const SizeT* p_d_row_offsets = row_offsets_(graph);
       const VertexT* p_d_col_ind = col_indices_(graph);
@@ -134,8 +134,8 @@ gdf_error gdf_subgraph_matching(gdf_graph *graph_src,
 
   //currently Gunrock's API requires that graph's col indices and subgraphs must be same type:
   //
-  GDF_REQUIRE( subg_dtype == ci_src_dtype, GDF_INVALID_API_CALL);
-  GDF_REQUIRE( subg_dtype == ci_qry_dtype, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS( subg_dtype == ci_src_dtype, "Invalid API parameter");
+  CUGRAPH_EXPECTS( subg_dtype == ci_qry_dtype, "Invalid API parameter");
 
   //TODO: hopefully multi-type-dispatch on various combos of types:
   //

--- a/cpp/src/snmg/COO2CSR/COO2CSR.cu
+++ b/cpp/src/snmg/COO2CSR/COO2CSR.cu
@@ -469,15 +469,15 @@ gdf_error gdf_snmg_coo2csr(size_t* part_offsets,
                            gdf_column* csrOff,
                            gdf_column* csrInd,
                            gdf_column* csrVal) {
-  GDF_REQUIRE(part_offsets != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(cooRow != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(cooCol != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(csrOff != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(csrInd != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(comm1 != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(cooRow->size > 0, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(cooCol->size > 0, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(cooCol->dtype == cooRow->dtype, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(part_offsets != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(cooRow != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(cooCol != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(csrOff != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(csrInd != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(comm1 != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(cooRow->size > 0, "Invalid API parameter");
+  CUGRAPH_EXPECTS(cooCol->size > 0, "Invalid API parameter");
+  CUGRAPH_EXPECTS(cooCol->dtype == cooRow->dtype, "Invalid API parameter");
 
   if (cooVal == nullptr) {
     if (cooRow->dtype == GDF_INT32) {

--- a/cpp/src/snmg/blas/spmv.cu
+++ b/cpp/src/snmg/blas/spmv.cu
@@ -79,25 +79,25 @@ template class SNMGcsrmv<int, float>;
 template <typename idx_t,typename val_t>
 gdf_error gdf_snmg_csrmv_impl (size_t * part_offsets, gdf_column * off, gdf_column * ind, gdf_column * val, gdf_column ** x_cols){
   
-  GDF_REQUIRE( part_offsets != nullptr, GDF_INVALID_API_CALL );
-  GDF_REQUIRE( off != nullptr, GDF_INVALID_API_CALL );
-  GDF_REQUIRE( ind != nullptr, GDF_INVALID_API_CALL );
-  GDF_REQUIRE( val != nullptr, GDF_INVALID_API_CALL );
-  GDF_REQUIRE( x_cols != nullptr, GDF_INVALID_API_CALL );
-  GDF_REQUIRE( off->size > 0, GDF_INVALID_API_CALL );
-  GDF_REQUIRE( ind->size > 0, GDF_INVALID_API_CALL );
-  GDF_REQUIRE( val->size > 0, GDF_INVALID_API_CALL );
-  GDF_REQUIRE( ind->size == val->size, GDF_COLUMN_SIZE_MISMATCH ); 
-  GDF_REQUIRE( off->dtype == ind->dtype, GDF_UNSUPPORTED_DTYPE );  
-  GDF_REQUIRE( off->null_count + ind->null_count + val->null_count == 0 , GDF_VALIDITY_UNSUPPORTED );                 
+  CUGRAPH_EXPECTS( part_offsets != nullptr, "Invalid API parameter" );
+  CUGRAPH_EXPECTS( off != nullptr, "Invalid API parameter" );
+  CUGRAPH_EXPECTS( ind != nullptr, "Invalid API parameter" );
+  CUGRAPH_EXPECTS( val != nullptr, "Invalid API parameter" );
+  CUGRAPH_EXPECTS( x_cols != nullptr, "Invalid API parameter" );
+  CUGRAPH_EXPECTS( off->size > 0, "Invalid API parameter" );
+  CUGRAPH_EXPECTS( ind->size > 0, "Invalid API parameter" );
+  CUGRAPH_EXPECTS( val->size > 0, "Invalid API parameter" );
+  CUGRAPH_EXPECTS( ind->size == val->size, "Column size mismatch" ); 
+  CUGRAPH_EXPECTS( off->dtype == ind->dtype, "Unsupported data type" );  
+  CUGRAPH_EXPECTS( off->null_count + ind->null_count + val->null_count == 0 , "Input column has non-zero null count");                 
 
   auto p = omp_get_num_threads();
 
   val_t* x[p];
   for (auto i = 0; i < p; ++i)
   {
-    GDF_REQUIRE( x_cols[i] != nullptr, GDF_INVALID_API_CALL );
-    GDF_REQUIRE( x_cols[i]->size > 0, GDF_INVALID_API_CALL );
+    CUGRAPH_EXPECTS( x_cols[i] != nullptr, "Invalid API parameter" );
+    CUGRAPH_EXPECTS( x_cols[i]->size > 0, "Invalid API parameter" );
     x[i]= static_cast<val_t*>(x_cols[i]->data);
   }
   #pragma omp master 

--- a/cpp/src/snmg/blas/spmv.cu
+++ b/cpp/src/snmg/blas/spmv.cu
@@ -35,7 +35,7 @@ SNMGcsrmv<IndexType,ValueType>::SNMGcsrmv(SNMGinfo & env_, size_t* part_off_,
   v_loc = part_off[i+1]-part_off[i];
   IndexType tmp;
   cudaMemcpy(&tmp, &off[v_loc], sizeof(IndexType),cudaMemcpyDeviceToHost);
-  cudaCheckError();
+  CUDA_CHECK_LAST();
   e_loc = tmp;
 
   // Allocate the local result

--- a/cpp/src/snmg/degree/degree.cu
+++ b/cpp/src/snmg/degree/degree.cu
@@ -61,7 +61,7 @@ gdf_error snmg_degree(int x, size_t* part_off, idx_t* off, idx_t* ind, idx_t** d
                                                      static_cast<idx_t>(loc_e),
                                                      ind,
                                                      local_result);
-    cudaCheckError();
+    CUDA_CHECK_LAST();
   }
 
   // Out-degree
@@ -78,7 +78,7 @@ gdf_error snmg_degree(int x, size_t* part_off, idx_t* off, idx_t* ind, idx_t** d
                                                          static_cast<idx_t>(loc_e),
                                                          off,
                                                          local_result + part_off[i]);
-    cudaCheckError();
+    CUDA_CHECK_LAST();
   }
 
   // Combining the local results into global results
@@ -130,7 +130,7 @@ gdf_error snmg_degree<int64_t>(int x,
                                                         static_cast<int64_t>(loc_e),
                                                         ind,
                                                         reinterpret_cast<double*>(local_result));
-    cudaCheckError();
+    CUDA_CHECK_LAST();
   }
 
   // Out-degree
@@ -148,7 +148,7 @@ gdf_error snmg_degree<int64_t>(int x,
                                                             off,
                                                             reinterpret_cast<double*>(local_result
                                                                 + part_off[i]));
-    cudaCheckError();
+    CUDA_CHECK_LAST();
   }
 
   // Convert the values written as doubles back to int64:
@@ -161,7 +161,7 @@ gdf_error snmg_degree<int64_t>(int x,
   nblocks.y = 1;
   nblocks.z = 1;
   type_convert<double, int64_t> <<<nblocks, nthreads>>>(reinterpret_cast<double*>(local_result), glob_v);
-  cudaCheckError();
+  CUDA_CHECK_LAST();
 
   // Combining the local results into global results
   treeReduce<int64_t, thrust::plus<int64_t> >(env, glob_v, local_result, degree);

--- a/cpp/src/snmg/degree/degree.cu
+++ b/cpp/src/snmg/degree/degree.cu
@@ -181,18 +181,18 @@ gdf_error gdf_snmg_degree_impl(int x,
                                gdf_column* off,
                                gdf_column* ind,
                                gdf_column** x_cols) {
-  GDF_REQUIRE(off->size > 0, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(ind->size > 0, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(off->dtype == ind->dtype, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(off->null_count + ind->null_count == 0, GDF_VALIDITY_UNSUPPORTED);
+  CUGRAPH_EXPECTS(off->size > 0, "Invalid API parameter");
+  CUGRAPH_EXPECTS(ind->size > 0, "Invalid API parameter");
+  CUGRAPH_EXPECTS(off->dtype == ind->dtype, "Unsupported data type");
+  CUGRAPH_EXPECTS(off->null_count + ind->null_count == 0, "Column must be valid");
 
   gdf_error status;
   auto p = omp_get_num_threads();
 
   idx_t* degree[p];
   for (auto i = 0; i < p; ++i) {
-    GDF_REQUIRE(x_cols[i] != nullptr, GDF_INVALID_API_CALL);
-    GDF_REQUIRE(x_cols[i]->size > 0, GDF_INVALID_API_CALL);
+    CUGRAPH_EXPECTS(x_cols[i] != nullptr, "Invalid API parameter");
+    CUGRAPH_EXPECTS(x_cols[i]->size > 0, "Invalid API parameter");
     degree[i] = static_cast<idx_t*>(x_cols[i]->data);
   }
 
@@ -209,10 +209,10 @@ gdf_error gdf_snmg_degree(int x,
                           gdf_column* off,
                           gdf_column* ind,
                           gdf_column** x_cols) {
-  GDF_REQUIRE(part_offsets != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(off != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(ind != nullptr, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(x_cols != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(part_offsets != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(off != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(ind != nullptr, "Invalid API parameter");
+  CUGRAPH_EXPECTS(x_cols != nullptr, "Invalid API parameter");
   switch (off->dtype) {
     case GDF_INT32:
       return gdf_snmg_degree_impl<int32_t>(x, part_offsets, off, ind, x_cols);

--- a/cpp/src/snmg/link_analysis/pagerank.cu
+++ b/cpp/src/snmg/link_analysis/pagerank.cu
@@ -277,33 +277,33 @@ gdf_error gdf_snmg_pagerank (
             const float damping_factor = 0.85, 
             const int n_iter = 10) {
     // null pointers check
-    GDF_REQUIRE(src_col_ptrs != nullptr, GDF_INVALID_API_CALL);
-    GDF_REQUIRE(dest_col_ptrs != nullptr, GDF_INVALID_API_CALL);
-    GDF_REQUIRE(pr_col != nullptr, GDF_INVALID_API_CALL);
+    CUGRAPH_EXPECTS(src_col_ptrs != nullptr, "Invalid API parameter");
+    CUGRAPH_EXPECTS(dest_col_ptrs != nullptr, "Invalid API parameter");
+    CUGRAPH_EXPECTS(pr_col != nullptr, "Invalid API parameter");
 
     // parameter values
-    GDF_REQUIRE(damping_factor > 0.0, GDF_INVALID_API_CALL);
-    GDF_REQUIRE(damping_factor < 1.0, GDF_INVALID_API_CALL);
-    GDF_REQUIRE(n_iter > 0, GDF_INVALID_API_CALL);
+    CUGRAPH_EXPECTS(damping_factor > 0.0, "Invalid API parameter");
+    CUGRAPH_EXPECTS(damping_factor < 1.0, "Invalid API parameter");
+    CUGRAPH_EXPECTS(n_iter > 0, "Invalid API parameter");
     // number of GPU
     int dev_count;
     cudaGetDeviceCount(&dev_count);
     cudaCheckError();
-    GDF_REQUIRE(n_gpus > 0, GDF_INVALID_API_CALL);
-    GDF_REQUIRE(n_gpus < static_cast<size_t>(dev_count+1), GDF_INVALID_API_CALL); 
+    CUGRAPH_EXPECTS(n_gpus > 0, "Invalid API parameter");
+    CUGRAPH_EXPECTS(n_gpus < static_cast<size_t>(dev_count+1), "Invalid API parameter"); 
 
     // for each GPU
     for (size_t i = 0; i < n_gpus; ++i)
     {
       // src/dest consistency
-      GDF_REQUIRE( src_col_ptrs[i]->size == dest_col_ptrs[i]->size, GDF_COLUMN_SIZE_MISMATCH );
-      GDF_REQUIRE( src_col_ptrs[i]->dtype == dest_col_ptrs[i]->dtype, GDF_UNSUPPORTED_DTYPE );
+      CUGRAPH_EXPECTS( src_col_ptrs[i]->size == dest_col_ptrs[i]->size, "Column size mismatch" );
+      CUGRAPH_EXPECTS( src_col_ptrs[i]->dtype == dest_col_ptrs[i]->dtype, "Unsupported data type" );
       //null mask
-      GDF_REQUIRE( src_col_ptrs[i]->null_count == 0 , GDF_VALIDITY_UNSUPPORTED );
-      GDF_REQUIRE( dest_col_ptrs[i]->null_count == 0 , GDF_VALIDITY_UNSUPPORTED );
+      CUGRAPH_EXPECTS( src_col_ptrs[i]->null_count == 0 , "Input column has non-zero null count");
+      CUGRAPH_EXPECTS( dest_col_ptrs[i]->null_count == 0 , "Input column has non-zero null count");
       // int 32 edge list indices
-      GDF_REQUIRE( src_col_ptrs[i]->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-      GDF_REQUIRE( dest_col_ptrs[i]->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
+      CUGRAPH_EXPECTS( src_col_ptrs[i]->dtype == GDF_INT32, "Unsupported data type");
+      CUGRAPH_EXPECTS( dest_col_ptrs[i]->dtype == GDF_INT32, "Unsupported data type");
     }
 
     gdf_error status =  gdf_snmg_pagerank_impl<int, float>(src_col_ptrs, dest_col_ptrs,

--- a/cpp/src/snmg/link_analysis/pagerank.cu
+++ b/cpp/src/snmg/link_analysis/pagerank.cu
@@ -54,7 +54,7 @@ SNMGpagerank<IndexType,ValueType>::SNMGpagerank(SNMGinfo & env_, size_t* part_of
   v_loc = part_off[id+1]-part_off[id];
   IndexType tmp_e;
   cudaMemcpy(&tmp_e, &off[v_loc], sizeof(IndexType),cudaMemcpyDeviceToHost);
-  cudaCheckError();
+  CUDA_CHECK_LAST();
   e_loc = tmp_e;
   stream = nullptr;
   is_setup = false;
@@ -77,7 +77,7 @@ void SNMGpagerank<IndexType,ValueType>::transition_vals(const IndexType *degree)
   int threads = min(static_cast<IndexType>(e_loc), 256);
   int blocks = min(static_cast<IndexType>(32*env.get_num_sm()), CUDA_MAX_BLOCKS);
   transition_kernel<IndexType, ValueType> <<<blocks, threads>>> (e_loc, ind, degree, val);
-  cudaCheckError();
+  CUDA_CHECK_LAST();
 }
 
 template <typename IndexType, typename ValueType>
@@ -85,7 +85,7 @@ void SNMGpagerank<IndexType,ValueType>::flag_leafs(const IndexType *degree) {
   int threads = min(static_cast<IndexType>(v_glob), 256);
   int blocks = min(static_cast<IndexType>(32*env.get_num_sm()), CUDA_MAX_BLOCKS);
   flag_leafs_kernel<IndexType, ValueType> <<<blocks, threads>>> (v_glob, degree, bookmark);
-  cudaCheckError();
+  CUDA_CHECK_LAST();
 }    
 
 
@@ -190,7 +190,7 @@ gdf_error gdf_snmg_pagerank_impl(
     cugraph::SNMGinfo env;
     auto i = env.get_thread_num();
     auto p = env.get_num_threads();
-    cudaCheckError();
+    CUDA_CHECK_LAST();
 
     // Local CSR columns
     gdf_column *col_csr_off = new gdf_column;
@@ -251,7 +251,7 @@ gdf_error gdf_snmg_pagerank_impl(
       //fill relevant fields
       ALLOC_TRY ((void**)&pr_col->data,   sizeof(val_t) * part_offset[p], nullptr);
       cudaMemcpy(pr_col->data, pagerank[i], sizeof(val_t) * part_offset[p], cudaMemcpyDeviceToDevice);
-      cudaCheckError();
+      CUDA_CHECK_LAST();
       pr_col->size = part_offset[p];
       pr_col->dtype = GDF_FLOAT32;
     }
@@ -288,7 +288,7 @@ gdf_error gdf_snmg_pagerank (
     // number of GPU
     int dev_count;
     cudaGetDeviceCount(&dev_count);
-    cudaCheckError();
+    CUDA_CHECK_LAST();
     CUGRAPH_EXPECTS(n_gpus > 0, "Invalid API parameter");
     CUGRAPH_EXPECTS(n_gpus < static_cast<size_t>(dev_count+1), "Invalid API parameter"); 
 

--- a/cpp/src/snmg/utils.cu
+++ b/cpp/src/snmg/utils.cu
@@ -41,7 +41,7 @@ static bool PeerAccessAlreadyEnabled = false;
   }
   // number of SM, usefull for kernels paramters
   cudaDeviceGetAttribute(&n_sm, cudaDevAttrMultiProcessorCount, i);
-  cudaCheckError();
+  CUDA_CHECK_LAST();
     } 
     SNMGinfo::~SNMGinfo() { }
 
@@ -62,7 +62,7 @@ static bool PeerAccessAlreadyEnabled = false;
         if (i != j) {
           int canAccessPeer = 0;
           cudaDeviceCanAccessPeer(&canAccessPeer, i, j);
-          cudaCheckError();
+          CUDA_CHECK_LAST();
           if (canAccessPeer) {
             cudaDeviceEnablePeerAccess(j, 0);
             cudaError_t status = cudaGetLastError();

--- a/cpp/src/snmg/utils.cuh
+++ b/cpp/src/snmg/utils.cuh
@@ -57,7 +57,7 @@ void allgather (SNMGinfo & env, size_t* offset, val_t* x_loc, val_t ** x_glob) {
   // After this call each peer has a full, updated, copy of x_glob
   for (int j = 0; j < p; ++j) {
     cudaMemcpyPeer(x_glob[j]+offset[i],j, x_loc,i, n_loc*sizeof(val_t));
-    cudaCheckError();
+    CUDA_CHECK_LAST();
   }
   
   //Make sure everyone has finished copying before returning
@@ -84,7 +84,7 @@ gdf_error treeReduce(SNMGinfo& env, size_t length, val_t* x_loc, val_t** x_glob)
     if((i - rank) % (rank * 2) == 0){
       int receiver = i - rank;
       cudaMemcpyPeer(x_glob[receiver], receiver, x_loc, i, length*sizeof(val_t));
-      cudaCheckError();
+      CUDA_CHECK_LAST();
     }
 
     // Sync everything now. This shouldn't be required as cudaMemcpyPeer is supposed to synchronize...
@@ -99,7 +99,7 @@ gdf_error treeReduce(SNMGinfo& env, size_t length, val_t* x_loc, val_t** x_glob)
                         x_loc,
                         x_loc,
                         op);
-      cudaCheckError();
+      CUDA_CHECK_LAST();
     }
     sync_all();
     rank *= 2;
@@ -108,7 +108,7 @@ gdf_error treeReduce(SNMGinfo& env, size_t length, val_t* x_loc, val_t** x_glob)
   // Thread 0 copies it's local result into it's global space
   if (i == 0) {
     cudaMemcpy(x_glob[i], x_loc, sizeof(val_t) * length, cudaMemcpyDefault);
-    cudaCheckError();
+    CUDA_CHECK_LAST();
   }
 
   // Sync everything before returning
@@ -136,7 +136,7 @@ gdf_error treeBroadcast(SNMGinfo& env, size_t length, val_t* x_loc, val_t** x_gl
     if(i % (rank * 2) == 0 and i + rank < p){
       int receiver = i + rank;
       cudaMemcpyPeer(x_glob[receiver], receiver, x_glob[i], i, sizeof(val_t) * length);
-      cudaCheckError();
+      CUDA_CHECK_LAST();
     }
     sync_all();
   }

--- a/cpp/src/sort/sort_impl.cuh
+++ b/cpp/src/sort/sort_impl.cuh
@@ -392,7 +392,7 @@ namespace cusort {
 
       tData[cpu_tid].h_output_length = h_writePositionsTransposed[cpu_tid][num_gpus];
       cudaDeviceSynchronize();
-      cudaCheckError();
+      CUDA_CHECK_LAST();
 
 #pragma omp barrier
 
@@ -418,14 +418,14 @@ namespace cusort {
            num_gpus);
       }
 
-      cudaCheckError();
+      CUDA_CHECK_LAST();
 
       ALLOC_TRY(&(tData[cpu_tid].d_output_keys), tData[cpu_tid].h_output_length * sizeof(Key_t), nullptr);
 
       if (!keys_only)
         ALLOC_TRY(&(tData[cpu_tid].d_output_values), tData[cpu_tid].h_output_length * sizeof(Value_t), nullptr);
 
-      cudaCheckError();
+      CUDA_CHECK_LAST();
 
       //
       //  Need all partition labeling to complete before we start copying data
@@ -469,7 +469,7 @@ namespace cusort {
                                                        tData[cpu_tid].h_output_length);
       }
 
-      cudaCheckError();
+      CUDA_CHECK_LAST();
       cudaDeviceSynchronize();
 
       CUDA_TRY(cudaMemcpy(tData[cpu_tid].d_output_keys, tData[cpu_tid].bdReorder.d_keys, tData[cpu_tid].h_output_length * sizeof(Key_t), cudaMemcpyDeviceToDevice));

--- a/cpp/src/structure/cugraph.cu
+++ b/cpp/src/structure/cugraph.cu
@@ -76,13 +76,13 @@ gdf_error gdf_adj_list_view(gdf_graph *graph, const gdf_column *offsets,
                             const gdf_column *edge_data) {
   //This function returns an error if this graph object has at least one graph
   //representation to prevent a single object storing two different graphs.
-  GDF_REQUIRE( ((graph->edgeList == nullptr) && (graph->adjList == nullptr) &&
-    (graph->transposedAdjList == nullptr)), GDF_INVALID_API_CALL);
-  GDF_REQUIRE( offsets->null_count == 0 , GDF_VALIDITY_UNSUPPORTED );
-  GDF_REQUIRE( indices->null_count == 0 , GDF_VALIDITY_UNSUPPORTED );
-  GDF_REQUIRE( (offsets->dtype == indices->dtype), GDF_UNSUPPORTED_DTYPE );
-  GDF_REQUIRE( ((offsets->dtype == GDF_INT32)), GDF_UNSUPPORTED_DTYPE );
-  GDF_REQUIRE( (offsets->size > 0), GDF_DATASET_EMPTY );
+  CUGRAPH_EXPECTS( ((graph->edgeList == nullptr) && (graph->adjList == nullptr) &&
+    (graph->transposedAdjList == nullptr)), "Invalid API parameter");
+  CUGRAPH_EXPECTS( offsets->null_count == 0 , "Input column has non-zero null count");
+  CUGRAPH_EXPECTS( indices->null_count == 0 , "Input column has non-zero null count");
+  CUGRAPH_EXPECTS( (offsets->dtype == indices->dtype), "Unsupported data type" );
+  CUGRAPH_EXPECTS( ((offsets->dtype == GDF_INT32)), "Unsupported data type" );
+  CUGRAPH_EXPECTS( (offsets->size > 0), "Column is empty");
 
 
   graph->adjList = new gdf_adj_list;
@@ -97,7 +97,7 @@ gdf_error gdf_adj_list_view(gdf_graph *graph, const gdf_column *offsets,
       graph->prop = new gdf_graph_properties();
 
   if (edge_data) {
-    GDF_REQUIRE(indices->size == edge_data->size, GDF_COLUMN_SIZE_MISMATCH);
+    CUGRAPH_EXPECTS(indices->size == edge_data->size, "Column size mismatch");
     graph->adjList->edge_data = new gdf_column;
     cpy_column_view(edge_data, graph->adjList->edge_data);
     
@@ -149,18 +149,18 @@ gdf_error gdf_adj_list_view(gdf_graph *graph, const gdf_column *offsets,
 }
 
 gdf_error gdf_adj_list::get_vertex_identifiers(gdf_column *identifiers) {
-  GDF_REQUIRE( offsets != nullptr , GDF_INVALID_API_CALL);
-  GDF_REQUIRE( offsets->data != nullptr , GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS( offsets != nullptr , "Invalid API parameter");
+  CUGRAPH_EXPECTS( offsets->data != nullptr , "Invalid API parameter");
   cugraph::sequence<int>((int)offsets->size-1, (int*)identifiers->data);
   return GDF_SUCCESS;
 }
 
 gdf_error gdf_adj_list::get_source_indices (gdf_column *src_indices) {
-  GDF_REQUIRE( offsets != nullptr , GDF_INVALID_API_CALL);
-  GDF_REQUIRE( offsets->data != nullptr , GDF_INVALID_API_CALL);
-  GDF_REQUIRE( src_indices->size == indices->size, GDF_COLUMN_SIZE_MISMATCH );
-  GDF_REQUIRE( src_indices->dtype == indices->dtype, GDF_UNSUPPORTED_DTYPE );
-  GDF_REQUIRE( src_indices->size > 0, GDF_DATASET_EMPTY );
+  CUGRAPH_EXPECTS( offsets != nullptr , "Invalid API parameter");
+  CUGRAPH_EXPECTS( offsets->data != nullptr , "Invalid API parameter");
+  CUGRAPH_EXPECTS( src_indices->size == indices->size, "Column size mismatch" );
+  CUGRAPH_EXPECTS( src_indices->dtype == indices->dtype, "Unsupported data type" );
+  CUGRAPH_EXPECTS( src_indices->size > 0, "Column is empty");
   cugraph::offsets_to_indices<int>((int*)offsets->data, offsets->size-1, (int*)src_indices->data);
 
   return GDF_SUCCESS;
@@ -171,14 +171,14 @@ gdf_error gdf_edge_list_view(gdf_graph *graph, const gdf_column *src_indices,
                              const gdf_column *edge_data) {
   //This function returns an error if this graph object has at least one graph
   //representation to prevent a single object storing two different graphs.
-  GDF_REQUIRE( ((graph->edgeList == nullptr) && (graph->adjList == nullptr) &&
-    (graph->transposedAdjList == nullptr)), GDF_INVALID_API_CALL);
-  GDF_REQUIRE( src_indices->size == dest_indices->size, GDF_COLUMN_SIZE_MISMATCH );
-  GDF_REQUIRE( src_indices->dtype == dest_indices->dtype, GDF_UNSUPPORTED_DTYPE );
-  GDF_REQUIRE( ((src_indices->dtype == GDF_INT32)), GDF_UNSUPPORTED_DTYPE );
-  GDF_REQUIRE( src_indices->size > 0, GDF_DATASET_EMPTY );
-  GDF_REQUIRE( src_indices->null_count == 0 , GDF_VALIDITY_UNSUPPORTED );
-  GDF_REQUIRE( dest_indices->null_count == 0 , GDF_VALIDITY_UNSUPPORTED );
+  CUGRAPH_EXPECTS( ((graph->edgeList == nullptr) && (graph->adjList == nullptr) &&
+    (graph->transposedAdjList == nullptr)), "Invalid API parameter");
+  CUGRAPH_EXPECTS( src_indices->size == dest_indices->size, "Column size mismatch" );
+  CUGRAPH_EXPECTS( src_indices->dtype == dest_indices->dtype, "Unsupported data type" );
+  CUGRAPH_EXPECTS( ((src_indices->dtype == GDF_INT32)), "Unsupported data type" );
+  CUGRAPH_EXPECTS( src_indices->size > 0, "Column is empty");
+  CUGRAPH_EXPECTS( src_indices->null_count == 0 , "Input column has non-zero null count");
+  CUGRAPH_EXPECTS( dest_indices->null_count == 0 , "Input column has non-zero null count");
 
   graph->edgeList = new gdf_edge_list;
   graph->edgeList->src_indices = new gdf_column;
@@ -192,7 +192,7 @@ gdf_error gdf_edge_list_view(gdf_graph *graph, const gdf_column *src_indices,
     graph->prop = new gdf_graph_properties();
 
   if (edge_data) {
-    GDF_REQUIRE(src_indices->size == edge_data->size, GDF_COLUMN_SIZE_MISMATCH);
+    CUGRAPH_EXPECTS(src_indices->size == edge_data->size, "Column size mismatch");
     graph->edgeList->edge_data = new gdf_column;
     cpy_column_view(edge_data, graph->edgeList->edge_data);
 
@@ -252,7 +252,7 @@ gdf_error gdf_edge_list_view(gdf_graph *graph, const gdf_column *src_indices,
 template <typename T, typename WT>
 gdf_error gdf_add_adj_list_impl (gdf_graph *graph) {
     if (graph->adjList == nullptr) {
-      GDF_REQUIRE( graph->edgeList != nullptr , GDF_INVALID_API_CALL);
+      CUGRAPH_EXPECTS( graph->edgeList != nullptr , "Invalid API parameter");
       int nnz = graph->edgeList->src_indices->size, status = 0;
       graph->adjList = new gdf_adj_list;
       graph->adjList->offsets = new gdf_column;
@@ -292,7 +292,7 @@ gdf_error gdf_add_adj_list_impl (gdf_graph *graph) {
 
 gdf_error gdf_add_edge_list (gdf_graph *graph) {
     if (graph->edgeList == nullptr) {
-      GDF_REQUIRE( graph->adjList != nullptr , GDF_INVALID_API_CALL);
+      CUGRAPH_EXPECTS( graph->adjList != nullptr , "Invalid API parameter");
       int *d_src;
       graph->edgeList = new gdf_edge_list;
       graph->edgeList->src_indices = new gdf_column;
@@ -322,7 +322,7 @@ gdf_error gdf_add_edge_list (gdf_graph *graph) {
 template <typename WT>
 gdf_error gdf_add_transposed_adj_list_impl (gdf_graph *graph) {
     if (graph->transposedAdjList == nullptr ) {
-      GDF_REQUIRE( graph->edgeList != nullptr , GDF_INVALID_API_CALL);
+      CUGRAPH_EXPECTS( graph->edgeList != nullptr , "Invalid API parameter");
       int nnz = graph->edgeList->src_indices->size, status = 0;
       graph->transposedAdjList = new gdf_adj_list;
       graph->transposedAdjList->offsets = new gdf_column;
@@ -363,8 +363,8 @@ gdf_error gdf_add_adj_list(gdf_graph *graph) {
   if (graph->adjList != nullptr)
     return GDF_SUCCESS;
 
-  GDF_REQUIRE( graph->edgeList != nullptr , GDF_INVALID_API_CALL);
-  GDF_REQUIRE( graph->edgeList->src_indices->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE );
+  CUGRAPH_EXPECTS( graph->edgeList != nullptr , "Invalid API parameter");
+  CUGRAPH_EXPECTS( graph->edgeList->src_indices->dtype == GDF_INT32, "Unsupported data type" );
 
   if (graph->edgeList->edge_data != nullptr) {
     switch (graph->edgeList->edge_data->dtype) {
@@ -382,8 +382,8 @@ gdf_error gdf_add_transposed_adj_list(gdf_graph *graph) {
   if (graph->edgeList == nullptr)
     gdf_add_edge_list(graph);
 
-  GDF_REQUIRE(graph->edgeList->src_indices->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(graph->edgeList->dest_indices->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
+  CUGRAPH_EXPECTS(graph->edgeList->src_indices->dtype == GDF_INT32, "Unsupported data type");
+  CUGRAPH_EXPECTS(graph->edgeList->dest_indices->dtype == GDF_INT32, "Unsupported data type");
 
   if (graph->edgeList->edge_data != nullptr) {
     switch (graph->edgeList->edge_data->dtype) {
@@ -429,8 +429,8 @@ gdf_error gdf_number_of_vertices(gdf_graph *graph) {
   //  int32_t implementation for now, since that's all that
   //  is supported elsewhere.
   //
-  GDF_REQUIRE( (graph->edgeList != nullptr), GDF_INVALID_API_CALL);
-  GDF_REQUIRE( (graph->edgeList->src_indices->dtype == GDF_INT32), GDF_UNSUPPORTED_DTYPE );
+  CUGRAPH_EXPECTS( (graph->edgeList != nullptr), "Invalid API parameter");
+  CUGRAPH_EXPECTS( (graph->edgeList->src_indices->dtype == GDF_INT32), "Unsupported data type" );
 
   int32_t  h_max[2];
   int32_t *d_max;

--- a/cpp/src/tests/centrality/katz_centrality_test.cu
+++ b/cpp/src/tests/centrality/katz_centrality_test.cu
@@ -126,10 +126,10 @@ class Tests_Katz : public ::testing::TestWithParam<Katz_Usecase> {
 
 // --gtest_filter=*simple_test*
 INSTANTIATE_TEST_CASE_P(simple_test, Tests_Katz,
-                        ::testing::Values(  Katz_Usecase("test/datasets/karate.mtx",      "test/ref/katz/karate.csv"    )
-                                           ,Katz_Usecase("test/datasets/netscience.mtx",  "test/ref/katz/netscience.csv")
-                                           ,Katz_Usecase("test/datasets/polbooks.mtx",    "test/ref/katz/polbooks.csv"  )
-                                           ,Katz_Usecase("test/datasets/dolphins.mtx",    "test/ref/katz/dolphins.csv"  )
+                        ::testing::Values(  Katz_Usecase("test/datasets/karate.mtx",      "ref/katz/karate.csv"    )
+                                           ,Katz_Usecase("test/datasets/netscience.mtx",  "ref/katz/netscience.csv")
+                                           ,Katz_Usecase("test/datasets/polbooks.mtx",    "ref/katz/polbooks.csv"  )
+                                           ,Katz_Usecase("test/datasets/dolphins.mtx",    "ref/katz/dolphins.csv"  )
                                          )
                        );
 

--- a/cpp/src/tests/centrality/katz_centrality_test.cu
+++ b/cpp/src/tests/centrality/katz_centrality_test.cu
@@ -83,7 +83,6 @@ class Tests_Katz : public ::testing::TestWithParam<Katz_Usecase> {
   void run_current_test(const Katz_Usecase& param) {
        gdf_graph_ptr G{new gdf_graph, gdf_graph_deleter};
        gdf_column_ptr col_src, col_dest, col_katz_centrality;
-       gdf_error status;
 
        FILE* fpin = fopen(param.matrix_file.c_str(),"r");
        ASSERT_NE(fpin, nullptr) << "fopen (" << param.matrix_file << ") failure.";
@@ -116,7 +115,6 @@ class Tests_Katz : public ::testing::TestWithParam<Katz_Usecase> {
       double alpha = 1/(static_cast<double>(max_out_degree) + 1);
 
       CUGRAPH_TRY(gdf_katz_centrality(G.get(), col_katz_centrality.get(), alpha, 100, 1e-6, false, true));
-      EXPECT_EQ(status,0);
 
       std::vector<int> top10CUGraph = getTopKIds(std::move(col_katz_centrality));
       std::vector<int> top10Golden  = getGoldenTopKIds(param.result_file);
@@ -128,10 +126,10 @@ class Tests_Katz : public ::testing::TestWithParam<Katz_Usecase> {
 
 // --gtest_filter=*simple_test*
 INSTANTIATE_TEST_CASE_P(simple_test, Tests_Katz,
-                        ::testing::Values(  Katz_Usecase("test/datasets/karate.mtx",      "ref/katz/karate.csv"    )
-                                           ,Katz_Usecase("test/datasets/netscience.mtx",  "ref/katz/netscience.csv")
-                                           ,Katz_Usecase("test/datasets/polbooks.mtx",    "ref/katz/polbooks.csv"  )
-                                           ,Katz_Usecase("test/datasets/dolphins.mtx",    "ref/katz/dolphins.csv"  )
+                        ::testing::Values(  Katz_Usecase("test/datasets/karate.mtx",      "test/ref/katz/karate.csv"    )
+                                           ,Katz_Usecase("test/datasets/netscience.mtx",  "test/ref/katz/netscience.csv")
+                                           ,Katz_Usecase("test/datasets/polbooks.mtx",    "test/ref/katz/polbooks.csv"  )
+                                           ,Katz_Usecase("test/datasets/dolphins.mtx",    "test/ref/katz/dolphins.csv"  )
                                          )
                        );
 

--- a/cpp/src/tests/centrality/katz_centrality_test.cu
+++ b/cpp/src/tests/centrality/katz_centrality_test.cu
@@ -111,11 +111,11 @@ class Tests_Katz : public ::testing::TestWithParam<Katz_Usecase> {
       col_dest = create_gdf_column(cooColInd);
       col_katz_centrality = create_gdf_column(katz_centrality);
 
-      ASSERT_EQ(gdf_edge_list_view(G.get(), col_src.get(), col_dest.get(), nullptr),0);
+      CUGRAPH_TRY(gdf_edge_list_view(G.get(), col_src.get(), col_dest.get(), nullptr));
       int max_out_degree = getMaxDegree(G.get());
       double alpha = 1/(static_cast<double>(max_out_degree) + 1);
 
-      status = gdf_katz_centrality(G.get(), col_katz_centrality.get(), alpha, 100, 1e-6, false, true);
+      CUGRAPH_TRY(gdf_katz_centrality(G.get(), col_katz_centrality.get(), alpha, 100, 1e-6, false, true));
       EXPECT_EQ(status,0);
 
       std::vector<int> top10CUGraph = getTopKIds(std::move(col_katz_centrality));

--- a/cpp/src/tests/gdf_graph/gdf_graph.cu
+++ b/cpp/src/tests/gdf_graph/gdf_graph.cu
@@ -114,7 +114,7 @@ TEST(gdf_edge_list, size_mismatch)
   col_dest = create_gdf_column(dest_h);
   col_weights = create_gdf_column(w_h);
 
-  ASSERT_EQ(gdf_edge_list_view(G.get(), col_src.get(), col_dest.get(), col_weights.get()),GDF_COLUMN_SIZE_MISMATCH);
+  ASSERT_THROW(gdf_edge_list_view(G.get(), col_src.get(), col_dest.get(), col_weights.get()), std::logic_error);
 }
 
 
@@ -131,7 +131,7 @@ TEST(gdf_edge_list, size_mismatch2)
   col_dest = create_gdf_column(dest_h);
   col_weights = create_gdf_column(w_h);
 
-  ASSERT_EQ(gdf_edge_list_view(G.get(), col_src.get(), col_dest.get(), col_weights.get()),GDF_COLUMN_SIZE_MISMATCH);
+  ASSERT_THROW(gdf_edge_list_view(G.get(), col_src.get(), col_dest.get(), col_weights.get()), std::logic_error);
 
 }
 
@@ -146,7 +146,7 @@ TEST(gdf_edge_list, wrong_type)
   col_src = create_gdf_column(src_h);
   col_dest = create_gdf_column(dest_h);
 
-  ASSERT_EQ(gdf_edge_list_view(G.get(), col_src.get(), col_dest.get(), nullptr),GDF_UNSUPPORTED_DTYPE);
+  ASSERT_THROW(gdf_edge_list_view(G.get(), col_src.get(), col_dest.get(), nullptr), std::logic_error);
 }
 
 TEST(gdf_adj_list, success)

--- a/cpp/src/tests/gdf_graph/gdf_graph.cu
+++ b/cpp/src/tests/gdf_graph/gdf_graph.cu
@@ -43,7 +43,7 @@ TEST(gdf_edge_list, success)
 
   size_t vertices = 0, edges = 0;
   char argv [1024] = "grmat --rmat_scale=20 --rmat_edgefactor=16 --device=0 --normalized --rmat_self_loops --quiet";
-  ASSERT_EQ(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, &col_weights), "cuGraph execution failed");
+  CUGRAPH_TRY(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, &col_weights));
   
   std::vector<int> src_h(edges), dest_h(edges);
   std::vector<float> w_h(edges);
@@ -52,7 +52,7 @@ TEST(gdf_edge_list, success)
   cudaMemcpy(&dest_h[0], col_dest.data, sizeof(int) * edges, cudaMemcpyDeviceToHost);
   cudaMemcpy(&w_h[0], col_weights.data, sizeof(float) * edges, cudaMemcpyDeviceToHost);
 
-  ASSERT_EQ(gdf_edge_list_view(G.get(), &col_src, &col_dest, &col_weights),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_edge_list_view(G.get(), &col_src, &col_dest, &col_weights));
 
   std::vector<int> src2_h(edges), dest2_h(edges);
   std::vector<float> w2_h(edges);
@@ -92,9 +92,9 @@ TEST(gdf_edge_list, success_no_weights)
  
   size_t vertices = 0, edges = 0;
   char argv [1024] = "grmat --rmat_scale=20 --rmat_edgefactor=16 --device=0 --normalized --rmat_self_loops --quiet";
-  ASSERT_EQ(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr), "cuGraph execution failed");
+  CUGRAPH_TRY(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr));
  
-  ASSERT_EQ(gdf_edge_list_view(G.get(), &col_src, &col_dest, nullptr),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_edge_list_view(G.get(), &col_src, &col_dest, nullptr));
 
   ALLOC_FREE_TRY(col_src.data, stream);
   ALLOC_FREE_TRY(col_dest.data, stream);
@@ -172,7 +172,7 @@ TEST(gdf_adj_list, success)
   col_ind = create_gdf_column(ind_h);
   col_w = create_gdf_column(w_h);
 
-  ASSERT_EQ(gdf_adj_list_view(G.get(), col_off.get(), col_ind.get(), col_w.get()),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_adj_list_view(G.get(), col_off.get(), col_ind.get(), col_w.get()));
 
   std::vector<int> off2_h(off_h.size()), ind2_h(ind_h.size());
   std::vector<float> w2_h(w_h.size());
@@ -203,7 +203,7 @@ TEST(gdf_adj_list, success_no_weights)
   col_off = create_gdf_column(off_h);
   col_ind = create_gdf_column(ind_h);
 
-  ASSERT_EQ(gdf_adj_list_view(G.get(), col_off.get(), col_ind.get(), nullptr),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_adj_list_view(G.get(), col_off.get(), col_ind.get(), nullptr));
 
   std::vector<int> off2_h(off_h.size()), ind2_h(ind_h.size());
 
@@ -246,10 +246,10 @@ TEST(gdf_number_of_vertices, success1)
   create_gdf_column(dest_h, &col_dest);
   create_gdf_column(w_h, &col_w);
 
-  ASSERT_EQ(gdf_edge_list_view(&G, &col_src, &col_dest, &col_w),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_edge_list_view(&G, &col_src, &col_dest, &col_w));
   ASSERT_EQ(G.numberOfVertices, 0);
 
-  ASSERT_EQ(gdf_number_of_vertices(&G), "cuGraph execution failed");
+  CUGRAPH_TRY(gdf_number_of_vertices(&G));
 
   ASSERT_EQ(G.numberOfVertices, 6);
 }
@@ -277,12 +277,12 @@ TEST(gdf_delete_adjacency_list, success1)
   create_gdf_column(ind_h, &col_ind);
   create_gdf_column(w_h, &col_w);
 
-  ASSERT_EQ(gdf_adj_list_view(&G, &col_off, &col_ind, &col_w),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_adj_list_view(&G, &col_off, &col_ind, &col_w));
   
   //cudaMemGetInfo(&free2, &total);
   //EXPECT_NE(free,free2);
   
-  ASSERT_EQ(gdf_delete_adj_list(&G),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_delete_adj_list(&G));
 
   //cudaMemGetInfo(&free2, &total);
   //EXPECT_EQ(free,free2);
@@ -311,12 +311,12 @@ TEST(gdf_delete_adjacency_list, success2)
   create_gdf_column(ind_h, col_ind);
   create_gdf_column(w_h, col_w);
 
-  ASSERT_EQ(gdf_adj_list_view(G, col_off, col_ind, col_w),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_adj_list_view(G, col_off, col_ind, col_w));
   
   //cudaMemGetInfo(&free2, &total);
   //EXPECT_NE(free,free2);
   
-  ASSERT_EQ(gdf_delete_adj_list(G),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_delete_adj_list(G));
 
   //cudaMemGetInfo(&free2, &total);
   //EXPECT_EQ(free,free2);
@@ -341,12 +341,12 @@ TEST(gdf_delete_edge_list, success1)
   create_gdf_column(dest_h, &col_dest);
   create_gdf_column(w_h, &col_w);
 
-  ASSERT_EQ(gdf_edge_list_view(&G, &col_src, &col_dest, &col_w),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_edge_list_view(&G, &col_src, &col_dest, &col_w));
   
   //cudaMemGetInfo(&free2, &total);
   //EXPECT_NE(free,free2);
   
-  ASSERT_EQ(gdf_delete_edge_list(&G),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_delete_edge_list(&G));
 
   //cudaMemGetInfo(&free2, &total);
   //EXPECT_EQ(free,free2);
@@ -365,12 +365,12 @@ TEST(gdf_delete_edge_list, success2)
   create_gdf_column(dest_h, col_dest);
   create_gdf_column(w_h, col_w);
 
-  ASSERT_EQ(gdf_edge_list_view(G, col_src, col_dest, col_w),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_edge_list_view(G, col_src, col_dest, col_w));
   
   //cudaMemGetInfo(&free2, &total);
   //EXPECT_NE(free,free2);
   
-  ASSERT_EQ(gdf_delete_edge_list(G),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_delete_edge_list(G));
 
   //cudaMemGetInfo(&free2, &total);
   //EXPECT_EQ(free,free2);
@@ -398,13 +398,13 @@ TEST(gdf_graph, gdf_add_transposed_adj_list)
   //cudaMemGetInfo(&free2, &total);
   //EXPECT_NE(free,free2);
 
-  ASSERT_EQ(gdf_edge_list_view(G, col_src, col_dest, nullptr),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_edge_list_view(G, col_src, col_dest, nullptr));
   
   //cudaMemGetInfo(&free3, &total);
   //EXPECT_EQ(free2,free3);
   //EXPECT_NE(free,free3);
 
-  ASSERT_EQ(gdf_add_transposed_adj_list(G),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_add_transposed_adj_list(G));
 
   //this check doen't work on small case (false positive)
   //cudaMemGetInfo(&free3, &total);
@@ -457,13 +457,13 @@ TEST(gdf_graph, gdf_add_adjList)
   //cudaMemGetInfo(&free2, &total);
   //EXPECT_NE(free,free2);
 
-  ASSERT_EQ(gdf_edge_list_view(G, col_src, col_dest, nullptr),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_edge_list_view(G, col_src, col_dest, nullptr));
   
   //cudaMemGetInfo(&free3, &total);
   //EXPECT_EQ(free2,free3);
   //EXPECT_NE(free,free3);
 
-  ASSERT_EQ(gdf_add_adj_list(G),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_add_adj_list(G));
 
   //this check doen't work on small case (false positive)
   //cudaMemGetInfo(&free3, &total);
@@ -525,9 +525,9 @@ TEST(gdf_graph, gdf_add_edge_list)
   create_gdf_column(ind_h, col_ind);
   create_gdf_column(w_h, col_w);
 
-  ASSERT_EQ(gdf_adj_list_view(G, col_off, col_ind, col_w),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_adj_list_view(G, col_off, col_ind, col_w));
 
-  ASSERT_EQ(gdf_add_edge_list(G),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_add_edge_list(G));
 
   std::vector<int> src_h(ind_h.size()), src2_h(ind_h.size()), dest2_h(ind_h.size());
   std::vector<float> w2_h(w_h.size());
@@ -572,8 +572,8 @@ TEST(gdf_graph, get_vertex_identifiers)
   create_gdf_column(ind_h, col_ind);
   create_gdf_column(idx2_h, col_idx);
 
-  ASSERT_EQ(gdf_adj_list_view(G, col_off, col_ind, nullptr),GDF_SUCCESS);
-  ASSERT_EQ(G->adjList->get_vertex_identifiers(col_idx),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_adj_list_view(G, col_off, col_ind, nullptr));
+  CUGRAPH_TRY(G->adjList->get_vertex_identifiers(col_idx));
 
   cudaMemcpy(&idx2_h[0], col_idx->data, sizeof(int) * col_idx->size, cudaMemcpyDeviceToHost);
   
@@ -607,8 +607,8 @@ TEST(gdf_graph, get_source_indices)
   create_gdf_column(ind_h, col_ind);
   create_gdf_column(src2_h, col_src);
 
-  ASSERT_EQ(gdf_adj_list_view(G, col_off, col_ind, nullptr),GDF_SUCCESS);
-  ASSERT_EQ(G->adjList->get_source_indices(col_src),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_adj_list_view(G, col_off, col_ind, nullptr));
+  CUGRAPH_TRY(G->adjList->get_source_indices(col_src));
   cudaMemcpy(&src2_h[0], col_src->data, sizeof(int) * col_src->size, cudaMemcpyDeviceToHost);
   
   offsets2indices(off_h, src_h);
@@ -646,24 +646,24 @@ TEST(gdf_graph, memory)
   size_t vertices = 0, edges = 0;
   char argv[1024] = "grmat --rmat_scale=23 --rmat_edgefactor=16 --device=0 --normalized --rmat_self_loops --quiet";
 
-  ASSERT_EQ(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr), "cuGraph execution failed");
+  CUGRAPH_TRY(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr));
 
   //cudaMemGetInfo(&free2, &total);
   //EXPECT_NE(free,free2);
 
-  ASSERT_EQ(gdf_edge_list_view(G, &col_src, &col_dest, nullptr),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_edge_list_view(G, &col_src, &col_dest, nullptr));
   
   //cudaMemGetInfo(&free3, &total);
   //EXPECT_EQ(free2,free3);
   //EXPECT_NE(free,free3);
 
-  ASSERT_EQ(gdf_add_transposed_adj_list(G),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_add_transposed_adj_list(G));
   //this check doen't work on small case (false positive)
   //cudaMemGetInfo(&free4_, &total);
   //EXPECT_NE(free4_,free2);
 
-  ASSERT_EQ(gdf_add_adj_list(G),GDF_SUCCESS);
-  ASSERT_EQ(gdf_delete_adj_list(G),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_add_adj_list(G));
+  CUGRAPH_TRY(gdf_delete_adj_list(G));
 
   //cudaMemGetInfo(&free4, &total);
   //EXPECT_EQ(free4,free4_);
@@ -705,7 +705,7 @@ TEST(gdf_graph, gdf_column_overhead)
   // check that gdf_column_overhead < 5 per cent
   //EXPECT_LT(free-free2, 2*sz*sizeof(int)*1.05);
 
-  ASSERT_EQ(gdf_edge_list_view(G, col_src, col_dest, nullptr),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_edge_list_view(G, col_src, col_dest, nullptr));
 
   //cudaMemGetInfo(&free3, &total);
   //EXPECT_EQ(free2,free3);

--- a/cpp/src/tests/gdf_graph/gdf_graph.cu
+++ b/cpp/src/tests/gdf_graph/gdf_graph.cu
@@ -43,7 +43,7 @@ TEST(gdf_edge_list, success)
 
   size_t vertices = 0, edges = 0;
   char argv [1024] = "grmat --rmat_scale=20 --rmat_edgefactor=16 --device=0 --normalized --rmat_self_loops --quiet";
-  ASSERT_EQ(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, &col_weights), GDF_SUCCESS);
+  ASSERT_EQ(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, &col_weights), "cuGraph execution failed");
   
   std::vector<int> src_h(edges), dest_h(edges);
   std::vector<float> w_h(edges);
@@ -92,7 +92,7 @@ TEST(gdf_edge_list, success_no_weights)
  
   size_t vertices = 0, edges = 0;
   char argv [1024] = "grmat --rmat_scale=20 --rmat_edgefactor=16 --device=0 --normalized --rmat_self_loops --quiet";
-  ASSERT_EQ(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr), GDF_SUCCESS);
+  ASSERT_EQ(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr), "cuGraph execution failed");
  
   ASSERT_EQ(gdf_edge_list_view(G.get(), &col_src, &col_dest, nullptr),GDF_SUCCESS);
 
@@ -249,7 +249,7 @@ TEST(gdf_number_of_vertices, success1)
   ASSERT_EQ(gdf_edge_list_view(&G, &col_src, &col_dest, &col_w),GDF_SUCCESS);
   ASSERT_EQ(G.numberOfVertices, 0);
 
-  ASSERT_EQ(gdf_number_of_vertices(&G), GDF_SUCCESS);
+  ASSERT_EQ(gdf_number_of_vertices(&G), "cuGraph execution failed");
 
   ASSERT_EQ(G.numberOfVertices, 6);
 }
@@ -646,7 +646,7 @@ TEST(gdf_graph, memory)
   size_t vertices = 0, edges = 0;
   char argv[1024] = "grmat --rmat_scale=23 --rmat_edgefactor=16 --device=0 --normalized --rmat_self_loops --quiet";
 
-  ASSERT_EQ(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr), GDF_SUCCESS);
+  ASSERT_EQ(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr), "cuGraph execution failed");
 
   //cudaMemGetInfo(&free2, &total);
   //EXPECT_NE(free,free2);

--- a/cpp/src/tests/grmat/grmat_test.cu
+++ b/cpp/src/tests/grmat/grmat_test.cu
@@ -141,7 +141,7 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
      size_t free_before, total_before;
      cudaMemGetInfo (&free_before, &total_before);
 
-     ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices1, edges1, &col_sources, &col_destinations, nullptr), GDF_SUCCESS);
+     ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices1, edges1, &col_sources, &col_destinations, nullptr), "cuGraph execution failed");
      
      size_t free_after, total_after;
      cudaMemGetInfo (&free_after, &total_after);
@@ -215,7 +215,7 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
 
     size_t vertices = 0, edges = 0;
 
-    ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices, edges, &col_sources, &col_destinations, nullptr), GDF_SUCCESS);
+    ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices, edges, &col_sources, &col_destinations, nullptr), "cuGraph execution failed");
 
     ASSERT_EQ((vertices < (1 << 30)), 1);
     cudaStream_t stream{nullptr};
@@ -244,7 +244,7 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
 
     size_t vertices = 0, edges = 0;
 
-    ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices, edges, &col_sources, &col_destinations, nullptr), GDF_SUCCESS);
+    ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices, edges, &col_sources, &col_destinations, nullptr), "cuGraph execution failed");
     std::vector<int> src1_h(edges), dest1_h(edges);
 
     (cudaMemcpy(&src1_h[0], col_sources.data, sizeof(int) * edges, cudaMemcpyDeviceToHost));
@@ -255,7 +255,7 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
     col_sources.null_count = 0;
     col_destinations.null_count = 0;
 
-    ASSERT_EQ(gdf_edge_list_view(G.get(), &col_sources, &col_destinations, nullptr), GDF_SUCCESS);
+    ASSERT_EQ(gdf_edge_list_view(G.get(), &col_sources, &col_destinations, nullptr), "cuGraph execution failed");
     std::vector<int> src2_h(edges), dest2_h(edges);
 
     (cudaMemcpy(&src2_h[0],  G.get()->edgeList->src_indices->data, sizeof(int) * edges, cudaMemcpyDeviceToHost));
@@ -292,7 +292,7 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
 
     size_t vertices1 = 0, edges1 = 0;
 
-    ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices1, edges1, &col_sources, &col_destinations, nullptr), GDF_SUCCESS);
+    ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices1, edges1, &col_sources, &col_destinations, nullptr), "cuGraph execution failed");
     std::vector<T1> src1_h(edges1), dest1_h(edges1);
 
     cudaMemcpy(&src1_h[0], col_sources.data, sizeof(T1) * edges1, cudaMemcpyDeviceToHost);
@@ -317,7 +317,7 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
  
     size_t vertices2 = 0, edges2 = 0;
 
-    ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices2, edges2, &col_sources, &col_destinations, nullptr), GDF_SUCCESS);
+    ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices2, edges2, &col_sources, &col_destinations, nullptr), "cuGraph execution failed");
 
     std::vector<T2> src2_h(edges2), dest2_h(edges2);
 
@@ -365,7 +365,7 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
 
     size_t vertices = 0, edges = 0;
 
-    ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices, edges, &col_sources, &col_destinations, nullptr), GDF_SUCCESS);
+    ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices, edges, &col_sources, &col_destinations, nullptr), "cuGraph execution failed");
 
     gdf_dtype_extra_info extra_info;
     extra_info.time_unit = TIME_UNIT_NONE;

--- a/cpp/src/tests/grmat/grmat_test.cu
+++ b/cpp/src/tests/grmat/grmat_test.cu
@@ -141,7 +141,7 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
      size_t free_before, total_before;
      cudaMemGetInfo (&free_before, &total_before);
 
-     ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices1, edges1, &col_sources, &col_destinations, nullptr), "cuGraph execution failed");
+     CUGRAPH_TRY(gdf_grmat_gen ((char *)param.argv.c_str(), vertices1, edges1, &col_sources, &col_destinations, nullptr));
      
      size_t free_after, total_after;
      cudaMemGetInfo (&free_after, &total_after);
@@ -215,7 +215,7 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
 
     size_t vertices = 0, edges = 0;
 
-    ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices, edges, &col_sources, &col_destinations, nullptr), "cuGraph execution failed");
+    CUGRAPH_TRY(gdf_grmat_gen ((char *)param.argv.c_str(), vertices, edges, &col_sources, &col_destinations, nullptr));
 
     ASSERT_EQ((vertices < (1 << 30)), 1);
     cudaStream_t stream{nullptr};
@@ -244,7 +244,7 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
 
     size_t vertices = 0, edges = 0;
 
-    ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices, edges, &col_sources, &col_destinations, nullptr), "cuGraph execution failed");
+    CUGRAPH_TRY(gdf_grmat_gen ((char *)param.argv.c_str(), vertices, edges, &col_sources, &col_destinations, nullptr));
     std::vector<int> src1_h(edges), dest1_h(edges);
 
     (cudaMemcpy(&src1_h[0], col_sources.data, sizeof(int) * edges, cudaMemcpyDeviceToHost));
@@ -255,7 +255,7 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
     col_sources.null_count = 0;
     col_destinations.null_count = 0;
 
-    ASSERT_EQ(gdf_edge_list_view(G.get(), &col_sources, &col_destinations, nullptr), "cuGraph execution failed");
+    CUGRAPH_TRY(gdf_edge_list_view(G.get(), &col_sources, &col_destinations, nullptr));
     std::vector<int> src2_h(edges), dest2_h(edges);
 
     (cudaMemcpy(&src2_h[0],  G.get()->edgeList->src_indices->data, sizeof(int) * edges, cudaMemcpyDeviceToHost));
@@ -292,7 +292,7 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
 
     size_t vertices1 = 0, edges1 = 0;
 
-    ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices1, edges1, &col_sources, &col_destinations, nullptr), "cuGraph execution failed");
+    CUGRAPH_TRY(gdf_grmat_gen ((char *)param.argv.c_str(), vertices1, edges1, &col_sources, &col_destinations, nullptr));
     std::vector<T1> src1_h(edges1), dest1_h(edges1);
 
     cudaMemcpy(&src1_h[0], col_sources.data, sizeof(T1) * edges1, cudaMemcpyDeviceToHost);
@@ -317,7 +317,7 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
  
     size_t vertices2 = 0, edges2 = 0;
 
-    ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices2, edges2, &col_sources, &col_destinations, nullptr), "cuGraph execution failed");
+    CUGRAPH_TRY(gdf_grmat_gen ((char *)param.argv.c_str(), vertices2, edges2, &col_sources, &col_destinations, nullptr));
 
     std::vector<T2> src2_h(edges2), dest2_h(edges2);
 
@@ -365,7 +365,7 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
 
     size_t vertices = 0, edges = 0;
 
-    ASSERT_EQ(gdf_grmat_gen ((char *)param.argv.c_str(), vertices, edges, &col_sources, &col_destinations, nullptr), "cuGraph execution failed");
+    CUGRAPH_TRY(gdf_grmat_gen ((char *)param.argv.c_str(), vertices, edges, &col_sources, &col_destinations, nullptr));
 
     gdf_dtype_extra_info extra_info;
     extra_info.time_unit = TIME_UNIT_NONE;
@@ -378,9 +378,9 @@ class Tests_Grmat : public ::testing::TestWithParam<Grmat_Usecase> {
     std::vector<T> grmat(vertices);
     col_grmat = create_gdf_column(grmat);
 
-    ASSERT_EQ(gdf_edge_list_view(G.get(), &col_sources, &col_destinations, nullptr),0);
+    CUGRAPH_TRY(gdf_edge_list_view(G.get(), &col_sources, &col_destinations, nullptr));
     if (manual_tanspose)
-      ASSERT_EQ(gdf_add_transposed_adj_list(G.get()),0);
+      CUGRAPH_TRY(gdf_add_transposed_adj_list(G.get()));
 
     int device = 0;
     (cudaGetDevice (&device));  

--- a/cpp/src/tests/nvgraph_plugin/nvgraph_gdf_jaccard.cpp
+++ b/cpp/src/tests/nvgraph_plugin/nvgraph_gdf_jaccard.cpp
@@ -89,7 +89,7 @@ TEST(nvgraph_jaccard, success)
   create_gdf_column(off_h, &col_off);
   create_gdf_column(ind_h, &col_ind);
 
-  ASSERT_EQ(gdf_adj_list_view(&G, &col_off, &col_ind, nullptr), "cuGraph execution failed");
+  CUGRAPH_TRY(gdf_adj_list_view(&G, &col_off, &col_ind, nullptr));
 
   int no_vertex = off_h.size()-1;
   size_t edges = ind_h.size();
@@ -145,17 +145,17 @@ TEST(nvgraph_jaccard_grmat, success)
   col_src.null_count = 0;
   col_dest.null_count = 0;
 
-  ASSERT_EQ(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr), "cuGraph execution failed");
+  CUGRAPH_TRY(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr));
   std::vector<int> src_h (col_src.size, 0);
   std::vector<int> dest_h (col_dest.size, 0);
   cudaMemcpy((void*)&src_h[0], (void*)col_src.data, sizeof(float)*edges, cudaMemcpyDeviceToHost);
   cudaMemcpy((void*)&dest_h[0], (void*)col_dest.data, sizeof(float)*edges, cudaMemcpyDeviceToHost);
 
 
-  ASSERT_EQ(gdf_edge_list_view(&G, &col_src, &col_dest, nullptr),GDF_SUCCESS);
+  CUGRAPH_TRY(gdf_edge_list_view(&G, &col_src, &col_dest, nullptr));
 
   if (!G.adjList)
-    ASSERT_EQ(gdf_add_adj_list(&G), "cuGraph execution failed");
+    CUGRAPH_TRY(gdf_add_adj_list(&G));
 
   
   int weighted = 0; //false, it assumes weight of size 1.0 for all the edges

--- a/cpp/src/tests/nvgraph_plugin/nvgraph_gdf_jaccard.cpp
+++ b/cpp/src/tests/nvgraph_plugin/nvgraph_gdf_jaccard.cpp
@@ -89,7 +89,7 @@ TEST(nvgraph_jaccard, success)
   create_gdf_column(off_h, &col_off);
   create_gdf_column(ind_h, &col_ind);
 
-  ASSERT_EQ(gdf_adj_list_view(&G, &col_off, &col_ind, nullptr), GDF_SUCCESS);
+  ASSERT_EQ(gdf_adj_list_view(&G, &col_off, &col_ind, nullptr), "cuGraph execution failed");
 
   int no_vertex = off_h.size()-1;
   size_t edges = ind_h.size();
@@ -145,7 +145,7 @@ TEST(nvgraph_jaccard_grmat, success)
   col_src.null_count = 0;
   col_dest.null_count = 0;
 
-  ASSERT_EQ(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr), GDF_SUCCESS);
+  ASSERT_EQ(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr), "cuGraph execution failed");
   std::vector<int> src_h (col_src.size, 0);
   std::vector<int> dest_h (col_dest.size, 0);
   cudaMemcpy((void*)&src_h[0], (void*)col_src.data, sizeof(float)*edges, cudaMemcpyDeviceToHost);
@@ -155,7 +155,7 @@ TEST(nvgraph_jaccard_grmat, success)
   ASSERT_EQ(gdf_edge_list_view(&G, &col_src, &col_dest, nullptr),GDF_SUCCESS);
 
   if (!G.adjList)
-    ASSERT_EQ(gdf_add_adj_list(&G), GDF_SUCCESS);
+    ASSERT_EQ(gdf_add_adj_list(&G), "cuGraph execution failed");
 
   
   int weighted = 0; //false, it assumes weight of size 1.0 for all the edges

--- a/cpp/src/tests/nvgraph_plugin/nvgraph_gdf_louvain.cpp
+++ b/cpp/src/tests/nvgraph_plugin/nvgraph_gdf_louvain.cpp
@@ -38,10 +38,10 @@ TEST(nvgraph_louvain, success)
   create_gdf_column(ind_h,&col_ind);
   create_gdf_column(w_h  ,&col_w);
 
-  ASSERT_EQ(gdf_adj_list_view(&G, &col_off, &col_ind, &col_w), GDF_SUCCESS);
+  ASSERT_EQ(gdf_adj_list_view(&G, &col_off, &col_ind, &col_w), "cuGraph execution failed");
 
   if (!(G.adjList))
-    ASSERT_EQ(gdf_add_adj_list(&G), GDF_SUCCESS);
+    ASSERT_EQ(gdf_add_adj_list(&G), "cuGraph execution failed");
 
   int no_vertex = off_h.size()-1;
   int weighted = 0; //false
@@ -95,17 +95,17 @@ TEST(nvgraph_louvain_grmat, success)
   col_dest.null_count = 0;
   col_weights.null_count = 0;
 
-  ASSERT_EQ(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr), GDF_SUCCESS);
+  ASSERT_EQ(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr), "cuGraph execution failed");
   cudaStream_t stream{nullptr};
   ALLOC_TRY ((void**)&col_weights.data, sizeof(int) * edges, stream);
   col_weights.size = edges;
   std::vector<float> w_h (edges, (float)1.0);
   cudaMemcpy (col_weights.data, (void*) &(w_h[0]), sizeof(float)*edges, cudaMemcpyHostToDevice);
-  ASSERT_EQ(gdf_edge_list_view(&G, &col_src, &col_dest, &col_weights), GDF_SUCCESS);
+  ASSERT_EQ(gdf_edge_list_view(&G, &col_src, &col_dest, &col_weights), "cuGraph execution failed");
 
   if (!(G.adjList))
   {
-    ASSERT_EQ(gdf_add_adj_list(&G), GDF_SUCCESS);
+    ASSERT_EQ(gdf_add_adj_list(&G), "cuGraph execution failed");
   }
   int weighted = 1; //false
   int has_init_cluster = 0; //false

--- a/cpp/src/tests/nvgraph_plugin/nvgraph_gdf_louvain.cpp
+++ b/cpp/src/tests/nvgraph_plugin/nvgraph_gdf_louvain.cpp
@@ -38,10 +38,10 @@ TEST(nvgraph_louvain, success)
   create_gdf_column(ind_h,&col_ind);
   create_gdf_column(w_h  ,&col_w);
 
-  ASSERT_EQ(gdf_adj_list_view(&G, &col_off, &col_ind, &col_w), "cuGraph execution failed");
+  CUGRAPH_TRY(gdf_adj_list_view(&G, &col_off, &col_ind, &col_w));
 
   if (!(G.adjList))
-    ASSERT_EQ(gdf_add_adj_list(&G), "cuGraph execution failed");
+    CUGRAPH_TRY(gdf_add_adj_list(&G));
 
   int no_vertex = off_h.size()-1;
   int weighted = 0; //false
@@ -95,17 +95,17 @@ TEST(nvgraph_louvain_grmat, success)
   col_dest.null_count = 0;
   col_weights.null_count = 0;
 
-  ASSERT_EQ(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr), "cuGraph execution failed");
+  CUGRAPH_TRY(gdf_grmat_gen(argv, vertices, edges, &col_src, &col_dest, nullptr));
   cudaStream_t stream{nullptr};
   ALLOC_TRY ((void**)&col_weights.data, sizeof(int) * edges, stream);
   col_weights.size = edges;
   std::vector<float> w_h (edges, (float)1.0);
   cudaMemcpy (col_weights.data, (void*) &(w_h[0]), sizeof(float)*edges, cudaMemcpyHostToDevice);
-  ASSERT_EQ(gdf_edge_list_view(&G, &col_src, &col_dest, &col_weights), "cuGraph execution failed");
+  CUGRAPH_TRY(gdf_edge_list_view(&G, &col_src, &col_dest, &col_weights));
 
   if (!(G.adjList))
   {
-    ASSERT_EQ(gdf_add_adj_list(&G), "cuGraph execution failed");
+    CUGRAPH_TRY(gdf_add_adj_list(&G));
   }
   int weighted = 1; //false
   int has_init_cluster = 0; //false

--- a/cpp/src/tests/pagerank/pagerank_test.cu
+++ b/cpp/src/tests/pagerank/pagerank_test.cu
@@ -113,9 +113,9 @@ class Tests_Pagerank : public ::testing::TestWithParam<Pagerank_Usecase> {
     col_dest = create_gdf_column(cooColInd);
     col_pagerank = create_gdf_column(pagerank);
 
-    ASSERT_EQ(gdf_edge_list_view(G.get(), col_src.get(), col_dest.get(), nullptr),0);
+    CUGRAPH_TRY(gdf_edge_list_view(G.get(), col_src.get(), col_dest.get(), nullptr));
     if (manual_tanspose)
-      ASSERT_EQ(gdf_add_transposed_adj_list(G.get()),0);
+      CUGRAPH_TRY(gdf_add_transposed_adj_list(G.get()));
 
     cudaDeviceSynchronize();
     if (PERF) {

--- a/cpp/src/tests/renumber/renumber_test.cu
+++ b/cpp/src/tests/renumber/renumber_test.cu
@@ -606,7 +606,7 @@ TEST_F(RenumberingTest, Random10MVertexListString)
   EXPECT_EQ(omap->to_host(local_strings, 0, unique_verts), 0);
 
   cudaDeviceSynchronize();
-  cudaCheckError();
+  CUDA_CHECK_LAST();
 
   printf("checking results\n");
 

--- a/cpp/src/tests/renumber/renumber_test.cu
+++ b/cpp/src/tests/renumber/renumber_test.cu
@@ -102,8 +102,8 @@ TEST_F(RenumberingTest, SmallFixedVertexList)
   EXPECT_EQ(cudaMemcpy(dst_d, dst_data, sizeof(uint32_t) * length, cudaMemcpyHostToDevice), cudaSuccess);
 
   size_t unique_verts = 0;
-  //EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint32_t>()), "cuGraph execution failed");
-  EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint32_t>()), "cuGraph execution failed");
+  //CUGRAPH_TRY(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint32_t>()));
+  CUGRAPH_TRY(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint32_t>()));
 
   EXPECT_EQ(cudaMemcpy(tmp_map, number_map_d, sizeof(uint32_t) * unique_verts, cudaMemcpyDeviceToHost), cudaSuccess);
   EXPECT_EQ(cudaMemcpy(tmp_results, src_d, sizeof(uint32_t) * length, cudaMemcpyDeviceToHost), cudaSuccess);
@@ -150,7 +150,7 @@ TEST_F(RenumberingTest, SmallFixedVertexListNegative)
   EXPECT_EQ(cudaMemcpy(dst_d, dst_data, sizeof(int64_t) * length, cudaMemcpyHostToDevice), cudaSuccess);
 
   size_t unique_verts = 0;
-  EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<int64_t>()), "cuGraph execution failed");
+  CUGRAPH_TRY(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<int64_t>()));
 
   EXPECT_EQ(cudaMemcpy(tmp_map, number_map_d, sizeof(int64_t) * unique_verts, cudaMemcpyDeviceToHost), cudaSuccess);
   EXPECT_EQ(cudaMemcpy(tmp_results, src_d, sizeof(int64_t) * length, cudaMemcpyDeviceToHost), cudaSuccess);
@@ -197,8 +197,8 @@ TEST_F(RenumberingTest, SmallFixedVertexList64Bit)
   EXPECT_EQ(cudaMemcpy(dst_d, dst_data, sizeof(uint64_t) * length, cudaMemcpyHostToDevice), cudaSuccess);
 
   size_t unique_verts = 0;
-  //EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint64_t>()), "cuGraph execution failed");
-  EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint64_t>()), "cuGraph execution failed");
+  //CUGRAPH_TRY(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint64_t>()));
+  CUGRAPH_TRY(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint64_t>()));
 
   EXPECT_EQ(cudaMemcpy(tmp_map, number_map_d, sizeof(uint64_t) * unique_verts, cudaMemcpyDeviceToHost), cudaSuccess);
   EXPECT_EQ(cudaMemcpy(tmp_results, src_d, sizeof(uint64_t) * length, cudaMemcpyDeviceToHost), cudaSuccess);
@@ -252,7 +252,7 @@ TEST_F(RenumberingTest, SmallFixedVertexListString)
   srcs->create_index((std::pair<const char *, size_t> *) src_d, true);
   dsts->create_index((std::pair<const char *, size_t> *) dst_d, true);
 
-  EXPECT_EQ(cugraph::renumber_vertices(length,
+  CUGRAPH_TRY(cugraph::renumber_vertices(length,
 				       src_d,
 				       dst_d,
 				       src_output_d,
@@ -260,8 +260,7 @@ TEST_F(RenumberingTest, SmallFixedVertexListString)
 				       &unique_verts,
 				       &output_map,
 				       cugraph::HashFunctionObjectString(7),
-				       cugraph::CompareString()),
-	    GDF_SUCCESS);
+				       cugraph::CompareString()));
 
   //
   //  Bring output_map back as local_strings so we can do comparisons
@@ -340,8 +339,8 @@ TEST_F(RenumberingTest, SmallFixedVertexList64BitTo32Bit)
   EXPECT_EQ(cudaMemcpy(dst_d, dst_data, sizeof(uint64_t) * length, cudaMemcpyHostToDevice), cudaSuccess);
 
   size_t unique_verts = 0;
-  //EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_renumbered_d, dst_renumbered_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint64_t>()), "cuGraph execution failed");
-  EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_renumbered_d, dst_renumbered_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint64_t>()), "cuGraph execution failed");
+  //CUGRAPH_TRY(cugraph::renumber_vertices(length, src_d, dst_d, src_renumbered_d, dst_renumbered_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint64_t>()));
+  CUGRAPH_TRY(cugraph::renumber_vertices(length, src_d, dst_d, src_renumbered_d, dst_renumbered_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint64_t>()));
 
   EXPECT_EQ(cudaMemcpy(tmp_map, number_map_d, sizeof(uint64_t) * unique_verts, cudaMemcpyDeviceToHost), cudaSuccess);
   EXPECT_EQ(cudaMemcpy(tmp_results, src_renumbered_d, sizeof(uint32_t) * length, cudaMemcpyDeviceToHost), cudaSuccess);
@@ -402,8 +401,8 @@ TEST_F(RenumberingTest, Random100KVertexSet)
   size_t unique_verts = 0;
 
   auto start = std::chrono::system_clock::now();
-  //EXPECT_EQ(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint64_t>()), "cuGraph execution failed");
-  EXPECT_EQ(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint64_t>()), "cuGraph execution failed");
+  //CUGRAPH_TRY(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint64_t>()));
+  CUGRAPH_TRY(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint64_t>()));
   auto end = std::chrono::system_clock::now();
   std::chrono::duration<double> elapsed_seconds = end-start;
 
@@ -491,7 +490,7 @@ TEST_F(RenumberingTest, Random10MVertexSet)
   //
   size_t unique_verts = 0;
   auto start = std::chrono::system_clock::now();
-  EXPECT_EQ(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(hash_size), thrust::less<uint64_t>()), "cuGraph execution failed");
+  CUGRAPH_TRY(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(hash_size), thrust::less<uint64_t>()));
   auto end = std::chrono::system_clock::now();
   std::chrono::duration<double> elapsed_seconds = end-start;
 
@@ -564,7 +563,7 @@ TEST_F(RenumberingTest, Random10MVertexListString)
 
   auto start = std::chrono::system_clock::now();
 
-  EXPECT_EQ(cugraph::renumber_vertices(num_verts,
+  CUGRAPH_TRY(cugraph::renumber_vertices(num_verts,
 				       src_pair_d,
 				       dst_pair_d,
 				       src_output_d,
@@ -572,8 +571,7 @@ TEST_F(RenumberingTest, Random10MVertexListString)
 				       &unique_verts,
 				       &output_map,
 				       cugraph::HashFunctionObjectString(hash_size),
-				       cugraph::CompareString()),
-	    GDF_SUCCESS);
+				       cugraph::CompareString()));
 
   auto end = std::chrono::system_clock::now();
   std::chrono::duration<double> elapsed_seconds = end-start;
@@ -690,7 +688,7 @@ TEST_F(RenumberingTest, Random100MVertexSet)
   //
   size_t unique_verts = 0;
   auto start = std::chrono::system_clock::now();
-  EXPECT_EQ(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(hash_size), thrust::less<uint64_t>()), "cuGraph execution failed");
+  CUGRAPH_TRY(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(hash_size), thrust::less<uint64_t>()));
   auto end = std::chrono::system_clock::now();
   std::chrono::duration<double> elapsed_seconds = end-start;
 
@@ -742,7 +740,7 @@ TEST_F(RenumberingTest, Random500MVertexSet)
   //
   size_t unique_verts = 0;
   auto start = std::chrono::system_clock::now();
-  EXPECT_EQ(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(hash_size), thrust::less<uint64_t>()), "cuGraph execution failed");
+  CUGRAPH_TRY(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(hash_size), thrust::less<uint64_t>()));
   auto end = std::chrono::system_clock::now();
   std::chrono::duration<double> elapsed_seconds = end-start;
 

--- a/cpp/src/tests/renumber/renumber_test.cu
+++ b/cpp/src/tests/renumber/renumber_test.cu
@@ -102,8 +102,8 @@ TEST_F(RenumberingTest, SmallFixedVertexList)
   EXPECT_EQ(cudaMemcpy(dst_d, dst_data, sizeof(uint32_t) * length, cudaMemcpyHostToDevice), cudaSuccess);
 
   size_t unique_verts = 0;
-  //EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint32_t>()), GDF_SUCCESS);
-  EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint32_t>()), GDF_SUCCESS);
+  //EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint32_t>()), "cuGraph execution failed");
+  EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint32_t>()), "cuGraph execution failed");
 
   EXPECT_EQ(cudaMemcpy(tmp_map, number_map_d, sizeof(uint32_t) * unique_verts, cudaMemcpyDeviceToHost), cudaSuccess);
   EXPECT_EQ(cudaMemcpy(tmp_results, src_d, sizeof(uint32_t) * length, cudaMemcpyDeviceToHost), cudaSuccess);
@@ -150,7 +150,7 @@ TEST_F(RenumberingTest, SmallFixedVertexListNegative)
   EXPECT_EQ(cudaMemcpy(dst_d, dst_data, sizeof(int64_t) * length, cudaMemcpyHostToDevice), cudaSuccess);
 
   size_t unique_verts = 0;
-  EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<int64_t>()), GDF_SUCCESS);
+  EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<int64_t>()), "cuGraph execution failed");
 
   EXPECT_EQ(cudaMemcpy(tmp_map, number_map_d, sizeof(int64_t) * unique_verts, cudaMemcpyDeviceToHost), cudaSuccess);
   EXPECT_EQ(cudaMemcpy(tmp_results, src_d, sizeof(int64_t) * length, cudaMemcpyDeviceToHost), cudaSuccess);
@@ -197,8 +197,8 @@ TEST_F(RenumberingTest, SmallFixedVertexList64Bit)
   EXPECT_EQ(cudaMemcpy(dst_d, dst_data, sizeof(uint64_t) * length, cudaMemcpyHostToDevice), cudaSuccess);
 
   size_t unique_verts = 0;
-  //EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint64_t>()), GDF_SUCCESS);
-  EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint64_t>()), GDF_SUCCESS);
+  //EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint64_t>()), "cuGraph execution failed");
+  EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint64_t>()), "cuGraph execution failed");
 
   EXPECT_EQ(cudaMemcpy(tmp_map, number_map_d, sizeof(uint64_t) * unique_verts, cudaMemcpyDeviceToHost), cudaSuccess);
   EXPECT_EQ(cudaMemcpy(tmp_results, src_d, sizeof(uint64_t) * length, cudaMemcpyDeviceToHost), cudaSuccess);
@@ -340,8 +340,8 @@ TEST_F(RenumberingTest, SmallFixedVertexList64BitTo32Bit)
   EXPECT_EQ(cudaMemcpy(dst_d, dst_data, sizeof(uint64_t) * length, cudaMemcpyHostToDevice), cudaSuccess);
 
   size_t unique_verts = 0;
-  //EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_renumbered_d, dst_renumbered_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint64_t>()), GDF_SUCCESS);
-  EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_renumbered_d, dst_renumbered_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint64_t>()), GDF_SUCCESS);
+  //EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_renumbered_d, dst_renumbered_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint64_t>()), "cuGraph execution failed");
+  EXPECT_EQ(cugraph::renumber_vertices(length, src_d, dst_d, src_renumbered_d, dst_renumbered_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint64_t>()), "cuGraph execution failed");
 
   EXPECT_EQ(cudaMemcpy(tmp_map, number_map_d, sizeof(uint64_t) * unique_verts, cudaMemcpyDeviceToHost), cudaSuccess);
   EXPECT_EQ(cudaMemcpy(tmp_results, src_renumbered_d, sizeof(uint32_t) * length, cudaMemcpyDeviceToHost), cudaSuccess);
@@ -402,8 +402,8 @@ TEST_F(RenumberingTest, Random100KVertexSet)
   size_t unique_verts = 0;
 
   auto start = std::chrono::system_clock::now();
-  //EXPECT_EQ(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint64_t>()), GDF_SUCCESS);
-  EXPECT_EQ(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint64_t>()), GDF_SUCCESS);
+  //EXPECT_EQ(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(8191), thrust::less<uint64_t>()), "cuGraph execution failed");
+  EXPECT_EQ(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(511), thrust::less<uint64_t>()), "cuGraph execution failed");
   auto end = std::chrono::system_clock::now();
   std::chrono::duration<double> elapsed_seconds = end-start;
 
@@ -491,7 +491,7 @@ TEST_F(RenumberingTest, Random10MVertexSet)
   //
   size_t unique_verts = 0;
   auto start = std::chrono::system_clock::now();
-  EXPECT_EQ(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(hash_size), thrust::less<uint64_t>()), GDF_SUCCESS);
+  EXPECT_EQ(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(hash_size), thrust::less<uint64_t>()), "cuGraph execution failed");
   auto end = std::chrono::system_clock::now();
   std::chrono::duration<double> elapsed_seconds = end-start;
 
@@ -690,7 +690,7 @@ TEST_F(RenumberingTest, Random100MVertexSet)
   //
   size_t unique_verts = 0;
   auto start = std::chrono::system_clock::now();
-  EXPECT_EQ(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(hash_size), thrust::less<uint64_t>()), GDF_SUCCESS);
+  EXPECT_EQ(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(hash_size), thrust::less<uint64_t>()), "cuGraph execution failed");
   auto end = std::chrono::system_clock::now();
   std::chrono::duration<double> elapsed_seconds = end-start;
 
@@ -742,7 +742,7 @@ TEST_F(RenumberingTest, Random500MVertexSet)
   //
   size_t unique_verts = 0;
   auto start = std::chrono::system_clock::now();
-  EXPECT_EQ(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(hash_size), thrust::less<uint64_t>()), GDF_SUCCESS);
+  EXPECT_EQ(cugraph::renumber_vertices(num_verts, src_d, dst_d, src_d, dst_d, &unique_verts, &number_map_d, cugraph::HashFunctionObjectInt(hash_size), thrust::less<uint64_t>()), "cuGraph execution failed");
   auto end = std::chrono::system_clock::now();
   std::chrono::duration<double> elapsed_seconds = end-start;
 

--- a/cpp/src/tests/snmg_pagerank/snmg_pagerank_test.cu
+++ b/cpp/src/tests/snmg_pagerank/snmg_pagerank_test.cu
@@ -127,9 +127,7 @@ class Tests_MGPagerank : public ::testing::TestWithParam<MGPagerank_Usecase> {
     gdf_column *src_col_ptrs[n_gpus];
     gdf_column *dest_col_ptrs[n_gpus];
     gdf_column *pr_col = new gdf_column;
-     
-    gdf_error status = GDF_SUCCESS;
-
+    
     int nthreads = n_gpus;
 
     // Only using the 4 fully connected GPUs on DGX1
@@ -162,11 +160,9 @@ class Tests_MGPagerank : public ::testing::TestWithParam<MGPagerank_Usecase> {
 
     t = omp_get_wtime();
 
-    status = gdf_snmg_pagerank (src_col_ptrs, dest_col_ptrs, pr_col, 
-                       nthreads, alpha, max_iter);
+    CUGRAPH_TRY(gdf_snmg_pagerank (src_col_ptrs, dest_col_ptrs, pr_col, 
+                       nthreads, alpha, max_iter));
     
-    EXPECT_EQ(status, "cuGraph execution failed");
-
     std::cout <<  omp_get_wtime() - t << std::endl;
 
     verify_pr<val_t>(pr_col, param);

--- a/cpp/src/tests/snmg_pagerank/snmg_pagerank_test.cu
+++ b/cpp/src/tests/snmg_pagerank/snmg_pagerank_test.cu
@@ -165,7 +165,7 @@ class Tests_MGPagerank : public ::testing::TestWithParam<MGPagerank_Usecase> {
     status = gdf_snmg_pagerank (src_col_ptrs, dest_col_ptrs, pr_col, 
                        nthreads, alpha, max_iter);
     
-    EXPECT_EQ(status, GDF_SUCCESS);
+    EXPECT_EQ(status, "cuGraph execution failed");
 
     std::cout <<  omp_get_wtime() - t << std::endl;
 

--- a/cpp/src/tests/sort/sort_test.cu
+++ b/cpp/src/tests/sort/sort_test.cu
@@ -191,7 +191,7 @@ void verify_sorted_order(Key_t **d_key, Value_t **d_value,
                         });
 
       cudaDeviceSynchronize();
-      cudaCheckError();
+      CUDA_CHECK_LAST();
 
       int result = thrust::reduce(rmm::exec_policy(stream)->on(stream), diffCounter, diffCounter + length, 0);
 
@@ -253,7 +253,7 @@ void verify_sorted_order(Key_t **d_key, Length_t *h_offsets,
                         });
 
       cudaDeviceSynchronize();
-      cudaCheckError();
+      CUDA_CHECK_LAST();
 
       int result = thrust::reduce(rmm::exec_policy(stream)->on(stream), diffCounter, diffCounter + length, 0);
 

--- a/cpp/src/tests/sssp/sssp_test.cu
+++ b/cpp/src/tests/sssp/sssp_test.cu
@@ -318,7 +318,7 @@ class Tests_SSSP : public ::testing::TestWithParam<SSSP_Usecase> {
       cudaDeviceSynchronize();
     }
 
-    ASSERT_EQ(ret, GDF_SUCCESS);
+    ASSERT_EQ(ret, "cuGraph execution failed");
 
     // MTX may have zero-degree vertices. So reset num_vertices after
     // conversion to CSR

--- a/cpp/src/tests/sssp/sssp_test.cu
+++ b/cpp/src/tests/sssp/sssp_test.cu
@@ -283,8 +283,7 @@ class Tests_SSSP : public ::testing::TestWithParam<SSSP_Usecase> {
     }
 
     gdf_graph G;
-    ASSERT_EQ(gdf_edge_list_view(&G, &col_src, &col_dest, &col_weights),
-              GDF_SUCCESS);
+    CUGRAPH_TRY(gdf_edge_list_view(&G, &col_src, &col_dest, &col_weights));
 
     std::vector<DistType> dist_vec;
     std::vector<MaxVType> pred_vec;
@@ -318,7 +317,7 @@ class Tests_SSSP : public ::testing::TestWithParam<SSSP_Usecase> {
       cudaDeviceSynchronize();
     }
 
-    ASSERT_EQ(ret, "cuGraph execution failed");
+    ASSERT_EQ(ret);
 
     // MTX may have zero-degree vertices. So reset num_vertices after
     // conversion to CSR

--- a/cpp/src/tests/test_utils.h
+++ b/cpp/src/tests/test_utils.h
@@ -48,6 +48,9 @@ extern "C" {
 
 #include "cugraph.h"
 
+#include "utilities/error_utils.h"
+
+
 #ifndef CUDA_RT_CALL
 #define CUDA_RT_CALL( call )                     \
 {                                                                                                  \

--- a/cpp/src/traversal/bfs.cu
+++ b/cpp/src/traversal/bfs.cu
@@ -340,7 +340,7 @@ namespace cugraph {
                           sizeof(IndexType),
                           cudaMemcpyDeviceToHost,
                           stream);
-          cudaCheckError();
+          CUDA_CHECK_LAST();
 
           //We need nf
           cudaStreamSynchronize(stream);
@@ -404,7 +404,7 @@ namespace cugraph {
                             sizeof(IndexType),
                             cudaMemcpyDeviceToHost,
                             stream);
-            cudaCheckError()
+            CUDA_CHECK_LAST()
             //We need last_left_unvisited_size
             cudaStreamSynchronize(stream);
 	    bfs_kernels::bottom_up_large(left_unvisited_queue,
@@ -426,7 +426,7 @@ namespace cugraph {
                           sizeof(IndexType),
                           cudaMemcpyDeviceToHost,
                           stream);
-          cudaCheckError()
+          CUDA_CHECK_LAST()
 
           //We will need nf
           cudaStreamSynchronize(stream);

--- a/cpp/src/traversal/bfs.cu
+++ b/cpp/src/traversal/bfs.cu
@@ -471,14 +471,14 @@ namespace cugraph {
 } // end namespace cugraph
 
 gdf_error gdf_bfs(gdf_graph *graph, gdf_column *distances, gdf_column *predecessors, int start_vertex, bool directed) {
-  GDF_REQUIRE(graph->adjList != nullptr || graph->edgeList != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(graph->adjList != nullptr || graph->edgeList != nullptr, "Invalid API parameter");
   gdf_error err = gdf_add_adj_list(graph);
   if (err != GDF_SUCCESS)
     return err;
-  GDF_REQUIRE(graph->adjList->offsets->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(graph->adjList->indices->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(distances->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(predecessors->dtype == GDF_INT32, GDF_UNSUPPORTED_DTYPE);
+  CUGRAPH_EXPECTS(graph->adjList->offsets->dtype == GDF_INT32, "Unsupported data type");
+  CUGRAPH_EXPECTS(graph->adjList->indices->dtype == GDF_INT32, "Unsupported data type");
+  CUGRAPH_EXPECTS(distances->dtype == GDF_INT32, "Unsupported data type");
+  CUGRAPH_EXPECTS(predecessors->dtype == GDF_INT32, "Unsupported data type");
 
   int n = graph->adjList->offsets->size - 1;
   int e = graph->adjList->indices->size;

--- a/cpp/src/traversal/bfs_kernels.cuh
+++ b/cpp/src/traversal/bfs_kernels.cuh
@@ -163,7 +163,7 @@ namespace bfs_kernels {
                                                               n,
                                                               unvisited,
                                                               unvisited_cnt);
-    cudaCheckError();
+    CUDA_CHECK_LAST();
   }
 
   //
@@ -228,7 +228,7 @@ namespace bfs_kernels {
                                                                visited_bmap,
                                                                node_degree,
                                                                mu);
-    cudaCheckError();
+    CUDA_CHECK_LAST();
   }
 
   //
@@ -528,7 +528,7 @@ namespace bfs_kernels {
                                                        distances,
                                                        predecessors,
                                                        edge_mask);
-    cudaCheckError();
+    CUDA_CHECK_LAST();
   }
 
   //
@@ -645,7 +645,7 @@ namespace bfs_kernels {
                                                                 distances,
                                                                 predecessors,
                                                                 edge_mask);
-    cudaCheckError();
+    CUDA_CHECK_LAST();
   }
 
   //
@@ -1125,7 +1125,7 @@ namespace bfs_kernels {
                                                         edge_mask,
                                                         isolated_bmap,
                                                         directed);
-    cudaCheckError();
+    CUDA_CHECK_LAST();
   }
 
   template<typename IndexType>
@@ -1252,7 +1252,7 @@ namespace bfs_kernels {
                                                                 row_ptr,
                                                                 degrees,
                                                                 nisolated);
-    cudaCheckError();
+    CUDA_CHECK_LAST();
   }
 
 }

--- a/cpp/src/traversal/sssp.cu
+++ b/cpp/src/traversal/sssp.cu
@@ -233,7 +233,7 @@ gdf_error SSSP<IndexType, DistType>::traverse(IndexType source_vertex) {
                     cudaMemcpyDeviceToDevice,
                     stream);
 
-    cudaCheckError();
+    CUDA_CHECK_LAST();
 
     // We need nf for the loop
     cudaStreamSynchronize(stream);
@@ -311,7 +311,7 @@ gdf_error gdf_sssp(gdf_graph* gdf_G,
     // conditions right now
     CUGRAPH_EXPECTS(sssp_distances->dtype == GDF_FLOAT32 ||
                     sssp_distances->dtype == GDF_FLOAT64,
-                GDF_INVALID_API_CALL);
+                "Invalid API parameter");
   }
 
   gdf_error err = gdf_add_adj_list(gdf_G);
@@ -319,19 +319,19 @@ gdf_error gdf_sssp(gdf_graph* gdf_G,
     return err;
 
   CUGRAPH_EXPECTS(gdf_G->adjList->offsets->dtype == GDF_INT32,
-              GDF_UNSUPPORTED_DTYPE);
+              "Unsupported data type");
   CUGRAPH_EXPECTS(gdf_G->adjList->indices->dtype == GDF_INT32,
-              GDF_UNSUPPORTED_DTYPE);
+              "Unsupported data type");
   CUGRAPH_EXPECTS(source_vert < gdf_G->adjList->offsets->size - 1,
-              GDF_INVALID_API_CALL);
+              "Invalid API parameter");
 
   if (pred_ptr)
     CUGRAPH_EXPECTS(predecessors->dtype == gdf_G->adjList->indices->dtype,
-                GDF_UNSUPPORTED_DTYPE);
+                "Unsupported data type");
 
   if (sssp_dist_ptr)
     CUGRAPH_EXPECTS(gdf_G->adjList->offsets->size - 1 <= sssp_distances->size,
-                GDF_INVALID_API_CALL);
+                "Invalid API parameter");
 
   if (!gdf_G->adjList->edge_data) {
     // Generate unit weights
@@ -381,15 +381,15 @@ gdf_error gdf_sssp(gdf_graph* gdf_G,
     // Got weighted graph
     CUGRAPH_EXPECTS(
         gdf_G->adjList->edge_data->size == gdf_G->adjList->indices->size,
-        GDF_INVALID_API_CALL);
+        "Invalid API parameter");
 
     CUGRAPH_EXPECTS(gdf_G->adjList->edge_data->dtype == GDF_FLOAT32 ||
                     gdf_G->adjList->edge_data->dtype == GDF_FLOAT64,
-                GDF_INVALID_API_CALL);
+                "Invalid API parameter");
 
     if (sssp_dist_ptr)
       CUGRAPH_EXPECTS(gdf_G->adjList->edge_data->dtype == sssp_distances->dtype,
-                  GDF_UNSUPPORTED_DTYPE);
+                  "Unsupported data type");
 
     // SSSP is not defined for graphs with negative weight cycles
     // Warn user about any negative edges
@@ -430,7 +430,7 @@ gdf_error gdf_sssp(gdf_graph* gdf_G,
   } else {
     CUGRAPH_EXPECTS(gdf_G->adjList->edge_data->dtype == GDF_FLOAT32 ||
                     gdf_G->adjList->edge_data->dtype == GDF_FLOAT64,
-                GDF_INVALID_API_CALL);
+                "Invalid API parameter");
   }
 
   return ret;

--- a/cpp/src/traversal/sssp.cu
+++ b/cpp/src/traversal/sssp.cu
@@ -288,9 +288,9 @@ gdf_error gdf_sssp(gdf_graph* gdf_G,
                    gdf_column* sssp_distances,
                    gdf_column* predecessors,
                    const int source_vert) {
-  GDF_REQUIRE(gdf_G, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(gdf_G->adjList || gdf_G->edgeList, GDF_INVALID_API_CALL);
-  GDF_REQUIRE(source_vert >= 0, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(gdf_G, "Invalid API parameter");
+  CUGRAPH_EXPECTS(gdf_G->adjList || gdf_G->edgeList, "Invalid API parameter");
+  CUGRAPH_EXPECTS(source_vert >= 0, "Invalid API parameter");
 
   void *sssp_dist_ptr, *pred_ptr;
   // NOTE: gdf_column struct doesn't have a default constructor. So we can get
@@ -303,13 +303,13 @@ gdf_error gdf_sssp(gdf_graph* gdf_G,
   pred_ptr =
       (predecessors && predecessors->size) ? predecessors->data : nullptr;
 
-  GDF_REQUIRE(sssp_dist_ptr || pred_ptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(sssp_dist_ptr || pred_ptr, "Invalid API parameter");
 
   if (sssp_dist_ptr) {
-    GDF_REQUIRE(!sssp_distances->valid, GDF_VALIDITY_UNSUPPORTED);
+    CUGRAPH_EXPECTS(!sssp_distances->valid, "Column must be valid");
     // Integral types are possible, but we don't want to deal with overflow
     // conditions right now
-    GDF_REQUIRE(sssp_distances->dtype == GDF_FLOAT32 ||
+    CUGRAPH_EXPECTS(sssp_distances->dtype == GDF_FLOAT32 ||
                     sssp_distances->dtype == GDF_FLOAT64,
                 GDF_INVALID_API_CALL);
   }
@@ -318,19 +318,19 @@ gdf_error gdf_sssp(gdf_graph* gdf_G,
   if (err != GDF_SUCCESS)
     return err;
 
-  GDF_REQUIRE(gdf_G->adjList->offsets->dtype == GDF_INT32,
+  CUGRAPH_EXPECTS(gdf_G->adjList->offsets->dtype == GDF_INT32,
               GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(gdf_G->adjList->indices->dtype == GDF_INT32,
+  CUGRAPH_EXPECTS(gdf_G->adjList->indices->dtype == GDF_INT32,
               GDF_UNSUPPORTED_DTYPE);
-  GDF_REQUIRE(source_vert < gdf_G->adjList->offsets->size - 1,
+  CUGRAPH_EXPECTS(source_vert < gdf_G->adjList->offsets->size - 1,
               GDF_INVALID_API_CALL);
 
   if (pred_ptr)
-    GDF_REQUIRE(predecessors->dtype == gdf_G->adjList->indices->dtype,
+    CUGRAPH_EXPECTS(predecessors->dtype == gdf_G->adjList->indices->dtype,
                 GDF_UNSUPPORTED_DTYPE);
 
   if (sssp_dist_ptr)
-    GDF_REQUIRE(gdf_G->adjList->offsets->size - 1 <= sssp_distances->size,
+    CUGRAPH_EXPECTS(gdf_G->adjList->offsets->size - 1 <= sssp_distances->size,
                 GDF_INVALID_API_CALL);
 
   if (!gdf_G->adjList->edge_data) {
@@ -379,16 +379,16 @@ gdf_error gdf_sssp(gdf_graph* gdf_G,
     }
   } else {
     // Got weighted graph
-    GDF_REQUIRE(
+    CUGRAPH_EXPECTS(
         gdf_G->adjList->edge_data->size == gdf_G->adjList->indices->size,
         GDF_INVALID_API_CALL);
 
-    GDF_REQUIRE(gdf_G->adjList->edge_data->dtype == GDF_FLOAT32 ||
+    CUGRAPH_EXPECTS(gdf_G->adjList->edge_data->dtype == GDF_FLOAT32 ||
                     gdf_G->adjList->edge_data->dtype == GDF_FLOAT64,
                 GDF_INVALID_API_CALL);
 
     if (sssp_dist_ptr)
-      GDF_REQUIRE(gdf_G->adjList->edge_data->dtype == sssp_distances->dtype,
+      CUGRAPH_EXPECTS(gdf_G->adjList->edge_data->dtype == sssp_distances->dtype,
                   GDF_UNSUPPORTED_DTYPE);
 
     // SSSP is not defined for graphs with negative weight cycles
@@ -428,7 +428,7 @@ gdf_error gdf_sssp(gdf_graph* gdf_G,
 
     ret = sssp.traverse(source_vert);
   } else {
-    GDF_REQUIRE(gdf_G->adjList->edge_data->dtype == GDF_FLOAT32 ||
+    CUGRAPH_EXPECTS(gdf_G->adjList->edge_data->dtype == GDF_FLOAT32 ||
                     gdf_G->adjList->edge_data->dtype == GDF_FLOAT64,
                 GDF_INVALID_API_CALL);
   }

--- a/cpp/src/traversal/sssp_kernels.cuh
+++ b/cpp/src/traversal/sssp_kernels.cuh
@@ -588,6 +588,6 @@ void frontier_expand(
       predecessors,
       edge_mask);
 
-  cudaCheckError();
+  CUDA_CHECK_LAST();
 }
 }

--- a/cpp/src/traversal/traversal_common.cuh
+++ b/cpp/src/traversal/traversal_common.cuh
@@ -180,7 +180,7 @@ void fill_vec(ValueType* vec, SizeType n, ValueType val, cudaStream_t stream) {
   grid.x = (n + block.x - 1) / block.x;
 
   fill_vec_kernel<<<grid, block, 0, stream>>>(vec, n, val);
-  cudaCheckError();
+  CUDA_CHECK_LAST();
 }
 
 template <typename IndexType>
@@ -388,7 +388,7 @@ void flag_isolated_vertices(IndexType n,
 
   flag_isolated_vertices_kernel<<<grid, block, 0, m_stream>>>(
       n, isolated_bmap, row_ptr, degrees, nisolated);
-  cudaCheckError();
+  CUDA_CHECK_LAST();
 }
 
 template <typename IndexType>
@@ -414,7 +414,7 @@ void set_frontier_degree(IndexType* frontier_degree,
   grid.x = min((n + block.x - 1) / block.x, (IndexType)MAXBLOCKS);
   set_frontier_degree_kernel<<<grid, block, 0, m_stream>>>(
       frontier_degree, frontier, degree, n);
-  cudaCheckError();
+  CUDA_CHECK_LAST();
 }
 
 template <typename IndexType>
@@ -472,6 +472,6 @@ void compute_bucket_offsets(IndexType* cumul,
 
   compute_bucket_offsets_kernel<<<grid, block, 0, m_stream>>>(
       cumul, bucket_offsets, frontier_size, total_degree);
-  cudaCheckError();
+  CUDA_CHECK_LAST();
 }
 }  // end namespace traversal

--- a/cpp/src/traversal/two_hop_neighbors.cu
+++ b/cpp/src/traversal/two_hop_neighbors.cu
@@ -127,10 +127,10 @@ gdf_error gdf_get_two_hop_neighbors_impl(IndexType num_verts,
 }
 
 gdf_error gdf_get_two_hop_neighbors(gdf_graph* graph, gdf_column* first, gdf_column* second) {
-    GDF_REQUIRE(graph != nullptr, GDF_INVALID_API_CALL);
-    GDF_REQUIRE(first != nullptr, GDF_INVALID_API_CALL);
-    GDF_REQUIRE(second != nullptr, GDF_INVALID_API_CALL);
-    GDF_TRY(gdf_add_adj_list(graph));
+    CUGRAPH_EXPECTS(graph != nullptr, "Invalid API parameter");
+    CUGRAPH_EXPECTS(first != nullptr, "Invalid API parameter");
+    CUGRAPH_EXPECTS(second != nullptr, "Invalid API parameter");
+    CUGRAPH_TRY(gdf_add_adj_list(graph));
 
     size_t num_verts = graph->adjList->offsets->size - 1;
     switch (graph->adjList->offsets->dtype) {

--- a/cpp/src/utilities/degree.cu
+++ b/cpp/src/utilities/degree.cu
@@ -55,7 +55,7 @@ gdf_error gdf_degree(gdf_graph *graph, gdf_column *degree, int x) {
   // x = 0: in+out degree
   // x = 1: in-degree
   // x = 2: out-degree
-  GDF_REQUIRE(graph->adjList != nullptr || graph->transposedAdjList != nullptr, GDF_INVALID_API_CALL);
+  CUGRAPH_EXPECTS(graph->adjList != nullptr || graph->transposedAdjList != nullptr, "Invalid API parameter");
   int n;
   int e;
   if(graph->adjList != nullptr) {

--- a/cpp/src/utilities/error_utils.h
+++ b/cpp/src/utilities/error_utils.h
@@ -23,7 +23,9 @@
 
 #include <rmm/rmm.h>
 
-//#include <cudf/types.h>
+#include "nvgraph_error_utils.h"
+
+#include <cudf/types.h>
 
 #define RMM_TRY(call)                                             \
   do {                                                            \
@@ -170,7 +172,12 @@ inline void check_stream(cudaStream_t stream, const char* file,
   } while (0);
 #endif
 
-#define CUDA_CHECK_LAST() CUDA_TRY(cudaPeekAtLastError())
+#define CUDA_CHECK_LAST() {                                       \
+  cudaError_t const status = cudaGetLastError();                  \
+  if(status != cudaSuccess) {                                     \
+   cugraph::detail::throw_cuda_error(status, __FILE__, __LINE__); \
+  }                                                               \
+}
 
 /**---------------------------------------------------------------------------*
  * @brief Debug macro to synchronize a stream and check for CUDA errors

--- a/cpp/src/utilities/error_utils.h
+++ b/cpp/src/utilities/error_utils.h
@@ -13,57 +13,183 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** ---------------------------------------------------------------------------*
- * @brief Error utilities
- *
- * @file error_utils.h
- * ---------------------------------------------------------------------------**/
-
-#ifndef GDF_ERRORUTILS_H
-#define GDF_ERRORUTILS_H
-
-#include <iostream>
+#ifndef ERRORUTILS_HPP
+#define ERRORUTILS_HPP
 
 #include <cuda.h>
 #include <cuda_runtime_api.h>
+#include <iostream>
+#include <stdexcept>
 
-#include <cudf/types.h>
-#include "nvgraph_error_utils.h"
+#include <rmm/rmm.h>
 
-#define cudaCheckError() {                                              \
-    cudaError_t e=cudaGetLastError();                                     \
-    if(e!=cudaSuccess) {                                                  \
-      std::cerr << "Cuda failure: "  << cudaGetErrorString(e) << " at: " << __FILE__ << ':' << __LINE__ << std::endl;        \
-    }                                                                     \
+//#include <cudf/types.h>
+
+#define RMM_TRY(call)                                             \
+  do {                                                            \
+    rmmError_t const status = (call);                             \
+    if (RMM_SUCCESS != status) {                                  \
+      cugraph::detail::throw_rmm_error(status, __FILE__, __LINE__);  \
+    }                                                             \
+  } while (0);
+
+#define RMM_TRY_CUDAERROR(x) \
+  if ((x) != RMM_SUCCESS) CUDA_TRY(cudaPeekAtLastError());
+
+namespace cugraph {
+/**---------------------------------------------------------------------------*
+ * @brief Exception thrown when logical precondition is violated.
+ *
+ * This exception should not be thrown directly and is instead thrown by the
+ * CUGRAPH_EXPECTS macro.
+ *
+ *---------------------------------------------------------------------------**/
+struct logic_error : public std::logic_error {
+  logic_error(char const* const message) : std::logic_error(message) {}
+
+  logic_error(std::string const& message) : std::logic_error(message) {}
+
+  // TODO Add an error code member? This would be useful for translating an
+  // exception to an error code in a pure-C API
+};
+/**---------------------------------------------------------------------------*
+ * @brief Exception thrown when a CUDA error is encountered.
+ *
+ *---------------------------------------------------------------------------**/
+struct cuda_error : public std::runtime_error {
+  cuda_error(std::string const& message) : std::runtime_error(message) {}
+};
+}  // namespace cugraph
+
+#define STRINGIFY_DETAIL(x) #x
+#define CUGRAPH_STRINGIFY(x) STRINGIFY_DETAIL(x)
+
+/**---------------------------------------------------------------------------*
+ * @brief Macro for checking (pre-)conditions that throws an exception when  
+ * a condition is violated.
+ * 
+ * Example usage:
+ * 
+ * @code
+ * CUGRAPH_EXPECTS(lhs->dtype == rhs->dtype, "Column type mismatch");
+ * @endcode
+ *
+ * @param[in] cond Expression that evaluates to true or false
+ * @param[in] reason String literal description of the reason that cond is
+ * expected to be true
+ * @throw cugraph::logic_error if the condition evaluates to false.
+ *---------------------------------------------------------------------------**/
+#define CUGRAPH_EXPECTS(cond, reason)                           \
+  (!!(cond))                                                 \
+      ? static_cast<void>(0)                                 \
+      : throw cugraph::logic_error("CUGRAPH failure at: " __FILE__ \
+                                ":" CUGRAPH_STRINGIFY(__LINE__) ": " reason)
+
+/**---------------------------------------------------------------------------*
+ * @brief Try evaluation an expression with a gdf_error type,
+ * and throw an appropriate exception if it fails.
+ *---------------------------------------------------------------------------**/
+#define CUGRAPH_TRY(_gdf_error_expression) do { \
+    auto _evaluated = _gdf_error_expression; \
+    if (_evaluated == GDF_SUCCESS) { break; } \
+    throw cugraph::logic_error( \
+        ("CUGRAPH error " + std::string(gdf_error_get_name(_evaluated)) + " at " \
+       __FILE__ ":"  \
+        CUGRAPH_STRINGIFY(__LINE__) " evaluating " CUGRAPH_STRINGIFY(#_gdf_error_expression)).c_str() ); \
+} while(0)
+
+/**---------------------------------------------------------------------------*
+ * @brief Indicates that an erroneous code path has been taken.
+ *
+ * In host code, throws a `cugraph::logic_error`.
+ *
+ *
+ * Example usage:
+ * ```
+ * CUGRAPH_FAIL("Non-arithmetic operation is not supported");
+ * ```
+ * 
+ * @param[in] reason String literal description of the reason
+ *---------------------------------------------------------------------------**/
+#define CUGRAPH_FAIL(reason)                              \
+  throw cugraph::logic_error("cuDF failure at: " __FILE__ \
+                          ":" CUGRAPH_STRINGIFY(__LINE__) ": " reason)
+
+namespace cugraph {
+namespace detail {
+
+inline void throw_rmm_error(rmmError_t error, const char* file,
+                             unsigned int line) {
+  // todo: throw cuda_error if the error is from cuda
+  throw cugraph::logic_error(
+      std::string{"RMM error encountered at: " + std::string{file} + ":" +
+                  std::to_string(line) + ": " + std::to_string(error) + " " +
+                  rmmGetErrorString(error)});
+}
+
+inline void throw_cuda_error(cudaError_t error, const char* file,
+                             unsigned int line) {
+  throw cugraph::cuda_error(
+      std::string{"CUDA error encountered at: " + std::string{file} + ":" +
+                  std::to_string(line) + ": " + std::to_string(error) + " " +
+                  cudaGetErrorName(error) + " " + cudaGetErrorString(error)});
+}
+
+inline void check_stream(cudaStream_t stream, const char* file,
+                         unsigned int line) {
+  cudaError_t error{cudaSuccess};
+  error = cudaStreamSynchronize(stream);
+  if (cudaSuccess != error) {
+    throw_cuda_error(error, file, line);
   }
 
-#define CUDA_TRY( call ) 									                            \
-{                                                                     \
-    cudaError_t cudaStatus = call;                                    \
-    if ( cudaSuccess != cudaStatus )                                  \
-    {                                                                 \
-        std::cerr << "ERROR: CUDA Runtime call " << #call             \
-                  << " in line " << __LINE__                            \
-                  << " of file " << __FILE__                            \
-                  << " failed with " << cudaGetErrorString(cudaStatus)  \
-                  << " (" << cudaStatus << ").\n";                     \
-        return GDF_CUDA_ERROR;                          							\
-    }												                                          \
-}                                                                                                  
+  error = cudaGetLastError();
+  if (cudaSuccess != error) {
+    throw_cuda_error(error, file, line);
+  }
+}
+}  // namespace detail
+}  // namespace cugraph
 
-#define RMM_TRY(x)  if ((x)!=RMM_SUCCESS) return GDF_MEMORYMANAGER_ERROR;
-
-#define RMM_TRY_CUDAERROR(x)  if ((x)!=RMM_SUCCESS) return cudaPeekAtLastError();
+/**---------------------------------------------------------------------------*
+ * @brief Error checking macro for CUDA runtime API functions.
+ *
+ * Invokes a CUDA runtime API function call, if the call does not return
+ * cudaSuccess, throws an exception detailing the CUDA error that occurred.
+ *
+ * This macro supersedes GDF_REQUIRE and should be preferred in all instances.
+ * GDF_REQUIRE should be considered deprecated.
+ *
+ *---------------------------------------------------------------------------**/
+#define CUDA_TRY(call)                                            \
+  do {                                                            \
+    cudaError_t const status = (call);                            \
+    if (cudaSuccess != status) {                                  \
+      cugraph::detail::throw_cuda_error(status, __FILE__, __LINE__); \
+    }                                                             \
+  } while (0);
+#endif
 
 #define CUDA_CHECK_LAST() CUDA_TRY(cudaPeekAtLastError())
 
-#define GDF_TRY(x) 														\
-{																							\
-gdf_error err_code = (x);											\
-if (err_code != GDF_SUCCESS) 									\
-	return err_code;														\
-}
-
-#define GDF_REQUIRE(F, S) if (!(F)) return (S);
-
-#endif // GDF_ERRORUTILS_H
+/**---------------------------------------------------------------------------*
+ * @brief Debug macro to synchronize a stream and check for CUDA errors
+ *
+ * In a non-release build, this macro will synchronize the specified stream, and
+ * check for any CUDA errors returned from cudaGetLastError. If an error is
+ * reported, an exception is thrown detailing the CUDA error that occurred.
+ *
+ * The intent of this macro is to provide a mechanism for synchronous and
+ * deterministic execution for debugging asynchronous CUDA execution. It should
+ * be used after any asynchronous CUDA call, e.g., cudaMemcpyAsync, or an
+ * asynchronous kernel launch.
+ *
+ * Similar to assert(), it is only present in non-Release builds.
+ *
+ *---------------------------------------------------------------------------**/
+#ifndef NDEBUG
+#define CHECK_STREAM(stream) \
+  cugraph::detail::check_stream((stream), __FILE__, __LINE__)
+#else
+#define CHECK_STREAM(stream) static_cast<void>(0)
+#endif

--- a/cpp/src/utilities/graph_utils.cuh
+++ b/cpp/src/utilities/graph_utils.cuh
@@ -120,7 +120,7 @@ namespace cugraph
                                          thrust::device_pointer_cast(x + n),
                                          thrust::device_pointer_cast(y),
                                          0.0f);
-        cudaCheckError();
+        CUDA_CHECK_LAST();
         return result;
     }
 
@@ -146,7 +146,7 @@ namespace cugraph
                           thrust::device_pointer_cast(y),
                           thrust::device_pointer_cast(y),
                           axpy_functor<T>(a));
-        cudaCheckError();
+        CUDA_CHECK_LAST();
     }
 
 //norm
@@ -168,7 +168,7 @@ namespace cugraph
                                                       square<T>(),
                                                       init,
                                                       thrust::plus<T>()));
-        cudaCheckError();
+        CUDA_CHECK_LAST();
         return result;
     }
 
@@ -178,7 +178,7 @@ namespace cugraph
         T result = thrust::reduce(rmm::exec_policy(stream)->on(stream),
                                   thrust::device_pointer_cast(x),
                                   thrust::device_pointer_cast(x + n));
-        cudaCheckError();
+        CUDA_CHECK_LAST();
         return result;
     }
 
@@ -191,7 +191,7 @@ namespace cugraph
                           thrust::make_constant_iterator(val),
                           thrust::device_pointer_cast(x),
                           thrust::multiplies<T>());
-        cudaCheckError();
+        CUDA_CHECK_LAST();
     }
 
     template<typename T>
@@ -203,7 +203,7 @@ namespace cugraph
                           thrust::make_constant_iterator(val),
                           thrust::device_pointer_cast(x),
                           thrust::plus<T>());
-        cudaCheckError();
+        CUDA_CHECK_LAST();
     }
 
     template<typename T>
@@ -212,7 +212,7 @@ namespace cugraph
         thrust::fill(rmm::exec_policy(stream)->on(stream),
                      thrust::device_pointer_cast(x),
                      thrust::device_pointer_cast(x + n), value);
-        cudaCheckError();
+        CUDA_CHECK_LAST();
     }
 
     template<typename T, typename M>
@@ -223,7 +223,7 @@ namespace cugraph
                      thrust::device_pointer_cast(src + n),
                      thrust::device_pointer_cast(map),
                      thrust::device_pointer_cast(dst));
-        cudaCheckError();
+        CUDA_CHECK_LAST();
     }
 
     template<typename T>
@@ -232,7 +232,7 @@ namespace cugraph
         std::cout.precision(15);
         std::cout << "sample size = " << n << ", offset = " << offset << std::endl;
         thrust::copy(dev_ptr + offset, dev_ptr + offset + n, std::ostream_iterator<T>(std::cout, " ")); //Assume no RMM dependency; TODO: check / test (potential BUG !!!!!)
-        cudaCheckError();
+        CUDA_CHECK_LAST();
         std::cout << std::endl;
     }
 
@@ -242,7 +242,7 @@ namespace cugraph
         thrust::device_ptr<T> res_ptr(res);
         cudaStream_t stream {nullptr};
         thrust::copy_n(rmm::exec_policy(stream)->on(stream), dev_ptr, n, res_ptr);
-        cudaCheckError();
+        CUDA_CHECK_LAST();
     }
 
     template<typename T>
@@ -274,7 +274,7 @@ namespace cugraph
                              thrust::device_pointer_cast(dangling_nodes),
                              dangling_functor<T>(1.0 - damping_factor),
                              is_zero<T>());
-        cudaCheckError();
+        CUDA_CHECK_LAST();
     }
 
 //google matrix kernels
@@ -370,7 +370,7 @@ namespace cugraph
         nblocks.y = 1;
         nblocks.z = 1;
         degree_coo<IndexType, IndexType> <<<nblocks, nthreads>>>(n, e, csrInd, degree);
-        cudaCheckError();
+        CUDA_CHECK_LAST();
 
         int y = 4;
         nthreads.x = 32 / y;
@@ -380,11 +380,11 @@ namespace cugraph
         nblocks.y = 1;
         nblocks.z = min((n + nthreads.z - 1) / nthreads.z, CUDA_MAX_BLOCKS); //1;
         equi_prob3<IndexType, ValueType> <<<nblocks, nthreads>>>(n, e, csrPtr, csrInd, val, degree);
-        cudaCheckError();
+        CUDA_CHECK_LAST();
 
         ValueType a = 0.0;
         fill(n, bookmark, a);
-        cudaCheckError();
+        CUDA_CHECK_LAST();
 
         nthreads.x = min(n, CUDA_MAX_KERNEL_THREADS);
         nthreads.y = 1;
@@ -393,7 +393,7 @@ namespace cugraph
         nblocks.y = 1;
         nblocks.z = 1;
         flag_leafs_kernel<IndexType, ValueType> <<<nblocks, nthreads>>>(n, degree, bookmark);
-        cudaCheckError();
+        CUDA_CHECK_LAST();
         ALLOC_FREE_TRY(degree, stream);
     }
 
@@ -506,7 +506,7 @@ namespace cugraph
         int nthreads = min(v, CUDA_MAX_KERNEL_THREADS);
         int nblocks = min((v + nthreads - 1) / nthreads, CUDA_MAX_BLOCKS);
         offsets_to_indices_kernel<<<nblocks, nthreads>>>(offsets, v, indices);
-        cudaCheckError();
+        CUDA_CHECK_LAST();
     }
 
     template<typename IndexType>
@@ -515,7 +515,7 @@ namespace cugraph
                          thrust::device_pointer_cast(vec),
                          thrust::device_pointer_cast(vec + n),
                          init);
-        cudaCheckError();
+        CUDA_CHECK_LAST();
     }
     
     template<typename DistType>
@@ -553,7 +553,7 @@ namespace cugraph
 				    thrust::device_pointer_cast(arr),
 				    thrust::device_pointer_cast(arr + n));
 
-		    cudaCheckError();
+		    CUDA_CHECK_LAST();
 
 		    return (result < 0);
 #endif

--- a/cpp/src/utilities/grmat.cu
+++ b/cpp/src/utilities/grmat.cu
@@ -330,8 +330,8 @@ gdf_error gdf_grmat_gen (const char* argv, size_t& vertices, size_t& edges, gdf_
         return GDF_DATASET_EMPTY;
     }
 
-    GDF_REQUIRE ((src->dtype == dest->dtype), GDF_DTYPE_MISMATCH);
-    GDF_REQUIRE (src->null_count == 0, GDF_VALIDITY_UNSUPPORTED);
+    CUGRAPH_EXPECTS ((src->dtype == dest->dtype), GDF_DTYPE_MISMATCH);
+    CUGRAPH_EXPECTS (src->null_count == 0, "Column must be valid");
 
     if (argc < 2 || args.CheckCmdLineFlag("help"))
     {
@@ -365,9 +365,9 @@ gdf_error gdf_grmat_gen (const char* argv, size_t& vertices, size_t& edges, gdf_
 
     free_args(argc, arg);
 
-    GDF_REQUIRE((src->size == dest->size), GDF_COLUMN_SIZE_MISMATCH);
-    GDF_REQUIRE ((src->dtype == dest->dtype), GDF_DTYPE_MISMATCH);
-    GDF_REQUIRE (src->null_count == 0, GDF_VALIDITY_UNSUPPORTED);
+    CUGRAPH_EXPECTS((src->size == dest->size), "Column size mismatch");
+    CUGRAPH_EXPECTS ((src->dtype == dest->dtype), GDF_DTYPE_MISMATCH);
+    CUGRAPH_EXPECTS (src->null_count == 0, "Column must be valid");
 
     return status;
 }

--- a/python/cugraph/tests/test_graph.py
+++ b/python/cugraph/tests/test_graph.py
@@ -21,7 +21,6 @@ import pytest
 from scipy.io import mmread
 
 import cudf
-import cudf._lib as libcudf
 import cugraph
 from cugraph.tests import utils
 import rmm

--- a/python/cugraph/tests/test_graph.py
+++ b/python/cugraph/tests/test_graph.py
@@ -357,16 +357,13 @@ def test_delete_edge_list_delete_adj_list(managed, pool, graph_file):
     G = cugraph.Graph()
     G.add_edge_list(sources, destinations, None)
     G.delete_edge_list()
-    with pytest.raises(libcudf.GDFError.GDFError) as excinfo:
+    with pytest.raises(RuntimeError):
         G.view_adj_list()
-    assert excinfo.value.errcode.decode() == 'GDF_INVALID_API_CALL'
 
     G.add_adj_list(offsets, indices, None)
     G.delete_adj_list()
-    with pytest.raises(libcudf.GDFError.GDFError) as excinfo:
+    with pytest.raises(RuntimeError):
         G.view_edge_list()
-    assert excinfo.value.errcode.decode() == 'GDF_INVALID_API_CALL'
-
 
 # Test all combinations of default/managed and pooled/non-pooled allocation
 @pytest.mark.parametrize('managed, pool',
@@ -405,22 +402,18 @@ def test_add_edge_or_adj_list_after_add_edge_or_adj_list(
 
     # If cugraph has a graph edge list, adding a new graph should fail.
     G.add_edge_list(sources, destinations, None)
-    with pytest.raises(libcudf.GDFError.GDFError) as excinfo:
+    with pytest.raises(RuntimeError):
         G.add_edge_list(sources, destinations, None)
-    assert excinfo.value.errcode.decode() == 'GDF_INVALID_API_CALL'
-    with pytest.raises(libcudf.GDFError.GDFError) as excinfo:
+    with pytest.raises(RuntimeError):
         G.add_adj_list(offsets, indices, None)
-    assert excinfo.value.errcode.decode() == 'GDF_INVALID_API_CALL'
     G.delete_edge_list()
 
     # If cugraph has a graph adjacency list, adding a new graph should fail.
     G.add_adj_list(sources, destinations, None)
-    with pytest.raises(libcudf.GDFError.GDFError) as excinfo:
+    with pytest.raises(RuntimeError):
         G.add_edge_list(sources, destinations, None)
-    assert excinfo.value.errcode.decode() == 'GDF_INVALID_API_CALL'
-    with pytest.raises(libcudf.GDFError.GDFError) as excinfo:
+    with pytest.raises(RuntimeError):
         G.add_adj_list(offsets, indices, None)
-    assert excinfo.value.errcode.decode() == 'GDF_INVALID_API_CALL'
     G.delete_adj_list()
 
 


### PR DESCRIPTION
Close #498 
Close #486 

RAPIDS is switching from error code based error handling to exception-based error handling.

The design is closely following cuDF solution. 
C++ exception type and message are propagated to the python layer, cuda and cugraph calls have specific macros simplifying the process. Expected test failures (C++ and python) have been updated to check exceptions instead of error codes. 

File and line, as well as error messages, are properly transiting through all layers. For instance, a misusage of the python API triggering a C++ exception will result in :
`RuntimeError: CUGRAPH failure at: /home/afender/cugraph/cpp/src/structure/cugraph.cu:175: Invalid API parameter`

I will do another PR with the API changes (after confirming the depreciation plan):
- remove gdf_error returns in API
- upgrade API doc. 


