### PR TITLE
[REVIEW] renumber vertex ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Improvements
 
 ## Bug Fixes
-
+- PR #634 renumber vertex ids passed in analytics
 
 # cuGraph 0.11.0 (Date TBD)
 

--- a/python/cugraph/centrality/katz_centrality_wrapper.pyx
+++ b/python/cugraph/centrality/katz_centrality_wrapper.pyx
@@ -68,7 +68,7 @@ def katz_centrality(input_graph, alpha=0.1, max_iter=100, tol=1.0e-5, nstart=Non
         if input_graph.renumbered is True:
             renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
                                           index=input_graph.edgelist.renumber_map)
-            nstart_vertex_renumbered = renumber_series.loc[nstart['vertex']]
+            nstart_vertex_renumbered = cudf.Series(renumber_series.loc[nstart['vertex']], dtype=np.int32)
             cudf.bindings.copying.apply_scatter([nstart['values']._column],
                                                 nstart_vertex_renumbered._column._data.mem,
                                                 [df['katz_centrality']._column])

--- a/python/cugraph/centrality/katz_centrality_wrapper.pyx
+++ b/python/cugraph/centrality/katz_centrality_wrapper.pyx
@@ -65,9 +65,17 @@ def katz_centrality(input_graph, alpha=0.1, max_iter=100, tol=1.0e-5, nstart=Non
 
     cdef bool has_guess = <bool> 0
     if nstart is not None:
-        cudf.bindings.copying.apply_scatter([nstart['values']._column],
-                                            nstart['vertex']._column._data.mem,
-                                            [df['katz_centrality']._column])
+        if input_graph.renumbered is True:
+            renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
+                                          index=input_graph.edgelist.renumber_map)
+            nstart_vertex_renumbered = renumber_series.loc[nstart['vertex']]
+            cudf.bindings.copying.apply_scatter([nstart['values']._column],
+                                                nstart_vertex_renumbered._column._data.mem,
+                                                [df['katz_centrality']._column])
+        else:
+            cudf.bindings.copying.apply_scatter([nstart['values']._column],
+                                                nstart['vertex']._column._data.mem,
+                                                [df['katz_centrality']._column])
         has_guess = <bool> 1
 
     g.adjList.get_vertex_identifiers(&c_identifier_col)

--- a/python/cugraph/community/subgraph_extraction_wrapper.pyx
+++ b/python/cugraph/community/subgraph_extraction_wrapper.pyx
@@ -55,7 +55,13 @@ def subgraph(input_graph, vertices, subgraph):
 
     cdef uintptr_t rGraph = graph_wrapper.allocate_cpp_graph()
     cdef Graph* rg = <Graph*>rGraph
-    cdef gdf_column vert_col = get_gdf_column_view(vertices)
+    if input_graph.renumbered is True:
+        renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
+                                      index=input_graph.edgelist.renumber_map)
+        vertices_renumbered = renumber_series.loc[vertices]
+        vert_col = get_gdf_column_view(vertices_renumbered)
+    else:
+        vert_col = get_gdf_column_view(vertices)
 
     extract_subgraph_vertex_nvgraph(g, &vert_col, rg)
 

--- a/python/cugraph/cores/k_core_wrapper.pyx
+++ b/python/cugraph/cores/k_core_wrapper.pyx
@@ -57,9 +57,10 @@ def k_core(input_graph, k_core_graph, k, core_number):
     cdef Graph* rg = <Graph*>rGraph
 
     cdef gdf_column c_vertex
+    [core_number['vertex'], core_number['values']] = graph_wrapper.datatype_cast([core_number['vertex'], core_number['values']], [np.int32])
     if input_graph.renumbered is True:
         renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
-                                      index=input_graph.edgelist.renumber_map)
+                                      index=input_graph.edgelist.renumber_map, dtype=np.int32)
         vertices_renumbered = renumber_series.loc[core_number['vertex']]
         c_vertex = get_gdf_column_view(vertices_renumbered)
     else:

--- a/python/cugraph/cores/k_core_wrapper.pyx
+++ b/python/cugraph/cores/k_core_wrapper.pyx
@@ -56,7 +56,14 @@ def k_core(input_graph, k_core_graph, k, core_number):
     cdef uintptr_t rGraph = graph_wrapper.allocate_cpp_graph()
     cdef Graph* rg = <Graph*>rGraph
 
-    cdef gdf_column c_vertex = get_gdf_column_view(core_number['vertex'])
+    cdef gdf_column c_vertex
+    if input_graph.renumbered is True:
+        renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
+                                      index=input_graph.edgelist.renumber_map)
+        vertices_renumbered = renumber_series.loc[core_number['vertex']]
+        c_vertex = get_gdf_column_view(vertices_renumbered)
+    else:
+        c_vertex = get_gdf_column_view(core_number['vertex'])
     cdef gdf_column c_values = get_gdf_column_view(core_number['values'])
     c_k_core.k_core(g, k, &c_vertex, &c_values, rg)
 

--- a/python/cugraph/link_analysis/pagerank_wrapper.pyx
+++ b/python/cugraph/link_analysis/pagerank_wrapper.pyx
@@ -76,7 +76,13 @@ def pagerank(input_graph, alpha=0.85, personalization=None, max_iter=100, tol=1.
         c_pagerank.pagerank(g, &c_pagerank_col, <gdf_column*> NULL, <gdf_column*> NULL,
                 <float> alpha, <float> tol, <int> max_iter, has_guess)
     else:
-        c_pers_vtx = get_gdf_column_view(personalization['vertex'])
+        if input_graph.renumbered is True:
+            renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
+                                          index=input_graph.edgelist.renumber_map)
+            vertex_renumbered = renumber_series.loc[personalization['vertex']]        
+            c_pers_vtx = get_gdf_column_view(vertex_renumbered)
+        else:
+            c_pers_vtx = get_gdf_column_view(personalization['vertex'])
         c_pers_val = get_gdf_column_view(personalization['values'])
         c_pagerank.pagerank(g, &c_pagerank_col, &c_pers_vtx, &c_pers_val,
                 <float> alpha, <float> tol, <int> max_iter, has_guess)

--- a/python/cugraph/link_analysis/pagerank_wrapper.pyx
+++ b/python/cugraph/link_analysis/pagerank_wrapper.pyx
@@ -78,12 +78,12 @@ def pagerank(input_graph, alpha=0.85, personalization=None, max_iter=100, tol=1.
     else:
         if input_graph.renumbered is True:
             renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
-                                          index=input_graph.edgelist.renumber_map)
+                                          index=input_graph.edgelist.renumber_map, dtype=np.int32)
             vertex_renumbered = renumber_series.loc[personalization['vertex']]        
             c_pers_vtx = get_gdf_column_view(vertex_renumbered)
         else:
