### PR TITLE
[REVIEW] Quote conda installs to avoid bash interpretation [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - PR #920 modify bfs test, update graph number_of_edges, update storage of transposedAdjList in Graph
 
 ## Bug Fixes
+- PR #938 Quote conda installs to avoid bash interpretation
 
 # cuGraph 0.14.0 (Date TBD)
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -57,20 +57,20 @@ source activate gdf
 
 logger "conda install required packages"
 conda install -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge -c defaults \
-      cudf=${MINOR_VERSION} \
-      rmm=${MINOR_VERSION} \
-      networkx>=2.3 \
+      "cudf=${MINOR_VERSION}" \
+      "rmm=${MINOR_VERSION}" \
+      "networkx>=2.3" \
       python-louvain \
-      cudatoolkit=$CUDA_REL \
-      dask>=2.12.0 \
-      distributed>=2.12.0 \
-      dask-cudf=${MINOR_VERSION} \
-      dask-cuda=${MINOR_VERSION} \
-      scikit-learn>=0.21 \
-      nccl>=2.5 \
-      ucx-py=${MINOR_VERSION} \
+      "cudatoolkit=$CUDA_REL" \
+      "dask>=2.12.0" \
+      "distributed>=2.12.0" \
+      "dask-cudf=${MINOR_VERSION}" \
+      "dask-cuda=${MINOR_VERSION}" \
+      "scikit-learn>=0.21" \
+      "nccl>=2.5" \
+      "ucx-py=${MINOR_VERSION}" \
       libcypher-parser \
-      ipython=7.3* \
+      "ipython=7.3*" \
       jupyterlab
 
 # Install the master version of dask and distributed


### PR DESCRIPTION
This just helps prevent bash from interpreting `>` and `*`.