### PR TITLE
[skip-ci] [REVIEW] Update benchmark scripts to use ASV_LABEL var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - PR #1014 Fix benchmarks script variable name
 - PR #1019 Remove deprecated CUDA library calls
 - PR #1024 Updated condata environment YML files
+- PR #1028 Update benchmarks script to use ASV_LABEL
 
 
 ## Bug Fixes

--- a/ci/benchmark/build.sh
+++ b/ci/benchmark/build.sh
@@ -140,7 +140,7 @@ function getReqs() {
 REQS=$(getReqs "${CUGRAPH_DEPS[@]}")
 
 BENCHMARK_META=$(jq -n \
-  --arg NODE "${NODE_NAME}" \
+  --arg NODE "${ASV_LABEL}" \
   --arg BRANCH "branch-${MINOR_VERSION}" \
   --argjson REQS "${REQS}" '
   {


### PR DESCRIPTION
This PR updates the benchmark CI scripts to use the new `ASV_LABEL` environment variable.