### PR TITLE
[REVIEW] fix setting RAFT_DIR from the RAFT_PATH env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - PR #941 Regression python/cudf fix
 - PR #945 Simplified benchmark --no-rmm-reinit option, updated default options
 - PR #946 Install meta packages for dependencies
+- PR #953 fix setting RAFT_DIR from the RAFT_PATH env var
 
 ## Bug Fixes
 - PR #936 Update Force Atlas 2 doc and wrapper

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -263,7 +263,7 @@ endif(NOT NCCL_PATH)
 if(DEFINED ENV{RAFT_PATH})
   message(STATUS "RAFT_PATH environment variable detected.")
   message(STATUS "RAFT_DIR set to $ENV{RAFT_PATH}")
-  set(RAFT_DIR ENV{RAFT_PATH})
+  set(RAFT_DIR "$ENV{RAFT_PATH}")
 
   ExternalProject_Add(raft
     DOWNLOAD_COMMAND  ""

--- a/python/setuputils.py
+++ b/python/setuputils.py
@@ -22,6 +22,8 @@ import subprocess
 import sys
 import warnings
 
+from pathlib import Path
+
 
 def get_environment_option(name):
     ENV_VARIABLE = os.environ.get(name, False)

--- a/python/setuputils.py
+++ b/python/setuputils.py
@@ -102,7 +102,7 @@ def use_raft_package(raft_path, cpp_build_path,
         os.remove('cugraph/raft')
         os.symlink('../' + raft_path + 'python/raft', 'cugraph/raft')
 
-    return raft_path + 'cpp/include'
+    return os.path.join(raft_path, 'cpp/include')
 
 
 def clone_repo_if_needed(name, cpp_build_path,


### PR DESCRIPTION
Fixes setting the RAFT_PATH env var for source builds.

Without this fix the path `-I../../../../ENV{RAFT_PATH}/cpp/include` is included in the C++ build args instead of the correct path.