### PR TITLE
[REVIEW] update setup.cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - PR #985 Add raft handle to BFS, BC and edge BC
 - PR #991 Update conda upload versions for new supported CUDA/Python
 - PR #988 Add clang and clang tools to the conda env
+- PR #997 Update setup.cfg to run pytests under cugraph tests directory only
 
 ## Bug Fixes
 - PR #936 Update Force Atlas 2 doc and wrapper

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -22,3 +22,6 @@ versionfile_source = cugraph/_version.py
 versionfile_build = cugraph/_version.py
 tag_prefix = v
 parentdir_prefix = cugraph-
+
+[tool:pytest]
+testpaths = cugraph/tests


### PR DESCRIPTION
Update setup.cfg for pytests to find tests from only under the cugraph/tests dir