### PR TITLE
[WIP] [skip-ci] Integrate cugunrock as a cmake ExternalProject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - PR #720 Updated error messages
 - PR #722 Refactor graph to remove gdf_column
 - PR #723 Added notebook testing to gpuCI gpu build
+- PR #737 Integrate cugunrock as a cmake ExternalProject
 
 ## Bug Fixes
 - PR #697 Updated versions in conda environments.

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -250,6 +250,26 @@ if (RMM_INCLUDE AND RMM_LIBRARY)
 endif (RMM_INCLUDE AND RMM_LIBRARY)
 
 ###################################################################################################
+# - External Projects -----------------------------------------------------------------------------
+
+# https://cmake.org/cmake/help/v3.0/module/ExternalProject.html
+include(ExternalProject)
+
+set(CUGUNROCK_DIR ${CMAKE_CURRENT_BINARY_DIR}/cugunrock CACHE STRING
+  "Path to cugunrock repo")
+
+ExternalProject_Add(cugunrock
+  GIT_REPOSITORY    https://github.com/rapidsai/cugunrock.git
+  GIT_TAG           fea_full_bc      # provide a branch, a tag, or even a commit hash
+  PREFIX            ${CUGUNROCK_DIR}
+  CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                    -DGPU_ARCHS=""
+                    -DGUNROCK_BUILD_SHARED_LIBS=OFF
+)
+
+add_library(gunrock STATIC IMPORTED)
+
+###################################################################################################
 # - library targets -------------------------------------------------------------------------------
 
 # target_link_directories is added in cmake 3.13, and cmake advises to use this instead of


### PR DESCRIPTION
Integrate cugunrock as a cmake ExternalProject.

This was only tested to build without error, still need to run a test that exercises `cugunrock` code in `libgunrock.a`

This also requires the `cugunrock` `fea_full_bc` branch that adds an install step and the ability to build a static library.