### PR TITLE
[REVIEW] add wrapper for gunrock HITS algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # cuGraph 0.15.0 (Date TBD)
 
 ## New Features
+- PR #937 Add wrapper for gunrock HITS algorithm
 
 ## Improvements
 - PR #913 Eliminate `rmm.device_array` usage

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -308,6 +308,7 @@ add_library(cugraph SHARED
     src/utilities/cusparse_helper.cu
     src/structure/graph.cu
     src/link_analysis/pagerank.cu
+    src/link_analysis/gunrock_hits.cu
     src/traversal/bfs.cu
     src/traversal/sssp.cu
     src/link_prediction/jaccard.cu

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -308,7 +308,7 @@ add_library(cugraph SHARED
     src/utilities/cusparse_helper.cu
     src/structure/graph.cu
     src/link_analysis/pagerank.cu
-    src/link_analysis/gunrock_hits.cu
+    src/link_analysis/gunrock_hits.cpp
     src/traversal/bfs.cu
     src/traversal/sssp.cu
     src/link_prediction/jaccard.cu

--- a/cpp/include/algorithms.hpp
+++ b/cpp/include/algorithms.hpp
@@ -774,4 +774,45 @@ void analyzeClustering_ratio_cut(experimental::GraphCSRView<VT, ET, WT> const &g
                                  WT *score);
 
 }  // namespace nvgraph
+
+namespace gunrock {
+
+/**
+ * @brief     Compute the HITS vertex values for a graph
+ *
+ * cuGraph uses the gunrock implementation of HITS
+ *
+ * @throws                           cugraph::logic_error on an error
+ *
+ * @tparam VT                        Type of vertex identifiers.
+ *                                   Supported value : int (signed, 32-bit)
+ * @tparam ET                        Type of edge identifiers.
+ *                                   Supported value : int (signed, 32-bit)
+ * @tparam WT                        Type of edge weights.
+ *                                   Supported value : float
+ *
+ * @param[in] graph                  input graph object (CSR). Edge weights are not used
+ *                                   for this algorithm.
+ * @param[in] max_iter               Maximum number of iterations to run
+ * @param[in] tolerance              Currently ignored.  gunrock implementation runs
+ *                                   the specified number of iterations and stops
+ * @param[in] starting value         Currently ignored.  gunrock does not support.
+ * @param[in] normalized             Currently ignored, gunrock computes this as true
+ * @param[out] *hubs                 Device memory pointing to the node value based
+ *                                   on outgoing links
+ * @param[out] *authorities          Device memory pointing to the node value based
+ *                                   on incoming links
+ *
+ */
+template <typename VT, typename ET, typename WT>
+void hits(experimental::GraphCSRView<VT, ET, WT> const &graph,
+          int max_iter,
+          WT tolerance,
+          WT const *starting_value,
+          bool normalized,
+          WT *hubs,
+          WT *authorities);
+
+}  // namespace gunrock
+
 }  // namespace cugraph

--- a/cpp/src/link_analysis/gunrock_hits.cpp
+++ b/cpp/src/link_analysis/gunrock_hits.cpp
@@ -24,9 +24,6 @@
 
 #include <utilities/error_utils.h>
 
