### PR TITLE
[REVIEW] Fix compiler argument syntax for ccache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Improvements
 - PR #765 Remove gdf_column from connected components
+- PR #781 Fix compiler argument syntax for ccache
 
 ## Bug Fixes
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -81,7 +81,7 @@ if((CUDA_VERSION_MAJOR EQUAL 10) OR (CUDA_VERSION_MAJOR GREATER 10))
 endif()
 
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Wno-deprecated-declarations -Xptxas --disable-warnings")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror=cross-execution-space-call -Wno-deprecated-declarations -Xptxas --disable-warnings")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wall,-Wno-error=sign-compare,-Wno-error=unused-but-set-variable")
 
 # Option to enable line info in CUDA device compilation to allow introspection when profiling /


### PR DESCRIPTION
Fix compiler argument syntax in `CMakeLists.txt` that cause ccache to throw preprocessor errors.

Here's the difference in compile times using ccache (more in [this gist](https://gist.github.com/trxcllnt/498c215de31d99ca277322961f3887bd)):

libcugraph C++ | Cold cache  | Warm cache
---------------|-------------|-----------
real           | 4m40.711s   | 1m16.574s
user           | 31m5.862s   | 2m31.904s
sys            | 2m53.182s   | 0m34.434s

cugraph Cython | Cold cache | Warm cache
---------------|------------|-----------
real           | 0m37.699s  | 0m24.048s
user           | 3m28.400s  | 0m29.646s
sys            | 0m11.022s  | 0m2.382s
