### PR TITLE
[gpuCI] Auto-merge branch-0.14 to branch-0.15 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - PR #807 Updating the Python docs
 - PR #820 OPG infra and all-gather smoke test
 - PR #799 Refactored graph class with RAII
+- PR #818 Initial version of new "benchmarks" folder
 - PR #829 Updated README and CONTRIBUTIOIN docs
 - PR #836 Remove SNMG code
 - PR #831 Updated Notebook - Added K-Truss, ECG, and Betweenness Centrality
@@ -42,7 +43,6 @@
 - PR #874 Update setup.py to use custom clean command
 - PR #878 Updated build script
 - PR #879 Add docs build script to repository
-- PR #818 Initial version of new "benchmarks" folder
 
 ## Bug Fixes
 - PR #763 Update RAPIDS conda dependencies to v0.14


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.14` that creates a PR to keep `branch-0.15` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.