-            c_pers_vtx = get_gdf_column_view(personalization['vertex'])
-        c_pers_val = get_gdf_column_view(personalization['values'])
+            c_pers_vtx = get_gdf_column_view(personalization['vertex'].astype(np.int32))
+        c_pers_val = get_gdf_column_view(personalization['values'].astype(df['pagerank'].dtype))
         c_pagerank.pagerank(g, &c_pagerank_col, &c_pers_vtx, &c_pers_val,
                 <float> alpha, <float> tol, <int> max_iter, has_guess)
 

--- a/python/cugraph/link_prediction/jaccard.py
+++ b/python/cugraph/link_prediction/jaccard.py
@@ -16,7 +16,7 @@ from cugraph.structure.graph import null_check
 import cudf
 
 
-def jaccard(input_graph, first=None, second=None):
+def jaccard(input_graph, vertex_pair=None):
     """
     Compute the Jaccard similarity between each pair of vertices connected by
     an edge, or between arbitrary pairs of vertices specified by the user.
@@ -36,12 +36,9 @@ def jaccard(input_graph, first=None, second=None):
         graph should be undirected where an undirected edge is represented by a
         directed edge in both direction. The adjacency list will be computed if
         not already present.
-    first : cudf.Series
-        Specifies the first vertices of each pair of vertices to compute for,
+    vertex_pair : cudf.DataFrame
+        Specifies the pair of vertices to compute for,
         must be specified along with second.
-    second : cudf.Series
-        Specifies the second vertices of each pair of vertices to compute for,
-        must be specified along with first.
 
     Returns
     -------
@@ -71,15 +68,14 @@ def jaccard(input_graph, first=None, second=None):
     >>> df = cugraph.jaccard(G)
     """
 
-    if (type(first) == cudf.Series and
-            type(second) == cudf.Series):
-        null_check(first)
-        null_check(second)
-    elif first is None and second is None:
+    if (type(vertex_pair) == cudf.DataFrame):
+        null_check(vertex_pair[vertex_pair.columns[0]])
+        null_check(vertex_pair[vertex_pair.columns[1]])
+    elif vertex_pair is None:
         pass
     else:
-        raise ValueError("Specify first and second or neither")
+        raise ValueError("vertex_pair must be a cudf dataframe")
 
-    df = jaccard_wrapper.jaccard(input_graph, first, second)
+    df = jaccard_wrapper.jaccard(input_graph, vertex_pair)
 
     return df

--- a/python/cugraph/link_prediction/jaccard.py
+++ b/python/cugraph/link_prediction/jaccard.py
@@ -37,8 +37,7 @@ def jaccard(input_graph, vertex_pair=None):
         directed edge in both direction. The adjacency list will be computed if
         not already present.
     vertex_pair : cudf.DataFrame
-        Specifies the pair of vertices to compute for,
-        must be specified along with second.
+        Specifies the pair of vertices to compute for
 
     Returns
     -------

--- a/python/cugraph/link_prediction/jaccard.py
+++ b/python/cugraph/link_prediction/jaccard.py
@@ -38,8 +38,8 @@ def jaccard(input_graph, vertex_pair=None):
         not already present.
     vertex_pair : cudf.DataFrame
         A GPU dataframe consisting of two columns representing pairs of
-        vertices. If provided, the jaccard coefficient is computed for the given
-        vertex pairs, else, it is computed for all vertex pairs.  
+        vertices. If provided, the jaccard coefficient is computed for the
+        given vertex pairs, else, it is computed for all vertex pairs.
 
     Returns
     -------

--- a/python/cugraph/link_prediction/jaccard.py
+++ b/python/cugraph/link_prediction/jaccard.py
@@ -37,7 +37,9 @@ def jaccard(input_graph, vertex_pair=None):
         directed edge in both direction. The adjacency list will be computed if
         not already present.
     vertex_pair : cudf.DataFrame
-        Specifies the pair of vertices to compute for
+        A GPU dataframe consisting of two columns representing pairs of
+        vertices. If provided, the jaccard coefficient is computed for the given
+        vertex pairs, else, it is computed for all vertex pairs.  
 
     Returns
     -------

