### PR TITLE
[REVIEW] Use Cython's `new_build_ext` (if available)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Improvements
 - PR #765 Remove gdf_column from connected components
+- PR #782 Use Cython's `new_build_ext` (if available)
 
 ## Bug Fixes
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -19,6 +19,11 @@ from setuptools import setup, find_packages
 from setuptools.extension import Extension
 from Cython.Build import cythonize
 
+try:
+    from Cython.Distutils.build_ext import new_build_ext as build_ext
+except ImportError:
+    from setuptools.command.build_ext import build_ext
+
 import versioneer
 from distutils.sysconfig import get_python_lib
 
@@ -54,6 +59,10 @@ if (os.environ.get('CONDA_PREFIX', None)):
     conda_include_dir = conda_prefix + '/include'
     conda_lib_dir = conda_prefix + '/lib'
 
+cmdclass = dict()
+cmdclass.update(versioneer.get_cmdclass())
+cmdclass["build_ext"] = build_ext
+
 EXTENSIONS = [
     Extension("*",
               sources=CYTHON_FILES,
@@ -88,5 +97,5 @@ setup(name='cugraph',
       packages=find_packages(include=['cugraph', 'cugraph.*']),
       install_requires=INSTALL_REQUIRES,
       license="Apache",
-      cmdclass=versioneer.get_cmdclass(),
+      cmdclass=cmdclass,
       zip_safe=False)


### PR DESCRIPTION
Copies over the changes made in this PR: https://github.com/rapidsai/ucx-py/pull/462

Using `new_build_ext` allows parallelizing the `cythonize()` call from the command line via `-j` like so:
```
python setup.py -j<num_cores>
```
