### PR TITLE
[BUG] Updated pagerank with @afender 's temp fix for double-free crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,8 @@
 - PR #889 Added missing conftest.py file to benchmarks dir
 - PR #896 opg dask infrastructure fixes
 - PR #907 Fix bfs directed missing vertices
-- PR #911 Env and changelog update 
+- PR #911 Env and changelog update
+- PR #923 Updated pagerank with @afender 's temp fix for double-free crash
 
 # cuGraph 0.13.0 (31 Mar 2020)
 

--- a/cpp/src/link_analysis/pagerank.cu
+++ b/cpp/src/link_analysis/pagerank.cu
@@ -77,7 +77,13 @@ bool pagerankIteration(IndexType n,
     return true;
   } else {
     if (iter < max_iter) {
-      std::swap(pr, tmp);
+      // FIXME: Copy the pagerank vector results to the tmp vector, since there
+      // are still raw pointers in pagerank pointing to tmp vector locations
+      // that were std::swapped out in the solver.  A thrust::swap would
+      // probably be more efficent if the vectors were passed everywhere instead
+      // of pointers. std::swap is unsafe though. Just copying for now, as this
+      // may soon be replaced by the pattern accelerator.
+      copy(n, pr, tmp);
     } else {
       scal(n, (ValueType)1.0 / nrm1(n, pr), pr);
     }


### PR DESCRIPTION
Original PR here: https://github.com/rapidsai/cugraph/pull/919  but this is targeting `branch-0.14`