--- a/python/cugraph/link_prediction/jaccard_wrapper.pyx
+++ b/python/cugraph/link_prediction/jaccard_wrapper.pyx
@@ -62,8 +62,16 @@ def jaccard(input_graph, first=None, second=None):
         result_size = len(first)
         result = cudf.Series(np.ones(result_size, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
-        c_first_col = get_gdf_column_view(first)
-        c_second_col = get_gdf_column_view(second)
+        if input_graph.renumbered is True:
+            renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
+                                          index=input_graph.edgelist.renumber_map)
+            first_renumbered = renumber_series.loc[first]
+            second_renumbered = renumber_series.loc[second]
+            c_first_col = get_gdf_column_view(first_renumbered)
+            c_second_col = get_gdf_column_view(second_renumbered)
+        else:
+            c_first_col = get_gdf_column_view(first)
+            c_second_col = get_gdf_column_view(second)
         c_jaccard.jaccard_list(g,
                                <gdf_column*> NULL,
                                &c_first_col,

--- a/python/cugraph/link_prediction/jaccard_wrapper.pyx
+++ b/python/cugraph/link_prediction/jaccard_wrapper.pyx
@@ -89,7 +89,7 @@ def jaccard(input_graph, vertex_pair=None):
 
     else:
         # error check performed in jaccard.py
-        assert first is None and second is None
+        assert vertex_pair is None
         # we should add get_number_of_edges() to Graph (and this should be
         # used instead of g.adjList.indices.size)
         num_edges = g.adjList.indices.size

--- a/python/cugraph/link_prediction/jaccard_wrapper.pyx
+++ b/python/cugraph/link_prediction/jaccard_wrapper.pyx
@@ -62,13 +62,13 @@ def jaccard(input_graph, vertex_pair=None):
         result_size = len(vertex_pair)
         result = cudf.Series(np.ones(result_size, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
-        first = vertex_pair[vertex_pair.columns[0]]
-        second = vertex_pair[vertex_pair.columns[1]]
+        first = vertex_pair[vertex_pair.columns[0]].astype(np.int32)
+        second = vertex_pair[vertex_pair.columns[1]].astype(np.int32)
         if input_graph.renumbered is True:
             renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
-                                          index=input_graph.edgelist.renumber_map)
-            first_renumbered = cudf.Series(renumber_series.loc[first],dtype=np.int32)
-            second_renumbered = cudf.Series(renumber_series.loc[second],dtype=np.int32)
+                                          index=input_graph.edgelist.renumber_map, dtype=np.int32)
+            first_renumbered = renumber_series.loc[first]
+            second_renumbered = renumber_series.loc[second]
             c_first_col = get_gdf_column_view(first_renumbered)
             c_second_col = get_gdf_column_view(second_renumbered)
         else:

--- a/python/cugraph/link_prediction/jaccard_wrapper.pyx
+++ b/python/cugraph/link_prediction/jaccard_wrapper.pyx
@@ -31,7 +31,7 @@ import rmm
 import numpy as np
 
 
-def jaccard(input_graph, first=None, second=None):
+def jaccard(input_graph, vertex_pair=None):
     """
     Call jaccard_list
     """
@@ -58,15 +58,17 @@ def jaccard(input_graph, first=None, second=None):
     cdef gdf_column c_second_col
     cdef gdf_column c_src_index_col
 
-    if type(first) == cudf.Series and type(second) == cudf.Series:
-        result_size = len(first)
+    if type(vertex_pair) == cudf.DataFrame:
+        result_size = len(vertex_pair)
         result = cudf.Series(np.ones(result_size, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
+        first = vertex_pair[vertex_pair.columns[0]]
+        second = vertex_pair[vertex_pair.columns[1]]
         if input_graph.renumbered is True:
             renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
                                           index=input_graph.edgelist.renumber_map)
-            first_renumbered = renumber_series.loc[first]
-            second_renumbered = renumber_series.loc[second]
+            first_renumbered = cudf.Series(renumber_series.loc[first],dtype=np.int32)
+            second_renumbered = cudf.Series(renumber_series.loc[second],dtype=np.int32)
             c_first_col = get_gdf_column_view(first_renumbered)
             c_second_col = get_gdf_column_view(second_renumbered)
         else:

--- a/python/cugraph/link_prediction/overlap.py
+++ b/python/cugraph/link_prediction/overlap.py
@@ -35,7 +35,9 @@ def overlap(input_graph, vertex_pair=None):
         as an edge list (edge weights are not used for this algorithm). The
         adjacency list will be computed if not already present.
     vertex_pair : cudf.DataFrame
-        Specifies the pair of vertices to compute for
+        A GPU dataframe consisting of two columns representing pairs of
+        vertices. If provided, the overlap coefficient is computed for the given
+        vertex pairs, else, it is computed for all vertex pairs. 
 
     Returns
     -------

--- a/python/cugraph/link_prediction/overlap.py
+++ b/python/cugraph/link_prediction/overlap.py
@@ -16,7 +16,7 @@ from cugraph.structure.graph import null_check
 import cudf
 
 
-def overlap(input_graph, first=None, second=None):
+def overlap(input_graph, vertex_pair=None):
     """
     Compute the Overlap Coefficient between each pair of vertices connected by
     an edge, or between arbitrary pairs of vertices specified by the user.
@@ -34,12 +34,8 @@ def overlap(input_graph, first=None, second=None):
         cuGraph graph descriptor, should contain the connectivity information
         as an edge list (edge weights are not used for this algorithm). The
         adjacency list will be computed if not already present.
-    first : cudf.Series
-        Specifies the first vertices of each pair of vertices to compute for,
-        must be specified along with second.
-    second : cudf.Series
-        Specifies the second vertices of each pair of vertices to compute for,
-        must be specified along with first.
+    vertex_pair : cudf.DataFrame
+        Specifies the pair of vertices to compute for 
 
     Returns
     -------
@@ -69,15 +65,14 @@ def overlap(input_graph, first=None, second=None):
     >>> df = cugraph.overlap(G)
     """
 
-    if (type(first) == cudf.Series and
-            type(second) == cudf.Series):
-        null_check(first)
-        null_check(second)
-    elif first is None and second is None:
+    if (type(vertex_pair) == cudf.DataFrame):
+        null_check(vertex_pair[vertex_pair.columns[0]])
+        null_check(vertex_pair[vertex_pair.columns[1]])
+    elif vertex_pair is None:
         pass
     else:
-        raise ValueError("Specify first and second or neither")
+        raise ValueError("vertex_pair must be a cudf dataframe")
 
-    df = overlap_wrapper.overlap(input_graph, first, second)
+    df = overlap_wrapper.overlap(input_graph, vertex_pair)
 
     return df

--- a/python/cugraph/link_prediction/overlap.py
+++ b/python/cugraph/link_prediction/overlap.py
@@ -35,7 +35,7 @@ def overlap(input_graph, vertex_pair=None):
         as an edge list (edge weights are not used for this algorithm). The
         adjacency list will be computed if not already present.
     vertex_pair : cudf.DataFrame
-        Specifies the pair of vertices to compute for 
+        Specifies the pair of vertices to compute for
 
     Returns
     -------

--- a/python/cugraph/link_prediction/overlap.py
+++ b/python/cugraph/link_prediction/overlap.py
@@ -36,8 +36,8 @@ def overlap(input_graph, vertex_pair=None):
         adjacency list will be computed if not already present.
     vertex_pair : cudf.DataFrame
         A GPU dataframe consisting of two columns representing pairs of
-        vertices. If provided, the overlap coefficient is computed for the given
-        vertex pairs, else, it is computed for all vertex pairs. 
+        vertices. If provided, the overlap coefficient is computed for the
+        given vertex pairs, else, it is computed for all vertex pairs.
 
     Returns
     -------

--- a/python/cugraph/link_prediction/overlap_wrapper.pyx
+++ b/python/cugraph/link_prediction/overlap_wrapper.pyx
@@ -31,7 +31,7 @@ import rmm
 import numpy as np
 
 
-def overlap(input_graph, first=None, second=None):
+def overlap(input_graph, vertex_pair=None):
     """
     Call overlap_list
     """
@@ -58,15 +58,18 @@ def overlap(input_graph, first=None, second=None):
     cdef gdf_column c_second_col
     cdef gdf_column c_src_index_col
 
-    if type(first) == cudf.Series and type(second) == cudf.Series:
-        result_size = len(first)
+    if type(vertex_pair) == cudf.DataFrame:
+        result_size = len(vertex_pair)
         result = cudf.Series(np.ones(result_size, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
+        first = vertex_pair[vertex_pair.columns[0]]
+        second = vertex_pair[vertex_pair.columns[1]]
+
         if input_graph.renumbered is True:
             renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
                                           index=input_graph.edgelist.renumber_map)
-            first_renumbered = renumber_series.loc[first]
-            second_renumbered = renumber_series.loc[second]
+            first_renumbered = cudf.Series(renumber_series.loc[first], dtype=np.int32)
+            second_renumbered = cudf.Series(renumber_series.loc[second], dtype=np.int32)
             c_first_col = get_gdf_column_view(first_renumbered)
             c_second_col = get_gdf_column_view(second_renumbered)
         else:

--- a/python/cugraph/link_prediction/overlap_wrapper.pyx
+++ b/python/cugraph/link_prediction/overlap_wrapper.pyx
@@ -89,7 +89,7 @@ def overlap(input_graph, vertex_pair=None):
 
     else:
         # error check performed in jaccard.py
-        assert first is None and second is None
+        assert vertex_pair is None
         # we should add get_number_of_edges() to Graph (and this should be
         # used instead of g.adjList.indices.size)
         num_edges = g.adjList.indices.size

--- a/python/cugraph/link_prediction/overlap_wrapper.pyx
+++ b/python/cugraph/link_prediction/overlap_wrapper.pyx
@@ -62,14 +62,14 @@ def overlap(input_graph, vertex_pair=None):
         result_size = len(vertex_pair)
         result = cudf.Series(np.ones(result_size, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
-        first = vertex_pair[vertex_pair.columns[0]]
-        second = vertex_pair[vertex_pair.columns[1]]
+        first = vertex_pair[vertex_pair.columns[0]].astype(np.int32)
+        second = vertex_pair[vertex_pair.columns[1]].astype(np.int32)
 
         if input_graph.renumbered is True:
             renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
-                                          index=input_graph.edgelist.renumber_map)
-            first_renumbered = cudf.Series(renumber_series.loc[first], dtype=np.int32)
-            second_renumbered = cudf.Series(renumber_series.loc[second], dtype=np.int32)
+                                          index=input_graph.edgelist.renumber_map, dtype=np.int32)
+            first_renumbered = renumber_series.loc[first]
+            second_renumbered = renumber_series.loc[second]
             c_first_col = get_gdf_column_view(first_renumbered)
             c_second_col = get_gdf_column_view(second_renumbered)
         else:

--- a/python/cugraph/link_prediction/overlap_wrapper.pyx
+++ b/python/cugraph/link_prediction/overlap_wrapper.pyx
@@ -62,8 +62,16 @@ def overlap(input_graph, first=None, second=None):
         result_size = len(first)
         result = cudf.Series(np.ones(result_size, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
-        c_first_col = get_gdf_column_view(first)
-        c_second_col = get_gdf_column_view(second)
+        if input_graph.renumbered is True:
+            renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
+                                          index=input_graph.edgelist.renumber_map)
+            first_renumbered = renumber_series.loc[first]
+            second_renumbered = renumber_series.loc[second]
+            c_first_col = get_gdf_column_view(first_renumbered)
+            c_second_col = get_gdf_column_view(second_renumbered)
+        else:
+            c_first_col = get_gdf_column_view(first)
+            c_second_col = get_gdf_column_view(second)
         c_overlap.overlap_list(g,
                                <gdf_column*> NULL,
                                &c_first_col,

--- a/python/cugraph/link_prediction/wjaccard.py
+++ b/python/cugraph/link_prediction/wjaccard.py
@@ -39,7 +39,7 @@ def jaccard_w(input_graph, weights, vertex_pair=None):
         Specifies the weights to be used for each vertex.
 
     vertex_pair : cudf.DataFrame
-        Specifies the pair of vertices to compute for 
+        Specifies the pair of vertices to compute for
 
     Returns
     -------

--- a/python/cugraph/link_prediction/wjaccard.py
+++ b/python/cugraph/link_prediction/wjaccard.py
@@ -40,8 +40,8 @@ def jaccard_w(input_graph, weights, vertex_pair=None):
 
     vertex_pair : cudf.DataFrame
         A GPU dataframe consisting of two columns representing pairs of
-        vertices. If provided, the jaccard coefficient is computed for the given
-        vertex pairs, else, it is computed for all vertex pairs.
+        vertices. If provided, the jaccard coefficient is computed for the
+        given vertex pairs, else, it is computed for all vertex pairs.
 
     Returns
     -------

--- a/python/cugraph/link_prediction/wjaccard.py
+++ b/python/cugraph/link_prediction/wjaccard.py
@@ -16,7 +16,7 @@ from cugraph.structure.graph import null_check
 import cudf
 
 
-def jaccard_w(input_graph, weights, first=None, second=None):
+def jaccard_w(input_graph, weights, vertex_pair=None):
     """
     Compute the weighted Jaccard similarity between each pair of vertices
     connected by an edge, or between arbitrary pairs of vertices specified by
@@ -38,13 +38,8 @@ def jaccard_w(input_graph, weights, first=None, second=None):
     weights : cudf.Series
         Specifies the weights to be used for each vertex.
 
-    first : cudf.Series
-        Specifies the first vertices of each pair of vertices to compute for,
-        must be specified along with second.
-
-    second : cudf.Series
-        Specifies the second vertices of each pair of vertices to compute for,
-        must be specified along with first.
+    vertex_pair : cudf.DataFrame
+        Specifies the pair of vertices to compute for 
 
     Returns
     -------
@@ -75,16 +70,15 @@ def jaccard_w(input_graph, weights, first=None, second=None):
     >>> df = cugraph.jaccard_w(G, weights)
     """
 
-    if (type(first) == cudf.Series and
-            type(second) == cudf.Series):
-        null_check(first)
-        null_check(second)
-    elif first is None and second is None:
+    if (type(vertex_pair) == cudf.DataFrame):
+        null_check(vertex_pair[vertex_pair.columns[0]])
+        null_check(vertex_pair[vertex_pair.columns[1]])
+    elif vertex_pair is None:
         pass
     else:
-        raise ValueError("Specify first and second or neither")
+        raise ValueError("vertex_pair must be a cudf dataframe")
 
     df = wjaccard_wrapper.jaccard_w(input_graph,
-                                    weights, first, second)
+                                    weights, vertex_pair)
 
     return df

--- a/python/cugraph/link_prediction/wjaccard.py
+++ b/python/cugraph/link_prediction/wjaccard.py
@@ -39,7 +39,9 @@ def jaccard_w(input_graph, weights, vertex_pair=None):
         Specifies the weights to be used for each vertex.
 
     vertex_pair : cudf.DataFrame
-        Specifies the pair of vertices to compute for
+        A GPU dataframe consisting of two columns representing pairs of
+        vertices. If provided, the jaccard coefficient is computed for the given
+        vertex pairs, else, it is computed for all vertex pairs.
 
     Returns
     -------

--- a/python/cugraph/link_prediction/wjaccard_wrapper.pyx
+++ b/python/cugraph/link_prediction/wjaccard_wrapper.pyx
@@ -64,14 +64,14 @@ def jaccard_w(input_graph, weights, vertex_pair=None):
         result = cudf.Series(np.ones(result_size, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
         c_weight_col = get_gdf_column_view(weights)
-        first = vertex_pair[vertex_pair.columns[0]]
-        second = vertex_pair[vertex_pair.columns[1]]
+        first = vertex_pair[vertex_pair.columns[0]].astype(np.int32)
+        second = vertex_pair[vertex_pair.columns[1]].astype(np.int32)
 
         if input_graph.renumbered is True:
             renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
-                                          index=input_graph.edgelist.renumber_map)
-            first_renumbered = cudf.Series(renumber_series.loc[first],dtype=np.int32)
-            second_renumbered = cudf.Series(renumber_series.loc[second],dtype=np.int32)
+                                          index=input_graph.edgelist.renumber_map, dtype=np.int32)
+            first_renumbered = renumber_series.loc[first]
+            second_renumbered = renumber_series.loc[second]
             c_first_col = get_gdf_column_view(first_renumbered)
             c_second_col = get_gdf_column_view(second_renumbered)
         else:

--- a/python/cugraph/link_prediction/wjaccard_wrapper.pyx
+++ b/python/cugraph/link_prediction/wjaccard_wrapper.pyx
@@ -64,8 +64,16 @@ def jaccard_w(input_graph, weights, first=None, second=None):
         result = cudf.Series(np.ones(result_size, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
         c_weight_col = get_gdf_column_view(weights)
-        c_first_col = get_gdf_column_view(first)
-        c_second_col = get_gdf_column_view(second)
+        if input_graph.renumbered is True:
+            renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
+                                          index=input_graph.edgelist.renumber_map)
+            first_renumbered = renumber_series.loc[first]
+            second_renumbered = renumber_series.loc[second]
+            c_first_col = get_gdf_column_view(first_renumbered)
+            c_second_col = get_gdf_column_view(second_renumbered)
+        else:
+            c_first_col = get_gdf_column_view(first)
+            c_second_col = get_gdf_column_view(second)
         jaccard_list(g,
                                &c_weight_col,
                                &c_first_col,

--- a/python/cugraph/link_prediction/wjaccard_wrapper.pyx
+++ b/python/cugraph/link_prediction/wjaccard_wrapper.pyx
@@ -31,7 +31,7 @@ import numpy as np
 from numpy.core.numeric import result_type
 
 
-def jaccard_w(input_graph, weights_arr, first=None, second=None):
+def jaccard_w(input_graph, weights_arr, vertex_pair=None):
     """
     Call jaccard_list
     """

--- a/python/cugraph/link_prediction/wjaccard_wrapper.pyx
+++ b/python/cugraph/link_prediction/wjaccard_wrapper.pyx
@@ -31,7 +31,7 @@ import numpy as np
 from numpy.core.numeric import result_type
 
 
-def jaccard_w(input_graph, weights, first=None, second=None):
+def jaccard_w(input_graph, weights, vertex_pair=None):
     """
     Call jaccard_list
     """
@@ -59,16 +59,19 @@ def jaccard_w(input_graph, weights, first=None, second=None):
     cdef gdf_column c_second_col
     cdef gdf_column c_index_col
 
-    if type(first) == cudf.Series and type(second) == cudf.Series:
-        result_size = len(first)
+    if type(vertex_pair) == cudf.DataFrame:
+        result_size = len(vertex_pair)
         result = cudf.Series(np.ones(result_size, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
         c_weight_col = get_gdf_column_view(weights)
+        first = vertex_pair[vertex_pair.columns[0]]
+        second = vertex_pair[vertex_pair.columns[1]]
+
         if input_graph.renumbered is True:
             renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
                                           index=input_graph.edgelist.renumber_map)
-            first_renumbered = renumber_series.loc[first]
-            second_renumbered = renumber_series.loc[second]
+            first_renumbered = cudf.Series(renumber_series.loc[first],dtype=np.int32)
+            second_renumbered = cudf.Series(renumber_series.loc[second],dtype=np.int32)
             c_first_col = get_gdf_column_view(first_renumbered)
             c_second_col = get_gdf_column_view(second_renumbered)
         else:

--- a/python/cugraph/link_prediction/wjaccard_wrapper.pyx
+++ b/python/cugraph/link_prediction/wjaccard_wrapper.pyx
@@ -91,7 +91,7 @@ def jaccard_w(input_graph, weights, vertex_pair=None):
 
     else:
         # error check performed in jaccard.py
-        assert first is None and second is None
+        assert vertex_pair is None
         # we should add get_number_of_edges() to Graph (and this should be
         # used instead of g.adjList.indices.size)
         num_edges = g.adjList.indices.size

--- a/python/cugraph/link_prediction/woverlap.py
+++ b/python/cugraph/link_prediction/woverlap.py
@@ -16,7 +16,7 @@ from cugraph.structure.graph import null_check
 import cudf
 
 
-def overlap_w(input_graph, weights, first=None, second=None):
+def overlap_w(input_graph, weights, vertex_pair=None):
     """
     Compute the weighted Overlap Coefficient between each pair of vertices
     connected by an edge, or between arbitrary pairs of vertices specified by
@@ -38,13 +38,8 @@ def overlap_w(input_graph, weights, first=None, second=None):
     weights : cudf.Series
         Specifies the weights to be used for each vertex.
 
-    first : cudf.Series
-        Specifies the first vertices of each pair of vertices to compute for,
-        must be specified along with second.
-
-    second : cudf.Series
-        Specifies the second vertices of each pair of vertices to compute for,
-        must be specified along with first.
+    vertex_pair : cudf.DataFrame
+        Specifies the pair of vertices to compute for 
 
     Returns
     -------
@@ -75,16 +70,15 @@ def overlap_w(input_graph, weights, first=None, second=None):
     >>> df = cugraph.overlap_w(G, weights)
     """
 
-    if (type(first) == cudf.Series and
-            type(second) == cudf.Series):
-        null_check(first)
-        null_check(second)
-    elif first is None and second is None:
+    if (type(vertex_pair) == cudf.DataFrame):
+        null_check(vertex_pair[vertex_pair.columns[0]])
+        null_check(vertex_pair[vertex_pair.columns[1]])
+    elif vertex_pair is None:
         pass
     else:
-        raise ValueError("Specify first and second or neither")
+        raise ValueError("vertex_pair must be a cudf dataframe")
 
     df = woverlap_wrapper.overlap_w(input_graph,
-                                    weights, first, second)
+                                    weights, vertex_pair)
 
     return df

--- a/python/cugraph/link_prediction/woverlap.py
+++ b/python/cugraph/link_prediction/woverlap.py
@@ -39,7 +39,7 @@ def overlap_w(input_graph, weights, vertex_pair=None):
         Specifies the weights to be used for each vertex.
 
     vertex_pair : cudf.DataFrame
-        Specifies the pair of vertices to compute for 
+        Specifies the pair of vertices to compute for
 
     Returns
     -------

--- a/python/cugraph/link_prediction/woverlap.py
+++ b/python/cugraph/link_prediction/woverlap.py
@@ -40,8 +40,8 @@ def overlap_w(input_graph, weights, vertex_pair=None):
 
     vertex_pair : cudf.DataFrame
         A GPU dataframe consisting of two columns representing pairs of
-        vertices. If provided, the overlap coefficient is computed for the given
-        vertex pairs, else, it is computed for all vertex pairs. 
+        vertices. If provided, the overlap coefficient is computed for the
+        given vertex pairs, else, it is computed for all vertex pairs.
 
     Returns
     -------

--- a/python/cugraph/link_prediction/woverlap.py
+++ b/python/cugraph/link_prediction/woverlap.py
@@ -39,7 +39,9 @@ def overlap_w(input_graph, weights, vertex_pair=None):
         Specifies the weights to be used for each vertex.
 
     vertex_pair : cudf.DataFrame
-        Specifies the pair of vertices to compute for
+        A GPU dataframe consisting of two columns representing pairs of
+        vertices. If provided, the overlap coefficient is computed for the given
+        vertex pairs, else, it is computed for all vertex pairs. 
 
     Returns
     -------

--- a/python/cugraph/link_prediction/woverlap_wrapper.pyx
+++ b/python/cugraph/link_prediction/woverlap_wrapper.pyx
@@ -64,14 +64,14 @@ def overlap_w(input_graph, weights, vertex_pair=None):
         result = cudf.Series(np.ones(result_size, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
         c_weight_col = get_gdf_column_view(weights)
-        first = vertex_pair[vertex_pair.columns[0]]
-        second = vertex_pair[vertex_pair.columns[1]]
+        first = vertex_pair[vertex_pair.columns[0]].astype(np.int32)
+        second = vertex_pair[vertex_pair.columns[1]].astype(np.int32)
 
         if input_graph.renumbered is True:
             renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
-                                          index=input_graph.edgelist.renumber_map)
-            first_renumbered = cudf.Series(renumber_series.loc[first], dtype=np.int32)
-            second_renumbered = cudf.Series(renumber_series.loc[second], dtype=np.int32)
+                                          index=input_graph.edgelist.renumber_map, dtype=np.int32)
+            first_renumbered = renumber_series.loc[first]
+            second_renumbered = renumber_series.loc[second]
             c_first_col = get_gdf_column_view(first_renumbered)
             c_second_col = get_gdf_column_view(second_renumbered)
         else:

--- a/python/cugraph/link_prediction/woverlap_wrapper.pyx
+++ b/python/cugraph/link_prediction/woverlap_wrapper.pyx
@@ -91,7 +91,7 @@ def overlap_w(input_graph, weights, vertex_pair=None):
 
     else:
         # error check performed in jaccard.py
-        assert first is None and second is None
+        assert vertex_pair is None
         # we should add get_number_of_edges() to Graph (and this should be
         # used instead of g.adjList.indices.size)
         num_edges = g.adjList.indices.size

--- a/python/cugraph/link_prediction/woverlap_wrapper.pyx
+++ b/python/cugraph/link_prediction/woverlap_wrapper.pyx
@@ -31,7 +31,7 @@ import numpy as np
 from cython cimport floating
 
 
-def overlap_w(input_graph, weights_arr, first=None, second=None):
+def overlap_w(input_graph, weights_arr, vertex_pair=None):
     """
     Call overlap_list
     """

--- a/python/cugraph/link_prediction/woverlap_wrapper.pyx
+++ b/python/cugraph/link_prediction/woverlap_wrapper.pyx
@@ -31,7 +31,7 @@ import numpy as np
 from cython cimport floating
 
 
-def overlap_w(input_graph, weights, first=None, second=None):
+def overlap_w(input_graph, weights, vertex_pair=None):
     """
     Call overlap_list
     """
@@ -59,16 +59,19 @@ def overlap_w(input_graph, weights, first=None, second=None):
     cdef gdf_column c_second_col
     cdef gdf_column c_index_col
 
-    if type(first) == cudf.Series and type(second) == cudf.Series:
-        result_size = len(first)
+    if type(vertex_pair) == cudf.DataFrame:
+        result_size = len(vertex_pair)
         result = cudf.Series(np.ones(result_size, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
         c_weight_col = get_gdf_column_view(weights)
+        first = vertex_pair[vertex_pair.columns[0]]
+        second = vertex_pair[vertex_pair.columns[1]]
+
         if input_graph.renumbered is True:
             renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
                                           index=input_graph.edgelist.renumber_map)
-            first_renumbered = renumber_series.loc[first]
-            second_renumbered = renumber_series.loc[second]
+            first_renumbered = cudf.Series(renumber_series.loc[first], dtype=np.int32)
+            second_renumbered = cudf.Series(renumber_series.loc[second], dtype=np.int32)
             c_first_col = get_gdf_column_view(first_renumbered)
             c_second_col = get_gdf_column_view(second_renumbered)
         else:

--- a/python/cugraph/link_prediction/woverlap_wrapper.pyx
+++ b/python/cugraph/link_prediction/woverlap_wrapper.pyx
@@ -64,8 +64,16 @@ def overlap_w(input_graph, weights, first=None, second=None):
         result = cudf.Series(np.ones(result_size, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
         c_weight_col = get_gdf_column_view(weights)
-        c_first_col = get_gdf_column_view(first)
-        c_second_col = get_gdf_column_view(second)
+        if input_graph.renumbered is True:
+            renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
+                                          index=input_graph.edgelist.renumber_map)
+            first_renumbered = renumber_series.loc[first]
+            second_renumbered = renumber_series.loc[second]
+            c_first_col = get_gdf_column_view(first_renumbered)
+            c_second_col = get_gdf_column_view(second_renumbered)
+        else:
+            c_first_col = get_gdf_column_view(first)
+            c_second_col = get_gdf_column_view(second)
         overlap_list(g,
                                &c_weight_col,
                                &c_first_col,

--- a/python/cugraph/structure/graph.py
+++ b/python/cugraph/structure/graph.py
@@ -494,9 +494,9 @@ class Graph:
                 df['in_degree'] = cudf.Series(
                     np.asarray([in_degree_col[i] for i in vertices_renumbered],
                                dtype=np.int32))
-                df['out_degree'] = cudf.Series(
-                    np.asarray([out_degree_col[i] for i in vertices_renumbered],
-                               dtype=np.int32))
+                df['out_degree'] = cudf.Series(np.asarray([out_degree_col[i]
+                                               for i in vertices_renumbered],
+                                               dtype=np.int32))
             else:
                 df['in_degree'] = cudf.Series(
                     np.asarray([in_degree_col[i] for i in vertex_subset],
@@ -531,7 +531,8 @@ class Graph:
                                               index=self.edgelist.renumber_map)
                 vertices_renumbered = renumber_series.loc[vertex_subset]
                 df['degree'] = cudf.Series(np.asarray(
-                    [degree_col[i] for i in vertices_renumbered], dtype=np.int32
+                    [degree_col[i] for i in vertices_renumbered],
+                    dtype=np.int32
                 ))
             else:
                 df['degree'] = cudf.Series(np.asarray(

--- a/python/cugraph/structure/graph.py
+++ b/python/cugraph/structure/graph.py
@@ -474,18 +474,34 @@ class Graph:
 
         df = cudf.DataFrame()
         if vertex_subset is None:
-            df['vertex'] = vertex_col
+            if self.renumbered is True:
+                df['vertex'] = input_graph.edgelist.renumber_map[vertex_col]
+            else:
+                df['vertex'] = vertex_col
             df['in_degree'] = in_degree_col
             df['out_degree'] = out_degree_col
         else:
             df['vertex'] = cudf.Series(
                 np.asarray(vertex_subset, dtype=np.int32))
-            df['in_degree'] = cudf.Series(
-                np.asarray([in_degree_col[i] for i in vertex_subset],
-                           dtype=np.int32))
-            df['out_degree'] = cudf.Series(
-                np.asarray([out_degree_col[i] for i in vertex_subset],
-                           dtype=np.int32))
+            if self.renumbered is True:
+                renumber_series = cudf.Series(self.edgelist.renumber_map.index,
+                                              index=self.edgelist.renumber_map)
+                vertices_renumbered = renumber_series.loc[vertex_subset]
+
+                df['in_degree'] = cudf.Series(
+                    np.asarray([in_degree_col[i] for i in vertices_renumbered],
+                               dtype=np.int32))
+                df['out_degree'] = cudf.Series(
+                    np.asarray([out_degree_col[i] for i in vertices_renumbered],
+                               dtype=np.int32))
+            else:
+                df['in_degree'] = cudf.Series(
+                    np.asarray([in_degree_col[i] for i in vertex_subset],
+                               dtype=np.int32))
+                df['out_degree'] = cudf.Series(
+                    np.asarray([out_degree_col[i] for i in vertex_subset],
+                               dtype=np.int32))
+
             # is this necessary???
             del vertex_col
             del in_degree_col
@@ -498,15 +514,26 @@ class Graph:
 
         df = cudf.DataFrame()
         if vertex_subset is None:
-            df['vertex'] = vertex_col
+            if self.renumbered is True:
+                df['vertex'] = input_graph.edgelist.renumber_map[vertex_col]
+            else:
+                df['vertex'] = vertex_col
             df['degree'] = degree_col
         else:
             df['vertex'] = cudf.Series(np.asarray(
                 vertex_subset, dtype=np.int32
             ))
-            df['degree'] = cudf.Series(np.asarray(
-                [degree_col[i] for i in vertex_subset], dtype=np.int32
-            ))
+            if self.renumbered is True:
+                renumber_series = cudf.Series(self.edgelist.renumber_map.index,
+                                              index=self.edgelist.renumber_map)
+                vertices_renumbered = renumber_series.loc[vertex_subset]
+                df['degree'] = cudf.Series(np.asarray(
+                    [degree_col[i] for i in vertices_renumbered], dtype=np.int32
+                ))
+            else:
+                df['degree'] = cudf.Series(np.asarray(
+                    [degree_col[i] for i in vertex_subset], dtype=np.int32
+                ))
             # is this necessary???
             del vertex_col
             del degree_col

--- a/python/cugraph/structure/graph.py
+++ b/python/cugraph/structure/graph.py
@@ -184,11 +184,14 @@ class Graph:
         """
         if self.edgelist is None:
             graph_wrapper.view_edge_list(self)
-        df = self.edgelist.edgelist_df
+        edgelist_df = self.edgelist.edgelist_df
         if self.renumbered:
-            df['src'] = self.edgelist.renumber_map[df['src']]
-            df['dst'] = self.edgelist.renumber_map[df['dst']]
-        return df
+            df = cudf.DataFrame()
+            df['src'] = self.edgelist.renumber_map[edgelist_df['src']]
+            df['dst'] = self.edgelist.renumber_map[edgelist_df['dst']]
+            return df
+        else:
+            return edgelist_df
 
     def delete_edge_list(self):
         """
@@ -475,7 +478,7 @@ class Graph:
         df = cudf.DataFrame()
         if vertex_subset is None:
             if self.renumbered is True:
-                df['vertex'] = input_graph.edgelist.renumber_map[vertex_col]
+                df['vertex'] = self.edgelist.renumber_map[vertex_col]
             else:
                 df['vertex'] = vertex_col
             df['in_degree'] = in_degree_col
@@ -515,7 +518,7 @@ class Graph:
         df = cudf.DataFrame()
         if vertex_subset is None:
             if self.renumbered is True:
-                df['vertex'] = input_graph.edgelist.renumber_map[vertex_col]
+                df['vertex'] = self.edgelist.renumber_map[vertex_col]
             else:
                 df['vertex'] = vertex_col
             df['degree'] = degree_col

--- a/python/cugraph/tests/test_jaccard.py
+++ b/python/cugraph/tests/test_jaccard.py
@@ -197,7 +197,7 @@ def test_jaccard_two_hop(managed, pool, graph_file):
     nx_coeff = []
     for u, v, p in preds:
         nx_coeff.append(p)
-    df = cugraph.jaccard(G, pairs['first'], pairs['second'])
+    df = cugraph.jaccard(G, pairs)
     assert len(nx_coeff) == len(df)
     for i in range(len(df)):
         diff = abs(nx_coeff[i] - df['jaccard_coeff'][i])
@@ -235,7 +235,7 @@ def test_jaccard_two_hop_edge_vals(managed, pool, graph_file):
     nx_coeff = []
     for u, v, p in preds:
         nx_coeff.append(p)
-    df = cugraph.jaccard(G, pairs['first'], pairs['second'])
+    df = cugraph.jaccard(G, pairs)
     assert len(nx_coeff) == len(df)
     for i in range(len(df)):
         diff = abs(nx_coeff[i] - df['jaccard_coeff'][i])

--- a/python/cugraph/tests/test_overlap.py
+++ b/python/cugraph/tests/test_overlap.py
@@ -24,7 +24,7 @@ from cugraph.tests import utils
 import rmm
 
 
-def cugraph_call(cu_M, first, second, edgevals=False):
+def cugraph_call(cu_M, pairs, edgevals=False):
     G = cugraph.DiGraph()
     # Device data
     if edgevals is True:
@@ -33,7 +33,7 @@ def cugraph_call(cu_M, first, second, edgevals=False):
         G.from_cudf_edgelist(cu_M, source='0', destination='1')
     # cugraph Overlap Call
     t1 = time.time()
-    df = cugraph.overlap(G, first, second)
+    df = cugraph.overlap(G, pairs)
     t2 = time.time() - t1
     print('Time : '+str(t2))
 
@@ -115,7 +115,7 @@ def test_overlap(managed, pool, graph_file):
     G.from_cudf_adjlist(row_offsets, col_indices, None)
     pairs = G.get_two_hop_neighbors()
 
-    cu_coeff = cugraph_call(cu_M, pairs['first'], pairs['second'])
+    cu_coeff = cugraph_call(cu_M, pairs)
     cpu_coeff = cpu_call(M, pairs['first'], pairs['second'])
 
     assert len(cu_coeff) == len(cpu_coeff)
@@ -153,7 +153,7 @@ def test_overlap_edge_vals(managed, pool, graph_file):
     G.from_cudf_adjlist(row_offsets, col_indices, None)
     pairs = G.get_two_hop_neighbors()
 
-    cu_coeff = cugraph_call(cu_M, pairs['first'], pairs['second'],
+    cu_coeff = cugraph_call(cu_M, pairs,
                             edgevals=True)
     cpu_coeff = cpu_call(M, pairs['first'], pairs['second'])
 

--- a/python/cugraph/tests/test_woverlap.py
+++ b/python/cugraph/tests/test_woverlap.py
@@ -24,7 +24,7 @@ import rmm
 import numpy as np
 
 
-def cugraph_call(cu_M, first, second):
+def cugraph_call(cu_M, pairs):
     # Device data
     weights_arr = cudf.Series(np.ones(max(cu_M['0'].max(),
                               cu_M['1'].max())+1, dtype=np.float32))
@@ -34,7 +34,7 @@ def cugraph_call(cu_M, first, second):
 
     # cugraph Overlap Call
     t1 = time.time()
-    df = cugraph.overlap_w(G, weights_arr, first, second)
+    df = cugraph.overlap_w(G, weights_arr, pairs)
     t2 = time.time() - t1
     print('Time : '+str(t2))
     return df['overlap_coeff'].to_array()
@@ -114,7 +114,7 @@ def test_woverlap(managed, pool, graph_file):
     G.from_cudf_adjlist(row_offsets, col_indices, None)
     pairs = G.get_two_hop_neighbors()
 
-    cu_coeff = cugraph_call(cu_M, pairs['first'], pairs['second'])
+    cu_coeff = cugraph_call(cu_M, pairs)
     cpu_coeff = cpu_call(M, pairs['first'], pairs['second'])
     assert len(cu_coeff) == len(cpu_coeff)
     for i in range(len(cu_coeff)):

--- a/python/cugraph/traversal/bfs_wrapper.pyx
+++ b/python/cugraph/traversal/bfs_wrapper.pyx
@@ -54,6 +54,8 @@ def bfs(input_graph, start, directed=True):
     # used instead of g.adjList.offsets.size - 1)
     num_verts = g.adjList.offsets.size - 1
 
+    if input_graph.renumbered is True:
+        start = input_graph.edgelist.renumber_map[input_graph.edgelist.renumber_map==start].index[0]
     if not 0 <= start < num_verts:
         raise ValueError("Starting vertex should be between 0 to number of vertices")
 

--- a/python/cugraph/traversal/bfs_wrapper.pyx
+++ b/python/cugraph/traversal/bfs_wrapper.pyx
@@ -73,6 +73,6 @@ def bfs(input_graph, start, directed=True):
 
     if input_graph.renumbered:
         df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
-        df['predecessor'] = input_graph.edgelist.renumber_map[df['predecessor']]
+        df['predecessor'][df['predecessor']>-1] = input_graph.edgelist.renumber_map[df['predecessor'][df['predecessor']>-1]]
 
     return df

--- a/python/cugraph/traversal/sssp_wrapper.pyx
+++ b/python/cugraph/traversal/sssp_wrapper.pyx
@@ -59,6 +59,8 @@ def sssp(input_graph, source):
     # used instead of g.adjList.offsets.size - 1)
     num_verts = g.adjList.offsets.size - 1
 
+    if input_graph.renumbered is True:
+        source = input_graph.edgelist.renumber_map[input_graph.edgelist.renumber_map==source].index[0]
     if not 0 <= source < num_verts:                
         raise ValueError("Starting vertex should be between 0 to number of vertices")
 

--- a/python/cugraph/traversal/sssp_wrapper.pyx
+++ b/python/cugraph/traversal/sssp_wrapper.pyx
@@ -86,6 +86,6 @@ def sssp(input_graph, source):
 
     if input_graph.renumbered:
         df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
-        df['predecessor'] = input_graph.edgelist.renumber_map[df['predecessor']]
+        df['predecessor'][df['predecessor']>-1] = input_graph.edgelist.renumber_map[df['predecessor'][df['predecessor']>-1]]
 
     return df


### PR DESCRIPTION
This PR takes user notations into consideration when vertices are passed as arguments for analytics. If the graph is renumbered, passed vertices are also auto-renumbered according to the renumbering map used for the graph.
Changed first and second cudf.Series (to provide vertex pairs for computation of coefficient) in jaccard, wjaccard, overlap and woverlap to  a cudf.DataFrame input since it is more intuitive.
closes #592 