### PR TITLE
Fix branch name variable for benchmarks script [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - PR #988 Add clang and clang tools to the conda env
 - PR #997 Update setup.cfg to run pytests under cugraph tests directory only
 - PR #1009 Update benchmarks script to include requirements used
+- PR #1014 Fix benchmarks script variable name
 
 ## Bug Fixes
 - PR #936 Update Force Atlas 2 doc and wrapper

--- a/ci/benchmark/build.sh
+++ b/ci/benchmark/build.sh
@@ -141,14 +141,17 @@ REQS=$(getReqs "${CUGRAPH_DEPS[@]}")
 
 BENCHMARK_META=$(jq -n \
   --arg NODE "${NODE_NAME}" \
-  --arg MINOR_VER "${MINOR_VERSION}" \
+  --arg BRANCH "branch-${MINOR_VERSION}" \
   --argjson REQS "${REQS}" '
   {
     "machineName": $NODE,
-    "commitBranch": $MINOR_VER,
+    "commitBranch": $BRANCH,
     "requirements": $REQS
   }
 ')
+
+echo "Benchmark meta:"
+echo "${BENCHMARK_META}" | jq "."
 
 logger "Running Benchmarks..."
 cd $BENCHMARKS_DIR


### PR DESCRIPTION
This PR fixes a typo for the benchmarks script.