### PR TITLE
[BUG] Added flag to not treat deprecation warnings as errors, for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - PR #746 Dask + Distributed 2.12.0+
 - PR #753 ECG Error
 - PR #758 Fix for graph comparison failure
+- PR #761 Added flag to not treat deprecation warnings as errors, for now
 
 # cuGraph 0.12.0 (04 Feb 2020)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -46,7 +46,7 @@ set(CMAKE_CUDA_STANDARD 14)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-error=deprecated-declarations")
 
 ###################################################################################################
 ###   C++ ABI changes.


### PR DESCRIPTION
Added flag to not treat deprecation warnings as errors, for now.  This will likely be removed when the RMM API calls have been updated for 0.14.