### PR TITLE
[REVIEW] multi column renumbering changes for python graph structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - PR #646 Skipping all tests in test_bfs_bsp.py since SG BFS is not formally supported
 - PR #652 Remove gdf_column in BFS
 - PR #660 enable auto renumbering
+- PR #666 Incorporate multicolumn renumbering in python graph class for Multi(Di)Graph
 
 ## Bug Fixes
 - PR #634 renumber vertex ids passed in analytics
@@ -41,7 +42,6 @@
 - PR #616 Remove c_ prefix
 - PR #618 Updated Docs
 - PR #619 Transition guide
-- PR #666 Incorporate multicolumn renumbering in python graph class for Multi(Di)Graph
 
 ## Bug Fixes
 - PR #570 Temporarily disabling 2 DB tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - PR #616 Remove c_ prefix
 - PR #618 Updated Docs
 - PR #619 Transition guide
+- PR #666 Incorporate multicolumn renumbering in python graph class for Multi(Di)Graph
 
 ## Bug Fixes
 - PR #570 Temporarily disabling 2 DB tests

--- a/python/cugraph/centrality/katz_centrality_wrapper.pyx
+++ b/python/cugraph/centrality/katz_centrality_wrapper.pyx
@@ -20,6 +20,7 @@ cimport cugraph.centrality.katz_centrality as c_katz
 from cugraph.structure.graph cimport *
 from cugraph.structure import graph_wrapper
 from cugraph.utilities.column_utils cimport *
