### PR TITLE
[REVIEW] Skipping all tests in test_bfs_bsp.py since SG BFS is not formally supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Improvements
 
 - PR #641 Add codeowners
+- PR #646 Skipping all tests in test_bfs_bsp.py since SG BFS is not formally supported
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## Bug Fixes
 
 
-# cuGraph 0.11.0 (Date TBD)
+# cuGraph 0.11.0 (11 Dec 2019)
 
 ## New Features
 - PR #588 Python graph class and related changes

--- a/python/cugraph/tests/test_bfs_bsp.py
+++ b/python/cugraph/tests/test_bfs_bsp.py
@@ -76,6 +76,7 @@ DATASETS = ['../datasets/dolphins.csv',
 
 
 # Test all combinations of default/managed and pooled/non-pooled allocation
+@pytest.mark.skip(reason="SG BFS is not yet formally supported")
 @pytest.mark.parametrize('managed, pool',
                          list(product([False, True], [False, True])))
 @pytest.mark.parametrize('graph_file', DATASETS)


### PR DESCRIPTION
Skipping all tests in `test_bfs_bsp.py` since SG BFS is not formally supported and they currently crash.

Also updated 0.11 release date in CHANGELOG.