### PR TITLE
[REVIEW] Fix unrenumber of predecessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - PR #938 Quote conda installs to avoid bash interpretation
 - PR #966 Fix build error (debug mode)
 - PR #983 Fix offset calculation in COO to CSR
+- PR #992 Fix unrenumber of predecessor
 
 # cuGraph 0.14.0 (03 Jun 2020)
 

--- a/python/cugraph/traversal/bfs_wrapper.pyx
+++ b/python/cugraph/traversal/bfs_wrapper.pyx
@@ -117,5 +117,7 @@ def bfs(input_graph, start, directed=True,
             df = unrenumbered_df[cols[1:n_cols + 1] + [cols[0]] + cols[n_cols:]]
         else: # Simple renumbering
             df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertex')
-            df['predecessor'][df['predecessor'] > -1] = input_graph.edgelist.renumber_map.iloc[df['predecessor'][df['predecessor'] > -1]]
+            df = unrenumber(input_graph.edgelist.renumber_map, df, 'predecessor')
+            df['predecessor'].fillna(-1, inplace=True)
+
     return df

--- a/python/cugraph/traversal/sssp_wrapper.pyx
+++ b/python/cugraph/traversal/sssp_wrapper.pyx
@@ -152,5 +152,7 @@ def sssp(input_graph, source):
             df = unrenumbered_df[cols[1:n_cols + 1] + [cols[0]] + cols[n_cols:]]
         else: # Simple renumbering
             df = unrenumber(input_graph.edgelist.renumber_map, df, 'vertex')
-            df['predecessor'][df['predecessor'] >- 1] = input_graph.edgelist.renumber_map.iloc[df['predecessor'][df['predecessor'] >- 1]]
+            df = unrenumber(input_graph.edgelist.renumber_map, df, 'predecessor')
+            df['predecessor'].fillna(-1, inplace=True)
+
     return df

--- a/python/cugraph/utilities/unrenumber.py
+++ b/python/cugraph/utilities/unrenumber.py
@@ -9,5 +9,13 @@ def unrenumber(renumber_map, df, col):
         cols = unrenumbered_df.columns.to_list()
         df = unrenumbered_df[cols[1:] + [cols[0]]]
     else:
-        df[col] = renumber_map.iloc[df[col]].reset_index(drop=True)
+        tmp = cudf.DataFrame()
+        tmp['OuTpUt'] = renumber_map
+        tmp['id'] = tmp.index
+        df['OrIgInAl'] = df.index
+        unrenumbered_df = df.merge(
+            tmp, left_on=col, right_on='id', how='left'
+        ).sort_values('OrIgInAl').reset_index(drop=True)
+        df[col] = unrenumbered_df['OuTpUt']
+        df = df.drop('OrIgInAl')
     return df


### PR DESCRIPTION
Reported in slack, several PRs are failing to build in CI due to a cuDF change.  A function that used to work now behaves a little differently and causes a failure.

Changed the way that the unrenumber is done.