### PR TITLE
[REVIEW] [BUG] Raise TypeError if a DiGraph is used with spectral*Clustering()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - PR #753 ECG Error
 - PR #758 Fix for graph comparison failure
 - PR #761 Added flag to not treat deprecation warnings as errors, for now
+- PR #774 Raise TypeError if a DiGraph is used with spectral*Clustering()
 
 # cuGraph 0.12.0 (04 Feb 2020)
 

--- a/python/cugraph/tests/test_balanced_cut.py
+++ b/python/cugraph/tests/test_balanced_cut.py
@@ -70,9 +70,9 @@ def test_edge_cut_clustering(managed, pool, graph_file, partitions):
     '''row_offsets = cudf.Series(M.indptr)
     col_indices = cudf.Series(M.indices)
 
-    G_adj = cugraph.DiGraph()
+    G_adj = cugraph.Graph()
     G_adj.from_cudf_adjlist(row_offsets, col_indices)'''
-    G_edge = cugraph.DiGraph()
+    G_edge = cugraph.Graph()
     G_edge.from_cudf_edgelist(cu_M, source='0', destination='1')
 
     # Get the edge_cut score for partitioning versus random assignment
@@ -118,10 +118,10 @@ def test_edge_cut_clustering_with_edgevals(managed, pool,
     col_indices = cudf.Series(M.indices)
     val = cudf.Series(M.data)
 
-    G_adj = cugraph.DiGraph()
+    G_adj = cugraph.Graph()
     G_adj.from_cudf_adjlist(row_offsets, col_indices, val)
     '''
-    G_edge = cugraph.DiGraph()
+    G_edge = cugraph.Graph()
     G_edge.from_cudf_edgelist(cu_M, source='0', destination='1',
                               edge_attr='2')
 
@@ -141,3 +141,33 @@ def test_edge_cut_clustering_with_edgevals(managed, pool,
     # assignment
     print(cu_score, rand_score)
     assert cu_score < rand_score
+
+
+# Test to ensure DiGraph objs are not accepted
+# Test all combinations of default/managed and pooled/non-pooled allocation
+@pytest.mark.parametrize('managed, pool',
+                         list(product([False, True], [False, True])))
+def test_digraph_rejected(managed, pool):
+    gc.collect()
+
+    rmm.reinitialize(
+        managed_memory=managed,
+        pool_allocator=pool,
+        initial_pool_size=2 << 27
+    )
+
+    assert(rmm.is_initialized())
+
+    df = cudf.DataFrame()
+    df['src'] = cudf.Series(range(10))
+    df['dst'] = cudf.Series(range(10))
+    df['val'] = cudf.Series(range(10))
+
+    G = cugraph.DiGraph()
+    G.from_cudf_edgelist(df, source="src",
+                         destination="dst",
+                         edge_attr="val",
+                         renumber=False)
+
+    with pytest.raises(Exception):
+        cugraph_call(G, 2)


### PR DESCRIPTION
 Updated tests, added tests, and changed Cython code to ensure a `DiGraph` cannot be passed to `cugraph.spectralModularityMaximizationClustering()` or `cugraph.spectralBalancedCutClustering()`

The new code will result in the following traceback if a `DiGraph` is used for the above algos:
```
  File "cugraph/community/spectral_clustering_wrapper.pyx", line 50, in cugraph.community.spectral_clustering_wrapper.spectralBalancedCutClustering
TypeError: DiGraph objects are not supported
```

I also added a FIXME to note a possible infinite loop situation encountered during benchmark development. The above type check for a `DiGraph` would have prevented this, but would have also masked it as well.

_sorry for the noise in the diff - my editor automatically removes trailing whitespace and there apparently was a lot in `kmeans.cu`_