### PR TITLE
[REVIEW] Move customization scripts to Jenkins [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - PR #897 Remove RMM ALLOC calls
 - PR #899 Update include paths to remove deleted cudf headers
 - PR #906 Update Louvain notebook
+- PR #948 Move doc customization scripts to Jenkins
 
 ## Bug Fixes
 - PR #927 Update scikit learn dependency

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -61,15 +61,3 @@ done
 mv $PROJECT_WORKSPACE/cpp/doxygen/html/* $DOCS_WORKSPACE/api/libcugraph/$BRANCH_VERSION
 mv $PROJECT_WORKSPACE/docs/build/html/* $DOCS_WORKSPACE/api/cugraph/$BRANCH_VERSION
 
-# Customize HTML documentation
-./update_symlinks.sh $NIGHTLY_VERSION
-./customization/lib_map.sh
-
-
-for PROJECT in ${PROJECTS[@]}; do
-    echo ""
-    echo "Customizing: $PROJECT"
-    ./customization/customize_docs_in_folder.sh api/$PROJECT/ $NIGHTLY_VERSION
-    git add $DOCS_WORKSPACE/api/$PROJECT/*
-done
-


### PR DESCRIPTION
This section is being moved to the Jenkins job as its not important to developers and allows easier editing to these scripts for OPS.