### PR TITLE
[REVIEW] Cleanup datasets download after run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Improvements
 
+- PR #688 Cleanup datasets after testing on gpuCI
+
 ## Bug Fixes
 
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -25,7 +25,7 @@ function cleanup {
 }
 
 # Set cleanup trap for Jenkins
-if [ -z "$JENKINS_HOME" ] ; then
+if [ ! -z "$JENKINS_HOME" ] ; then
   logger "Jenkins environment detected, setting cleanup trap..."
   trap cleanup EXIT
 fi

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -8,7 +8,7 @@ NUMARGS=$#
 ARGS=$*
 
 # Logger function for build status output
-function logger() {
+function logger {
   echo -e "\n>>>> $@\n"
 }
 
@@ -16,6 +16,19 @@ function logger() {
 function hasArg {
     (( ${NUMARGS} != 0 )) && (echo " ${ARGS} " | grep -q " $1 ")
 }
+
+# Cleanup function for datasets removal
+function cleanup {
+  logger "Remove `datasets/test` and `datasets/benchmark`..."
+  rm -rf $WORKSPACE/datasets/test
+  rm -rf $WORKSPACE/datasets/benchmark
+}
+
+# Set cleanup trap for Jenkins
+if [ -z "$JENKINS_HOME" ] ; then
+  logger "Jenkins environment detected, setting cleanup trap..."
+  trap cleanup EXIT
+fi
 
 # Set path, build parallel level, and CUDA version
 export PATH=/conda/bin:/usr/local/cuda/bin:$PATH

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -19,7 +19,7 @@ function hasArg {
 
 # Cleanup function for datasets removal
 function cleanup {
-  logger "Remove `datasets/test` and `datasets/benchmark`..."
+  logger "Remove './datasets/test' and './datasets/benchmark'..."
   rm -rf $WORKSPACE/datasets/test
   rm -rf $WORKSPACE/datasets/benchmark
 }


### PR DESCRIPTION
gpuCI nodes are running out of space due to the datasets download for cuGraph. The files are not cleaned up after the testing and remain on disk. This creates a trap for Jenkins that will remove these files on exit.