-#include <rmm/thrust_rmm_allocator.h>
-#include <thrust/for_each.h>
-
 #include <gunrock/gunrock.h>
 
 namespace cugraph {
@@ -42,6 +39,9 @@ void hits(cugraph::experimental::GraphCSRView<vertex_t, edge_t, weight_t> const 
           weight_t *hubs,
           weight_t *authorities)
 {
+  CUGRAPH_EXPECTS(hubs != nullptr, "Invalid API parameter: hubs array should be of size V");
+  CUGRAPH_EXPECTS(authorities != nullptr, "Invalid API parameter: authorities array should be of size V");
+
   //
   //  NOTE:  gunrock doesn't support tolerance parameter
   //         gunrock doesn't support passing a starting value

--- a/cpp/src/link_analysis/gunrock_hits.cpp
+++ b/cpp/src/link_analysis/gunrock_hits.cpp
@@ -40,7 +40,8 @@ void hits(cugraph::experimental::GraphCSRView<vertex_t, edge_t, weight_t> const 
           weight_t *authorities)
 {
   CUGRAPH_EXPECTS(hubs != nullptr, "Invalid API parameter: hubs array should be of size V");
-  CUGRAPH_EXPECTS(authorities != nullptr, "Invalid API parameter: authorities array should be of size V");
+  CUGRAPH_EXPECTS(authorities != nullptr,
+                  "Invalid API parameter: authorities array should be of size V");
 
   //
   //  NOTE:  gunrock doesn't support tolerance parameter

--- a/cpp/src/link_analysis/gunrock_hits.cu
+++ b/cpp/src/link_analysis/gunrock_hits.cu
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * ---------------------------------------------------------------------------*
+ * @brief wrapper calling gunrock's HITS analytic
+ * --------------------------------------------------------------------------*/
+
+#include <algorithms.hpp>
+#include <graph.hpp>
+
+#include <utilities/error_utils.h>
+
+#include <rmm/thrust_rmm_allocator.h>
+#include <thrust/for_each.h>
+
+#include <gunrock/gunrock.h>
+
+namespace cugraph {
+
+namespace gunrock {
+
+template <typename vertex_t, typename edge_t, typename weight_t>
+void hits(cugraph::experimental::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+          int max_iter,
+          weight_t tolerance,
+          weight_t const *starting_value,
+          bool normalized,
+          weight_t *hubs,
+          weight_t *authorities)
+{
+  //
+  //  NOTE:  gunrock doesn't support tolerance parameter
+  //         gunrock doesn't support passing a starting value
+  //         gunrock doesn't support the normalized parameter
+  //
+  //  FIXME: gunrock uses a 2-norm, while networkx uses a 1-norm.
+  //         They will add a parameter to allow us to specify
+  //         which norm to use.
+  //
+  std::vector<edge_t> local_offsets(graph.number_of_vertices + 1);
+  std::vector<vertex_t> local_indices(graph.number_of_edges);
+  std::vector<weight_t> local_hubs(graph.number_of_vertices);
+  std::vector<weight_t> local_authorities(graph.number_of_vertices);
+
+  //    Ideally:
+  //
+  //::hits(graph.number_of_vertices, graph.number_of_edges, graph.offsets, graph.indices,
+  //       max_iter, hubs, authorities, DEVICE);
+  //
+  //    For now, the following:
+
+  CUDA_TRY(cudaMemcpy(local_offsets.data(),
+                      graph.offsets,
+                      (graph.number_of_vertices + 1) * sizeof(edge_t),
+                      cudaMemcpyDeviceToHost));
+  CUDA_TRY(cudaMemcpy(local_indices.data(),
+                      graph.indices,
+                      graph.number_of_edges * sizeof(vertex_t),
+                      cudaMemcpyDeviceToHost));
+
+  ::hits(graph.number_of_vertices,
+         graph.number_of_edges,
+         local_offsets.data(),
+         local_indices.data(),
+         max_iter,
+         local_hubs.data(),
+         local_authorities.data());
+
+  CUDA_TRY(cudaMemcpy(
+    hubs, local_hubs.data(), graph.number_of_vertices * sizeof(weight_t), cudaMemcpyHostToDevice));
+  CUDA_TRY(cudaMemcpy(authorities,
+                      local_authorities.data(),
+                      graph.number_of_vertices * sizeof(weight_t),
+                      cudaMemcpyHostToDevice));
+}
+
+template void hits(cugraph::experimental::GraphCSRView<int32_t, int32_t, float> const &,
+                   int,
+                   float,
+                   float const *,
+                   bool,
+                   float *,
+                   float *);
+
+}  // namespace gunrock
+
+}  // namespace cugraph

--- a/python/cugraph/__init__.py
+++ b/python/cugraph/__init__.py
@@ -37,7 +37,7 @@ from cugraph.structure import (
 from cugraph.centrality import katz_centrality, betweenness_centrality
 from cugraph.cores import core_number, k_core
 from cugraph.components import weakly_connected_components, strongly_connected_components
-from cugraph.link_analysis import pagerank
+from cugraph.link_analysis import pagerank, hits
 
 from cugraph.link_prediction import jaccard, overlap, jaccard_w, overlap_w
 from cugraph.traversal import bfs, sssp, filter_unreachable

--- a/python/cugraph/link_analysis/hits.pxd
+++ b/python/cugraph/link_analysis/hits.pxd
@@ -11,5 +11,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cugraph.link_analysis.pagerank import pagerank
-from cugraph.link_analysis.hits import hits
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+
+from cugraph.structure.graph_new cimport *
+from libcpp cimport bool
+
+
+cdef extern from "algorithms.hpp" namespace "cugraph::gunrock":
+
+    cdef void hits[VT,ET,WT](
+        const GraphCSRView[VT,ET,WT] &graph,
+        int max_iter,
+        WT tolerance,
+        const WT *starting_value,
+        bool normalized,
+        WT *hubs,
+        WT *authorities) except +

--- a/python/cugraph/link_analysis/hits.pxd
+++ b/python/cugraph/link_analysis/hits.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2020, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/link_analysis/hits.py
+++ b/python/cugraph/link_analysis/hits.py
@@ -30,6 +30,10 @@ def hits(G,
     The cuGraph implementation of HITS is a wrapper around the gunrock
     implementation of HITS.
 
+    Note that the gunrock implementation uses a 2-norm, while networkx
+    uses a 1-norm.  The raw scores will be different, but the rank ordering
+    should be comparable with networkx.
+
     Parameters
     ----------
     graph : cugraph.Graph

--- a/python/cugraph/link_analysis/hits.py
+++ b/python/cugraph/link_analysis/hits.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 from cugraph.link_analysis import hits_wrapper
-from cugraph.structure.graph import null_check
 
 
 def hits(G,

--- a/python/cugraph/link_analysis/hits.py
+++ b/python/cugraph/link_analysis/hits.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2019 - 2020, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cugraph.link_analysis import hits_wrapper
+from cugraph.structure.graph import null_check
+
+
+def hits(G,
+         max_iter=100,
+         tol=1.0e-5,
+         nstart=None,
+         normalized=True):
+    """
+    Compute HITS hubs and authorities values for each vertex
+
+    The HITS algorithm computes two numbers for a node.  Authorities
+    estimates the node value based on the incoming links.  Hubs estimates
+    the node value based on outgoing links.
+
+    The cuGraph implementation of HITS is a wrapper around the gunrock
+    implementation of HITS.
+
+    Parameters
+    ----------
+    graph : cugraph.Graph
+        cuGraph graph descriptor, should contain the connectivity information
+        as an edge list (edge weights are not used for this algorithm).
+        The adjacency list will be computed if not already present.
+    max_iter : int
+        The maximum number of iterations before an answer is returned.
+        The gunrock implementation does not currently support tolerance,
+        so this will in fact be the number of iterations the HITS algorithm
+        executes.
+    tolerance : float
+        Set the tolerance the approximation, this parameter should be a small
+        magnitude value.  This parameter is not currently supported.
+    nstart : cudf.Dataframe
+        Not currently supported
+    normalized : bool
+        Not currently supported, always used as True
+
+    Returns
+    -------
+    HubsAndAuthorities : cudf.DataFrame
+        GPU data frame containing three cudf.Series of size V: the vertex
+        identifiers and the corresponding hubs values and the corresponding
+        authorities values.
+
+        df['vertex'] : cudf.Series
+            Contains the vertex identifiers
+        df['hubs'] : cudf.Series
+            Contains the hubs score
+        df['authorities'] : cudf.Series
+            Contains the authorities score
+
+
+    Examples
+    --------
+    >>> gdf = cudf.read_csv('datasets/karate.csv', delimiter=' ',
+    >>>                   dtype=['int32', 'int32', 'float32'], header=None)
+    >>> G = cugraph.Graph()
+    >>> G.from_cudf_edgelist(gdf, source='0', destination='1')
+    >>> hits = cugraph.hits(G, max_iter = 50)
+    """
+
+    df = hits_wrapper.hits(G, max_iter, tol)
+
+    return df

--- a/python/cugraph/link_analysis/hits_wrapper.pyx
+++ b/python/cugraph/link_analysis/hits_wrapper.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2020, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/link_analysis/hits_wrapper.pyx
+++ b/python/cugraph/link_analysis/hits_wrapper.pyx
@@ -1,0 +1,73 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+# cython: language_level = 3
+
+from cugraph.link_analysis.hits cimport hits as c_hits
+from cugraph.structure.graph_new cimport *
+from cugraph.utilities.unrenumber import unrenumber
+from libcpp cimport bool
+from libc.stdint cimport uintptr_t
+from cugraph.structure import graph_new_wrapper
+import cudf
+import rmm
+import numpy as np
+import numpy.ctypeslib as ctypeslib
+
+
+def hits(input_graph, max_iter=100, tol=1.0e-5, nstart=None, normalized=True):
+    """
+    Call HITS
+    """
+
+    if nstart is not None:
+        raise ValueError('nstart is not currently supported')
+
+    if not input_graph.adjlist:
+        input_graph.view_adj_list()
+
+    [offsets, indices] = graph_new_wrapper.datatype_cast([input_graph.adjlist.offsets, input_graph.adjlist.indices], [np.int32])
+
+    num_verts = input_graph.number_of_vertices()
+    num_edges = input_graph.number_of_edges(directed_edges=True)
+
+    df = cudf.DataFrame()
+    df['vertex'] = cudf.Series(np.zeros(num_verts, dtype=np.int32))
+    df['hubs'] = cudf.Series(np.zeros(num_verts, dtype=np.float32))
+    df['authorities'] = cudf.Series(np.zeros(num_verts, dtype=np.float32))
+
+    #cdef bool normalized = <bool> 1
+
+    cdef uintptr_t c_identifier = df['vertex'].__cuda_array_interface__['data'][0];
+    cdef uintptr_t c_hubs = df['hubs'].__cuda_array_interface__['data'][0];
+    cdef uintptr_t c_authorities = df['authorities'].__cuda_array_interface__['data'][0];
+
+    cdef uintptr_t c_offsets = offsets.__cuda_array_interface__['data'][0]
+    cdef uintptr_t c_indices = indices.__cuda_array_interface__['data'][0]
+    cdef uintptr_t c_weights = <uintptr_t>NULL
+
+    cdef GraphCSRView[int,int,float] graph_float
+    
+    graph_float = GraphCSRView[int,int,float](<int*>c_offsets, <int*>c_indices, <float*>c_weights, num_verts, num_edges)
+
+    c_hits[int,int,float](graph_float, max_iter, tol, <float*> NULL,
+                          normalized, <float*>c_hubs, <float*>c_authorities);
+    graph_float.get_vertex_identifiers(<int*>c_identifier)
+
+    if input_graph.renumbered:
+        df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertex')
+
+    return df

--- a/python/cugraph/tests/test_hits.py
+++ b/python/cugraph/tests/test_hits.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gc
+import time
+import numpy as np
+import pandas as pd
+
+import pytest
+
+import cudf
+import cugraph
+from cugraph.tests import utils
+
+# Temporarily suppress warnings till networkX fixes deprecation warnings
+# (Using or importing the ABCs from 'collections' instead of from
+# 'collections.abc' is deprecated, and in 3.8 it will stop working) for
+# python 3.7.  Also, this import networkx needs to be relocated in the
+# third-party group once this gets fixed.
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    import networkx as nx
+
+
+print('Networkx version : {} '.format(nx.__version__))
+
+
+def cudify(d):
+    if d is None:
+        return None
+
+    k = np.fromiter(d.keys(), dtype='int32')
+    v = np.fromiter(d.values(), dtype='float32')
+    cuD = cudf.DataFrame({'vertex': k, 'values': v})
+    return cuD
+
+
+def cugraph_call(cu_M, max_iter, tol):
+    # cugraph Pagerank Call
+    G = cugraph.DiGraph()
+    G.from_cudf_edgelist(cu_M, source='0', destination='1')
+    t1 = time.time()
+    df = cugraph.hits(G, max_iter, tol)
+    t2 = time.time() - t1
+    print('Cugraph Time : '+str(t2))
+
+    return df
+
+
+# The function selects personalization_perc% of accessible vertices in graph M
+# and randomly assigns them personalization values
+def networkx_call(M, max_iter, tol):
+    # in NVGRAPH tests we read as CSR and feed as CSC,
+    # so here we do this explicitly
+    print('Format conversion ... ')
+
+    # Directed NetworkX graph
+    Gnx = nx.from_pandas_edgelist(M, source='0', target='1',
+                                  create_using=nx.DiGraph())
+
+    # Networkx Hits Call
+    print('Solving... ')
+    t1 = time.time()
+
+    # same parameters as in NVGRAPH
+    pr = nx.hits(Gnx, max_iter, tol, normalized=True)
+    t2 = time.time() - t1
+
+    print('Networkx Time : ' + str(t2))
+
+    return pr
+
+
+DATASETS = ['../datasets/dolphins.csv',
+            '../datasets/karate.csv']
+
+MAX_ITERATIONS = [50]
+TOLERANCE = [1.0e-06]
+
+
+# Test all combinations of default/managed and pooled/non-pooled allocation
+
+@pytest.mark.parametrize('graph_file', DATASETS)
+@pytest.mark.parametrize('max_iter', MAX_ITERATIONS)
+@pytest.mark.parametrize('tol', TOLERANCE)
+def test_hits(graph_file, max_iter, tol):
+    gc.collect()
+
+    M = utils.read_csv_for_nx(graph_file)
+    hubs, authorities = networkx_call(M, max_iter, tol)
+
+    cu_M = utils.read_csv_file(graph_file)
+    cugraph_hits = cugraph_call(cu_M, max_iter, tol)
+
+    # Calculating mismatch
+    #hubs = sorted(hubs.items(), key=lambda x: x[0])
+    #print("hubs = ", hubs)
+
+    #
+    #  Scores don't match.  Networkx uses the 1-norm,
+    #  gunrock uses a 2-norm.  Eventually we'll add that
+    #  as a parameter. For now, let's check the order
+    #  which should match.  We'll allow 6 digits to right
+    #  of decimal point accuracy
+    #
+    pdf = pd.DataFrame.from_dict(hubs, orient='index').sort_index()
+    pdf = pdf.multiply(1000000).floordiv(1)
+    cugraph_hits['nx_hubs'] = cudf.Series.from_pandas(pdf[0])
+
+    pdf = pd.DataFrame.from_dict(authorities, orient='index').sort_index()
+    pdf = pdf.multiply(1000000).floordiv(1)
+    cugraph_hits['nx_authorities'] = cudf.Series.from_pandas(pdf[0])
+
+    #
+    #  Sort by hubs (cugraph) in descending order.  Then we'll
+    #  check to make sure all scores are in descending order.
+    #
+    cugraph_hits = cugraph_hits.sort_values('hubs', False)
+
+    assert cugraph_hits['hubs'].is_monotonic_decreasing
+    assert cugraph_hits['nx_hubs'].is_monotonic_decreasing
+
+    cugraph_hits = cugraph_hits.sort_values('authorities', False)
+
+    assert cugraph_hits['authorities'].is_monotonic_decreasing
+    assert cugraph_hits['nx_authorities'].is_monotonic_decreasing
+

--- a/python/cugraph/tests/test_hits.py
+++ b/python/cugraph/tests/test_hits.py
@@ -104,8 +104,8 @@ def test_hits(graph_file, max_iter, tol):
     cugraph_hits = cugraph_call(cu_M, max_iter, tol)
 
     # Calculating mismatch
-    #hubs = sorted(hubs.items(), key=lambda x: x[0])
-    #print("hubs = ", hubs)
+    # hubs = sorted(hubs.items(), key=lambda x: x[0])
+    # print("hubs = ", hubs)
 
     #
     #  Scores don't match.  Networkx uses the 1-norm,
@@ -135,4 +135,3 @@ def test_hits(graph_file, max_iter, tol):
 
     assert cugraph_hits['authorities'].is_monotonic_decreasing
     assert cugraph_hits['nx_authorities'].is_monotonic_decreasing
-

--- a/python/cugraph/tests/test_hits.py
+++ b/python/cugraph/tests/test_hits.py
@@ -47,7 +47,7 @@ def cudify(d):
 
 
 def cugraph_call(cu_M, max_iter, tol):
-    # cugraph Pagerank Call
+    # cugraph hits Call
     G = cugraph.DiGraph()
     G.from_cudf_edgelist(cu_M, source='0', destination='1')
     t1 = time.time()

--- a/python/cugraph/tests/test_hits.py
+++ b/python/cugraph/tests/test_hits.py
@@ -20,7 +20,7 @@ import pytest
 
 import cudf
 import cugraph
-from cugraph.tests import utils, test_utils
+from cugraph.tests import utils
 
 # Temporarily suppress warnings till networkX fixes deprecation warnings
 # (Using or importing the ABCs from 'collections' instead of from
@@ -72,8 +72,7 @@ def networkx_call(M, max_iter, tol):
 
     # Directed NetworkX graph
     Gnx = nx.from_pandas_edgelist(M, source='0', target='1',
-                                  #create_using=nx.DiGraph())
-                                  create_using=nx.Graph())
+                                  create_using=nx.DiGraph())
 
     # same parameters as in NVGRAPH
     pr = nx.hits(Gnx, max_iter, tol, normalized=True)
@@ -84,14 +83,15 @@ def networkx_call(M, max_iter, tol):
     return pr
 
 
-DATASETS = [ '../datasets/netscience.csv' ]
-MAX_ITERATIONS = [100]
+DATASETS = ['../datasets/dolphins.csv',
+            '../datasets/karate.csv']
+
+MAX_ITERATIONS = [50]
 TOLERANCE = [1.0e-06]
 
 
 # Test all combinations of default/managed and pooled/non-pooled allocation
 
-#@pytest.mark.parametrize('graph_file', test_utils.DATASETS)
 @pytest.mark.parametrize('graph_file', DATASETS)
 @pytest.mark.parametrize('max_iter', MAX_ITERATIONS)
 @pytest.mark.parametrize('tol', TOLERANCE)
@@ -127,19 +127,12 @@ def test_hits(graph_file, max_iter, tol):
     #  Sort by hubs (cugraph) in descending order.  Then we'll
     #  check to make sure all scores are in descending order.
     #
-    cugraph_hits = cugraph_hits.sort_values('nx_hubs', False)
-    print("cugraph_hits sorted by nx_hubs\n", cugraph_hits)
-
     cugraph_hits = cugraph_hits.sort_values('hubs', False)
-
-    print("cugraph_hits sorted by hubs\n", cugraph_hits)
 
     assert cugraph_hits['hubs'].is_monotonic_decreasing
     assert cugraph_hits['nx_hubs'].is_monotonic_decreasing
 
     cugraph_hits = cugraph_hits.sort_values('authorities', False)
-
-    print("cugraph_hits sorted by authorities\n", cugraph_hits)
 
     assert cugraph_hits['authorities'].is_monotonic_decreasing
     assert cugraph_hits['nx_authorities'].is_monotonic_decreasing


### PR DESCRIPTION
Integration of the gunrock HITS algorithm.

Note, gunrock currently assumes that input and output comes from host memory.  https://github.com/gunrock/gunrock/issues/759 is a request for gunrock to modify this.  In the meantime, this wrapper will pull the CSR from device memory to the host to call gunrock, and will take the host results and copy them into the device memory.

