### PR TITLE
[REVIEW] disable renumbering for already renumbered inputs in problematic tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #651 fix cudf error in katz wrapper and test nstart
 - PR #663 Replaced use of cudf._lib.gdf_dtype_from_value based on cudf refactoring
 - PR #672 fix snmg pagerank based on cudf Buffer changes
+- PR #680 disable renumbering for already renumbered inputs in problematic tests
 
 # cuGraph 0.11.0 (11 Dec 2019)
 

--- a/python/cugraph/tests/test_graph.py
+++ b/python/cugraph/tests/test_graph.py
@@ -432,7 +432,8 @@ def test_two_hop_neighbors(managed, pool, graph_file):
     cu_M = utils.read_csv_file(graph_file)
 
     G = cugraph.DiGraph()
-    G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2', renumber=False)
+    G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2',
+                         renumber=False)
 
     df = G.get_two_hop_neighbors()
     Mnx = utils.read_csv_for_nx(graph_file)

--- a/python/cugraph/tests/test_graph.py
+++ b/python/cugraph/tests/test_graph.py
@@ -432,7 +432,7 @@ def test_two_hop_neighbors(managed, pool, graph_file):
     cu_M = utils.read_csv_file(graph_file)
 
     G = cugraph.DiGraph()
-    G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2')
+    G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2', renumber=False)
 
     df = G.get_two_hop_neighbors()
     Mnx = utils.read_csv_for_nx(graph_file)

--- a/python/cugraph/tests/test_jaccard.py
+++ b/python/cugraph/tests/test_jaccard.py
@@ -214,7 +214,8 @@ def test_jaccard_two_hop_edge_vals(managed, pool, graph_file):
     Gnx = nx.from_pandas_edgelist(M, source='0', target='1',
                                   edge_attr='weight', create_using=nx.Graph())
     G = cugraph.Graph()
-    G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2', renumber=False)
+    G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2', 
+                         renumber=False)
     pairs = G.get_two_hop_neighbors()
     nx_pairs = []
     for i in range(len(pairs)):

--- a/python/cugraph/tests/test_jaccard.py
+++ b/python/cugraph/tests/test_jaccard.py
@@ -39,9 +39,9 @@ def cugraph_call(cu_M, edgevals=False):
     G = cugraph.DiGraph()
     if edgevals is True:
         G.from_cudf_edgelist(cu_M, source='0', destination='1',
-                             edge_attr='2')
+                             edge_attr='2', renumber=False)
     else:
-        G.from_cudf_edgelist(cu_M, source='0', destination='1')
+        G.from_cudf_edgelist(cu_M, source='0', destination='1', renumber=False)
 
     # cugraph Jaccard Call
     t1 = time.time()
@@ -176,7 +176,7 @@ def test_jaccard_two_hop(managed, pool, graph_file):
     Gnx = nx.from_pandas_edgelist(M, source='0', target='1',
                                   create_using=nx.Graph())
     G = cugraph.Graph()
-    G.from_cudf_edgelist(cu_M, source='0', destination='1')
+    G.from_cudf_edgelist(cu_M, source='0', destination='1', renumber=False)
     pairs = G.get_two_hop_neighbors()
     nx_pairs = []
     for i in range(len(pairs)):
@@ -214,7 +214,7 @@ def test_jaccard_two_hop_edge_vals(managed, pool, graph_file):
     Gnx = nx.from_pandas_edgelist(M, source='0', target='1',
                                   edge_attr='weight', create_using=nx.Graph())
     G = cugraph.Graph()
-    G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2')
+    G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2', renumber=False)
     pairs = G.get_two_hop_neighbors()
     nx_pairs = []
     for i in range(len(pairs)):

--- a/python/cugraph/tests/test_jaccard.py
+++ b/python/cugraph/tests/test_jaccard.py
@@ -214,7 +214,7 @@ def test_jaccard_two_hop_edge_vals(managed, pool, graph_file):
     Gnx = nx.from_pandas_edgelist(M, source='0', target='1',
                                   edge_attr='weight', create_using=nx.Graph())
     G = cugraph.Graph()
-    G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2', 
+    G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2',
                          renumber=False)
     pairs = G.get_two_hop_neighbors()
     nx_pairs = []

--- a/python/cugraph/tests/test_k_core.py
+++ b/python/cugraph/tests/test_k_core.py
@@ -37,7 +37,7 @@ print('Networkx version : {} '.format(nx.__version__))
 def calc_k_cores(graph_file):
     cu_M = utils.read_csv_file(graph_file)
     G = cugraph.DiGraph()
