### PR TITLE
[REVIEW] change variable names in wjaccard and woverlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - PR #646 Skipping all tests in test_bfs_bsp.py since SG BFS is not formally supported
 
 ## Bug Fixes
-
+- PR #649 Change variable names in wjaccard and woverlap to avoid exception
 
 # cuGraph 0.11.0 (11 Dec 2019)
 

--- a/python/cugraph/link_prediction/wjaccard_wrapper.pyx
+++ b/python/cugraph/link_prediction/wjaccard_wrapper.pyx
@@ -31,7 +31,7 @@ import numpy as np
 from numpy.core.numeric import result_type
 
 
-def jaccard_w(input_graph, weights, first=None, second=None):
+def jaccard_w(input_graph, weights_arr, first=None, second=None):
     """
     Call jaccard_list
     """
@@ -63,7 +63,7 @@ def jaccard_w(input_graph, weights, first=None, second=None):
         result_size = len(first)
         result = cudf.Series(np.ones(result_size, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
-        c_weight_col = get_gdf_column_view(weights)
+        c_weight_col = get_gdf_column_view(weights_arr)
         c_first_col = get_gdf_column_view(first)
         c_second_col = get_gdf_column_view(second)
         jaccard_list(g,
@@ -86,7 +86,7 @@ def jaccard_w(input_graph, weights, first=None, second=None):
         num_edges = g.adjList.indices.size
         result = cudf.Series(np.ones(num_edges, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
-        c_weight_col = get_gdf_column_view(weights)
+        c_weight_col = get_gdf_column_view(weights_arr)
 
         jaccard(g, &c_weight_col, &c_result_col)
         

--- a/python/cugraph/link_prediction/woverlap_wrapper.pyx
+++ b/python/cugraph/link_prediction/woverlap_wrapper.pyx
@@ -31,7 +31,7 @@ import numpy as np
 from cython cimport floating
 
 
-def overlap_w(input_graph, weights, first=None, second=None):
+def overlap_w(input_graph, weights_arr, first=None, second=None):
     """
     Call overlap_list
     """
@@ -63,7 +63,7 @@ def overlap_w(input_graph, weights, first=None, second=None):
         result_size = len(first)
         result = cudf.Series(np.ones(result_size, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
-        c_weight_col = get_gdf_column_view(weights)
+        c_weight_col = get_gdf_column_view(weights_arr)
         c_first_col = get_gdf_column_view(first)
         c_second_col = get_gdf_column_view(second)
         overlap_list(g,
@@ -86,7 +86,7 @@ def overlap_w(input_graph, weights, first=None, second=None):
         num_edges = g.adjList.indices.size
         result = cudf.Series(np.ones(num_edges, dtype=np.float32))
         c_result_col = get_gdf_column_view(result)
-        c_weight_col = get_gdf_column_view(weights)
+        c_weight_col = get_gdf_column_view(weights_arr)
 
         overlap(g, &c_weight_col, &c_result_col)
         


### PR DESCRIPTION
Changes variable names of graph weights and weight_arr in the wrapper to avoid exception when graph has no edge weights i.e. is None