### PR TITLE
[REVIEW] Fix error in Graph.edges(), update cuDF rename() calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ cpp/doxygen/html
 # Raft symlink
 python/cugraph/raft
 python/_external_repositories/
+
+# created by Dask tests
+python/dask-worker-space

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #952 Updated get_test_data.sh to also (optionally) download and install datasets for benchmark runs
 - PR #953 fix setting RAFT_DIR from the RAFT_PATH env var
 - PR #954 Update cuGraph error handling to use RAFT
+- PR #976 Fix error in Graph.edges(), update cuDF rename() calls
 
 ## Bug Fixes
 - PR #936 Update Force Atlas 2 doc and wrapper

--- a/python/cugraph/community/subgraph_extraction_wrapper.pyx
+++ b/python/cugraph/community/subgraph_extraction_wrapper.pyx
@@ -84,8 +84,8 @@ def subgraph(input_graph, vertices, subgraph):
     vertices_df['v'] = vertices_renumbered
     vertices_df = vertices_df.reset_index(drop=True).reset_index()
 
-    df = df.merge(vertices_df, left_on='src', right_on='index', how='left').drop(['src', 'index']).rename({'v': 'src'})
-    df = df.merge(vertices_df, left_on='dst', right_on='index', how='left').drop(['dst', 'index']).rename({'v': 'dst'})
+    df = df.merge(vertices_df, left_on='src', right_on='index', how='left').drop(['src', 'index']).rename(columns={'v': 'src'}, copy=False)
+    df = df.merge(vertices_df, left_on='dst', right_on='index', how='left').drop(['dst', 'index']).rename(columns={'v': 'dst'}, copy=False)
     
     if input_graph.renumbered:
         df = unrenumber(input_graph.edgelist.renumber_map, df, 'src')

--- a/python/cugraph/proto/structure/bicliques.py
+++ b/python/cugraph/proto/structure/bicliques.py
@@ -180,7 +180,7 @@ def _count_features(_gdf, sort=True):
 
     c = _gdf.groupby(['dst'], as_index=False).agg(aggs)
 
-    c = c.rename(columns={'count_dst': 'count'})
+    c = c.rename(columns={'count_dst': 'count'}, copy=False)
 
     if (sort):
         c = c.sort_values(by='count', ascending=False)

--- a/python/cugraph/structure/graph.py
+++ b/python/cugraph/structure/graph.py
@@ -263,12 +263,14 @@ class Graph:
             if isinstance(self.edgelist.renumber_map, cudf.DataFrame):
                 df = cudf.DataFrame()
                 ncols = len(edgelist_df.columns) - 2
-                unrnb_df_ = edgelist_df.merge(self.edgelist.renumber_map,
-                                              left_on='src', right_on='id',
-                                              how='left').drop(['id', 'src'])
-                unrnb_df = unrnb_df_.merge(self.edgelist.renumber_map,
-                                           left_on='dst', right_on='id',
-                                           how='left').drop(['id', 'dst'])
+                unrnb_df = edgelist_df.merge(
+                    self.edgelist.renumber_map,
+                    left_on='src', right_on='id', how='left'
+                ).drop(['id', 'src']).rename(columns={'0': 'src'}, copy=False)
+                unrnb_df = unrnb_df.merge(
+                    self.edgelist.renumber_map,
+                    left_on='dst', right_on='id', how='left'
+                ).drop(['id', 'dst']).rename(columns={'0': 'dst'}, copy=False)
                 cols = unrnb_df.columns.to_list()
                 df = unrnb_df[cols[ncols:]+cols[0:ncols]]
             else:

--- a/python/cugraph/structure/renumber.py
+++ b/python/cugraph/structure/renumber.py
@@ -134,7 +134,9 @@ def renumber_from_cudf(_df, source_cols_names, dest_cols_names):
     for i in range(len(source_cols_names)):
         _src_map.update({source_cols_names[i]: str(i)})
 
-    _tmp_df_src = _df[source_cols_names].rename(_src_map).reset_index()
+    _tmp_df_src = _df[source_cols_names] \
+        .rename(columns=_src_map, copy=False) \
+        .reset_index()
 
     # --------------------------------------------------------
     # get the destination column names and map to indexes
