### PR TITLE
[REVIEW] Call cudaDeviceGetAttribute instead of cudaGetDeviceProperties in triangle counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Improvements
 
 - PR #688 Cleanup datasets after testing on gpuCI
+- PR #694 Replace the expensive cudaGetDeviceProperties call in triangle counting with cheaper cudaDeviceGetAttribute calls
 
 ## Bug Fixes
 

--- a/cpp/src/nvgraph/include/triangles_counting.hxx
+++ b/cpp/src/nvgraph/include/triangles_counting.hxx
@@ -44,7 +44,9 @@ private:
     uint64_t            m_triangles_number;
     spmat_t<IndexType>  m_mat;
     int                 m_dev_id;
-    cudaDeviceProp      m_dev_props;
+    int m_shared_mem_per_block{};
+    int m_multi_processor_count{};
+    int m_max_threads_per_multi_processor{};
 
     Vector<IndexType>   m_seq;
 


### PR DESCRIPTION
Partially address #476 

Based on
https://devblogs.nvidia.com/cuda-pro-tip-the-fast-way-to-query-device-properties/

cudaGetDeviceProperties can be much slower than cudaDeviceGetAttribute.

This PR replaces cudaGetDeviceProperties with cudaDeviceGetAttribute in triangle counting that results in over 100x speed up in device property query time in triangle counting (the overall speed up in triangle counting should be much smaller as device query time takes only a small percentage of triangle counting execution time).