### PR TITLE
[WIP] [skip-ci] Integration gunrock's betweenness centrality

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -164,6 +164,29 @@ if(BUILD_TESTS)
     endif(GTEST_FOUND)
 endif(BUILD_TESTS)
 
+###################################################################################################
+# - gunrock ------------------------------------------------------------------------------------------
+#   TODO:  TEMPORARY... Rick is working on a better solution
+
+find_path(GUNROCK_INCLUDE "gunrock"
+    HINTS
+    "$ENV{GUNROCK_ROOT}/include"
+    "$ENV{CONDA_PREFIX}/include/gunrock"
+    "$ENV{CONDA_PREFIX}/include")
+
+find_library(GUNROCK_LIBRARY "gunrock"
+    HINTS
+    "$ENV{GUNROCK_ROOT}/lib"
+    "$ENV{CONDA_PREFIX}/lib")
+
+message(STATUS "GUNROCK: GUNROCK_LIBRARY set to ${GUNROCK_LIBRARY}")
+message(STATUS "GUNROCK: GUNROCK_INCLUDE set to ${GUNROCK_INCLUDE}")
+
+add_library(gunrock STATIC IMPORTED ${GUNROCK_LIBRARY})
+if (GUNROCK_INCLUDE AND GUNROCK_LIBRARY)
+    set_target_properties(gunrock PROPERTIES IMPORTED_LOCATION ${GUNROCK_LIBRARY})
+endif (GUNROCK_INCLUDE AND GUNROCK_LIBRARY)
+
 
 ###################################################################################################
 # - NVStrings -------------------------------------------------------------------------------------
