### PR TITLE
[REVIEW] Fix spectral clustering renumbering issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - PR #1025: Explicitly skip raft test folder for pytest 6.0.0
 - PR #1027 Fix documentation
 - PR #1033 Fix reparition error in big datasets, updated coroutine, fixed warnings
+- PR #1040 Fix spectral clustering renumbering issue
 
 # cuGraph 0.14.0 (03 Jun 2020)
 

--- a/python/cugraph/community/spectral_clustering.py
+++ b/python/cugraph/community/spectral_clustering.py
@@ -82,7 +82,7 @@ def spectralBalancedCutClustering(
     )
 
     if G.renumbered:
-        # FIXME:  This is a hack to get around an 
+        # FIXME:  This is a hack to get around an
         # API problem.  The spectral API assumes that
         # the data frame remains in internal vertex
         # id order.  It should not do that.

--- a/python/cugraph/community/spectral_clustering.py
+++ b/python/cugraph/community/spectral_clustering.py
@@ -82,7 +82,11 @@ def spectralBalancedCutClustering(
     )
 
     if G.renumbered:
-        df = G.unrenumber(df, "vertex")
+        # FIXME:  This is a hack to get around an 
+        # API problem.  The spectral API assumes that
+        # the data frame remains in internal vertex
+        # id order.  It should not do that.
+        df = G.unrenumber(df, "vertex", preserve_order=True)
 
     return df
 


### PR DESCRIPTION
Spectral clustering code in python is inherently written to rely upon the order of the vertices being preserved when we unrenumber.  This should be fixed, but in the meantime we can use the preserve_order flag to correct this.

Fixes #1032 