### PR TITLE
[REVIEW] Update prebuild.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - PR #987 Move graph out of experimental namespace
 - PR #984 Removing codecov until we figure out how to interpret failures that block CI
 - PR #985 Add raft handle to BFS, BC and edge BC
+- PR #991 Update conda upload versions for new supported CUDA/Python
 
 ## Bug Fixes
 - PR #936 Update Force Atlas 2 doc and wrapper

--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -3,13 +3,13 @@
 export BUILD_CUGRAPH=1
 export BUILD_LIBCUGRAPH=1
 
-if [[ "$CUDA" == "10.0" ]]; then
+if [[ "$CUDA" == "10.1" ]]; then
     export UPLOAD_CUGRAPH=1
 else
     export UPLOAD_CUGRAPH=0
 fi
 
-if [[ "$PYTHON" == "3.6" ]]; then
+if [[ "$PYTHON" == "3.7" ]]; then
     export UPLOAD_LIBCUGRAPH=1
 else
     export UPLOAD_LIBCUGRAPH=0


### PR DESCRIPTION
Update conda upload versions for new supported CUDA/Python

Edited ci/cpu/prebuild.sh with CUDA 10.1 and python 3.7 as new defaults.