### PR TITLE
[REVIEW] Remove BUILD_ABI references in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - PR #564 Update cudf type aliases
 - PR #562 Remove pyarrow dependency so we inherit the one cudf uses
 - PR #576 Remove adj list conversion automation from c++
+- PR #585 Remove BUILD_ABI references from CI scripts
 
 ## Bug Fixes
 - PR #570 Temporarily disabling 2 DB tests

--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-export BUILD_ABI=1
 export BUILD_CUGRAPH=1
 export BUILD_LIBCUGRAPH=1
 

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -21,7 +21,6 @@ build:
     - CXX
     - CUDAHOSTCXX
     - PARALLEL_LEVEL
-    - BUILD_ABI
 
 requirements:
   build:

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -21,7 +21,6 @@ build:
     - CXX
     - CUDAHOSTCXX
     - PARALLEL_LEVEL
-    - BUILD_ABI
     - VERSION_SUFFIX
 
 requirements:


### PR DESCRIPTION
Removing BUILD_ABI references in CI as we will ALWAYS build with it on. Not removing the option from CMake in case users want to build from source with it OFF.