### PR TITLE
[REVIEW] Add clang and clang tools to the conda env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - PR #987 Move graph out of experimental namespace
 - PR #984 Removing codecov until we figure out how to interpret failures that block CI
 - PR #985 Add raft handle to BFS, BC and edge BC
+- PR #988 Add clang and clang tools to the conda env
 
 ## Bug Fixes
 - PR #936 Update Force Atlas 2 doc and wrapper

--- a/conda/environments/cugraph_dev_cuda10.0.yml
+++ b/conda/environments/cugraph_dev_cuda10.0.yml
@@ -17,6 +17,8 @@ dependencies:
 - networkx
 - python-louvain
 - cudatoolkit=10.0
+- clang=8.0.1
+- clang-tools=8.0.1
 - cmake>=3.12
 - python>=3.6,<3.8
 - notebook>=0.5.0

--- a/conda/environments/cugraph_dev_cuda10.1.yml
+++ b/conda/environments/cugraph_dev_cuda10.1.yml
@@ -17,6 +17,8 @@ dependencies:
 - networkx
 - python-louvain
 - cudatoolkit=10.1
+- clang=8.0.1
+- clang-tools=8.0.1
 - cmake>=3.12
 - python>=3.6,<3.8
 - notebook>=0.5.0

--- a/conda/environments/cugraph_dev_cuda10.2.yml
+++ b/conda/environments/cugraph_dev_cuda10.2.yml
@@ -17,6 +17,8 @@ dependencies:
 - networkx
 - python-louvain
 - cudatoolkit=10.2
+- clang=8.0.1
+- clang-tools=8.0.1
 - cmake>=3.12
 - python>=3.6,<3.8
 - notebook>=0.5.0


### PR DESCRIPTION
- Adding clang tools to the conda environment so that developers can use it to run clang format