### PR TITLE
[REVIEW] update bfs optimization path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ## Bug Fixes
 - PR #763 Update RAPIDS conda dependencies to v0.14
-
+- PR #800 Fix bfs error in optimization path
+ 
 # cuGraph 0.13.0 (Date TBD)
 
 ## New Features

--- a/cpp/src/traversal/bfs.cu
+++ b/cpp/src/traversal/bfs.cu
@@ -252,7 +252,7 @@ namespace detail {
     //undirected g : need parents to be in children's neighbors
     bool can_use_bottom_up = !directed && distances;
 
-    while (nf > 0) {
+    while (nf > 0 && nu > 0) {
       //Each vertices can appear only once in the frontierer array - we know it will fit
       new_frontier = frontier + nf;
       IndexType old_nf = nf;

--- a/python/cugraph/traversal/bfs.py
+++ b/python/cugraph/traversal/bfs.py
@@ -27,10 +27,6 @@ def bfs(G, start):
         as an adjacency list.
     start : Integer
         The index of the graph vertex from which the traversal begins
-    directed : bool
-        Indicates whether the graph in question is a directed graph, or whether
-        each edge has a corresponding reverse edge. (Allows optimizations if
-        the graph is undirected)
 
     Returns
     -------

--- a/python/cugraph/traversal/bfs.py
+++ b/python/cugraph/traversal/bfs.py
@@ -12,9 +12,10 @@
 # limitations under the License.
 
 from cugraph.traversal import bfs_wrapper
+from cugraph.structure.graph import Graph
 
 
-def bfs(G, start, directed=True):
+def bfs(G, start):
     """
     Find the distances and predecessors for a breadth first traversal of a
     graph.
@@ -52,6 +53,11 @@ def bfs(G, start, directed=True):
     >>> G.add_edge_list(sources, destinations, None)
     >>> df = cugraph.bfs(G, 0)
     """
+
+    if type(G) is Graph:
+        directed = False
+    else:
+        directed = True
 
     df = bfs_wrapper.bfs(G, start, directed)
 


### PR DESCRIPTION
--> Remove "directed" param in bfs API
Bfs can be optimized when the graph is symmetric by setting directed=False. Since we now have Graph and DiGraph classes, "directed" can be removed from the API and internally set. For a Graph type, which stores symmetric edges, directed is set to False. For DiGraph, which doesn't go through symmetrization, directed is set to True.
Closes #316 

--> Fix bfs optimization path error
When directed is False, a bottomup approach is employed. We need to check nu (undiscovered nodes) as well to avoid the configuration error. Closes #801 