+from cugraph.utilities.unrenumber import unrenumber
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport calloc, malloc, free
@@ -85,11 +86,6 @@ def katz_centrality(input_graph, alpha=0.1, max_iter=100, tol=1.0e-5, nstart=Non
     c_katz.katz_centrality(g, &c_katz_centrality_col, alpha, max_iter, tol, has_guess, normalized)
 
     if input_graph.renumbered:
-        if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
-            unrenumered_df = df.merge(input_graph.edgelist.renumber_map, left_on='vertex', right_on='id', how='left').drop(['id', 'vertex'])
-            cols = unrenumered_df.columns
-            df = unrenumered_df[[cols[1:], cols[0]]]
-        else:
-            df['vertex']=input_graph.edgelist.renumber_map[df['vertex']]
+        df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertex')
 
     return df

--- a/python/cugraph/centrality/katz_centrality_wrapper.pyx
+++ b/python/cugraph/centrality/katz_centrality_wrapper.pyx
@@ -85,6 +85,11 @@ def katz_centrality(input_graph, alpha=0.1, max_iter=100, tol=1.0e-5, nstart=Non
     c_katz.katz_centrality(g, &c_katz_centrality_col, alpha, max_iter, tol, has_guess, normalized)
 
     if input_graph.renumbered:
-        df['vertex']=input_graph.edgelist.renumber_map[df['vertex']]
+        if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
+            unrenumered_df = df.merge(input_graph.edgelist.renumber_map, left_on='vertex', right_on='id', how='left').drop(['id', 'vertex'])
+            cols = unrenumered_df.columns
+            df = unrenumered_df[[cols[1:], cols[0]]]
+        else:
+            df['vertex']=input_graph.edgelist.renumber_map[df['vertex']]
 
     return df

--- a/python/cugraph/community/ecg_wrapper.pyx
+++ b/python/cugraph/community/ecg_wrapper.pyx
@@ -20,6 +20,7 @@ cimport cugraph.community.ecg as c_ecg
 from cugraph.structure.graph cimport *
 from cugraph.structure import graph_wrapper
 from cugraph.utilities.column_utils cimport *
+from cugraph.utilities.unrenumber import unrenumber
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport calloc, malloc, free
@@ -58,13 +59,6 @@ def ecg(input_graph, min_weight=.05, ensemble_size=16):
     df['vertex'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
     cdef gdf_column c_index_col = get_gdf_column_view(df['vertex'])
     g.adjList.get_vertex_identifiers(&c_index_col)
-    if input_graph.renumbered:
-        if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
-            unrenumered_df = df.merge(input_graph.edgelist.renumber_map, left_on='vertex', right_on='id', how='left').drop(['id', 'vertex'])
-            cols = unrenumered_df.columns
-            df = unrenumered_df[[cols[1:], cols[0]]]
-        else:
-            df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
 
     df['partition'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
     cdef uintptr_t c_ecg_ptr = get_column_data_ptr(df['partition']._column)
@@ -73,6 +67,9 @@ def ecg(input_graph, min_weight=.05, ensemble_size=16):
         c_ecg.ecg[int32_t, float] (<Graph*>g, min_weight, ensemble_size, <int32_t*>c_ecg_ptr)
     else:
         c_ecg.ecg[int32_t, double] (<Graph*>g, min_weight, ensemble_size, <int32_t*>c_ecg_ptr)
+
+    if input_graph.renumbered:
+        df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertex')
 
     return df
     

--- a/python/cugraph/community/louvain_wrapper.pyx
+++ b/python/cugraph/community/louvain_wrapper.pyx
@@ -97,7 +97,12 @@ def louvain(input_graph):
     
 
     if input_graph.renumbered:
-        df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
+        if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
+            unrenumered_df = df.merge(input_graph.edgelist.renumber_map, left_on='vertex', right_on='id', how='left').drop(['id', 'vertex'])
+            cols = unrenumered_df.columns
+            df = unrenumered_df[[cols[1:], cols[0]]]
+        else:
+            df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
 
     if single_precision:
         return df, <double>final_modularity_single_precision

--- a/python/cugraph/community/louvain_wrapper.pyx
+++ b/python/cugraph/community/louvain_wrapper.pyx
@@ -20,6 +20,7 @@ cimport cugraph.community.louvain as c_louvain
 from cugraph.structure.graph cimport *
 from cugraph.structure import graph_wrapper
 from cugraph.utilities.column_utils cimport *
+from cugraph.utilities.unrenumber import unrenumber
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport calloc, malloc, free
@@ -97,12 +98,7 @@ def louvain(input_graph):
     
 
     if input_graph.renumbered:
-        if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
-            unrenumered_df = df.merge(input_graph.edgelist.renumber_map, left_on='vertex', right_on='id', how='left').drop(['id', 'vertex'])
-            cols = unrenumered_df.columns
-            df = unrenumered_df[[cols[1:], cols[0]]]
-        else:
-            df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
+        df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertex')
 
     if single_precision:
         return df, <double>final_modularity_single_precision

--- a/python/cugraph/community/spectral_clustering_wrapper.pyx
+++ b/python/cugraph/community/spectral_clustering_wrapper.pyx
@@ -20,6 +20,7 @@ from cugraph.community.spectral_clustering cimport *
 from cugraph.structure.graph cimport *
 from cugraph.structure import graph_wrapper
 from cugraph.utilities.column_utils cimport *
+from cugraph.utilities.unrenumber import unrenumber
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport calloc, malloc, free
@@ -85,12 +86,7 @@ def spectralBalancedCutClustering(input_graph,
     
 
     if input_graph.renumbered:
-        if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
-            unrenumered_df = df.merge(input_graph.edgelist.renumber_map, left_on='vertex', right_on='id', how='left').drop(['id', 'vertex'])
-            cols = unrenumered_df.columns
-            df = unrenumered_df[[cols[1:], cols[0]]]
-        else:
-            df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
+        df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertex')
 
     return df
 
@@ -144,12 +140,7 @@ def spectralModularityMaximizationClustering(input_graph,
     
 
     if input_graph.renumbered:
-        if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
-            unrenumered_df = df.merge(input_graph.edgelist.renumber_map, left_on='vertex', right_on='id', how='left').drop(['id', 'vertex'])
-            cols = unrenumered_df.columns
-            df = unrenumered_df[[cols[1:], cols[0]]]
-        else:
-            df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
+        df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertex')
 
     return df
 

--- a/python/cugraph/community/spectral_clustering_wrapper.pyx
+++ b/python/cugraph/community/spectral_clustering_wrapper.pyx
@@ -85,7 +85,12 @@ def spectralBalancedCutClustering(input_graph,
     
 
     if input_graph.renumbered:
-        df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
+        if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
+            unrenumered_df = df.merge(input_graph.edgelist.renumber_map, left_on='vertex', right_on='id', how='left').drop(['id', 'vertex'])
+            cols = unrenumered_df.columns
+            df = unrenumered_df[[cols[1:], cols[0]]]
+        else:
+            df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
 
     return df
 
@@ -139,7 +144,12 @@ def spectralModularityMaximizationClustering(input_graph,
     
 
     if input_graph.renumbered:
-        df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
+        if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
+            unrenumered_df = df.merge(input_graph.edgelist.renumber_map, left_on='vertex', right_on='id', how='left').drop(['id', 'vertex'])
+            cols = unrenumered_df.columns
+            df = unrenumered_df[[cols[1:], cols[0]]]
+        else:
+            df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
 
     return df
 

--- a/python/cugraph/cores/core_number_wrapper.pyx
+++ b/python/cugraph/cores/core_number_wrapper.pyx
@@ -20,6 +20,7 @@ cimport cugraph.cores.core_number as c_core
 from cugraph.structure.graph cimport *
 from cugraph.structure import graph_wrapper
 from cugraph.utilities.column_utils cimport *
+from cugraph.utilities.unrenumber import unrenumber
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport calloc, malloc, free
@@ -68,11 +69,6 @@ def core_number(input_graph):
     c_core.core_number(g, &c_core_number_col)
 
     if input_graph.renumbered:
-        if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
-            unrenumered_df = df.merge(input_graph.edgelist.renumber_map, left_on='vertex', right_on='id', how='left').drop(['id', 'vertex'])
-            cols = unrenumered_df.columns
-            df = unrenumered_df[[cols[1:], cols[0]]]
-        else:
-            df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
+        df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertex')
 
     return df

--- a/python/cugraph/cores/core_number_wrapper.pyx
+++ b/python/cugraph/cores/core_number_wrapper.pyx
@@ -68,6 +68,11 @@ def core_number(input_graph):
     c_core.core_number(g, &c_core_number_col)
 
     if input_graph.renumbered:
-        df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
+        if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
+            unrenumered_df = df.merge(input_graph.edgelist.renumber_map, left_on='vertex', right_on='id', how='left').drop(['id', 'vertex'])
+            cols = unrenumered_df.columns
+            df = unrenumered_df[[cols[1:], cols[0]]]
+        else:
+            df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
 
     return df

--- a/python/cugraph/link_analysis/pagerank_wrapper.pyx
+++ b/python/cugraph/link_analysis/pagerank_wrapper.pyx
@@ -66,10 +66,11 @@ def pagerank(input_graph, alpha=0.85, personalization=None, max_iter=100, tol=1.
         if len(nstart) != num_verts:
             raise ValueError('nstart must have initial guess for all vertices')
         if input_graph.renumbered is True:
-            renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
-                                          index=input_graph.edgelist.renumber_map, dtype=np.int32)        
-            vertex_renumbered = renumber_series.loc[nstart['vertex']]
-            df['pagerank'][vertex_renumbered] = nstart['values']
+            renumber_df = cudf.DataFrame()
+            renumber_df['map'] = input_graph.edgelist.renumber_map
+            renumber_df['id'] = input_graph.edgelist.renumber_map.index.astype(np.int32)
+            guess = nstart.merge(renumber_df, left_on='vertex', right_on='map', how='left').drop('map')
+            df['pagerank'][guess['id']] = guess['values']
         else:
             df['pagerank'][nstart['vertex']] = nstart['values']
         has_guess = <bool> 1

--- a/python/cugraph/link_analysis/pagerank_wrapper.pyx
+++ b/python/cugraph/link_analysis/pagerank_wrapper.pyx
@@ -19,6 +19,7 @@
 cimport cugraph.link_analysis.pagerank as c_pagerank
 from cugraph.structure.graph cimport *
 from cugraph.utilities.column_utils cimport *
+from cugraph.utilities.unrenumber import unrenumber
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport calloc, malloc, free
@@ -107,10 +108,6 @@ def pagerank(input_graph, alpha=0.85, personalization=None, max_iter=100, tol=1.
 
     g.transposedAdjList.get_vertex_identifiers(&c_identifier)
     if input_graph.renumbered:
-        if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
-            unrenumered_df = df.merge(input_graph.edgelist.renumber_map, left_on='vertex', right_on='id', how='left').drop(['id', 'vertex'])
-            cols = unrenumered_df.columns
-            df = unrenumered_df[[cols[1:], cols[0]]]
-        else:
-            df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
+        df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertex')
+
     return df

--- a/python/cugraph/link_analysis/pagerank_wrapper.pyx
+++ b/python/cugraph/link_analysis/pagerank_wrapper.pyx
@@ -107,5 +107,10 @@ def pagerank(input_graph, alpha=0.85, personalization=None, max_iter=100, tol=1.
 
     g.transposedAdjList.get_vertex_identifiers(&c_identifier)
     if input_graph.renumbered:
-        df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
+        if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
+            unrenumered_df = df.merge(input_graph.edgelist.renumber_map, left_on='vertex', right_on='id', how='left').drop(['id', 'vertex'])
+            cols = unrenumered_df.columns
+            df = unrenumered_df[[cols[1:], cols[0]]]
+        else:
+            df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
     return df

--- a/python/cugraph/link_prediction/jaccard_wrapper.pyx
+++ b/python/cugraph/link_prediction/jaccard_wrapper.pyx
@@ -108,11 +108,16 @@ def jaccard(input_graph, vertex_pair=None):
         g.adjList.get_source_indices(&c_src_index_col)
         
         df['destination'] = cudf.Series(dest_data)
+        df['jaccard_coeff'] = result
 
         if input_graph.renumbered:
-            df['source'] = input_graph.edgelist.renumber_map[df['source']]
-            df['destination'] = input_graph.edgelist.renumber_map[df['destination']]
-
-        df['jaccard_coeff'] = result
+            if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
+                unrenumered_df_ = df.merge(input_graph.edgelist.renumber_map, left_on='source', right_on='id', how='left').drop(['id', 'source'])
+                unrenumered_df = unrenumered_df_.merge(input_graph.edgelist.renumber_map, left_on='destination', right_on='id', how='left').drop(['id', 'destination'])
+                cols = unrenumered_df.columns
+                df = unrenumered_df[[cols[1:], cols[0]]]
+            else:
+                df['source'] = input_graph.edgelist.renumber_map[df['source']]
+                df['destination'] = input_graph.edgelist.renumber_map[df['destination']]
 
         return df

--- a/python/cugraph/link_prediction/overlap_wrapper.pyx
+++ b/python/cugraph/link_prediction/overlap_wrapper.pyx
@@ -110,11 +110,16 @@ def overlap(input_graph, vertex_pair=None):
         g.adjList.get_source_indices(&c_src_index_col);
         
         df['destination'] = cudf.Series(dest_data)
+        df['overlap_coeff'] = result
 
         if input_graph.renumbered:
-            df['source'] = input_graph.edgelist.renumber_map[df['source']]
-            df['destination'] = input_graph.edgelist.renumber_map[df['destination']]
-
-        df['overlap_coeff'] = result
+            if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
+                unrenumered_df_ = df.merge(input_graph.edgelist.renumber_map, left_on='source', right_on='id', how='left').drop(['id', 'source'])
+                unrenumered_df = unrenumered_df_.merge(input_graph.edgelist.renumber_map, left_on='destination', right_on='id', how='left').drop(['id', 'destination'])
+                cols = unrenumered_df.columns
+                df = unrenumered_df[[cols[1:], cols[0]]]
+            else:
+                df['source'] = input_graph.edgelist.renumber_map[df['source']]
+                df['destination'] = input_graph.edgelist.renumber_map[df['destination']]
 
         return df

--- a/python/cugraph/link_prediction/wjaccard_wrapper.pyx
+++ b/python/cugraph/link_prediction/wjaccard_wrapper.pyx
@@ -113,11 +113,16 @@ def jaccard_w(input_graph, weights_arr, vertex_pair=None):
         g.adjList.get_source_indices(&c_index_col);
         
         df['destination'] = cudf.Series(dest_data)
+        df['jaccard_coeff'] = result
 
         if input_graph.renumbered:
-            df['source'] = input_graph.edgelist.renumber_map[df['source']]
-            df['destination'] = input_graph.edgelist.renumber_map[df['destination']]
-
-        df['jaccard_coeff'] = result
+            if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
+                unrenumered_df_ = df.merge(input_graph.edgelist.renumber_map, left_on='source', right_on='id', how='left').drop(['id', 'source'])
+                unrenumered_df = unrenumered_df_.merge(input_graph.edgelist.renumber_map, left_on='destination', right_on='id', how='left').drop(['id', 'destination'])
+                cols = unrenumered_df.columns
+                df = unrenumered_df[[cols[1:], cols[0]]]
+            else:
+                df['source'] = input_graph.edgelist.renumber_map[df['source']]
+                df['destination'] = input_graph.edgelist.renumber_map[df['destination']]
 
         return df

--- a/python/cugraph/link_prediction/woverlap_wrapper.pyx
+++ b/python/cugraph/link_prediction/woverlap_wrapper.pyx
@@ -113,11 +113,16 @@ def overlap_w(input_graph, weights_arr, vertex_pair=None):
         g.adjList.get_source_indices(&c_index_col);
         
         df['destination'] = cudf.Series(dest_data)
+        df['overlap_coeff'] = result
 
         if input_graph.renumbered:
-            df['source'] = input_graph.edgelist.renumber_map[df['source']]
-            df['destination'] = input_graph.edgelist.renumber_map[df['destination']]
-
-        df['overlap_coeff'] = result
+            if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
+                unrenumered_df_ = df.merge(input_graph.edgelist.renumber_map, left_on='source', right_on='id', how='left').drop(['id', 'source'])
+                unrenumered_df = unrenumered_df_.merge(input_graph.edgelist.renumber_map, left_on='destination', right_on='id', how='left').drop(['id', 'destination'])
+                cols = unrenumered_df.columns
+                df = unrenumered_df[[cols[1:], cols[0]]]
+            else:
+                df['source'] = input_graph.edgelist.renumber_map[df['source']]
+                df['destination'] = input_graph.edgelist.renumber_map[df['destination']]
 
         return df

--- a/python/cugraph/structure/graph.py
+++ b/python/cugraph/structure/graph.py
@@ -232,12 +232,12 @@ class Graph:
                 df = unrnb_df[[cols[ncols:], cols[0:ncols]]]
             else:
                 df = cudf.DataFrame()
-                for col in edgelist_df.columns:
-                    if col in ['src', 'dst']:
-                        df[col] = self.edgelist.renumber_map[edgelist_df[col]].\
+                for c in edgelist_df.columns:
+                    if c in ['src', 'dst']:
+                        df[c] = self.edgelist.renumber_map[edgelist_df[c]].\
                             reset_index().drop('index')
                     else:
-                        df[col] = edgelist_df[col]
+                        df[c] = edgelist_df[c]
             return df
         else:
             return edgelist_df

--- a/python/cugraph/structure/graph.py
+++ b/python/cugraph/structure/graph.py
@@ -222,10 +222,14 @@ class Graph:
             if isinstance(self.edgelist.renumber_map, cudf.DataFrame):
                 df = cudf.DataFrame()
                 ncols = len(self.edgelist.edgelist_df) - 2
-                unrenumered_df_ = edgelist_df.merge(self.edgelist.renumber_map, left_on='src', right_on='id', how='left').drop(['id', 'src'])
-                unrenumered_df = unrenumered_df_.merge(self.edgelist.renumber_map, left_on='dst', right_on='id', how='left').drop(['id', 'dst'])
-                cols = unrenumered_df.columns
-                df = unrenumered_df[[cols[ncols:], cols[0:ncols]]]
+                unrnb_df_ = edgelist_df.merge(self.edgelist.renumber_map,
+                                              left_on='src', right_on='id',
+                                              how='left').drop(['id', 'src'])
+                unrnb_df = unrnb_df_.merge(self.edgelist.renumber_map,
+                                           left_on='dst', right_on='id',
+                                           how='left').drop(['id', 'dst'])
+                cols = unrnb_df.columns
+                df = unrnb_df[[cols[ncols:], cols[0:ncols]]]
             else:
                 df = cudf.DataFrame()
                 for col in edgelist_df.columns:

--- a/python/cugraph/structure/graph.py
+++ b/python/cugraph/structure/graph.py
@@ -167,7 +167,7 @@ class Graph:
                                                                destination)
             else:
                 source_col, dest_col, renumber_map = rnb(input_df[source],
-                                                     input_df[destination])
+                                                         input_df[destination])
             self.renumbered = True
         else:
             if type(source) is list and type(destination) is list:

--- a/python/cugraph/tests/test_pagerank.py
+++ b/python/cugraph/tests/test_pagerank.py
@@ -135,7 +135,7 @@ MAX_ITERATIONS = [500]
 TOLERANCE = [1.0e-06]
 ALPHA = [0.85]
 PERSONALIZATION_PERC = [0, 10, 50]
-HAS_GUESS = [0]
+HAS_GUESS = [0, 1]
 
 
 # Test all combinations of default/managed and pooled/non-pooled allocation

--- a/python/cugraph/traversal/sssp_wrapper.pyx
+++ b/python/cugraph/traversal/sssp_wrapper.pyx
@@ -92,7 +92,15 @@ def sssp(input_graph, source):
         c_bfs.bfs[int](g, <int*>c_distance_ptr, <int*>c_predecessors_ptr, <int>source)
 
     if input_graph.renumbered:
-        df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
-        df['predecessor'][df['predecessor']>-1] = input_graph.edgelist.renumber_map[df['predecessor'][df['predecessor']>-1]]
+        if isinstance(input_graph.edgelist.renumber_map, cudf.DataFrame):
+            n_cols = len(input_graph.edgelist.renumber_map.columns) - 1
+            unrenumered_df_ = df.merge(input_graph.edgelist.renumber_map, left_on='vertex', right_on='id', how='left').drop(['id', 'vertex'])
+            unrenumered_df = unrenumered_df_.merge(input_graph.edgelist.renumber_map, left_on='predecessor', right_on='id', how='left').drop(['id', 'predecessor'])
+            unrenumered_df.columns = ['distance']+['vertex_'+str(i) for i in range(n_cols)]+['predecessor_'+str(i) for i in range(n_cols)]
+            cols = unrenumered_df.columns
+            df = unrenumered_df[[cols[1:n_cols+1], cols[0], cols[n_cols:]]]
+        else:
+            df['vertex'] = input_graph.edgelist.renumber_map[df['vertex']]
+            df['predecessor'][df['predecessor']>-1] = input_graph.edgelist.renumber_map[df['predecessor'][df['predecessor']>-1]]
 
     return df

--- a/python/cugraph/utilities/unrenumber.py
+++ b/python/cugraph/utilities/unrenumber.py
@@ -1,8 +1,11 @@
 import cudf
 
+
 def unrenumber(renumber_map, df, col):
     if isinstance(renumber_map, cudf.DataFrame):
-        unrenumered_df = df.merge(renumber_map, left_on=col, right_on='id', how='left').drop(['id', col])
+        unrenumered_df = df.merge(renumber_map, left_on=col,
+                                  right_on='id',
+                                  how='left').drop(['id', col])
         cols = unrenumered_df.columns
         df = unrenumered_df[[cols[1:], cols[0]]]
     else:

--- a/python/cugraph/utilities/unrenumber.py
+++ b/python/cugraph/utilities/unrenumber.py
@@ -1,0 +1,10 @@
+import cudf
+
+def unrenumber(renumber_map, df, col):
+    if isinstance(renumber_map, cudf.DataFrame):
+        unrenumered_df = df.merge(renumber_map, left_on=col, right_on='id', how='left').drop(['id', col])
+        cols = unrenumered_df.columns
+        df = unrenumered_df[[cols[1:], cols[0]]]
+    else:
+        df[col] = renumber_map[df[col]]
+    return df


### PR DESCRIPTION
With Multi-column renumbering #636 , python bindings need to be updated for a renumber_map with multiple columns as a dataframe. The PR addresses the following:
--> Updates in python API (Graph and MultiGraph) to accept multiple source and destination columns and call auto renumbering
--> Updates all algorithms returning vertices to un-renumber to multiple columns as per users notation.
Closes #604 
Further followup is needed as described in #678 