@@ -142,7 +144,9 @@ def renumber_from_cudf(_df, source_cols_names, dest_cols_names):
     for i in range(len(dest_cols_names)):
         _dst_map.update({dest_cols_names[i]: str(i)})
 
-    _tmp_df_dst = _df[dest_cols_names].rename(_dst_map).reset_index()
+    _tmp_df_dst = _df[dest_cols_names] \
+        .rename(columns=_dst_map, copy=False) \
+        .reset_index()
 
     _vals = list(_src_map.values())
 

--- a/python/cugraph/tests/test_betweenness_centrality.py
+++ b/python/cugraph/tests/test_betweenness_centrality.py
@@ -143,8 +143,9 @@ def _calc_bc_subset(G, Gnx, normalized, weight, endpoints, k, seed,
                                         weight=weight,
                                         endpoints=endpoints,
                                         result_dtype=result_dtype)
-    sorted_df = df.sort_values("vertex").rename({"betweenness_centrality":
-                                                 "cu_bc"})
+    sorted_df = df.sort_values("vertex").rename(
+        columns={"betweenness_centrality": "cu_bc"}, copy=False
+    )
 
     nx_bc = nx.betweenness_centrality(Gnx,
                                       k=k,
@@ -179,8 +180,9 @@ def _calc_bc_subset_fixed(G, Gnx, normalized, weight, endpoints, k, seed,
                                         endpoints=endpoints,
                                         seed=seed,
                                         result_dtype=result_dtype)
-    sorted_df = df.sort_values("vertex").rename({"betweenness_centrality":
-                                                 "cu_bc"})
+    sorted_df = df.sort_values("vertex").rename(
+        columns={"betweenness_centrality": "cu_bc"}, copy=False
+    )
 
     # The second call is going to process source that were already sampled
     # We set seed to None as k : int, seed : not none should not be normal
@@ -192,8 +194,9 @@ def _calc_bc_subset_fixed(G, Gnx, normalized, weight, endpoints, k, seed,
                                          endpoints=endpoints,
                                          seed=None,
                                          result_dtype=result_dtype)
-    sorted_df2 = df2.sort_values("vertex").rename({"betweenness_centrality":
-                                                   "ref_bc"})
+    sorted_df2 = df2.sort_values("vertex").rename(
+        columns={"betweenness_centrality": "ref_bc"}, copy=False
+    )
 
     merged_sorted_df = cudf.concat([sorted_df, sorted_df2["ref_bc"]], axis=1,
                                    sort=False)
@@ -218,8 +221,9 @@ def _calc_bc_full(G, Gnx, normalized, weight, endpoints,
                                       weight=weight,
                                       endpoints=endpoints)
 
-    sorted_df = df.sort_values("vertex").rename({"betweenness_centrality":
-                                                 "cu_bc"})
+    sorted_df = df.sort_values("vertex").rename(
+        columns={"betweenness_centrality": "cu_bc"}, copy=False
+    )
     _, nx_bc = zip(*sorted(nx_bc.items()))
     nx_df = cudf.DataFrame({"ref_bc": nx_bc})
 

--- a/python/cugraph/tests/test_bfs.py
+++ b/python/cugraph/tests/test_bfs.py
@@ -185,7 +185,8 @@ def _compare_bfs_spc(G, Gnx, source):
     # the vertices.
     # There is no guarantee when we get `df` that the vertices are sorted
     # thus we enforce the order so that we can leverage faster comparison after
-    sorted_df = df.sort_values('vertex').rename({"sp_counter": "cu_spc"})
+    sorted_df = df.sort_values('vertex') \
+        .rename(columns={"sp_counter": "cu_spc"}, copy=False)
 
     # This will allows to detect vertices identifier that could have been
     # wrongly present multiple times

--- a/python/cugraph/tests/test_core_number.py
+++ b/python/cugraph/tests/test_core_number.py
@@ -43,7 +43,7 @@ def calc_core_number(graph_file):
     nc = nx.core_number(Gnx)
     pdf = [nc[k] for k in sorted(nc.keys())]
     cn['nx_core_number'] = pdf
-    cn = cn.rename({'core_number': 'cu_core_number'})
+    cn = cn.rename(columns={'core_number': 'cu_core_number'}, copy=False)
     return cn
 
 

--- a/python/cugraph/tests/test_edge_betweenness_centrality.py
+++ b/python/cugraph/tests/test_edge_betweenness_centrality.py
@@ -147,10 +147,10 @@ def _calc_bc_subset(G, Gnx, normalized, weight, k, seed,
                                                 seed=seed)
 
     nx_df = generate_nx_result(nx_bc_dict, type(Gnx) is nx.DiGraph) \
-        .rename({"betweenness_centrality": "ref_bc"})
+        .rename(columns={"betweenness_centrality": "ref_bc"}, copy=False)
 
     sorted_df = df.sort_values(["src", "dst"])      \
-        .rename({"betweenness_centrality": "cu_bc"})
+        .rename(columns={"betweenness_centrality": "cu_bc"}, copy=False)
 
     sorted_df = cudf.concat([sorted_df, nx_df["ref_bc"]],
                             axis=1, sort=False)
@@ -188,9 +188,9 @@ def _calc_bc_subset_fixed(G, Gnx, normalized, weight, k, seed,
                                               result_dtype=result_dtype)
 
     sorted_df = df.sort_values(["src", "dst"])      \
-        .rename({"betweenness_centrality": "cu_bc"})
+        .rename(columns={"betweenness_centrality": "cu_bc"}, copy=False)
     sorted_df2 = df2.sort_values(["src", "dst"]) \
-        .rename({"betweenness_centrality": "ref_bc"})
+        .rename(columns={"betweenness_centrality": "ref_bc"}, copy=False)
 
     sorted_df = cudf.concat([sorted_df, sorted_df2["ref_bc"]],
                             axis=1, sort=False)
@@ -214,10 +214,10 @@ def _calc_bc_full(G, Gnx, normalized, weight, k, seed, result_dtype):
                                                 weight=weight)
 
     nx_df = generate_nx_result(nx_bc_dict, type(Gnx) is nx.DiGraph) \
