### PR TITLE
[REVIEW] Fix support for using a cudf.DataFrame with a MG graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - PR #992 Fix unrenumber of predecessor
 - PR #1008 Fix for cudf updates disabling iteration of Series/Columns/Index
 - PR #1012 Fix Local build script README
+- PR #1022 Fix support for using a cudf.DataFrame with a MG graph
  
 # cuGraph 0.14.0 (03 Jun 2020)
 

--- a/python/cugraph/structure/number_map.py
+++ b/python/cugraph/structure/number_map.py
@@ -94,7 +94,7 @@ class NumberMap:
             index_name = NumberMap.generate_unused_column_name(df.columns)
             tmp_df[index_name] = tmp_df.index
             return (
-                tmp_df.merge(self.df, on=self.col_names, how="left")
+                self.df.merge(tmp_df, on=self.col_names, how="right")
                 .sort_values(index_name)
                 .drop(columns=[index_name])
                 .reset_index()["id"]
@@ -119,16 +119,16 @@ class NumberMap:
                 merge_df = self.df
 
             if col_names is None:
-                ret = tmp_df.merge(merge_df, on=self.col_names, how="left")
+                ret = merge_df.merge(tmp_df, on=self.col_names, how="right")
             elif col_names == self.col_names:
-                ret = tmp_df.merge(merge_df, on=self.col_names, how="left")
+                ret = merge_df.merge(tmp_df, on=self.col_names, how="right")
             else:
                 ret = (
-                    tmp_df.merge(
-                        merge_df,
-                        left_on=col_names,
-                        right_on=self.col_names,
-                        how="left",
+                    merge_df.merge(
+                        tmp_df,
+                        right_on=col_names,
+                        left_on=self.col_names,
+                        how="right",
                     )
                     .drop(columns=self.col_names)
                 )
@@ -148,11 +148,11 @@ class NumberMap:
         def from_internal_vertex_id(
             self, df, internal_column_name, external_column_names
         ):
-            tmp_df = df.merge(
-                self.df,
-                left_on=internal_column_name,
-                right_on="id",
-                how="left",
+            tmp_df = self.df.merge(
+                df,
+                right_on=internal_column_name,
+                left_on="id",
+                how="right",
             )
             if internal_column_name != "id":
                 tmp_df = tmp_df.drop(columns=["id"])
@@ -301,11 +301,11 @@ class NumberMap:
                 self.numbered = True
 
         def to_internal_vertex_id(self, ddf, col_names):
-            return ddf.merge(
-                self.ddf,
-                left_on=col_names,
-                right_on=self.col_names,
-                how="left",
+            return self.ddf.merge(
+                ddf,
+                right_on=col_names,
+                left_on=self.col_names,
+                how="right",
             )["global_id"]
 
         def add_internal_vertex_id(self, ddf, id_column_name, col_names, drop,
@@ -317,16 +317,16 @@ class NumberMap:
 
             ret = None
             if col_names is None:
-                ret = ddf.merge(
-                    self.ddf, on=self.col_names, how="left"
+                ret = self.ddf.merge(
+                    ddf, on=self.col_names, how="right"
                 )
             elif col_names == self.col_names:
-                ret = ddf.merge(
-                    self.ddf, on=col_names, how="left"
+                ret = self.ddf.merge(
+                    ddf, on=col_names, how="right"
                 )
             else:
-                ret = ddf.merge(
-                    self.ddf, left_on=col_names, right_on=self.col_names
+                ret = self.ddf.merge(
+                    ddf, right_on=col_names, left_on=self.col_names
                 ).map_partitions(
                     lambda df: df.drop(columns=self.col_names)
                 )

--- a/python/cugraph/tests/dask/test_mg_renumber.py
+++ b/python/cugraph/tests/dask/test_mg_renumber.py
@@ -165,3 +165,85 @@ def test_dask_pagerank(client_connection):
             err = err + 1
     print("Mismatches:", err)
     assert err == 0
+
+
+# Test all combinations of default/managed and pooled/non-pooled allocation
+@pytest.mark.parametrize("graph_file", utils.DATASETS)
+def test_opg_renumber3(graph_file, client_connection):
+    gc.collect()
+
+    M = utils.read_csv_for_nx(graph_file)
+    sources = cudf.Series(M["0"])
+    destinations = cudf.Series(M["1"])
+
+    translate = 1000
+
+    gdf = cudf.DataFrame()
+    gdf["src_old"] = sources
+    gdf["dst_old"] = destinations
+    gdf["src"] = sources + translate
+    gdf["dst"] = destinations + translate
+    gdf["weight"] = gdf.index.astype(np.float)
+
+    ddf = dask.dataframe.from_pandas(gdf, npartitions=2)
+
+    ren2, num2 = NumberMap.renumber(
+        ddf, ["src", "src_old"], ["dst", "dst_old"]
+    )
+
+    test_df = gdf[['src', 'src_old']].head()
+
+    #
+    #  This call raises an exception in branch-0.15
+    #  prior to this PR
+    #
+    test_df = num2.add_internal_vertex_id(test_df, 'src', ['src', 'src_old'])
+    assert(True)
+
+
+def test_dask_pagerank(client_connection):
+    gc.collect()
+
+    pandas.set_option('display.max_rows', 10000)
+
+    input_data_path = r"../datasets/karate.csv"
+    chunksize = dcg.get_chunksize(input_data_path)
+
+    ddf = dask_cudf.read_csv(input_data_path, chunksize=chunksize,
+                             delimiter=' ',
+                             names=['src', 'dst', 'value'],
+                             dtype=['int32', 'int32', 'float32'])
+
+    df = cudf.read_csv(input_data_path,
+                       delimiter=' ',
+                       names=['src', 'dst', 'value'],
+                       dtype=['int32', 'int32', 'float32'])
+
+    g = cugraph.DiGraph()
+    g.from_cudf_edgelist(df, 'src', 'dst')
+
+    dg = cugraph.DiGraph()
+    dg.from_dask_cudf_edgelist(ddf)
+
+    # Pre compute local data
+    # dg.compute_local_data(by='dst')
+
+    expected_pr = cugraph.pagerank(g)
+    result_pr = dcg.pagerank(dg)
+
+    err = 0
+    tol = 1.0e-05
+
+    assert len(expected_pr) == len(result_pr)
+
+    compare_pr = expected_pr.merge(
+        result_pr, on="vertex", suffixes=['_local', '_dask']
+    )
+
+    for i in range(len(compare_pr)):
+        diff = abs(compare_pr['pagerank_local'].iloc[i] -
+                   compare_pr['pagerank_dask'].iloc[i])
+        if diff > tol * 1.1:
+            err = err + 1
+    print("Mismatches:", err)
+    assert err == 0

--- a/python/cugraph/tests/test_graph.py
+++ b/python/cugraph/tests/test_graph.py
@@ -755,7 +755,7 @@ def test_neighbors(graph_file):
     Gnx = nx.from_pandas_edgelist(M, source='0', target='1',
                                   create_using=nx.Graph())
     for n in nodes.values_host:
-        cu_neighbors = G.neighbors(n).tolist()
+        cu_neighbors = G.neighbors(n).to_arrow().to_pylist()
         nx_neighbors = [i for i in Gnx.neighbors(n)]
         cu_neighbors.sort()
         nx_neighbors.sort()

--- a/python/setup.py
+++ b/python/setup.py
@@ -84,6 +84,7 @@ class CleanCommand(Command):
         os.system('rm -rf build')
         os.system('rm -rf dist')
         os.system('rm -rf dask-worker-space')
+        os.system('rm -f cugraph/raft')
         os.system('find . -name "__pycache__" -type d -exec rm -rf {} +')
         os.system('rm -rf *.egg-info')
         os.system('find . -name "*.cpp" -type f -delete')


### PR DESCRIPTION
Fix bug found in testing MG pagerank.  Mixing cudf.DataFrame and dask_cudf.DataFrame wasn't working properly in NumberMap.

Also, cudf dropped support for tolist, which breaks one of our unit tests.  Changed to use the suggested method in the error message.