### PR TITLE
[BUG] Changed hardcoded test output file to a generated tempfile file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - PR #570 Temporarily disabling 2 DB tests
 - PR #573 Fix pagerank test and symmetrize for cudf 0.11
 - PR #574 dev env update
+- PR #580 Changed hardcoded test output file to a generated tempfile file name
 
 # cuGraph 0.10.0 (16 Oct 2019)
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -44,7 +44,7 @@ logger "Activate conda env..."
 source activate gdf
 
 logger "conda install required packages"
-conda install -c nvidia -c rapidsai -c rapidsai-nightly -c numba -c conda-forge \
+conda install -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge -c defaults \
       cudf=${MINOR_VERSION} \
       rmm=${MINOR_VERSION} \
       networkx>=2.3 \
@@ -57,7 +57,7 @@ conda install -c nvidia -c rapidsai -c rapidsai-nightly -c numba -c conda-forge 
       libcypher-parser
 
 # Install the master version of dask and distributed
-logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps" 
+logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"
 pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
 
 logger "pip install git+https://github.com/dask/dask.git --upgrade --no-deps"
@@ -109,4 +109,3 @@ else
     cd $WORKSPACE/python
     py.test --cache-clear --junitxml=${WORKSPACE}/junit-cugraph.xml -v
 fi
-

--- a/python/cugraph/tests/dask/test_hibench_small.py
+++ b/python/cugraph/tests/dask/test_hibench_small.py
@@ -3,6 +3,9 @@ import gc
 import dask_cudf
 import pandas as pd
 import time
+import tempfile
+import os
+
 # Temporarily suppress warnings till networkX fixes deprecation warnings
 # (Using or importing the ABCs from 'collections' instead of from
 # 'collections.abc' is deprecated, and in 3.8 it will stop working) for
@@ -53,9 +56,17 @@ def test_pagerank():
     t5 = time.time()
     print("Compute time: ", t5-t4)
     print(res_df)
-    t6 = time.time()
+
+    # Use tempfile.mkstemp() to get a temp file name. Close and delete the file
+    # so to_csv() can create it using the unique temp name
+    (tempfileHandle, tempfileName) = tempfile.mkstemp(suffix=".csv",
+                                                      prefix="pagerank_")
+    os.close(tempfileHandle)
+    os.remove(tempfileName)
+
     # For bigdatax4, chunksize=100000000 to avoid oom on write csv
-    res_df.to_csv('~/pagerank.csv', header=False, index=False)
+    t6 = time.time()
+    res_df.to_csv(tempfileName, header=False, index=False)
     t7 = time.time()
     print("Write csv time: ", t7-t6)
 
@@ -70,3 +81,4 @@ def test_pagerank():
 
     client.close()
     cluster.close()
+    os.remove(tempfileName)


### PR DESCRIPTION
Changed hardcoded `~/pagerank.csv` test output file to a generated tempfile to avoid permission problems for certain test environments that cannot write to ~ (such as the nightly unit test runs).

I'm not sure if users expect the resulting output file to remain (since the previous version never deleted it after the test ended), but that can be something done here as well if necessary.
