### PR TITLE
[skip ci] Update master references for main branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Read the section on [building cuGraph from source](SOURCEBUILD.md) to validate t
 ```git remote add upstream https://github.com/rapidsai/cugraph.git```
 
 3. Checkout the latest branch
-cuGraph only allows contribution to the current branch and not master or a future branch.  PLease check the [cuGraph](https://github.com/rapidsai/cugraph) page for the name of the current branch.  
+cuGraph only allows contribution to the current branch and not main or a future branch.  PLease check the [cuGraph](https://github.com/rapidsai/cugraph) page for the name of the current branch.  
 ```git checkout branch-x.x```
 
 4. Code .....
@@ -155,7 +155,3 @@ All code must adhere to the [RAPIDS Style Guide](https://docs.rapids.ai/resource
 
 ### Tests
 All code must have associate test cases.  Code without test will not be accepted
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The [RAPIDS](https://rapids.ai) cuGraph library is a collection of GPU accelerat
 
  For more project details, see [rapids.ai](https://rapids.ai/).
 
-**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cudf/blob/master/README.md) ensure you are on the latest branch.
+**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cudf/blob/main/README.md) ensure you are on the latest branch.
 
 
 


### PR DESCRIPTION
This PR changes any 'master' references to 'main' in markdown files throughout the repo as part of the new 'master' to 'main' branch migration.