### PR TITLE
[REVIEW] Fix BFS for directed graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - PR #899 Update include paths to remove deleted cudf headers
 
 ## Bug Fixes
+- PR #907 Fix bfs directed missing vertices
 - PR #763 Update RAPIDS conda dependencies to v0.14
 - PR #795 Fix some documentation
 - PR #800 Fix bfs error in optimization path

--- a/cpp/src/traversal/bfs.cu
+++ b/cpp/src/traversal/bfs.cu
@@ -264,7 +264,7 @@ void BFS<IndexType>::traverse(IndexType source_vertex)
   // In case the shortest path counters need to be computeed, the bottom_up approach cannot be used
   bool can_use_bottom_up = (!sp_counters && !directed && distances);
 
-  while (nf > 0 && nu > 0) {
+  while (nf > 0) {
     // Each vertices can appear only once in the frontierer array - we know it will fit
     new_frontier     = frontier + nf;
     IndexType old_nf = nf;

--- a/cpp/src/traversal/bfs_kernels.cuh
+++ b/cpp/src/traversal/bfs_kernels.cuh
@@ -495,7 +495,7 @@ void bottom_up_main(IndexType *unvisited,
   dim3 grid, block;
   block.x = MAIN_BOTTOMUP_DIMX;
 
-  grid.x = min((IndexType)MAXBLOCKS, ((unvisited_size + block.x - 1)) / block.x);
+  grid.x = min((IndexType)MAXBLOCKS, ((unvisited_size + block.x)) / block.x);
 
   main_bottomup_kernel<<<grid, block, 0, m_stream>>>(unvisited,
                                                      unvisited_size,


### PR DESCRIPTION
The current version of BFS may skip vertices in the last iteration when running on directed graphs.
This fixes the behavior, and avoid a potential Kernel Configuration issue by ensuring that the kernel is started with a positive value.