### PR TITLE
[REVIEW] update some documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Bug Fixes
 - PR #763 Update RAPIDS conda dependencies to v0.14
+- PR #795 Fix some documentation
 
 # cuGraph 0.13.0 (Date TBD)
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -46,6 +46,13 @@ Katz Centrality
     :members:
     :undoc-members:
 
+Betweenness Centrality
+----------------------
+
+.. automodule:: cugraph.centrality.betweenness_centrality
+    :members:
+    :undoc-members:
+
 Community
 =========
 

--- a/python/cugraph/structure/convert_matrix.py
+++ b/python/cugraph/structure/convert_matrix.py
@@ -24,6 +24,7 @@ def from_cudf_edgelist(df, source='source', destination='destination',
     Return a new graph created from the edge list representaion. This function
     is added for NetworkX compatibility (this function is a RAPIDS version of
     NetworkX's from_pandas_edge_list()).
+
     Parameters
     ----------
     df : cudf.DataFrame
@@ -38,12 +39,14 @@ def from_cudf_edgelist(df, source='source', destination='destination',
     weight : string or integer, optional
         This pointer can be ``None``. If not, this is used to index the weight
         column.
+
     Examples
     --------
     >>> M = cudf.read_csv('datasets/karate.csv', delimiter=' ',
     >>>                   dtype=['int32', 'int32', 'float32'], header=None)
     >>> G = cugraph.Graph()
     >>> G = cugraph.from_cudf_edgelist(M, source='0', target='1', weight='2')
+
     """
     if create_using is Graph:
         G = Graph()

--- a/python/cugraph/structure/graph.py
+++ b/python/cugraph/structure/graph.py
@@ -67,6 +67,7 @@ class Graph:
         --------
         >>> import cuGraph
         >>> G = cuGraph.Graph()
+
         """
         self.symmetrized = symmetrized
         self.renumbered = False
@@ -146,6 +147,7 @@ class Graph:
         >>> G = cugraph.Graph()
         >>> G.from_cudf_edgelist(M, source='0', destination='1', edge_attr='2',
                                  renumber=False)
+
         """
 
         if self.edgelist is not None or self.adjlist is not None:
@@ -288,6 +290,7 @@ class Graph:
         stores references to the deep-copies of the passed objects pointed by
         offset_col and index_col.
         Undirected edges must be stored as directed edges in both directions.
+
         Parameters
         ----------
         offset_col : cudf.Series
@@ -319,6 +322,7 @@ class Graph:
         >>> indices = cudf.Series(M.indices)
         >>> G = cugraph.Graph()
         >>> G.from_cudf_adjlist(offsets, indices, None)
+
         """
         if self.edgelist is not None or self.adjlist is not None:
             raise Exception('Graph already has values')
@@ -380,6 +384,7 @@ class Graph:
             The gdf column contains the weight value for each edge.
             The expected type of the gdf_column element is floating point
             number.
+
         """
         if self.transposedadjlist is None:
             graph_wrapper.view_transposed_adj_list(self)
@@ -398,6 +403,7 @@ class Graph:
         """
         Compute vertex pairs that are two hops apart. The resulting pairs are
         sorted before returning.
+
         Returns
         -------
         df : cudf.DataFrame
@@ -405,6 +411,7 @@ class Graph:
                 the first vertex id of a pair.
             df['second'] : cudf.Series
                 the second vertex id of a pair.
+
         """
         df = graph_wrapper.get_two_hop_neighbors(self)
         if self.renumbered is True:
@@ -445,12 +452,14 @@ class Graph:
         """
         An alias of number_of_vertices(). This function is added for NetworkX
         compatibility.
+
         """
         return self.number_of_vertices()
 
     def number_of_edges(self):
         """
         Get the number of edges in the graph.
+
         """
         if self.edge_count is None:
             if self.edgelist is not None:
@@ -476,11 +485,13 @@ class Graph:
         degrees for the entire set of vertices. If vertex_subset is provided,
         this method optionally filters out all but those listed in
         vertex_subset.
+
         Parameters
         ----------
         vertex_subset : cudf.Series or iterable container, optional
             A container of vertices for displaying corresponding in-degree.
             If not set, degrees are computed for the entire set of vertices.
+
         Returns
         -------
         df : cudf.DataFrame
@@ -493,6 +504,7 @@ class Graph:
                 specified).
             df['degree'] : cudf.Series
                 The computed in-degree of the corresponding vertex.
+
         Examples
         --------
         >>> M = cudf.read_csv('datasets/karate.csv', delimiter=' ',
@@ -502,6 +514,7 @@ class Graph:
         >>> G = cugraph.Graph()
         >>> G.add_edge_list(sources, destinations, None)
         >>> df = G.in_degree([0,9,12])
+
         """
         return self._degree(vertex_subset, x=1)
 
@@ -512,11 +525,13 @@ class Graph:
         degrees for the entire set of vertices. If vertex_subset is provided,
         this method optionally filters out all but those listed in
         vertex_subset.
+
         Parameters
         ----------
         vertex_subset : cudf.Series or iterable container, optional
             A container of vertices for displaying corresponding out-degree.
             If not set, degrees are computed for the entire set of vertices.
+
         Returns
         -------
         df : cudf.DataFrame
@@ -529,6 +544,7 @@ class Graph:
                 specified).
             df['degree'] : cudf.Series
                 The computed out-degree of the corresponding vertex.
+
         Examples
         --------
         >>> M = cudf.read_csv('datasets/karate.csv', delimiter=' ',
@@ -538,6 +554,7 @@ class Graph:
         >>> G = cugraph.Graph()
         >>> G.add_edge_list(sources, destinations, None)
         >>> df = G.out_degree([0,9,12])
+
         """
         return self._degree(vertex_subset, x=2)
 
@@ -547,11 +564,13 @@ class Graph:
         degrees for the entire set of vertices. If vertex_subset is provided,
         this method optionally filters out all but those listed in
         vertex_subset.
+
         Parameters
         ----------
         vertex_subset : cudf.Series or iterable container, optional
             A container of vertices for displaying corresponding degree. If not
             set, degrees are computed for the entire set of vertices.
+
         Returns
         -------
         df : cudf.DataFrame
@@ -564,6 +583,7 @@ class Graph:
                 specified).
             df['degree'] : cudf.Series
                 The computed degree of the corresponding vertex.
+
         Examples
         --------
         >>> M = cudf.read_csv('datasets/karate.csv', delimiter=' ',
@@ -573,6 +593,7 @@ class Graph:
         >>> G = cugraph.Graph()
         >>> G.add_edge_list(sources, destinations, None)
         >>> df = G.degree([0,9,12])
+
         """
         return self._degree(vertex_subset)
 
@@ -582,11 +603,13 @@ class Graph:
         computes vertex degrees for the entire set of vertices. If
         vertex_subset is provided, this method optionally filters out all but
         those listed in vertex_subset.
+
         Parameters
         ----------
         vertex_subset : cudf.Series or iterable container, optional
             A container of vertices for displaying corresponding degree. If not
             set, degrees are computed for the entire set of vertices.
+
         Returns
         -------
         df : cudf.DataFrame
@@ -597,6 +620,7 @@ class Graph:
                 The in-degree of the vertex.
             df['out_degree'] : cudf.Series
                 The out-degree of the vertex.
+
         Examples
         --------
         >>> M = cudf.read_csv('datasets/karate.csv', delimiter=' ',
@@ -606,6 +630,7 @@ class Graph:
         >>> G = cugraph.Graph()
         >>> G.add_edge_list(sources, destinations, None)
         >>> df = G.degrees([0,9,12])
+
         """
         vertex_col, in_degree_col, out_degree_col = graph_wrapper._degrees(
                                                         self)

--- a/python/cugraph/structure/renumber.py
+++ b/python/cugraph/structure/renumber.py
@@ -45,7 +45,7 @@ def renumber(source_col, dest_col):
         Destination indices must be an integer type.
     numbering_map : cudf.Series
         This cudf.Series wraps a gdf column of size V (V: number of vertices).
-        The gdf column contains a numbering map that mpas the new ids to the
+        The gdf column contains a numbering map that maps the new ids to the
         original ids.
 
     Examples


### PR DESCRIPTION
Betweenness centrality was not added to the api.rst file.

Also cleaned up some warnings in the construction of python documentation.

There are still some warnings, related to the additional indentation we do for documenting when particular columns in a data frame have specific meaning.