### PR TITLE
[REVIEW] Add un-renumbering to connected components and update tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - PR #753 ECG Error
 - PR #758 Fix for graph comparison failure
 - PR #761 Added flag to not treat deprecation warnings as errors, for now
+- PR #771 Added unrenumbering in wcc and scc. Updated tests to compare vertices of largest component
 
 # cuGraph 0.12.0 (04 Feb 2020)
 

--- a/python/cugraph/components/connectivity_wrapper.pyx
+++ b/python/cugraph/components/connectivity_wrapper.pyx
@@ -62,8 +62,8 @@ def weakly_connected_components(input_graph):
     num_verts = g.adjList.offsets.size - 1
 
     df = cudf.DataFrame()
-    df['label'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
-    df['vertex'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
+    df['labels'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
+    df['vertices'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
     
     cdef cudf_table* tbl = table_from_dataframe(df)
 
@@ -74,7 +74,7 @@ def weakly_connected_components(input_graph):
     del tbl
 
     if input_graph.renumbered:
-        df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertex')
+        df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertices')
 
     return df
 
@@ -102,8 +102,8 @@ def strongly_connected_components(input_graph):
     num_verts = g.adjList.offsets.size - 1
 
     df = cudf.DataFrame()
-    df['label'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
-    df['vertex'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
+    df['labels'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
+    df['vertices'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
     
     cdef cudf_table* tbl = table_from_dataframe(df)
 
@@ -114,6 +114,6 @@ def strongly_connected_components(input_graph):
     del tbl
 
     if input_graph.renumbered:
-        df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertex')
+        df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertices')
 
     return df

--- a/python/cugraph/components/connectivity_wrapper.pyx
+++ b/python/cugraph/components/connectivity_wrapper.pyx
@@ -24,6 +24,7 @@ from cudf._lib.utils cimport table_from_dataframe
 from libc.stdint cimport uintptr_t
 from cugraph.structure.symmetrize import symmetrize
 from cugraph.structure.graph import Graph as type_Graph
+from cugraph.utilities.unrenumber import unrenumber
 
 import cudf
 import cudf._lib as libcudf
@@ -61,8 +62,8 @@ def weakly_connected_components(input_graph):
     num_verts = g.adjList.offsets.size - 1
 
     df = cudf.DataFrame()
-    df['labels'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
-    df['vertices'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
+    df['label'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
+    df['vertex'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
     
     cdef cudf_table* tbl = table_from_dataframe(df)
 
@@ -71,6 +72,9 @@ def weakly_connected_components(input_graph):
     
 
     del tbl
+
+    if input_graph.renumbered:
+        df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertex')
 
     return df
 
@@ -98,8 +102,8 @@ def strongly_connected_components(input_graph):
     num_verts = g.adjList.offsets.size - 1
 
     df = cudf.DataFrame()
-    df['labels'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
-    df['vertices'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
+    df['label'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
+    df['vertex'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
     
     cdef cudf_table* tbl = table_from_dataframe(df)
 
@@ -108,5 +112,8 @@ def strongly_connected_components(input_graph):
     
 
     del tbl
+
+    if input_graph.renumbered:
+        df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertex')
 
     return df

--- a/python/cugraph/tests/test_connectivity.py
+++ b/python/cugraph/tests/test_connectivity.py
@@ -70,7 +70,7 @@ def cugraph_weak_call(cu_M):
 
     label_vertex_dict = defaultdict(list)
     for i in range(len(df)):
-        label_vertex_dict[df['label'][i]].append(df['vertex'][i])
+        label_vertex_dict[df['labels'][i]].append(df['vertices'][i])
     return label_vertex_dict
 
 
@@ -103,7 +103,7 @@ def cugraph_strong_call(cu_M):
 
     label_vertex_dict = defaultdict(list)
     for i in range(len(df)):
-        label_vertex_dict[df['label'][i]].append(df['vertex'][i])
+        label_vertex_dict[df['labels'][i]].append(df['vertices'][i])
     return label_vertex_dict
 
 

--- a/python/cugraph/tests/test_connectivity.py
+++ b/python/cugraph/tests/test_connectivity.py
@@ -14,7 +14,7 @@
 import gc
 from itertools import product
 import time
-
+from collections import defaultdict
 import pytest
 
 import cugraph
@@ -53,7 +53,6 @@ def networkx_weak_call(M):
     # same parameters as in NVGRAPH
     result = nx.weakly_connected_components(Gnx)
     t2 = time.time() - t1
-
     print('Time : ' + str(t2))
 
     labels = sorted(result)
@@ -69,10 +68,10 @@ def cugraph_weak_call(cu_M):
     t2 = time.time() - t1
     print('Time : '+str(t2))
 
-    result = df['labels'].to_array()
-
-    labels = sorted(result)
-    return labels
+    label_vertex_dict = defaultdict(list)
+    for i in range(len(df)):
+        label_vertex_dict[df['label'][i]].append(df['vertex'][i])
+    return label_vertex_dict
 
 
 def networkx_strong_call(M):
@@ -97,16 +96,15 @@ def cugraph_strong_call(cu_M):
     # cugraph Pagerank Call
     G = cugraph.DiGraph()
     G.from_cudf_edgelist(cu_M, source='0', destination='1')
-    print(G.number_of_vertices())
     t1 = time.time()
     df = cugraph.strongly_connected_components(G)
     t2 = time.time() - t1
     print('Time : '+str(t2))
 
-    result = df['labels'].to_array()
-
-    labels = sorted(result)
-    return labels
+    label_vertex_dict = defaultdict(list)
+    for i in range(len(df)):
+        label_vertex_dict[df['label'][i]].append(df['vertex'][i])
+    return label_vertex_dict
 
 
 # these should come w/ cugraph/python:
@@ -117,27 +115,6 @@ DATASETS = ['../datasets/dolphins.csv',
 STRONGDATASETS = ['../datasets/dolphins.csv',
                   '../datasets/netscience.csv',
                   '../datasets/email-Eu-core.csv']
-
-
-# vcount how many `val`s in ls container:
-#
-def counter_f(ls, val):
-    return sum(1 for x in ls if x == val)
-
-
-# return number of uniques values in lst container:
-#
-def get_n_uniqs(lst):
-    return len(set(lst))
-
-
-# gets unique values of list and then counts the
-# occurences of each unique value within list;
-# note: because of using set(), the "keys"
-# (unique values) will be sorted in set(lst)
-#
-def get_uniq_counts(lst):
-    return [counter_f(lst, uniq_val) for uniq_val in set(lst)]
 
 
 # Test all combinations of default/managed and pooled/non-pooled allocation
@@ -167,17 +144,25 @@ def test_weak_cc(managed, pool, graph_file):
     # while cugraph returns a component label for each vertex;
 
     nx_n_components = len(netx_labels)
-    cg_n_components = get_n_uniqs(cugraph_labels)
+    cg_n_components = len(cugraph_labels)
 
+    # Comapre number of components
     assert nx_n_components == cg_n_components
 
-    lst_nx_components_lens = [len(c) for c in sorted(netx_labels, key=len)]
+    lst_nx_components = sorted(netx_labels, key=len, reverse=True)
+    lst_nx_components_lens = [len(c) for c in lst_nx_components]
 
-    # get counts of uniques:
-    #
-    lst_cg_components_lens = sorted(get_uniq_counts(cugraph_labels))
+    cugraph_vertex_lst = cugraph_labels.values()
+    lst_cg_components = sorted(cugraph_vertex_lst, key=len, reverse=True)
+    lst_cg_components_lens = [len(c) for c in lst_cg_components]
 
+    # Compare lengths of each component
     assert lst_nx_components_lens == lst_cg_components_lens
+
+    # Compare vertices of largest component
+    nx_vertices = sorted(lst_nx_components[0])
+    cg_vertices = sorted(lst_cg_components[0])
+    assert nx_vertices == cg_vertices
 
 
 # Test all combinations of default/managed and pooled/non-pooled allocation
@@ -207,14 +192,22 @@ def test_strong_cc(managed, pool, graph_file):
     # while cugraph returns a component label for each vertex;
 
     nx_n_components = len(netx_labels)
-    cg_n_components = get_n_uniqs(cugraph_labels)
+    cg_n_components = len(cugraph_labels)
 
+    # Comapre number of components
     assert nx_n_components == cg_n_components
 
-    lst_nx_components_lens = [len(c) for c in sorted(netx_labels, key=len)]
+    lst_nx_components = sorted(netx_labels, key=len, reverse=True)
+    lst_nx_components_lens = [len(c) for c in lst_nx_components]
 
-    # get counts of uniques:
-    #
-    lst_cg_components_lens = sorted(get_uniq_counts(cugraph_labels))
+    cugraph_vertex_lst = cugraph_labels.values()
+    lst_cg_components = sorted(cugraph_vertex_lst, key=len, reverse=True)
+    lst_cg_components_lens = [len(c) for c in lst_cg_components]
 
+    # Compare lengths of each component
     assert lst_nx_components_lens == lst_cg_components_lens
+
+    # Compare vertices of largest component
+    nx_vertices = sorted(lst_nx_components[0])
+    cg_vertices = sorted(lst_cg_components[0])
+    assert nx_vertices == cg_vertices


### PR DESCRIPTION
--> Added un-renumbering block to wcc and scc
--> Updated tests to compare vertices for the largest component. This is to ensure correct labeling and un-renumbering. (Previously the test was just comparing number and lengths of components)

closes #767 