@@ -286,6 +309,7 @@ add_library(cugraph SHARED
     src/snmg/utils.cu
     src/components/connectivity.cu
     src/centrality/katz_centrality.cu
+    src/centrality/betweenness_centrality.cu
     src/snmg/degree/degree.cu
     src/snmg/COO2CSR/COO2CSR.cu
     src/nvgraph/arnoldi.cu
@@ -345,7 +369,7 @@ target_include_directories(cugraph
 # - link libraries --------------------------------------------------------------------------------
 
 target_link_libraries(cugraph PRIVATE
-    ${CUDF_LIBRARY} ${RMM_LIBRARY} ${NVSTRINGS_LIBRARY} cublas cusparse curand cusolver cudart cuda ${LIBCYPHERPARSER_LIBRARY})
+    ${CUDF_LIBRARY} ${RMM_LIBRARY} ${GUNROCK_LIBRARY} ${NVSTRINGS_LIBRARY} cublas cusparse curand cusolver cudart cuda ${LIBCYPHERPARSER_LIBRARY})
 if(OpenMP_CXX_FOUND)
 target_link_libraries(cugraph PRIVATE
 ###################################################################################################

--- a/cpp/include/algorithms.hpp
+++ b/cpp/include/algorithms.hpp
@@ -62,4 +62,28 @@ void pagerank(experimental::GraphCSC<VT,ET,WT> const &graph,
               int64_t max_iter = 500,
               bool has_guess = false);
 
+/**
+ * @brief     Compute betweenness centrality for a graph
+ *
+ * Betweenness centrality for a vertex is the sum of the fraction of
+ * all pairs shortest paths that pass through the vertex.
+ * 
+ * @throws                           cugraph::logic_error with a custom message when an error occurs.
+ *
+ * @tparam VT                        Type of vertex identifiers. Supported value : int (signed, 32-bit)
+ * @tparam ET                        Type of edge identifiers.  Supported value : int (signed, 32-bit)
+ * @tparam WT                        Type of edge weights. Supported values : float or double.   
+ * @tparam result_t                  Type of computed result.  Supported values :  float
+ *
+ * @param[in] graph                  cuGRAPH graph descriptor, should contain the connectivity information as a transposed adjacency list (CSR). Edge weights are not used for this algorithm.
+ * @param[out] result                Device array of centrality scores
+ *
+ *
+ * TODO:  Could add parameters for sampling and normalization, current implementation
+ *        computes exact answer and normalizes.
+ */
+template <typename VT, typename ET, typename WT, typename result_t>
+void betweenness_centrality(experimental::GraphCSR<VT,ET,WT> const &graph,
+                            result_t *result);
+
 } //namespace cugraph

--- a/cpp/src/centrality/betweenness_centrality.cu
+++ b/cpp/src/centrality/betweenness_centrality.cu
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <vector>
+
+#include <thrust/transform.h>
+
+#include <algorithms.hpp>
+#include <graph.hpp>
+#include "rmm_utils.h"
+
+#include <utilities/error_utils.h>
+
+#include <gunrock/gunrock.h>
+
+namespace cugraph {
+
+template <typename VT, typename ET, typename WT, typename result_t>
+void betweenness_centrality(experimental::GraphCSR<VT,ET,WT> const &graph,
+                            result_t *result) {
+
+  cudaStream_t stream{nullptr};
+
+  //
+  //  gunrock currently (as of 2/28/2020) only operates on a graph and results in
+  //  host memory.  [That is, the first step in gunrock is to allocate device memory
+  //  and copy the data into device memory, the last step is to allocate host memory
+  //  and copy the results into the host memory]
+  //
+  //  They are working on fixing this.  In the meantime, to get the features into
+  //  cuGraph we will first copy the graph back into local memory and when we are finished
+  //  copy the result back into device memory.
+  //
+  std::vector<ET>        v_offsets(graph.number_of_vertices + 1);
+  std::vector<VT>        v_indices(graph.number_of_edges);
+  std::vector<result_t>  v_result(graph.number_of_vertices);
+  std::vector<float>     v_sigmas(graph.number_of_vertices);
+  std::vector<int>       v_labels(graph.number_of_vertices);
+  
+  // fill them
+  CUDA_TRY(cudaMemcpy(v_offsets.data(), graph.offsets, sizeof(ET) * (graph.number_of_vertices + 1), cudaMemcpyDeviceToHost));
+  CUDA_TRY(cudaMemcpy(v_indices.data(), graph.indices, sizeof(VT) * graph.number_of_edges, cudaMemcpyDeviceToHost));
+
+  bc(graph.number_of_vertices,
+     graph.number_of_edges,
+     v_offsets.data(),
+     v_indices.data(),
+     -1,
+     v_result.data(),
+     v_sigmas.data(),
+     v_labels.data());
+
+  // copy to results
+  CUDA_TRY(cudaMemcpy(result, v_result.data(), sizeof(result_t) * graph.number_of_vertices, cudaMemcpyHostToDevice));
+
+  // normalize result
+  float denominator = (graph.number_of_vertices - 1) * (graph.number_of_vertices - 2);
+
+  thrust::transform(rmm::exec_policy(stream)->on(stream),
+                    result, result + graph.number_of_vertices, result,
+                    [denominator] __device__ (float f) {
+                        return (f * 2) / denominator;
+                    });
+}
+
+template void betweenness_centrality<int, int, float, float>(experimental::GraphCSR<int,int,float> const &graph, float* result);
+
+} //namespace cugraph
+

--- a/cpp/src/tests/CMakeLists.txt
+++ b/cpp/src/tests/CMakeLists.txt
@@ -124,6 +124,14 @@ set(KATZ_TEST_SRC
   ConfigureTest(KATZ_TEST "${KATZ_TEST_SRC}" "")
 
 ###################################################################################################
+# - betweenness centrality tests -------------------------------------------------------------------------
+
+set(BETWEENNESS_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/centrality/betweenness_centrality_test.cu")
+
+  ConfigureTest(BETWEENNESS_TEST "${BETWEENNESS_TEST_SRC}" "")
+
+###################################################################################################
 # - gdfgraph tests --------------------------------------------------------------------------------
 
 set(GDFGRAPH_TEST_SRC

--- a/cpp/src/tests/centrality/betweenness_centrality_test.cu
+++ b/cpp/src/tests/centrality/betweenness_centrality_test.cu
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include <thrust/device_vector.h>
+
+#include <graph.hpp>
+#include <algorithms.hpp>
+
+struct BetweennessCentralityTest : public ::testing::Test
+{
+};
+
+TEST_F(BetweennessCentralityTest, SimpleGraph)
+{
+  std::vector<int>  graph_offsets{ { 0, 1, 2, 5, 7, 10, 12, 14 } };
+  std::vector<int>  graph_indices{ { 2, 2, 0, 1, 3, 2, 4, 3, 5, 6, 4, 6, 4, 5 } };
+
+  std::vector<float> expected{ {0.0, 0.0, 0.6, 0.6, 0.5333333, 0.0, 0.0 } };
+
+  int num_verts = graph_offsets.size() - 1;
+  int num_edges = graph_indices.size();
+
+  thrust::device_vector<int>    d_graph_offsets(graph_offsets);
+  thrust::device_vector<int>    d_graph_indices(graph_indices);
+  thrust::device_vector<float>  d_result(num_verts);
+
+  std::vector<float>            result(num_verts);
+
+  cugraph::experimental::GraphCSR<int,int,float> G(d_graph_offsets.data().get(),
+                                                   d_graph_indices.data().get(),
+                                                   nullptr,
+                                                   num_verts,
+                                                   num_edges);
+
+  cugraph::betweenness_centrality(G, d_result.data().get());
+
+  cudaMemcpy(result.data(), d_result.data().get(), sizeof(float) * num_verts, cudaMemcpyDeviceToHost);
+
+  for (int i = 0 ; i < num_verts ; ++i)
+    EXPECT_FLOAT_EQ(result[i], expected[i]);
+}


### PR DESCRIPTION
This PR integrates the betweenness centrality implementation from gunrock into cugraph.

For this release, the gunrock analytics assume that they are called with host-side arrays.  They are working to fix this, however in an effort to get the integration underway this PR will copy the graph (and any other pertinent information) from the device onto the host before calling gunrock.  Once gunrock has adapted to accepting device-side arrays we will update to eliminate the extra copy.