### PR TITLE
[REVIEW] Use Numba to allocate the array directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Improvements
+- PR #913 Eliminate `rmm.device_array` usage
 - PR #903 Add short commit hash to conda package
 
 ## Bug Fixes

--- a/python/cugraph/layout/force_atlas2_wrapper.pyx
+++ b/python/cugraph/layout/force_atlas2_wrapper.pyx
@@ -26,7 +26,7 @@ from libc.stdint cimport uintptr_t
 
 import cudf
 import cudf._lib as libcudf
-import rmm
+from numba import cuda
 import numpy as np
 import numpy.ctypeslib as ctypeslib
 
@@ -103,7 +103,7 @@ def force_atlas2(input_graph,
     if input_graph.edgelist.weights \
             and input_graph.edgelist.edgelist_df['weights'].dtype == np.float64:
 
-        pos = rmm.device_array(
+        pos = cuda.device_array(
                         (num_verts, 2),
                         order="F",
                         dtype=np.float64)
@@ -135,7 +135,7 @@ def force_atlas2(input_graph,
         df['x'] = pos_df['x']
         df['y'] = pos_df['y']
     else:
-        pos = rmm.device_array(
+        pos = cuda.device_array(
                 (num_verts, 2),
                 order="F",
                 dtype=np.float32)


### PR DESCRIPTION
Since Numba has added support for external memory managers (EMM) and cuDF configures Numba to use RMM on import, we can just use Numba directly here. This should eliminate the last usage of `device_array` in cuGraph :)

xref: https://github.com/rapidsai/rmm/issues/180