-    G.from_cudf_edgelist(cu_M, source='0', destination='1')
+    G.from_cudf_edgelist(cu_M, source='0', destination='1', renumber=False)
     ck = cugraph.k_core(G)
     NM = utils.read_csv_for_nx(graph_file)
     Gnx = nx.from_pandas_edgelist(NM, source='0', target='1',

--- a/python/cugraph/tests/test_overlap.py
+++ b/python/cugraph/tests/test_overlap.py
@@ -27,7 +27,8 @@ def cugraph_call(cu_M, pairs, edgevals=False):
     G = cugraph.DiGraph()
     # Device data
     if edgevals is True:
-        G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2', renumber=False)
+        G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2', 
+                             renumber=False)
     else:
         G.from_cudf_edgelist(cu_M, source='0', destination='1', renumber=False)
     # cugraph Overlap Call

--- a/python/cugraph/tests/test_overlap.py
+++ b/python/cugraph/tests/test_overlap.py
@@ -27,7 +27,7 @@ def cugraph_call(cu_M, pairs, edgevals=False):
     G = cugraph.DiGraph()
     # Device data
     if edgevals is True:
-        G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2', 
+        G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2',
                              renumber=False)
     else:
         G.from_cudf_edgelist(cu_M, source='0', destination='1', renumber=False)

--- a/python/cugraph/tests/test_overlap.py
+++ b/python/cugraph/tests/test_overlap.py
@@ -27,9 +27,9 @@ def cugraph_call(cu_M, pairs, edgevals=False):
     G = cugraph.DiGraph()
     # Device data
     if edgevals is True:
-        G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2')
+        G.from_cudf_edgelist(cu_M, source='0', destination='1', edge_attr='2', renumber=False)
     else:
-        G.from_cudf_edgelist(cu_M, source='0', destination='1')
+        G.from_cudf_edgelist(cu_M, source='0', destination='1', renumber=False)
     # cugraph Overlap Call
     t1 = time.time()
     df = cugraph.overlap(G, pairs)
@@ -113,7 +113,7 @@ def test_overlap(managed, pool, graph_file):
 
     cu_M = utils.read_csv_file(graph_file)
     G = cugraph.Graph()
-    G.from_cudf_edgelist(cu_M, source='0', destination='1')
+    G.from_cudf_edgelist(cu_M, source='0', destination='1', renumber=False)
     pairs = G.get_two_hop_neighbors()
 
     cu_coeff = cugraph_call(cu_M, pairs)
@@ -152,7 +152,7 @@ def test_overlap_edge_vals(managed, pool, graph_file):
 
     cu_M = utils.read_csv_file(graph_file)
     G = cugraph.Graph()
-    G.from_cudf_edgelist(cu_M, source='0', destination='1')
+    G.from_cudf_edgelist(cu_M, source='0', destination='1', renumber=False)
     pairs = G.get_two_hop_neighbors()
 
     cu_coeff = cugraph_call(cu_M, pairs,

--- a/python/cugraph/tests/test_woverlap.py
+++ b/python/cugraph/tests/test_woverlap.py
@@ -113,7 +113,7 @@ def test_woverlap(managed, pool, graph_file):
 
     cu_M = utils.read_csv_file(graph_file)
     G = cugraph.Graph()
-    G.from_cudf_edgelist(cu_M, source='0', destination='1')
+    G.from_cudf_edgelist(cu_M, source='0', destination='1', renumber=False)
     pairs = G.get_two_hop_neighbors()
 
     cu_coeff = cugraph_call(cu_M, pairs)

--- a/python/cugraph/tests/test_woverlap.py
+++ b/python/cugraph/tests/test_woverlap.py
@@ -30,7 +30,7 @@ def cugraph_call(cu_M, pairs):
                               cu_M['1'].max())+1, dtype=np.float32))
 
     G = cugraph.DiGraph()
-    G.from_cudf_edgelist(cu_M, source='0', destination='1')
+    G.from_cudf_edgelist(cu_M, source='0', destination='1', renumber=False)
 
     # cugraph Overlap Call
     t1 = time.time()


### PR DESCRIPTION
Fixing tests that were renumbering already renumbered input and causing failures.

This is a temporary patch to fix the build. The root cause should be investigated further.