### PR TITLE
[REVIEW] Remove gunrock from Betweenness Centrality

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -226,27 +226,6 @@ ExternalProject_Add(cuhornet
   INSTALL_COMMAND   ""
 )
 
-# - GUNROCK
-set(CUGUNROCK_DIR ${CMAKE_CURRENT_BINARY_DIR}/cugunrock CACHE STRING
-  "Path to cugunrock repo")
-
-ExternalProject_Add(cugunrock
-  GIT_REPOSITORY    https://github.com/rapidsai/cugunrock.git
-  GIT_TAG           fea_full_bc      # provide a branch, a tag, or even a commit hash
-  PREFIX            ${CUGUNROCK_DIR}
-  CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-                    -DGPU_ARCHS=""
-                    -DGUNROCK_BUILD_SHARED_LIBS=OFF
-                    -DGUNROCK_BUILD_TESTS=OFF
-  BUILD_BYPRODUCTS  ${CUGUNROCK_DIR}/lib/libgunrock.a
-)
-
-add_library(gunrock STATIC IMPORTED)
-
-add_dependencies(gunrock cugunrock)
-
-set_property(TARGET gunrock PROPERTY IMPORTED_LOCATION ${CUGUNROCK_DIR}/lib/libgunrock.a)
-
 # - NCCL
 if(NOT NCCL_PATH)
     find_package(NCCL REQUIRED)
@@ -339,11 +318,6 @@ add_library(cugraph SHARED
     src/nvgraph/partition.cu
 )
 
-#
-# NOTE:  This dependency will force the building of cugraph to
-#        wait until after cugunrock is constructed.
-#
-add_dependencies(cugraph cugunrock)
 add_dependencies(cugraph raft)
 
 if (BUILD_MPI)