-        .rename({"betweenness_centrality": "ref_bc"})
+        .rename(columns={"betweenness_centrality": "ref_bc"}, copy=False)
 
     sorted_df = df.sort_values(["src", "dst"])      \
-        .rename({"betweenness_centrality": "cu_bc"})
+        .rename(columns={"betweenness_centrality": "cu_bc"}, copy=False)
 
     sorted_df = cudf.concat([sorted_df, nx_df["ref_bc"]],
                             axis=1, sort=False)

--- a/python/cugraph/tests/test_hits.py
+++ b/python/cugraph/tests/test_hits.py
@@ -127,12 +127,12 @@ def test_hits(graph_file, max_iter, tol):
     #  Sort by hubs (cugraph) in descending order.  Then we'll
     #  check to make sure all scores are in descending order.
     #
-    cugraph_hits = cugraph_hits.sort_values('hubs', False)
+    cugraph_hits = cugraph_hits.sort_values('hubs', ascending=False)
 
     assert cugraph_hits['hubs'].is_monotonic_decreasing
     assert cugraph_hits['nx_hubs'].is_monotonic_decreasing
 
-    cugraph_hits = cugraph_hits.sort_values('authorities', False)
+    cugraph_hits = cugraph_hits.sort_values('authorities', ascending=False)
 
     assert cugraph_hits['authorities'].is_monotonic_decreasing
     assert cugraph_hits['nx_authorities'].is_monotonic_decreasing

--- a/python/cugraph/tests/test_katz_centrality.py
+++ b/python/cugraph/tests/test_katz_centrality.py
@@ -55,7 +55,7 @@ def calc_katz(graph_file):
     nk = nx.katz_centrality(Gnx, alpha=katz_alpha)
     pdf = [nk[k] for k in sorted(nk.keys())]
     k_df['nx_katz'] = pdf
-    k_df = k_df.rename({'katz_centrality': 'cu_katz'})
+    k_df = k_df.rename(columns={'katz_centrality': 'cu_katz'}, copy=False)
     return k_df
 
 


### PR DESCRIPTION
* Fixes places that are breaking from changes in cuDF's `DataFrame.rename()` method
* Ensures columns are named `src, dst` in `Graph.view_edge_list()` when graph was created via `renumber_from_cudf`. Presently they're named `0_x` and `0_y`, causing `Graph.edges()` to throw an error