### PR TITLE
[WIP] Update ASV directory for benchmark run [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - PR #1020 Updated Louvain to honor max_level, ECG now calls Louvain for 1 level, then full run.
 - PR #1031 MG notebook
 - PR #1034 Expose resolution (gamma) parameter in Louvain
+- PR #1041 Use S3 bucket directly for benchmark plugin
 
 ## Bug Fixes
 - PR #936 Update Force Atlas 2 doc and wrapper

--- a/ci/benchmark/build.sh
+++ b/ci/benchmark/build.sh
@@ -41,12 +41,7 @@ export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 
 # Set Benchmark Vars
 export DATASETS_DIR=${WORKSPACE}/datasets
-export ASVRESULTS_DIR=${WORKSPACE}/ci/artifacts/asv/results
 export BENCHMARKS_DIR=${WORKSPACE}/benchmarks
-
-# Ensure ASV results directory exists
-
-mkdir -p ${ASVRESULTS_DIR}
 
 ##########################################
 # Environment Setup                      #
@@ -159,7 +154,7 @@ set +e
 time pytest -v -m "small and managedmem_on and poolallocator_on" \
     --benchmark-gpu-device=0 \
     --benchmark-gpu-max-rounds=3 \
-    --benchmark-asv-output-dir="${ASVRESULTS_DIR}" \
+    --benchmark-asv-output-dir="${S3_ASV_DIR}" \
     --benchmark-asv-metadata="${BENCHMARK_META}"
 
 


### PR DESCRIPTION
Updates pytest to use an S3 bucket as the ASV results directory. The variable used here is defined inside the Jenkins build, I promise.

Depends on:
- [ ] https://github.com/rapidsai/asvdb/pull/6