@@ -377,7 +351,7 @@ target_include_directories(cugraph
 # - link libraries --------------------------------------------------------------------------------
 
 target_link_libraries(cugraph PRIVATE
-    ${RMM_LIBRARY} gunrock ${NVSTRINGS_LIBRARY} cublas cusparse curand cusolver cudart cuda ${LIBCYPHERPARSER_LIBRARY} ${MPI_CXX_LIBRARIES} ${NCCL_LIBRARIES})
+    ${RMM_LIBRARY} ${NVSTRINGS_LIBRARY} cublas cusparse curand cusolver cudart cuda ${LIBCYPHERPARSER_LIBRARY} ${MPI_CXX_LIBRARIES} ${NCCL_LIBRARIES})
 
 if(OpenMP_CXX_FOUND)
 target_link_libraries(cugraph PRIVATE

--- a/cpp/include/algorithms.hpp
+++ b/cpp/include/algorithms.hpp
@@ -187,11 +187,6 @@ void overlap_list(experimental::GraphCSRView<VT, ET, WT> const &graph,
                   VT const *second,
                   WT *result);
 
-enum class cugraph_bc_implem_t {
-  CUGRAPH_DEFAULT = 0,  ///> Native cugraph implementation
-  CUGRAPH_GUNROCK       ///> Gunrock implementation
-};
-
 /**
  *
  * @brief                                       ForceAtlas2 is a continuous graph layout algorithm
@@ -270,7 +265,7 @@ void force_atlas2(experimental::GraphCOOView<VT, ET, WT> &graph,
  * Betweenness centrality for a vertex is the sum of the fraction of
  * all pairs shortest paths that pass through the vertex.
  *
- * Note that both the native and the gunrock implementations do not support a weighted graph.
+ * The current implementation does not support a weighted graph.
  *
  * @throws                           cugraph::logic_error with a custom message when an error
  * occurs.
@@ -295,19 +290,16 @@ void force_atlas2(experimental::GraphCOOView<VT, ET, WT> &graph,
  * @param[in] vertices               If specified, host array of vertex ids to estimate betweenness
  * centrality, these vertices will serve as sources for the traversal algorihtm to obtain
  * shortest path counters.
- * @param[in] implem                 Cugraph currently supports 2 implementations: native and
- * gunrock
  *
  */
 template <typename VT, typename ET, typename WT, typename result_t>
 void betweenness_centrality(experimental::GraphCSRView<VT, ET, WT> const &graph,
                             result_t *result,
-                            bool normalized            = true,
-                            bool endpoints             = false,
-                            WT const *weight           = nullptr,
-                            VT k                       = 0,
-                            VT const *vertices         = nullptr,
-                            cugraph_bc_implem_t implem = cugraph_bc_implem_t::CUGRAPH_DEFAULT);
+                            bool normalized    = true,
+                            bool endpoints     = false,
+                            WT const *weight   = nullptr,
+                            VT k               = 0,
+                            VT const *vertices = nullptr);
 
 enum class cugraph_cc_t {
   CUGRAPH_WEAK = 0,  ///> Weakly Connected Components

--- a/cpp/src/centrality/betweenness_centrality.cu
+++ b/cpp/src/centrality/betweenness_centrality.cu
@@ -23,8 +23,6 @@
 
 #include <utilities/error_utils.h>
 
-#include <gunrock/gunrock.h>
-
 #include "betweenness_centrality.cuh"
 
 namespace cugraph {
@@ -295,92 +293,6 @@ void betweenness_centrality(experimental::GraphCSRView<VT, ET, WT> const &graph,
 }
 }  // namespace detail
 
-namespace gunrock {
-
-// NOTE: sample_seeds is not really available anymore,  as it has been
-//       replaced by k and vertices parameters, delegating the random
-//       generation to somewhere else (i.e python's side)
-template <typename VT, typename ET, typename WT, typename result_t>
-void betweenness_centrality(experimental::GraphCSRView<VT, ET, WT> const &graph,
-                            result_t *result,
-                            bool normalize,
-                            VT const *sample_seeds    = nullptr,
-                            VT number_of_sample_seeds = 0)
-{
-  cudaStream_t stream{nullptr};
-
-  //
-  //  gunrock currently (as of 2/28/2020) only operates on a graph and results in
-  //  host memory.  [That is, the first step in gunrock is to allocate device memory
-  //  and copy the data into device memory, the last step is to allocate host memory
-  //  and copy the results into the host memory]
-  //
-  //  They are working on fixing this.  In the meantime, to get the features into
-  //  cuGraph we will first copy the graph back into local memory and when we are finished
-  //  copy the result back into device memory.
-  //
-  std::vector<ET> v_offsets(graph.number_of_vertices + 1);
-  std::vector<VT> v_indices(graph.number_of_edges);
-  std::vector<float> v_result(graph.number_of_vertices);
-  std::vector<float> v_sigmas(graph.number_of_vertices);
-  std::vector<int> v_labels(graph.number_of_vertices);
-
-  // fill them
-  CUDA_TRY(cudaMemcpy(v_offsets.data(),
-                      graph.offsets,
-                      sizeof(ET) * (graph.number_of_vertices + 1),
-                      cudaMemcpyDeviceToHost));
-  CUDA_TRY(cudaMemcpy(
-    v_indices.data(), graph.indices, sizeof(VT) * graph.number_of_edges, cudaMemcpyDeviceToHost));
-
-  if (sample_seeds == nullptr) {
-    bc(graph.number_of_vertices,
-       graph.number_of_edges,
-       v_offsets.data(),
-       v_indices.data(),
-       -1,
-       v_result.data(),
-       v_sigmas.data(),
-       v_labels.data());
-  } else {
-    //
-    //  Gunrock, as currently implemented
-    //  doesn't support this method.
-    //
-    CUGRAPH_FAIL("gunrock doesn't currently support sampling seeds");
-  }
-
-  // copy to results
-  CUDA_TRY(cudaMemcpy(
-    result, v_result.data(), sizeof(result_t) * graph.number_of_vertices, cudaMemcpyHostToDevice));
-
-  // Rescale result (Based on normalize and directed/undirected)
-  if (normalize) {
-    if (graph.number_of_vertices > 2) {
-      float denominator = (graph.number_of_vertices - 1) * (graph.number_of_vertices - 2);
-
-      thrust::transform(rmm::exec_policy(stream)->on(stream),
-                        result,
-                        result + graph.number_of_vertices,
-                        result,
-                        [denominator] __device__(float f) { return (f * 2) / denominator; });
-    }
-  } else {
-    //
-    //  gunrock answer needs to be doubled to match networkx
-    //
-    if (graph.prop.directed) {
-      thrust::transform(rmm::exec_policy(stream)->on(stream),
-                        result,
-                        result + graph.number_of_vertices,
-                        result,
-                        [] __device__(float f) { return (f * 2); });
-    }
-  }
-}
-
-}  // namespace gunrock
-
 /**
  * @param[out]  result          array<result_t>(number_of_vertices)
  * @param[in]   normalize       bool True -> Apply normalization
@@ -396,34 +308,9 @@ void betweenness_centrality(experimental::GraphCSRView<VT, ET, WT> const &graph,
                             bool endpoints,
                             WT const *weight,
                             VT k,
-                            VT const *vertices,
-                            cugraph_bc_implem_t implem)
+                            VT const *vertices)
 {
-  // FIXME: Gunrock call returns float and not result_t hence the implementation
-  //       switch
-  if ((typeid(result_t) == typeid(double)) && (implem == cugraph_bc_implem_t::CUGRAPH_GUNROCK)) {
-    implem = cugraph_bc_implem_t::CUGRAPH_DEFAULT;
-    std::cerr << "[WARN] result_t type is 'double', switching to default "
-              << "implementation" << std::endl;
-  }
-  //
-  // NOTE:  gunrock implementation doesn't yet support the unused parameters:
-  //     - endpoints
-  //     - weight
-  //     - k
-  //     - vertices
-  //
-  // These parameters are present in the API to support future features.
-  //
-  if (implem == cugraph_bc_implem_t::CUGRAPH_DEFAULT) {
-    detail::betweenness_centrality(graph, result, normalize, endpoints, weight, k, vertices);
-  } else if (implem == cugraph_bc_implem_t::CUGRAPH_GUNROCK) {
-    gunrock::betweenness_centrality(graph, result, normalize);
-  } else {
-    CUGRAPH_FAIL(
-      "Invalid Betweenness Centrality implementation, please refer to cugraph_bc_implem_t for "
-      "valid implementations");
-  }
+  detail::betweenness_centrality(graph, result, normalize, endpoints, weight, k, vertices);
 }
 
 template void betweenness_centrality<int, int, float, float>(
@@ -433,8 +320,7 @@ template void betweenness_centrality<int, int, float, float>(
   bool,
   float const *,
   int,
-  int const *,
-  cugraph_bc_implem_t);
+  int const *);
 template void betweenness_centrality<int, int, double, double>(
   experimental::GraphCSRView<int, int, double> const &,
   double *,
@@ -442,7 +328,6 @@ template void betweenness_centrality<int, int, double, double>(
   bool,
   double const *,
   int,
-  int const *,
-  cugraph_bc_implem_t);
+  int const *);
 
 }  // namespace cugraph

--- a/cpp/tests/centrality/betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/betweenness_centrality_test.cu
@@ -283,8 +283,7 @@ class Tests_BC : public ::testing::TestWithParam<BC_Usecase> {
                                                    endpoints,
                                                    static_cast<WT *>(nullptr),
                                                    configuration.number_of_sources_,
-                                                   sources_ptr,
-                                                   cugraph::cugraph_bc_implem_t::CUGRAPH_DEFAULT),
+                                                   sources_ptr),
                    cugraph::logic_error);
       return;
     } else {
@@ -294,8 +293,7 @@ class Tests_BC : public ::testing::TestWithParam<BC_Usecase> {
                                       endpoints,
                                       static_cast<WT *>(nullptr),
                                       configuration.number_of_sources_,
-                                      sources_ptr,
-                                      cugraph::cugraph_bc_implem_t::CUGRAPH_DEFAULT);
+                                      sources_ptr);
     }
     cudaDeviceSynchronize();
     CUDA_TRY(cudaMemcpy(result.data(),

--- a/python/cugraph/centrality/betweenness_centrality.pxd
+++ b/python/cugraph/centrality/betweenness_centrality.pxd
@@ -22,10 +22,6 @@ from libcpp cimport bool
 
 cdef extern from "algorithms.hpp" namespace "cugraph":
 
-    ctypedef enum cugraph_bc_implem_t:
-        CUGRAPH_DEFAULT "cugraph::cugraph_bc_implem_t::CUGRAPH_DEFAULT"
-        CUGRAPH_GUNROCK "cugraph::cugraph_bc_implem_t::CUGRAPH_GUNROCK"
-
     cdef void betweenness_centrality[VT,ET,WT,result_t](
         const GraphCSRView[VT,ET,WT] &graph,
         result_t *result,
@@ -33,6 +29,5 @@ cdef extern from "algorithms.hpp" namespace "cugraph":
         bool endpoints,
         const WT *weight,
         VT k,
-        const VT *vertices,
-        cugraph_bc_implem_t implem) except +
+        const VT *vertices) except +
 

--- a/python/cugraph/centrality/betweenness_centrality.py
+++ b/python/cugraph/centrality/betweenness_centrality.py
@@ -18,7 +18,7 @@ from cugraph.centrality import betweenness_centrality_wrapper
 
 # NOTE: result_type=float could ne an intuitive way to indicate the result type
 def betweenness_centrality(G, k=None, normalized=True,
-                           weight=None, endpoints=False, implementation=None,
+                           weight=None, endpoints=False,
                            seed=None, result_dtype=np.float64):
     """
     Compute the betweenness centrality for all nodes of the graph G from a
@@ -63,13 +63,6 @@ def betweenness_centrality(G, k=None, normalized=True,
         If true, include the endpoints in the shortest path counts.
         (Not Supported)
 
-    implementation : string, optional, default=None
-        if implementation is None or "default", uses native cugraph,
-        if "gunrock" uses gunrock based bc.
-        The default version supports normalized, k and seed options.
-        "gunrock" might be faster when considering all the sources, but
-        only return float results and consider all the vertices as sources.
-
     seed : optional
         if k is specified and k is an integer, use seed to initialize the
         random number generator.
@@ -79,7 +72,6 @@ def betweenness_centrality(G, k=None, normalized=True,
 
     result_dtype : np.float32 or np.float64, optional, default=np.float64
         Indicate the data type of the betweenness centrality scores
-        Using double automatically switch implementation to "default"
 
     Returns
     -------
@@ -103,10 +95,6 @@ def betweenness_centrality(G, k=None, normalized=True,
     >>> bc = cugraph.betweenness_centrality(G)
     """
 
-    #
-    # Some features not implemented in gunrock implementation, failing fast,
-    # but passing parameters through
-    #
     # vertices is intended to be a cuDF series that contains a sampling of
     # k vertices out of the graph.
     #
@@ -114,18 +102,8 @@ def betweenness_centrality(G, k=None, normalized=True,
     # workaround.
     #
     vertices = None
-    if implementation is None:
-        implementation = "default"
-    if implementation not in ["default", "gunrock"]:
-        raise ValueError("Only two implementations are supported: 'default' "
-                         "and 'gunrock'")
 
     if k is not None:
-        if implementation == "gunrock":
-            raise ValueError("sampling feature of betweenness "
-                             "centrality not currently supported "
-                             "with gunrock implementation, "
-                             "please use None or 'default'")
         # In order to compare with pre-set sources,
         # k can either be a list or an integer or None
         #  int: Generate an random sample with k elements
@@ -171,6 +149,5 @@ def betweenness_centrality(G, k=None, normalized=True,
                                                                endpoints,
                                                                weight,
                                                                k, vertices,
-                                                               implementation,
                                                                result_dtype)
     return df

--- a/python/cugraph/centrality/betweenness_centrality_wrapper.pyx
+++ b/python/cugraph/centrality/betweenness_centrality_wrapper.pyx
@@ -17,7 +17,6 @@
 # cython: language_level = 3
 
 from cugraph.centrality.betweenness_centrality cimport betweenness_centrality as c_betweenness_centrality
-from cugraph.centrality.betweenness_centrality cimport cugraph_bc_implem_t
 from cugraph.structure.graph_new cimport *
 from cugraph.utilities.unrenumber import unrenumber
 from libcpp cimport bool
@@ -31,22 +30,12 @@ import numpy.ctypeslib as ctypeslib
 
 
 def betweenness_centrality(input_graph, normalized, endpoints, weight, k,
-                           vertices, implementation, result_dtype):
+                           vertices, result_dtype):
     """
     Call betweenness centrality
     """
-    # NOTE: This is based on the fact that the call to the wrapper already
-    #       checked for the validity of the implementation parameter
-    cdef cugraph_bc_implem_t bc_implementation = cugraph_bc_implem_t.CUGRAPH_DEFAULT
     cdef GraphCSRView[int, int, float] graph_float
     cdef GraphCSRView[int, int, double] graph_double
-
-    if (implementation == "default"): # Redundant
-        bc_implementation = cugraph_bc_implem_t.CUGRAPH_DEFAULT
-    elif (implementation == "gunrock"):
-        bc_implementation = cugraph_bc_implem_t.CUGRAPH_GUNROCK
-    else:
-        raise ValueError()
 
     if not input_graph.adjlist:
         input_graph.view_adj_list()
@@ -94,8 +83,7 @@ def betweenness_centrality(input_graph, normalized, endpoints, weight, k,
                                                          <float*> c_betweenness,
                                                          normalized, endpoints,
                                                          <float*> c_weight, c_k,
-                                                         <int*> c_vertices,
-                                                         <cugraph_bc_implem_t> bc_implementation)
+                                                         <int*> c_vertices)
         graph_float.get_vertex_identifiers(<int*>c_identifier)
     elif result_dtype == np.float64:
         graph_double = GraphCSRView[int, int, double](<int*>c_offsets, <int*>c_indices,
@@ -107,8 +95,7 @@ def betweenness_centrality(input_graph, normalized, endpoints, weight, k,
                                                            <double*> c_betweenness,
                                                            normalized, endpoints,
                                                            <double*> c_weight, c_k,
-                                                           <int*> c_vertices,
-                                                           <cugraph_bc_implem_t> bc_implementation)
+                                                           <int*> c_vertices)
         graph_double.get_vertex_identifiers(<int*>c_identifier)
     else:
         raise TypeError("result type for betweenness centrality can only be "

--- a/python/cugraph/tests/test_betweenness_centrality.py
+++ b/python/cugraph/tests/test_betweenness_centrality.py
@@ -37,7 +37,6 @@ with warnings.catch_warnings():
 # =============================================================================
 DIRECTED_GRAPH_OPTIONS = [False, True]
 DEFAULT_EPSILON = 0.0001
-IMPLEMENTATION_OPTIONS = ['default', 'gunrock']
 
 TINY_DATASETS = ['../datasets/karate.csv']
 
@@ -74,7 +73,7 @@ def build_graphs(graph_file, directed=True):
 
 def calc_betweenness_centrality(graph_file, directed=True, normalized=False,
                                 weight=None, endpoints=False,
-                                k=None, seed=None, implementation=None,
+                                k=None, seed=None,
                                 result_dtype=np.float32):
     """ Generate both cugraph and networkx betweenness centrality
 
@@ -96,10 +95,6 @@ def calc_betweenness_centrality(graph_file, directed=True, normalized=False,
     seed : int or None, optional, default=None
         Seed for random sampling  of the starting point
 
-    implementation : string or None, optional, default=None
-        There are 2 possibilities 'default' and 'gunrock', if None falls back
-        into 'default'
-
     Returns
     -------
         cu_bc : dict
@@ -119,14 +114,13 @@ def calc_betweenness_centrality(graph_file, directed=True, normalized=False,
         calc_func = _calc_bc_full
     cu_bc, nx_bc = calc_func(G, Gnx, normalized=normalized, weight=weight,
                              endpoints=endpoints, k=k, seed=seed,
-                             implementation=implementation,
                              result_dtype=result_dtype)
 
     return cu_bc, nx_bc
 
 
 def _calc_bc_subset(G, Gnx, normalized, weight, endpoints, k, seed,
-                    implementation, result_dtype):
+                    result_dtype):
     # NOTE: Networkx API does not allow passing a list of vertices
     # And the sampling is operated on Gnx.nodes() directly
     # We first mimic acquisition of the nodes to compare with same sources
@@ -136,7 +130,6 @@ def _calc_bc_subset(G, Gnx, normalized, weight, endpoints, k, seed,
                                         weight=weight,
                                         endpoints=endpoints,
                                         k=sources,
-                                        implementation=implementation,
                                         result_dtype=result_dtype)
     nx_bc = nx.betweenness_centrality(Gnx, normalized=normalized, k=k,
                                       seed=seed)
@@ -147,7 +140,7 @@ def _calc_bc_subset(G, Gnx, normalized, weight, endpoints, k, seed,
 
 
 def _calc_bc_subset_fixed(G, Gnx, normalized, weight, endpoints, k, seed,
-                          implementation, result_dtype):
+                          result_dtype):
     assert isinstance(k, int), "This test is meant for verifying coherence " \
                                "when k is given as an int"
     # In the fixed set we compare cu_bc against itself as we random.seed(seed)
@@ -161,7 +154,6 @@ def _calc_bc_subset_fixed(G, Gnx, normalized, weight, endpoints, k, seed,
     df = cugraph.betweenness_centrality(G, k=k, normalized=normalized,
                                         weight=weight,
                                         endpoints=endpoints,
-                                        implementation=implementation,
                                         seed=seed,
                                         result_dtype=result_dtype)
     # The second call is going to process source that were already sampled
@@ -170,7 +162,6 @@ def _calc_bc_subset_fixed(G, Gnx, normalized, weight, endpoints, k, seed,
     df2 = cugraph.betweenness_centrality(G, k=sources, normalized=normalized,
                                          weight=weight,
                                          endpoints=endpoints,
-                                         implementation=implementation,
                                          seed=None,
                                          result_dtype=result_dtype)
     cu_bc = {key: score for key, score in
@@ -183,13 +174,12 @@ def _calc_bc_subset_fixed(G, Gnx, normalized, weight, endpoints, k, seed,
     return cu_bc, cu_bc2
 
 
-def _calc_bc_full(G, Gnx, normalized, weight, endpoints, implementation,
+def _calc_bc_full(G, Gnx, normalized, weight, endpoints,
                   k, seed,
                   result_dtype):
     df = cugraph.betweenness_centrality(G, normalized=normalized,
                                         weight=weight,
                                         endpoints=endpoints,
-                                        implementation=implementation,
                                         result_dtype=result_dtype)
     assert df['betweenness_centrality'].dtype == result_dtype,  \
         "'betweenness_centrality' column has not the expected type"
@@ -258,64 +248,56 @@ def prepare_test():
 # =============================================================================
 @pytest.mark.parametrize('graph_file', TINY_DATASETS)
 @pytest.mark.parametrize('directed', DIRECTED_GRAPH_OPTIONS)
-@pytest.mark.parametrize('implementation', IMPLEMENTATION_OPTIONS)
 @pytest.mark.parametrize('result_dtype', RESULT_DTYPE_OPTIONS)
 def test_betweenness_centrality_normalized_tiny(graph_file,
-                                                directed, implementation,
+                                                directed,
                                                 result_dtype):
     """Test Normalized Betweenness Centrality"""
     prepare_test()
     cu_bc, nx_bc = calc_betweenness_centrality(graph_file, directed=directed,
                                                normalized=True,
-                                               implementation=implementation,
                                                result_dtype=result_dtype)
     compare_scores(cu_bc, nx_bc)
 
 
 @pytest.mark.parametrize('graph_file', TINY_DATASETS)
 @pytest.mark.parametrize('directed', DIRECTED_GRAPH_OPTIONS)
-@pytest.mark.parametrize('implementation', IMPLEMENTATION_OPTIONS)
 @pytest.mark.parametrize('result_dtype', RESULT_DTYPE_OPTIONS)
 def test_betweenness_centrality_unnormalized_tiny(graph_file,
-                                                  directed, implementation,
+                                                  directed,
                                                   result_dtype):
     """Test Unnormalized Betweenness Centrality"""
     prepare_test()
     cu_bc, nx_bc = calc_betweenness_centrality(graph_file, directed=directed,
                                                normalized=False,
-                                               implementation=implementation,
                                                result_dtype=result_dtype)
     compare_scores(cu_bc, nx_bc)
 
 
 @pytest.mark.parametrize('graph_file', SMALL_DATASETS)
 @pytest.mark.parametrize('directed', DIRECTED_GRAPH_OPTIONS)
-@pytest.mark.parametrize('implementation', IMPLEMENTATION_OPTIONS)
 @pytest.mark.parametrize('result_dtype', RESULT_DTYPE_OPTIONS)
 def test_betweenness_centrality_normalized_small(graph_file,
-                                                 directed, implementation,
+                                                 directed,
                                                  result_dtype):
     """Test Unnormalized Betweenness Centrality"""
     prepare_test()
     cu_bc, nx_bc = calc_betweenness_centrality(graph_file, directed=directed,
                                                normalized=True,
-                                               implementation=implementation,
                                                result_dtype=result_dtype)
     compare_scores(cu_bc, nx_bc)
 
 
 @pytest.mark.parametrize('graph_file', SMALL_DATASETS)
 @pytest.mark.parametrize('directed', DIRECTED_GRAPH_OPTIONS)
-@pytest.mark.parametrize('implementation', IMPLEMENTATION_OPTIONS)
 @pytest.mark.parametrize('result_dtype', RESULT_DTYPE_OPTIONS)
 def test_betweenness_centrality_unnormalized_small(graph_file,
-                                                   directed, implementation,
+                                                   directed,
                                                    result_dtype):
     """Test Unnormalized Betweenness Centrality"""
     prepare_test()
     cu_bc, nx_bc = calc_betweenness_centrality(graph_file, directed=directed,
                                                normalized=False,
-                                               implementation=implementation,
                                                result_dtype=result_dtype)
     compare_scores(cu_bc, nx_bc)
 
@@ -392,38 +374,6 @@ def test_betweenness_centrality_unnormalized_subset_small(graph_file,
                                                seed=subset_seed,
                                                result_dtype=result_dtype)
     compare_scores(cu_bc, nx_bc)
-
-
-@pytest.mark.parametrize('graph_file', TINY_DATASETS)
-@pytest.mark.parametrize('directed', DIRECTED_GRAPH_OPTIONS)
-@pytest.mark.parametrize('result_dtype', RESULT_DTYPE_OPTIONS)
-def test_betweenness_centrality_invalid_implementation(graph_file,
-                                                       directed,
-                                                       result_dtype):
-    """Test calls betwenness_centrality with an invalid implementation name"""
-    prepare_test()
-    with pytest.raises(ValueError):
-        cu_bc, nx_bc = calc_betweenness_centrality(graph_file,
-                                                   directed=directed,
-                                                   implementation="invalid",
-                                                   result_dtype=result_dtype)
-
-
-@pytest.mark.parametrize('graph_file', TINY_DATASETS)
-@pytest.mark.parametrize('directed', DIRECTED_GRAPH_OPTIONS)
-@pytest.mark.parametrize('result_dtype', RESULT_DTYPE_OPTIONS)
-def test_betweenness_centrality_gunrock_subset(graph_file,
-                                               directed,
-                                               result_dtype):
-    """Test calls betwenness_centrality with subset and gunrock"""
-    prepare_test()
-    with pytest.raises(ValueError):
-        cu_bc, nx_bc = calc_betweenness_centrality(graph_file,
-                                                   directed=directed,
-                                                   normalized=False,
-                                                   k=1,
-                                                   implementation="gunrock",
-                                                   result_dtype=result_dtype)
 
 
 @pytest.mark.parametrize('graph_file', TINY_DATASETS)


### PR DESCRIPTION
The current version of Betweenness Centrality proposed two implementation, 'default' and 'gunrock', as the 'default' implementation cover more cases the 'gunrock' path can be removed. Furthermore some tests over the 'gunrock' path seemed to break under various configuration.
This removes the 'gunrock' path and the possibility to choose between implementation.
The implementation parameter is removed, and only the 'default' path persists.