### PR TITLE
[REVIEW] Update CI scripts to remove references to master [skip ci] 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# built from https://github.com/rapidsai/cudf/blob/master/Dockerfile
+# built from https://github.com/rapidsai/cudf/blob/main/Dockerfile
 FROM cudf
 
 ADD src /cugraph/src

--- a/ci/checks/changelog.sh
+++ b/ci/checks/changelog.sh
@@ -4,8 +4,8 @@
 # cuGraph CHANGELOG Tester #
 ############################
 
-# Checkout master for comparison
-git checkout --quiet master
+# Checkout main for comparison
+git checkout --quiet main
 
 # Switch back to tip of PR branch
 git checkout --quiet current-pr-branch
@@ -14,7 +14,7 @@ git checkout --quiet current-pr-branch
 set +e
 
 # Get list of modified files between matster and PR branch
-CHANGELOG=`git diff --name-only master...current-pr-branch | grep CHANGELOG.md`
+CHANGELOG=`git diff --name-only main...current-pr-branch | grep CHANGELOG.md`
 # Check if CHANGELOG has PR ID
 PRNUM=`cat CHANGELOG.md | grep "$PR_ID"`
 RETVAL=0

--- a/ci/cpu/cugraph/upload-anaconda.sh
+++ b/ci/cpu/cugraph/upload-anaconda.sh
@@ -7,7 +7,6 @@ set -e
 if [ "$UPLOAD_CUGRAPH" == "1" ]; then
   export UPLOADFILE=`conda build conda/recipes/cugraph -c rapidsai -c nvidia -c numba -c conda-forge -c defaults --python=$PYTHON --output`
 
-  SOURCE_BRANCH=master
 
   # Have to label all CUDA versions due to the compatibility to work with any CUDA
   if [ "$LABEL_MAIN" == "1" ]; then
@@ -22,8 +21,7 @@ if [ "$UPLOAD_CUGRAPH" == "1" ]; then
 
   test -e ${UPLOADFILE}
 
-  # Restrict uploads to master branch
-  if [ ${GIT_BRANCH} != ${SOURCE_BRANCH} ]; then
+  if [ ${BUILD_MODE} != "branch" ]; then
     echo "Skipping upload"
     return 0
   fi

--- a/ci/cpu/libcugraph/upload-anaconda.sh
+++ b/ci/cpu/libcugraph/upload-anaconda.sh
@@ -9,15 +9,13 @@ if [ "$UPLOAD_LIBCUGRAPH" == "1" ]; then
 
   export UPLOADFILE=`conda build conda/recipes/libcugraph --output`
 
-  SOURCE_BRANCH=master
 
   LABEL_OPTION="--label main"
   echo "LABEL_OPTION=${LABEL_OPTION}"
 
   test -e ${UPLOADFILE}
 
-  # Restrict uploads to master branch
-  if [ ${GIT_BRANCH} != ${SOURCE_BRANCH} ]; then
+  if [ ${BUILD_MODE} != "branch" ]; then
     echo "Skipping upload"
     return 0
   fi

--- a/conda_build.sh
+++ b/conda_build.sh
@@ -8,7 +8,7 @@ conda build -c nvidia -c rapidsai -c rapidsai-nightly/label/cuda${CUDA_REL} -c c
 
 if [ "$UPLOAD_PACKAGE" == '1' ]; then
     export UPLOADFILE=`conda build -c nvidia -c rapidsai -c conda-forge -c defaults --python=${PYTHON} conda/recipes/cugraph --output`
-    SOURCE_BRANCH=master
+    SOURCE_BRANCH=main
 
     test -e ${UPLOADFILE}
 


### PR DESCRIPTION
This PR removes unecessary references to master or updates references to the new main branch in CI scripts and other OPS-owned files.