### PR TITLE
[REVIEW] Add tooltip requirements to benchmarks/build.sh [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - PR #991 Update conda upload versions for new supported CUDA/Python
 - PR #988 Add clang and clang tools to the conda env
 - PR #997 Update setup.cfg to run pytests under cugraph tests directory only
+- PR #1009 Update benchmarks script to include requirements used
 
 ## Bug Fixes
 - PR #936 Update Force Atlas 2 doc and wrapper

--- a/ci/benchmark/build.sh
+++ b/ci/benchmark/build.sh
@@ -63,10 +63,28 @@ nvidia-smi
 logger "Activate conda env..."
 source activate rapids
 
+
+# Enter dependencies to be shown in ASV tooltips.
+# These dependencies will also be installed by conda.
+# A dependency can exist in both arrays without causing issues.
+CUGRAPH_DEPS=(cudf rmm)
+LIBCUGRAPH_DEPS=(cudf rmm)
+
+# Concatenate dependency arrays, convert to JSON array,
+# and remove duplicates.
+X=("${CUGRAPH_DEPS[@]}" "${LIBCUGRAPH_DEPS[@]}")
+DEPS=$(printf '%s\n' "${X[@]}" | jq -R . | jq -s 'unique')
+
+# Create install args for conda (i.e. "cudf=0.15" "rmm=0.15")
+CONDA_INSTALL=
+for DEP in $(echo "${DEPS}" | jq -r '.[]'); do
+  CONDA_INSTALL+="${DEP}=${MINOR_VERSION}"
+  CONDA_INSTALL+=" "
+done
+
 logger "conda install required packages"
 conda install -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge -c defaults \
-      "cudf=${MINOR_VERSION}" \
-      "rmm=${MINOR_VERSION}" \
+      ${CONDA_INSTALL} \
       "cudatoolkit=$CUDA_REL" \
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \
@@ -107,17 +125,42 @@ if (( ${ERRORCODE} != 0 )); then
     exit ${ERRORCODE}
 fi
 
+# Build object with k/v pairs of "dependency:version"
+DEP_VER_DICT=$(jq -n '{}')
+for DEP in $(echo "${DEPS}" | jq -r '.[]'); do
+  VER=$(conda list | grep "^${DEP}" | awk '{print $2"-"$3}')
+  DEP_VER_DICT=$(echo "${DEP_VER_DICT}" | jq -c --arg DEP "${DEP}" --arg VER "${VER}" '. + { ($DEP): $VER }')
+done
+
+# Pass in an array of dependencies to get a dict of "dependency:version"
+function getReqs() {
+  local DEPS_ARR=("$@")
+  local REQS="{}"
+  for DEP in "${DEPS_ARR[@]}"; do
+    VER=$(echo "${DEP_VER_DICT}" | jq -r --arg DEP "${DEP}" '.[$DEP]')
+    REQS=$(echo "${REQS}" | jq -c --arg DEP "${DEP}" --arg VER "${VER}" '. + { ($DEP): $VER }')
+  done
+
+  echo "${REQS}"
+}
+
+REQS=$(getReqs "${CUGRAPH_DEPS[@]}")
+
 logger "Running Benchmarks..."
 cd $BENCHMARKS_DIR
 set +e
 time pytest -v -m "small and managedmem_on and poolallocator_on" \
     --benchmark-gpu-device=0 \
     --benchmark-gpu-max-rounds=3 \
-    --benchmark-asv-metadata="machineName=${NODE_NAME}, commitBranch=branch-${MINOR_VERSION}" \
+    --benchmark-asv-metadata="machineName=${NODE_NAME}, commitBranch=branch-${MINOR_VERSION}, requirements=${REQS}" \
     --benchmark-asv-output-dir=${ASVRESULTS_DIR}
+
+
 
 EXITCODE=$?
 
+# libcugraph reqs
+# REQS=$(getReqs "${LIBCUGRAPH_DEPS[@]}")
+
 set -e
 JOBEXITCODE=0
-

--- a/ci/benchmark/build.sh
+++ b/ci/benchmark/build.sh
@@ -139,7 +139,7 @@ function getReqs() {
 
 REQS=$(getReqs "${CUGRAPH_DEPS[@]}")
 
-BECHMARK_META=$(jq -n \
+BENCHMARK_META=$(jq -n \
   --arg NODE "${NODE_NAME}" \
   --arg MINOR_VER "${MINOR_VERSION}" \
   --argjson REQS "${REQS}" '
@@ -157,13 +157,14 @@ time pytest -v -m "small and managedmem_on and poolallocator_on" \
     --benchmark-gpu-device=0 \
     --benchmark-gpu-max-rounds=3 \
     --benchmark-asv-output-dir="${ASVRESULTS_DIR}" \
-    --benchmark-asv-metadata="${BECHMARK_META}"
+    --benchmark-asv-metadata="${BENCHMARK_META}"
 
 
 
 EXITCODE=$?
 
-# libcugraph reqs
+# The reqs below can be passed as requirements for
+# C++ benchmarks in the future.
 # REQS=$(getReqs "${LIBCUGRAPH_DEPS[@]}")
 
 set -e

--- a/ci/benchmark/build.sh
+++ b/ci/benchmark/build.sh
@@ -146,7 +146,7 @@ BECHMARK_META=$(jq -n \
   {
     "machineName": $NODE,
     "commitBranch": $MINOR_VER,
-    "requirements": $REQS,
+    "requirements": $REQS
   }
 ')
 


### PR DESCRIPTION
This PR adds the `requirements` field to the `benchmark-asv-metadata` flag of `pytest` in order to enable tooltips to appear on ASV graphs that contain dependency versions.