### PR TITLE
[REVIEW] force index dtype to int64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 - PR #1017 Fix more mg bugs
 - PR #1022 Fix support for using a cudf.DataFrame with a MG graph
 - PR #1027 Fix documentation
-- PR #1033 Fix reparition error in big datasets due to incorrect index dtype
+- PR #1033 Fix reparition error in big datasets, updated coroutine, fixed warnings
 
 # cuGraph 0.14.0 (03 Jun 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - PR #1017 Fix more mg bugs
 - PR #1022 Fix support for using a cudf.DataFrame with a MG graph
 - PR #1027 Fix documentation
+- PR #1033 Fix reparition error in big datasets due to incorrect index dtype
 
 # cuGraph 0.14.0 (03 Jun 2020)
 

--- a/python/cugraph/comms/comms.py
+++ b/python/cugraph/comms/comms.py
@@ -55,6 +55,13 @@ def get_comms():
     return __instance
 
 
+# Get workers in the Comms
+def get_workers():
+    if is_initialized():
+        global __instance
+        return __instance.worker_addresses
+
+
 # Get sessionId for finding sessionstate of workers.
 def get_session_id():
     if is_initialized():

--- a/python/cugraph/dask/common/part_utils.py
+++ b/python/cugraph/dask/common/part_utils.py
@@ -173,7 +173,7 @@ def load_balance_func(ddf_, by, client=None):
     gpu_fututres = [(first(who_has[key]),
                      part.key[1], part) for key, part in key_to_part]
     worker_to_data = create_dict(gpu_fututres)
-    #print(worker_to_data)
+
     # Calculate cumulative sum in each dataframe partition
     cumsum_parts = [client.submit(get_cumsum,
                     wf[1][0][0],

--- a/python/cugraph/dask/common/part_utils.py
+++ b/python/cugraph/dask/common/part_utils.py
@@ -112,6 +112,7 @@ def create_dict(futures):
 
 def set_global_index(df, cumsum):
     df.index = df.index + cumsum
+    df.index = df.index.astype('int64')
     return df
 
 
@@ -172,7 +173,7 @@ def load_balance_func(ddf_, by, client=None):
     gpu_fututres = [(first(who_has[key]),
                      part.key[1], part) for key, part in key_to_part]
     worker_to_data = create_dict(gpu_fututres)
-
+    #print(worker_to_data)
     # Calculate cumulative sum in each dataframe partition
     cumsum_parts = [client.submit(get_cumsum,
                     wf[1][0][0],


### PR DESCRIPTION
--> fix repartitioning error due to index values stored as float for big datasets
--> fix warnings coming from dask cugraph
--> update to native coroutine (does not support python<3.5)