### PR TITLE
[REVIEW] Enable Ninja build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PR #782 Use Cython's `new_build_ext` (if available)
 - PR #788 Added options and config file to enable codecov
 - PR #793 Fix legacy cudf imports/cimports
+- PR #803 Enable Ninja build
 
 ## Bug Fixes
 - PR #763 Update RAPIDS conda dependencies to v0.14

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -293,6 +293,7 @@ ExternalProject_Add(cugunrock
                     -DGPU_ARCHS=""
                     -DGUNROCK_BUILD_SHARED_LIBS=OFF
                     -DGUNROCK_BUILD_TESTS=OFF
+  BUILD_BYPRODUCTS  ${CUGUNROCK_DIR}/lib/libgunrock.a
 )
 
 add_library(gunrock STATIC IMPORTED)


### PR DESCRIPTION
Add `BUILD_BYPRODUCTS` entry to cugunrock project to fix `cmake -GNinja`, similar to the fix in https://github.com/rapidsai/cuml/pull/1984.