### PR TITLE
[REVIEW] Update setup.py for custom clean command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - PR #865 Added C++ docs
 - PR #866 Use RAII graph class in KTruss
 - PR #867 Updates to support the latest flake8 version
+- PR #874 Update setup.py to use custom clean command
 
 ## Bug Fixes
 - PR #763 Update RAPIDS conda dependencies to v0.14

--- a/python/setup.py
+++ b/python/setup.py
@@ -15,7 +15,7 @@ import os
 import sys
 import shutil
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages, Command
 from setuptools.extension import Extension
 
 try:
@@ -58,9 +58,30 @@ if (os.environ.get('CONDA_PREFIX', None)):
     conda_include_dir = conda_prefix + '/include'
     conda_lib_dir = conda_prefix + '/lib'
 
+
+class CleanCommand(Command):
+    """Custom clean command to tidy up the project root."""
+    user_options = [('all', None, None), ]
+
+    def initialize_options(self):
+        self.all = None
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        os.system('rm -rf build')
+        os.system('rm -rf dist')
+        os.system('rm -rf dask-worker-space')
+        os.system('find . -name "__pycache__" -type d -exec rm -rf {} +')
+        os.system('rm -rf *.egg-info')
+        os.system('find . -name "*.cpp" -type f -delete')
+        os.system('find . -name "*.cpython*.so" -type f -delete')
+
 cmdclass = dict()
 cmdclass.update(versioneer.get_cmdclass())
 cmdclass["build_ext"] = build_ext
+cmdclass["clean"] = CleanCommand
 
 EXTENSIONS = [
     Extension("*",

--- a/python/setup.py
+++ b/python/setup.py
@@ -78,6 +78,7 @@ class CleanCommand(Command):
         os.system('find . -name "*.cpp" -type f -delete')
         os.system('find . -name "*.cpython*.so" -type f -delete')
 
+
 cmdclass = dict()
 cmdclass.update(versioneer.get_cmdclass())
 cmdclass["build_ext"] = build_ext

--- a/python/setup.py
+++ b/python/setup.py
@@ -70,6 +70,8 @@ class CleanCommand(Command):
         pass
 
     def run(self):
+        setupFileDir = os.path.dirname(os.path.abspath(__file__))
+        os.chdir(setupFileDir)
         os.system('rm -rf build')
         os.system('rm -rf dist')
         os.system('rm -rf dask-worker-space')


### PR DESCRIPTION
Closes #615 
Added a custom clean which recursively removes the following files/directories if present:
dist/
cugraph.egg-info
build/
dask-worker-space/
__pycache__/
cython generated cpp files
