### PR TITLE
[REVIEW] Add tolerance support to MG Pagerank and fix kernel launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - PR #991 Update conda upload versions for new supported CUDA/Python
 - PR #988 Add clang and clang tools to the conda env
 - PR #997 Update setup.cfg to run pytests under cugraph tests directory only
+- PR #1007 Add tolerance support to MG Pagerank and fix
 
 ## Bug Fixes
 - PR #936 Update Force Atlas 2 doc and wrapper

--- a/cpp/src/community/louvain_kernels.cu
+++ b/cpp/src/community/louvain_kernels.cu
@@ -34,7 +34,7 @@ constexpr int BLOCK_SIZE_1D = 64;
 }
 
 template <typename vertex_t, typename edge_t, typename weight_t>
-__global__  // __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
+__global__  //
   void
   compute_vertex_sums(vertex_t n_vertex,
                       edge_t const *offsets,

--- a/cpp/src/layout/fa2_kernels.hpp
+++ b/cpp/src/layout/fa2_kernels.hpp
@@ -23,20 +23,19 @@ namespace cugraph {
 namespace detail {
 
 template <typename vertex_t, typename edge_t, typename weight_t>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
-  attraction_kernel(const vertex_t *restrict row,
-                    const vertex_t *restrict col,
-                    const weight_t *restrict v,
-                    const edge_t e,
-                    const float *restrict x_pos,
-                    const float *restrict y_pos,
-                    float *restrict attract_x,
-                    float *restrict attract_y,
-                    const int *restrict mass,
-                    bool outbound_attraction_distribution,
-                    bool lin_log_mode,
-                    const float edge_weight_influence,
-                    const float coef)
+__global__ void attraction_kernel(const vertex_t *restrict row,
+                                  const vertex_t *restrict col,
+                                  const weight_t *restrict v,
+                                  const edge_t e,
+                                  const float *restrict x_pos,
+                                  const float *restrict y_pos,
+                                  float *restrict attract_x,
+                                  float *restrict attract_y,
+                                  const int *restrict mass,
+                                  bool outbound_attraction_distribution,
+                                  bool lin_log_mode,
+                                  const float edge_weight_influence,
+                                  const float coef)
 {
   vertex_t i, src, dst;
   weight_t weight = 1;
@@ -116,14 +115,13 @@ void apply_attraction(const vertex_t *restrict row,
 }
 
 template <typename vertex_t>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
-  linear_gravity_kernel(const float *restrict x_pos,
-                        const float *restrict y_pos,
-                        float *restrict attract_x,
-                        float *restrict attract_y,
-                        const int *restrict mass,
-                        const float gravity,
-                        const vertex_t n)
+__global__ void linear_gravity_kernel(const float *restrict x_pos,
+                                      const float *restrict y_pos,
+                                      float *restrict attract_x,
+                                      float *restrict attract_y,
+                                      const int *restrict mass,
+                                      const float gravity,
+                                      const vertex_t n)
 {
   // For every node.
   for (int i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x) {
@@ -137,15 +135,14 @@ __global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
 }
 
 template <typename vertex_t>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
-  strong_gravity_kernel(const float *restrict x_pos,
-                        const float *restrict y_pos,
-                        float *restrict attract_x,
-                        float *restrict attract_y,
-                        const int *restrict mass,
-                        const float gravity,
-                        const float scaling_ratio,
-                        const vertex_t n)
+__global__ void strong_gravity_kernel(const float *restrict x_pos,
+                                      const float *restrict y_pos,
+                                      float *restrict attract_x,
+                                      float *restrict attract_y,
+                                      const int *restrict mass,
+                                      const float gravity,
+                                      const float scaling_ratio,
+                                      const vertex_t n)
 {
   // For every node.
   for (int i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x) {
@@ -187,17 +184,16 @@ void apply_gravity(const float *restrict x_pos,
 }
 
 template <typename vertex_t>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
-  local_speed_kernel(const float *restrict repel_x,
-                     const float *restrict repel_y,
-                     const float *restrict attract_x,
-                     const float *restrict attract_y,
-                     const float *restrict old_dx,
-                     const float *restrict old_dy,
-                     const int *restrict mass,
-                     float *restrict swinging,
-                     float *restrict traction,
-                     const vertex_t n)
+__global__ void local_speed_kernel(const float *restrict repel_x,
+                                   const float *restrict repel_y,
+                                   const float *restrict attract_x,
+                                   const float *restrict attract_y,
+                                   const float *restrict old_dx,
+                                   const float *restrict old_dy,
+                                   const int *restrict mass,
+                                   float *restrict swinging,
+                                   float *restrict traction,
+                                   const vertex_t n)
 {
   // For every node.
   for (int i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x) {
@@ -272,18 +268,17 @@ void adapt_speed(const float jitter_tolerance,
 }
 
 template <typename vertex_t>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
-  update_positions_kernel(float *restrict x_pos,
-                          float *restrict y_pos,
-                          const float *restrict repel_x,
-                          const float *restrict repel_y,
-                          const float *restrict attract_x,
-                          const float *restrict attract_y,
-                          float *restrict old_dx,
-                          float *restrict old_dy,
-                          const float *restrict swinging,
-                          const float speed,
-                          const vertex_t n)
+__global__ void update_positions_kernel(float *restrict x_pos,
+                                        float *restrict y_pos,
+                                        const float *restrict repel_x,
+                                        const float *restrict repel_y,
+                                        const float *restrict attract_x,
+                                        const float *restrict attract_y,
+                                        float *restrict old_dx,
+                                        float *restrict old_dy,
+                                        const float *restrict swinging,
+                                        const float speed,
+                                        const vertex_t n)
 {
   // For every node.
   for (int i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x) {

--- a/cpp/src/link_analysis/pagerank.cu
+++ b/cpp/src/link_analysis/pagerank.cu
@@ -267,8 +267,8 @@ void pagerank_impl(GraphCSCView<VT, ET, WT> const &graph,
                    VT *personalization_subset     = nullptr,
                    WT *personalization_values     = nullptr,
                    double alpha                   = 0.85,
-                   double tolerance               = 1e-4,
-                   int64_t max_iter               = 200,
+                   double tolerance               = 1e-5,
+                   int64_t max_iter               = 100,
                    bool has_guess                 = false)
 {
   bool has_personalization = false;

--- a/cpp/src/link_analysis/pagerank.cu
+++ b/cpp/src/link_analysis/pagerank.cu
@@ -332,7 +332,7 @@ void pagerank_impl(GraphCSCView<VT, ET, WT> const &graph,
   switch (status) {
     case 0: break;
     case -1: CUGRAPH_FAIL("Error : bad parameters in Pagerank");
-    case 1: CUGRAPH_FAIL("Warning : Pagerank did not reached the desired tolerance");
+    case 1: break;  // Warning : Pagerank did not reached the desired tolerance
     default: CUGRAPH_FAIL("Pagerank exec failed");
   }
 
@@ -363,7 +363,7 @@ void pagerank(raft::handle_t const &handle,
                     "Invalid API parameter: Multi-GPU Pagerank does not guess, please use the "
                     "single GPU version for this feature");
     CUGRAPH_EXPECTS(max_iter > 0, "The number of iteration must be positive");
-    return cugraph::opg::pagerank<VT, ET, WT>(handle, graph, pagerank, alpha, max_iter);
+    cugraph::opg::pagerank<VT, ET, WT>(handle, graph, pagerank, alpha, max_iter, tolerance);
   } else  // Single GPU
     return detail::pagerank_impl<VT, ET, WT>(graph,
                                              pagerank,

--- a/cpp/src/link_analysis/pagerank_1D.cu
+++ b/cpp/src/link_analysis/pagerank_1D.cu
@@ -138,7 +138,6 @@ int Pagerank<VT, ET, WT>::solve(int max_iter, float tolerance, WT *pagerank)
         cugraph::detail::copy(v_glob, pr, prev_pr.data().get());
     }
     cugraph::detail::scal(v_glob, one / cugraph::detail::nrm1(v_glob, pr), pr);
-    std::cout << "it " << i << std::endl;
     return i;
   } else {
     CUGRAPH_FAIL("OPG PageRank : Solve was called before setup");

--- a/cpp/src/link_analysis/pagerank_1D.cu
+++ b/cpp/src/link_analysis/pagerank_1D.cu
@@ -34,7 +34,10 @@ __global__ void transition_kernel(const size_t e, const VT *ind, const VT *degre
 
 template <typename VT, typename ET, typename WT>
 Pagerank<VT, ET, WT>::Pagerank(const raft::handle_t &handle_, GraphCSCView<VT, ET, WT> const &G)
-  : comm(handle_.get_comms()), bookmark(G.number_of_vertices), val(G.local_edges[comm.get_rank()])
+  : comm(handle_.get_comms()),
+    bookmark(G.number_of_vertices),
+    prev_pr(G.number_of_vertices),
+    val(G.local_edges[comm.get_rank()])
 {
   v_glob         = G.number_of_vertices;
   v_loc          = G.local_vertices[comm.get_rank()];
@@ -102,13 +105,14 @@ void Pagerank<VT, ET, WT>::setup(WT _alpha, VT *degree)
 
 // run the power iteration on the google matrix
 template <typename VT, typename ET, typename WT>
-void Pagerank<VT, ET, WT>::solve(int max_iter, WT *pagerank)
+int Pagerank<VT, ET, WT>::solve(int max_iter, float tolerance, WT *pagerank)
 {
   if (is_setup) {
     WT dot_res;
     WT one = 1.0;
     WT *pr = pagerank;
     cugraph::detail::fill(v_glob, pagerank, one / v_glob);
+    cugraph::detail::fill(v_glob, prev_pr.data().get(), one / v_glob);
     // This cuda sync was added to fix #426
     // This should not be requiered in theory
     // This is not needed on one GPU at this time
@@ -116,14 +120,25 @@ void Pagerank<VT, ET, WT>::solve(int max_iter, WT *pagerank)
     dot_res = cugraph::detail::dot(v_glob, bookmark.data().get(), pr);
     OPGcsrmv<VT, ET, WT> spmv_solver(
       comm, local_vertices, part_off, off, ind, val.data().get(), pagerank);
-    for (auto i = 0; i < max_iter; ++i) {
+
+    WT residual;
+    int i;
+    for (i = 0; i < max_iter; ++i) {
       spmv_solver.run(pagerank);
       cugraph::detail::scal(v_glob, alpha, pr);
       cugraph::detail::addv(v_glob, dot_res * (one / v_glob), pr);
       dot_res = cugraph::detail::dot(v_glob, bookmark.data().get(), pr);
       cugraph::detail::scal(v_glob, one / cugraph::detail::nrm2(v_glob, pr), pr);
+
+      cugraph::detail::axpy(v_glob, (WT)-1.0, pr, prev_pr.data().get());
+      residual = cugraph::detail::nrm2(v_glob, prev_pr.data().get());
+      if (residual < tolerance)
+        break;
+      else
+        cugraph::detail::copy(v_glob, pr, prev_pr.data().get());
     }
     cugraph::detail::scal(v_glob, one / cugraph::detail::nrm1(v_glob, pr), pr);
+    return i;
   } else {
     CUGRAPH_FAIL("OPG PageRank : Solve was called before setup");
   }

--- a/cpp/src/link_analysis/pagerank_1D.cu
+++ b/cpp/src/link_analysis/pagerank_1D.cu
@@ -138,6 +138,7 @@ int Pagerank<VT, ET, WT>::solve(int max_iter, float tolerance, WT *pagerank)
         cugraph::detail::copy(v_glob, pr, prev_pr.data().get());
     }
     cugraph::detail::scal(v_glob, one / cugraph::detail::nrm1(v_glob, pr), pr);
+    std::cout << "it " << i << std::endl;
     return i;
   } else {
     CUGRAPH_FAIL("OPG PageRank : Solve was called before setup");

--- a/cpp/src/link_analysis/pagerank_1D.cuh
+++ b/cpp/src/link_analysis/pagerank_1D.cuh
@@ -75,9 +75,9 @@ template <typename VT, typename ET, typename WT>
 int pagerank(raft::handle_t const &handle,
              const GraphCSCView<VT, ET, WT> &G,
              WT *pagerank_result,
-             const float damping_factor = 0.85,
-             const int n_iter           = 200,
-             const float tolerance      = 1e-4)
+             const double damping_factor = 0.85,
+             const int64_t n_iter        = 100,
+             const double tolerance      = 1e-5)
 {
   // null pointers check
   CUGRAPH_EXPECTS(G.offsets != nullptr, "Invalid API parameter - offsets is null");

--- a/cpp/src/link_analysis/pagerank_1D.cuh
+++ b/cpp/src/link_analysis/pagerank_1D.cuh
@@ -52,6 +52,7 @@ class Pagerank {
   VT *ind;
   rmm::device_vector<WT> val;       // values of the substochastic matrix
   rmm::device_vector<WT> bookmark;  // constant vector with dangling node info
+  rmm::device_vector<WT> prev_pr;   // record the last pagerank for convergence check
 
   bool is_setup;
 
@@ -66,16 +67,17 @@ class Pagerank {
   // Artificially create the google matrix by setting val and bookmark
   void setup(WT _alpha, VT *degree);
 
-  // run the power iteration on the google matrix
-  void solve(int max_iter, WT *pagerank);
+  // run the power iteration on the google matrix, return the number of iterations
+  int solve(int max_iter, float tolerance, WT *pagerank);
 };
 
 template <typename VT, typename ET, typename WT>
-void pagerank(raft::handle_t const &handle,
-              const GraphCSCView<VT, ET, WT> &G,
-              WT *pagerank_result,
-              const float damping_factor = 0.85,
-              const int n_iter           = 40)
+int pagerank(raft::handle_t const &handle,
+             const GraphCSCView<VT, ET, WT> &G,
+             WT *pagerank_result,
+             const float damping_factor = 0.85,
+             const int n_iter           = 200,
+             const float tolerance      = 1e-4)
 {
   // null pointers check
   CUGRAPH_EXPECTS(G.offsets != nullptr, "Invalid API parameter - offsets is null");
@@ -101,8 +103,8 @@ void pagerank(raft::handle_t const &handle,
   // Set all constants info
   pr_solver.setup(damping_factor, degree.data().get());
 
-  // Run n_iter pagerank MG SPMVs.
-  pr_solver.solve(n_iter, pagerank_result);
+  // Run pagerank
+  return pr_solver.solve(n_iter, tolerance, pagerank_result);
 }
 
 }  // namespace opg

--- a/cpp/src/link_prediction/jaccard.cu
+++ b/cpp/src/link_prediction/jaccard.cu
@@ -29,7 +29,7 @@ namespace detail {
 
 // Volume of neighboors (*weight_s)
 template <bool weighted, typename vertex_t, typename edge_t, typename weight_t>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS) jaccard_row_sum(
+__global__ void jaccard_row_sum(
   vertex_t n, edge_t const *csrPtr, vertex_t const *csrInd, weight_t const *v, weight_t *work)
 {
   vertex_t row;
@@ -53,13 +53,13 @@ __global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS) jaccard_row_sum(
 
 // Volume of intersections (*weight_i) and cumulated volume of neighboors (*weight_s)
 template <bool weighted, typename vertex_t, typename edge_t, typename weight_t>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS) jaccard_is(vertex_t n,
-                                                                      edge_t const *csrPtr,
-                                                                      vertex_t const *csrInd,
-                                                                      weight_t const *v,
-                                                                      weight_t *work,
-                                                                      weight_t *weight_i,
-                                                                      weight_t *weight_s)
+__global__ void jaccard_is(vertex_t n,
+                           edge_t const *csrPtr,
+                           vertex_t const *csrInd,
+                           weight_t const *v,
+                           weight_t *work,
+                           weight_t *weight_i,
+                           weight_t *weight_s)
 {
   edge_t i, j, Ni, Nj;
   vertex_t row, col;
@@ -117,16 +117,15 @@ __global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS) jaccard_is(vertex_t n
 // Volume of intersections (*weight_i) and cumulated volume of neighboors (*weight_s)
 // Using list of node pairs
 template <bool weighted, typename vertex_t, typename edge_t, typename weight_t>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
-  jaccard_is_pairs(edge_t num_pairs,
-                   edge_t const *csrPtr,
-                   vertex_t const *csrInd,
-                   vertex_t const *first_pair,
-                   vertex_t const *second_pair,
-                   weight_t const *v,
-                   weight_t *work,
-                   weight_t *weight_i,
-                   weight_t *weight_s)
+__global__ void jaccard_is_pairs(edge_t num_pairs,
+                                 edge_t const *csrPtr,
+                                 vertex_t const *csrInd,
+                                 vertex_t const *first_pair,
+                                 vertex_t const *second_pair,
+                                 weight_t const *v,
+                                 weight_t *work,
+                                 weight_t *weight_i,
+                                 weight_t *weight_s)
 {
   edge_t i, idx, Ni, Nj, match;
   vertex_t row, col, ref, cur, ref_col, cur_col;
@@ -182,8 +181,10 @@ __global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
 
 // Jaccard  weights (*weight)
 template <bool weighted, typename vertex_t, typename edge_t, typename weight_t>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
-  jaccard_jw(edge_t e, weight_t const *weight_i, weight_t const *weight_s, weight_t *weight_j)
+__global__ void jaccard_jw(edge_t e,
+                           weight_t const *weight_i,
+                           weight_t const *weight_s,
+                           weight_t *weight_j)
 {
   edge_t j;
   weight_t Wi, Ws, Wu;

--- a/cpp/src/link_prediction/overlap.cu
+++ b/cpp/src/link_prediction/overlap.cu
@@ -30,7 +30,7 @@ namespace detail {
 // Volume of neighboors (*weight_s)
 // TODO: Identical kernel to jaccard_row_sum!!
 template <bool weighted, typename vertex_t, typename edge_t, typename weight_t>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS) overlap_row_sum(
+__global__ void overlap_row_sum(
   vertex_t n, edge_t const *csrPtr, vertex_t const *csrInd, weight_t const *v, weight_t *work)
 {
   vertex_t row;
@@ -55,13 +55,13 @@ __global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS) overlap_row_sum(
 // Volume of intersections (*weight_i) and cumulated volume of neighboors (*weight_s)
 // TODO: Identical kernel to jaccard_row_sum!!
 template <bool weighted, typename vertex_t, typename edge_t, typename weight_t>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS) overlap_is(vertex_t n,
-                                                                      edge_t const *csrPtr,
-                                                                      vertex_t const *csrInd,
-                                                                      weight_t const *v,
-                                                                      weight_t *work,
-                                                                      weight_t *weight_i,
-                                                                      weight_t *weight_s)
+__global__ void overlap_is(vertex_t n,
+                           edge_t const *csrPtr,
+                           vertex_t const *csrInd,
+                           weight_t const *v,
+                           weight_t *work,
+                           weight_t *weight_i,
+                           weight_t *weight_s)
 {
   edge_t i, j, Ni, Nj;
   vertex_t row, col;
@@ -120,16 +120,15 @@ __global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS) overlap_is(vertex_t n
 // Using list of node pairs
 // NOTE:  NOT the same as jaccard
 template <bool weighted, typename vertex_t, typename edge_t, typename weight_t>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
-  overlap_is_pairs(edge_t num_pairs,
-                   edge_t const *csrPtr,
-                   vertex_t const *csrInd,
-                   vertex_t const *first_pair,
-                   vertex_t const *second_pair,
-                   weight_t const *v,
-                   weight_t *work,
-                   weight_t *weight_i,
-                   weight_t *weight_s)
+__global__ void overlap_is_pairs(edge_t num_pairs,
+                                 edge_t const *csrPtr,
+                                 vertex_t const *csrInd,
+                                 vertex_t const *first_pair,
+                                 vertex_t const *second_pair,
+                                 weight_t const *v,
+                                 weight_t *work,
+                                 weight_t *weight_i,
+                                 weight_t *weight_s)
 {
   edge_t i, idx, Ni, Nj, match;
   vertex_t row, col, ref, cur, ref_col, cur_col;
@@ -185,12 +184,12 @@ __global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
 
 // Overlap  weights (*weight)
 template <bool weighted, typename vertex_t, typename edge_t, typename weight_t>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS) overlap_jw(edge_t e,
-                                                                      edge_t const *csrPtr,
-                                                                      vertex_t const *csrInd,
-                                                                      weight_t *weight_i,
-                                                                      weight_t *weight_s,
-                                                                      weight_t *weight_j)
+__global__ void overlap_jw(edge_t e,
+                           edge_t const *csrPtr,
+                           vertex_t const *csrInd,
+                           weight_t *weight_i,
+                           weight_t *weight_s,
+                           weight_t *weight_j)
 {
   edge_t j;
   weight_t Wi, Wu;

--- a/cpp/src/utilities/graph_utils.cuh
+++ b/cpp/src/utilities/graph_utils.cuh
@@ -278,31 +278,34 @@ void update_dangling_nodes(size_t n, T *dangling_nodes, T damping_factor)
 
 // google matrix kernels
 template <typename IndexType, typename ValueType>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
-  degree_coo(const IndexType n, const IndexType e, const IndexType *ind, ValueType *degree)
+__global__ void degree_coo(const IndexType n,
+                           const IndexType e,
+                           const IndexType *ind,
+                           ValueType *degree)
 {
   for (int i = threadIdx.x + blockIdx.x * blockDim.x; i < e; i += gridDim.x * blockDim.x)
     atomicAdd(&degree[ind[i]], (ValueType)1.0);
 }
 
 template <typename IndexType, typename ValueType>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
-  flag_leafs_kernel(const size_t n, const IndexType *degree, ValueType *bookmark)
+__global__ void flag_leafs_kernel(const size_t n, const IndexType *degree, ValueType *bookmark)
 {
   for (auto i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x)
     if (degree[i] == 0) bookmark[i] = 1.0;
 }
 
 template <typename IndexType, typename ValueType>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
-  degree_offsets(const IndexType n, const IndexType e, const IndexType *ind, ValueType *degree)
+__global__ void degree_offsets(const IndexType n,
+                               const IndexType e,
+                               const IndexType *ind,
+                               ValueType *degree)
 {
   for (int i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x)
     degree[i] += ind[i + 1] - ind[i];
 }
 
 template <typename FromType, typename ToType>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS) type_convert(FromType *array, int n)
+__global__ void type_convert(FromType *array, int n)
 {
   for (int i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x) {
     ToType val   = array[i];
@@ -312,12 +315,12 @@ __global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS) type_convert(FromType
 }
 
 template <typename IndexType, typename ValueType>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS) equi_prob3(const IndexType n,
-                                                                      const IndexType e,
-                                                                      const IndexType *csrPtr,
-                                                                      const IndexType *csrInd,
-                                                                      ValueType *val,
-                                                                      IndexType *degree)
+__global__ void equi_prob3(const IndexType n,
+                           const IndexType e,
+                           const IndexType *csrPtr,
+                           const IndexType *csrInd,
+                           ValueType *val,
+                           IndexType *degree)
 {
   int j, row, col;
   for (row = threadIdx.z + blockIdx.z * blockDim.z; row < n; row += gridDim.z * blockDim.z) {
@@ -331,12 +334,12 @@ __global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS) equi_prob3(const Inde
 }
 
 template <typename IndexType, typename ValueType>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS) equi_prob2(const IndexType n,
-                                                                      const IndexType e,
-                                                                      const IndexType *csrPtr,
-                                                                      const IndexType *csrInd,
-                                                                      ValueType *val,
-                                                                      IndexType *degree)
+__global__ void equi_prob2(const IndexType n,
+                           const IndexType e,
+                           const IndexType *csrPtr,
+                           const IndexType *csrInd,
+                           ValueType *val,
+                           IndexType *degree)
 {
   int row = blockIdx.x * blockDim.x + threadIdx.x;
   if (row < n) {
@@ -400,8 +403,10 @@ void HT_matrix_csc_coo(const IndexType n,
 }
 
 template <typename IndexType, typename ValueType>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
-  permute_vals_kernel(const IndexType e, IndexType *perm, ValueType *in, ValueType *out)
+__global__ void permute_vals_kernel(const IndexType e,
+                                    IndexType *perm,
+                                    ValueType *in,
+                                    ValueType *out)
 {
   for (int i = threadIdx.x + blockIdx.x * blockDim.x; i < e; i += gridDim.x * blockDim.x)
     out[i] = in[perm[i]];
@@ -486,8 +491,7 @@ void remove_duplicate(
 }
 
 template <typename IndexType>
-__global__ void __launch_bounds__(CUDA_MAX_KERNEL_THREADS)
-  offsets_to_indices_kernel(const IndexType *offsets, IndexType v, IndexType *indices)
+__global__ void offsets_to_indices_kernel(const IndexType *offsets, IndexType v, IndexType *indices)
 {
   int tid, ctaStart;
   tid      = threadIdx.x;

--- a/python/cugraph/dask/opg_pagerank/pagerank.py
+++ b/python/cugraph/dask/opg_pagerank/pagerank.py
@@ -96,10 +96,6 @@ def pagerank(input_graph,
     >>> pr = dcg.pagerank(dg)
     """
 
-    if tol != 1.0e-5:
-        warnings.warn("Tolerance is currently not supported. \
-Setting it to default 1.0e-5")
-    tol = 1.0e-5
     if personalization is not None or nstart is not None:
         warnings.warn("personalization and nstart currently not \
 supported. Setting them to None")

--- a/python/cugraph/tests/dask/test_opg_pagerank.py
+++ b/python/cugraph/tests/dask/test_opg_pagerank.py
@@ -50,7 +50,7 @@ def test_dask_pagerank():
     # dg.compute_local_data(by='dst')
 
     expected_pr = cugraph.pagerank(g)
-    result_pr = dcg.pagerank(dg)
+    result_pr = dcg.pagerank(dg, tol=1e-6)
 
     err = 0
     tol = 1.0e-05


### PR DESCRIPTION
- Closes #999 
- Added tolerance in MG PR
- Removed error throwing when not reaching tolerance in both MG and SG. The solver now exits when the first one between max_iter and tolerance is reached.
- Fixed cuda launch bounds (so that we can accept this from the device properties/handle and not limit it with the old #define)
- The MG pagerank backend returns the number of iterations to the cpp API driver