### PR TITLE
[REVIEW] Katz Centrality : Auto calculation of alpha parameter if set to none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - PR #834 Updated local gpuci build
 - PR #845 Add .clang-format & format all files
 - PR #859 Updated main docs
+- PR #862 Katz Centrality : Auto calculation of alpha parameter if set to none
 
 ## Bug Fixes
 - PR #763 Update RAPIDS conda dependencies to v0.14

--- a/cpp/include/graph.hpp
+++ b/cpp/include/graph.hpp
@@ -54,8 +54,8 @@ enum class DegreeDirection {
 template <typename VT, typename ET, typename WT>
 class GraphViewBase {
  public:
-  Comm comm;
   WT *edge_data;  ///< edge weight
+  Comm comm;
 
   GraphProperties prop;
 

--- a/cpp/src/centrality/katz_centrality.cu
+++ b/cpp/src/centrality/katz_centrality.cu
@@ -42,10 +42,8 @@ void katz_centrality(experimental::GraphCSRView<VT, ET, WT> const &graph,
   using HornetInit    = hornet::HornetInit<VT>;
   using Katz          = hornets_nest::KatzCentralityStatic;
 
-  //Ask hornet to calculate alpha
-  if (alpha == 0) {
-    alpha = std::numeric_limits<double>::max();
-  }
+  // Ask hornet to calculate alpha
+  if (alpha == 0) { alpha = std::numeric_limits<double>::max(); }
 
   HornetInit init(graph.number_of_vertices, graph.number_of_edges, graph.offsets, graph.indices);
   HornetGraph hnt(init, hornet::DeviceType::DEVICE);

--- a/cpp/src/centrality/katz_centrality.cu
+++ b/cpp/src/centrality/katz_centrality.cu
@@ -42,14 +42,15 @@ void katz_centrality(experimental::GraphCSRView<VT, ET, WT> const &graph,
   using HornetInit    = hornet::HornetInit<VT>;
   using Katz          = hornets_nest::KatzCentralityStatic;
 
+  //Ask hornet to calculate alpha
+  if (alpha == 0) {
+    alpha = std::numeric_limits<double>::max();
+  }
+
   HornetInit init(graph.number_of_vertices, graph.number_of_edges, graph.offsets, graph.indices);
   HornetGraph hnt(init, hornet::DeviceType::DEVICE);
   Katz katz(hnt, alpha, max_iter, tol, normalized, isStatic, result);
-  if (katz.getAlpha() < alpha) {
-    CUGRAPH_FAIL("Error : alpha is not small enough for convergence");
-  }
   katz.run();
-  if (!katz.hasConverged()) { CUGRAPH_FAIL("Error : Convergence not reached"); }
 }
 
 template void katz_centrality<int, int, float, double>(

--- a/python/cugraph/centrality/katz_centrality.py
+++ b/python/cugraph/centrality/katz_centrality.py
@@ -15,7 +15,7 @@ from cugraph.centrality import katz_centrality_wrapper
 
 
 def katz_centrality(G,
-                    alpha=0.1,
+                    alpha=None,
                     max_iter=100,
                     tol=1.0e-6,
                     nstart=None,
@@ -37,9 +37,9 @@ def katz_centrality(G,
         cuGraph graph descriptor with connectivity information. The graph can
         contain either directed (DiGraph) or undirected edges (Graph).
     alpha : float
-        Attenuation factor with a default value of 0.1.  If alpha is not less
-        than 1/(lambda_max) where lambda_max is the maximum degree
-        GDF_CUDA_ERROR is returned
+        Attenuation factor defaulted to None. If alpha is not specified then
+        it is internally calculated as 1/(lambda_max) where lambda_max is the
+        maximum degree
     max_iter : int
         The maximum number of iterations before an answer is returned. This can
         be used to limit the execution time and do an early exit before the

--- a/python/cugraph/centrality/katz_centrality.py
+++ b/python/cugraph/centrality/katz_centrality.py
@@ -38,8 +38,16 @@ def katz_centrality(G,
         contain either directed (DiGraph) or undirected edges (Graph).
     alpha : float
         Attenuation factor defaulted to None. If alpha is not specified then
-        it is internally calculated as 1/(lambda_max) where lambda_max is the
-        maximum degree
+        it is internally calculated as 1/(degree_max) where degree_max is the
+        maximum out degree.
+        NOTE : The maximum acceptable value of alpha for convergence
+        alpha_max = 1/(lambda_max) where lambda_max is the largest eigenvalue
+        of the graph.
+        Since lambda_max is always lesser than or equal to degree_max for a
+        graph, alpha_max will always be greater than or equal to
+        (1/degree_max). Therefore, setting alpha to (1/degree_max) will
+        guarantee that it will never exceed alpha_max thus in turn fulfilling
+        the requirement for convergence.
     max_iter : int
         The maximum number of iterations before an answer is returned. This can
         be used to limit the execution time and do an early exit before the

--- a/python/cugraph/centrality/katz_centrality_wrapper.pyx
+++ b/python/cugraph/centrality/katz_centrality_wrapper.pyx
@@ -29,32 +29,19 @@ import rmm
 import numpy as np
 
 
-def katz_centrality(input_graph, alpha=0.1, max_iter=100, tol=1.0e-5, nstart=None, normalized=True):
-    """
-    Call katz_centrality
-    """
-    if not input_graph.adjlist:
-        input_graph.view_adj_list()
-
-    [offsets, indices] = graph_wrapper.datatype_cast([input_graph.adjlist.offsets, input_graph.adjlist.indices], [np.int32])
-
+def get_output_df(input_graph, nstart):
     num_verts = input_graph.number_of_vertices()
-    num_edges = len(indices)
-
     df = cudf.DataFrame()
     df['vertex'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
-
-    has_guess = False
 
     if nstart is None:
         df['katz_centrality'] = cudf.Series(np.zeros(num_verts, dtype=np.float64))
     else:
-        has_guess = True
         if len(nstart) != num_verts:
             raise ValueError('nstart must have initial guess for all vertices')
 
         nstart = graph_wrapper.datatype_cast([nstart], [np.float64])
-        
+
         if input_graph.renumbered is True:
             renumber_series = cudf.Series(input_graph.edgelist.renumber_map.index,
                                           index=input_graph.edgelist.renumber_map)
@@ -66,14 +53,22 @@ def katz_centrality(input_graph, alpha=0.1, max_iter=100, tol=1.0e-5, nstart=Non
             df['katz_centrality'] = cudf.Series(cudf._lib.copying.scatter(nstart['values']._column,
                                                 nstart['vertex']._column,
                                                 df['katz_centrality']._column))
+    return df
+
+
+def katz_centrality(input_graph, alpha=0.1, max_iter=100, tol=1.0e-5, nstart=None, normalized=True):
+    """
+    Call katz_centrality
+    """
+
+    df = get_output_df(input_graph, nstart)
+    if nstart is not None:
+        has_guess = True
 
     cdef uintptr_t c_identifier = df['vertex'].__cuda_array_interface__['data'][0]
     cdef uintptr_t c_katz = df['katz_centrality'].__cuda_array_interface__['data'][0]
-    cdef uintptr_t c_offsets = offsets.__cuda_array_interface__['data'][0]
-    cdef uintptr_t c_indices = indices.__cuda_array_interface__['data'][0]
-    
-    cdef GraphCSRView[int,int,float] graph
-    graph = GraphCSRView[int,int,float](<int*>c_offsets, <int*>c_indices, <float*>NULL, num_verts, num_edges)
+
+    cdef GraphCSRViewFloat graph = get_graph_view[GraphCSRViewFloat](input_graph, True)
 
     c_katz_centrality[int,int,float,double](graph, <double*> c_katz, alpha, max_iter, tol, has_guess, normalized)
 

--- a/python/cugraph/centrality/katz_centrality_wrapper.pyx
+++ b/python/cugraph/centrality/katz_centrality_wrapper.pyx
@@ -56,7 +56,7 @@ def get_output_df(input_graph, nstart):
     return df
 
 
-def katz_centrality(input_graph, alpha=0.1, max_iter=100, tol=1.0e-5, nstart=None, normalized=True):
+def katz_centrality(input_graph, alpha=None, max_iter=100, tol=1.0e-5, nstart=None, normalized=True):
     """
     Call katz_centrality
     """
@@ -64,6 +64,8 @@ def katz_centrality(input_graph, alpha=0.1, max_iter=100, tol=1.0e-5, nstart=Non
     df = get_output_df(input_graph, nstart)
     if nstart is not None:
         has_guess = True
+    if alpha is None:
+        alpha = 0
 
     cdef uintptr_t c_identifier = df['vertex'].__cuda_array_interface__['data'][0]
     cdef uintptr_t c_katz = df['katz_centrality'].__cuda_array_interface__['data'][0]

--- a/python/cugraph/structure/graph_new.pxd
+++ b/python/cugraph/structure/graph_new.pxd
@@ -66,7 +66,7 @@ cdef extern from "graph.hpp" namespace "cugraph::experimental":
 
         void get_source_indices(VT *) const
         void degree(ET *,DegreeDirection) const
-        
+
         GraphCompressedSparseBaseView(const VT *, const ET *, const WT *, size_t, size_t)
 
     cdef cppclass GraphCSRView[VT,ET,WT](GraphCompressedSparseBaseView[VT,ET,WT]):
@@ -136,27 +136,39 @@ cdef extern from "<utility>" namespace "std" nogil:
     cdef GraphSparseContents[int,int,float] move(GraphSparseContents[int,int,float])
     cdef GraphSparseContents[int,int,double] move(GraphSparseContents[int,int,double])
 
-ctypedef unique_ptr[GraphCOO[int,int,float]] GraphCOOPtrFloat 
+ctypedef unique_ptr[GraphCOO[int,int,float]] GraphCOOPtrFloat
 ctypedef unique_ptr[GraphCOO[int,int,double]] GraphCOOPtrDouble
 
 ctypedef fused GraphCOOPtrType:
     GraphCOOPtrFloat
     GraphCOOPtrDouble
 
-ctypedef unique_ptr[GraphCSR[int,int,float]] GraphCSRPtrFloat 
+ctypedef unique_ptr[GraphCSR[int,int,float]] GraphCSRPtrFloat
 ctypedef unique_ptr[GraphCSR[int,int,double]] GraphCSRPtrDouble
 
 ctypedef fused GraphCSRPtrType:
     GraphCSRPtrFloat
     GraphCSRPtrDouble
 
-ctypedef GraphCOOView[int,int,float] GraphCOOViewFloat 
+ctypedef GraphCOOView[int,int,float] GraphCOOViewFloat
 ctypedef GraphCOOView[int,int,double] GraphCOOViewDouble
+ctypedef GraphCSRView[int,int,float] GraphCSRViewFloat
+ctypedef GraphCSRView[int,int,double] GraphCSRViewDouble
 
 ctypedef fused GraphCOOViewType:
     GraphCOOViewFloat
     GraphCOOViewDouble
 
+ctypedef fused GraphCSRViewType:
+    GraphCSRViewFloat
+    GraphCSRViewDouble
+
+ctypedef fused GraphViewType:
+    GraphCOOViewFloat
+    GraphCOOViewDouble
+    GraphCSRViewFloat
+    GraphCSRViewDouble
+
 cdef coo_to_df(GraphCOOPtrType graph)
 cdef csr_to_series(GraphCSRPtrType graph)
-cdef GraphCOOViewType get_graph_view(input_graph, GraphCOOViewType* dummy=*)
+cdef GraphViewType get_graph_view(input_graph, GraphViewType* dummy=*)

--- a/python/cugraph/structure/graph_new.pxd
+++ b/python/cugraph/structure/graph_new.pxd
@@ -171,4 +171,4 @@ ctypedef fused GraphViewType:
 
 cdef coo_to_df(GraphCOOPtrType graph)
 cdef csr_to_series(GraphCSRPtrType graph)
-cdef GraphViewType get_graph_view(input_graph, GraphViewType* dummy=*)
+cdef GraphViewType get_graph_view(input_graph, bool weightless=*, GraphViewType* dummy=*)

--- a/python/cugraph/structure/graph_new.pyx
+++ b/python/cugraph/structure/graph_new.pyx
@@ -68,7 +68,7 @@ cdef csr_to_series(GraphCSRPtrType graph):
     return (csr_offsets, csr_indices, csr_weights)
 
 
-cdef GraphCSRViewType get_csr_graph_view(input_graph, GraphCSRViewType* dummy=NULL):
+cdef GraphCSRViewType get_csr_graph_view(input_graph, bool weightless=False, GraphCSRViewType* dummy=NULL):
     if not input_graph.adjlist:
         input_graph.view_adj_list()
 
@@ -76,7 +76,7 @@ cdef GraphCSRViewType get_csr_graph_view(input_graph, GraphCSRViewType* dummy=NU
     cdef uintptr_t c_ind = input_graph.adjlist.indices.__cuda_array_interface__['data'][0]
     cdef uintptr_t c_weights = <uintptr_t>NULL
 
-    if input_graph.adjlist.weights:
+    if input_graph.adjlist.weights and not weightless:
         c_weights = input_graph.adjlist.weights.__cuda_array_interface__['data'][0]
 
     num_verts = input_graph.number_of_vertices()
@@ -89,7 +89,7 @@ cdef GraphCSRViewType get_csr_graph_view(input_graph, GraphCSRViewType* dummy=NU
     return in_graph
 
 
-cdef GraphCOOViewType get_coo_graph_view(input_graph, GraphCOOViewType* dummy=NULL):
+cdef GraphCOOViewType get_coo_graph_view(input_graph, bool weightless=False, GraphCOOViewType* dummy=NULL):
     if not input_graph.edgelist:
         input_graph.view_edge_list()
 
@@ -97,7 +97,7 @@ cdef GraphCOOViewType get_coo_graph_view(input_graph, GraphCOOViewType* dummy=NU
     cdef uintptr_t c_dst = input_graph.edgelist.edgelist_df['dst'].__cuda_array_interface__['data'][0]
     cdef uintptr_t c_weights = <uintptr_t>NULL
 
-    if input_graph.edgelist.weights:
+    if input_graph.edgelist.weights and not weightless:
         c_weights = input_graph.edgelist.edgelist_df['weights'].__cuda_array_interface__['data'][0]
 
     num_verts = input_graph.number_of_vertices()
@@ -110,12 +110,12 @@ cdef GraphCOOViewType get_coo_graph_view(input_graph, GraphCOOViewType* dummy=NU
     return in_graph
 
 
-cdef GraphViewType get_graph_view(input_graph, GraphViewType* dummy=NULL):
+cdef GraphViewType get_graph_view(input_graph, bool weightless = False, GraphViewType* dummy=NULL):
     if GraphViewType is GraphCOOViewFloat:
-        return get_coo_graph_view[GraphCOOViewFloat](input_graph, dummy)
+        return get_coo_graph_view[GraphCOOViewFloat](input_graph, weightless, dummy)
     elif GraphViewType is GraphCOOViewDouble:
-        return get_coo_graph_view[GraphCOOViewDouble](input_graph, dummy)
+        return get_coo_graph_view[GraphCOOViewDouble](input_graph, weightless, dummy)
     elif GraphViewType is GraphCSRViewFloat:
-        return get_csr_graph_view[GraphCSRViewFloat](input_graph, dummy)
+        return get_csr_graph_view[GraphCSRViewFloat](input_graph, weightless, dummy)
     elif GraphViewType is GraphCSRViewDouble:
-        return get_csr_graph_view[GraphCSRViewDouble](input_graph, dummy)
+        return get_csr_graph_view[GraphCSRViewDouble](input_graph, weightless, dummy)

--- a/python/cugraph/structure/graph_new.pyx
+++ b/python/cugraph/structure/graph_new.pyx
@@ -68,11 +68,30 @@ cdef csr_to_series(GraphCSRPtrType graph):
     return (csr_offsets, csr_indices, csr_weights)
 
 
-cdef GraphCOOViewType get_graph_view(input_graph, GraphCOOViewType* dummy=NULL):
+cdef GraphCSRViewType get_csr_graph_view(input_graph, GraphCSRViewType* dummy=NULL):
+    if not input_graph.adjlist:
+        input_graph.view_adj_list()
+
+    cdef uintptr_t c_off = input_graph.adjlist.offsets.__cuda_array_interface__['data'][0]
+    cdef uintptr_t c_ind = input_graph.adjlist.indices.__cuda_array_interface__['data'][0]
+    cdef uintptr_t c_weights = <uintptr_t>NULL
+
+    if input_graph.adjlist.weights:
+        c_weights = input_graph.adjlist.weights.__cuda_array_interface__['data'][0]
+
+    num_verts = input_graph.number_of_vertices()
+    num_edges = len(input_graph.adjlist.indices)
+    cdef GraphCSRViewType in_graph
+    if GraphCSRViewType is GraphCSRViewFloat:
+        in_graph = GraphCSRViewFloat(<int*>c_off, <int*>c_ind, <float*>c_weights, num_verts, num_edges)
+    elif GraphCSRViewType is GraphCSRViewDouble:
+        in_graph = GraphCSRViewDouble(<int*>c_off, <int*>c_ind, <double*>c_weights, num_verts, num_edges)
+    return in_graph
+
+
+cdef GraphCOOViewType get_coo_graph_view(input_graph, GraphCOOViewType* dummy=NULL):
     if not input_graph.edgelist:
         input_graph.view_edge_list()
-
-    weights = None
 
     cdef uintptr_t c_src = input_graph.edgelist.edgelist_df['src'].__cuda_array_interface__['data'][0]
     cdef uintptr_t c_dst = input_graph.edgelist.edgelist_df['dst'].__cuda_array_interface__['data'][0]
@@ -89,3 +108,14 @@ cdef GraphCOOViewType get_graph_view(input_graph, GraphCOOViewType* dummy=NULL):
     elif GraphCOOViewType is GraphCOOViewDouble:
         in_graph = GraphCOOViewDouble(<int*>c_src, <int*>c_dst, <double*>c_weights, num_verts, num_edges)
     return in_graph
+
+
+cdef GraphViewType get_graph_view(input_graph, GraphViewType* dummy=NULL):
+    if GraphViewType is GraphCOOViewFloat:
+        return get_coo_graph_view[GraphCOOViewFloat](input_graph, dummy)
+    elif GraphViewType is GraphCOOViewDouble:
+        return get_coo_graph_view[GraphCOOViewDouble](input_graph, dummy)
+    elif GraphViewType is GraphCSRViewFloat:
+        return get_csr_graph_view[GraphCSRViewFloat](input_graph, dummy)
+    elif GraphViewType is GraphCSRViewDouble:
+        return get_csr_graph_view[GraphCSRViewDouble](input_graph, dummy)

--- a/python/cugraph/tests/test_katz_centrality.py
+++ b/python/cugraph/tests/test_katz_centrality.py
@@ -47,7 +47,7 @@ def calc_katz(graph_file):
     largest_out_degree = largest_out_degree['out_degree'].iloc[0]
     katz_alpha = 1/(largest_out_degree + 1)
 
-    k_df = cugraph.katz_centrality(G, katz_alpha, max_iter=1000)
+    k_df = cugraph.katz_centrality(G, None, max_iter=1000)
 
     NM = utils.read_csv_for_nx(graph_file)
     Gnx = nx.from_pandas_edgelist(NM, create_using=nx.DiGraph(),


### PR DESCRIPTION
Fixes #730 
- Katz will automatically calculate alpha parameter if it is not provided by the user
- The code will no longer inform the user if the value of alpha is greater than the minimum alpha for convergence
- The code will no longer inform the user if the centrality calculation does not converge