### PR TITLE
[WIP] MNMG Renumbering - sort partitions by degree

### DIFF
--- a/cpp/tests/community/balanced_edge_test.cpp
+++ b/cpp/tests/community/balanced_edge_test.cpp
@@ -73,4 +73,122 @@ TEST(balanced_edge, success)
   ASSERT_LT(score, float{55.0});
 }
 
+TEST(balanced_edge_4, success)
+{
+  std::vector<int> off_h = {0,  16,  25,  35,  41,  44,  48,  52,  56,  61,  63, 66,
+                            67, 69,  74,  76,  78,  80,  82,  84,  87,  89,  91, 93,
+                            98, 101, 104, 106, 110, 113, 117, 121, 127, 139, 156};
+  std::vector<int> ind_h = {
+    1,  2,  3,  4,  5,  6,  7,  8,  10, 11, 12, 13, 17, 19, 21, 31, 0,  2,  3,  7,  13, 17, 19,
+    21, 30, 0,  1,  3,  7,  8,  9,  13, 27, 28, 32, 0,  1,  2,  7,  12, 13, 0,  6,  10, 0,  6,
+    10, 16, 0,  4,  5,  16, 0,  1,  2,  3,  0,  2,  30, 32, 33, 2,  33, 0,  4,  5,  0,  0,  3,
+    0,  1,  2,  3,  33, 32, 33, 32, 33, 5,  6,  0,  1,  32, 33, 0,  1,  33, 32, 33, 0,  1,  32,
+    33, 25, 27, 29, 32, 33, 25, 27, 31, 23, 24, 31, 29, 33, 2,  23, 24, 33, 2,  31, 33, 23, 26,
+    32, 33, 1,  8,  32, 33, 0,  24, 25, 28, 32, 33, 2,  8,  14, 15, 18, 20, 22, 23, 29, 30, 31,
+    33, 8,  9,  13, 14, 15, 18, 19, 20, 22, 23, 26, 27, 28, 29, 30, 31, 32};
+  std::vector<float> w_h = {
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+  int num_verts = off_h.size() - 1;
+  int num_edges = ind_h.size();
+
+  std::vector<int> cluster_id(num_verts, -1);
+
+  rmm::device_vector<int> offsets_v(off_h);
+  rmm::device_vector<int> indices_v(ind_h);
+  rmm::device_vector<float> weights_v(w_h);
+  rmm::device_vector<int> result_v(cluster_id);
+
+  cugraph::GraphCSRView<int, int, float> G(
+    offsets_v.data().get(), indices_v.data().get(), weights_v.data().get(), num_verts, num_edges);
+
+  int num_clusters{4};
+  int num_eigenvectors{4};
+  float evs_tolerance{.00001};
+  float kmean_tolerance{.00001};
+  int evs_max_iter{100};
+  int kmean_max_iter{100};
+  float score;
+
+  cugraph::ext_raft::balancedCutClustering(G,
+                                           num_clusters,
+                                           num_eigenvectors,
+                                           evs_tolerance,
+                                           evs_max_iter,
+                                           kmean_tolerance,
+                                           kmean_max_iter,
+                                           result_v.data().get());
+  cugraph::ext_raft::analyzeClustering_edge_cut(G, num_clusters, result_v.data().get(), &score);
+
+  std::cout << "score = " << score << std::endl;
+  ASSERT_LT(score, float{55.0});
+}
+
+TEST(balanced_edge_4_rotate, success)
+{
+  std::vector<int> off_h = {   0,   3,   4,   5,  11,  13,  15,  17,  19,  21,  24,  26,
+                              28,  30,  35,  38,  41,  43,  47,  50,  54,  58,  64,  76,
+                              93, 109, 118, 128, 134, 137, 141, 145, 149, 154, 156 };
+  std::vector<int> ind_h = {
+    11, 12, 13, 14, 15, 16, 17, 18, 20, 21, 22, 23, 27, 29, 31,  7, 10, 12, 13, 17, 23, 27, 29,
+    31,  6, 10, 11, 13, 17, 18, 19, 23,  3,  4,  8, 10, 11, 12, 17, 22, 23, 10, 16, 20, 10, 16,
+    20, 26, 10, 14, 15, 26, 10, 11, 12, 13, 10, 12,  6,  8,  9, 12,  9, 10, 14, 15, 10, 10, 13,
+    10, 11, 12, 13,  9,  8,  9,  8,  9, 15, 16, 10, 11,  8,  9, 10,  7,  9,  8,  9, 10, 11,  8,
+     9,  1,  3,  5,  8,  9,  1,  3,  7, 33,  0,  7,  5,  9, 12, 33,  0,  9, 12,  7,  9, 33,  2,
+     8,  9, 11, 18,  8,  9, 10,  0,  1,  4,  8,  9, 12, 18, 24, 25, 28, 30, 32, 33,  5,  6,  7,
+     9, 18, 19, 23, 24, 25, 28, 29, 30, 32, 33,  2,  3,  4,  5,  6,  7,  8};
+  std::vector<float> w_h = {
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+  int num_verts = off_h.size() - 1;
+  int num_edges = ind_h.size();
+
+  std::vector<int> cluster_id(num_verts, -1);
+
+  rmm::device_vector<int> offsets_v(off_h);
+  rmm::device_vector<int> indices_v(ind_h);
+  rmm::device_vector<float> weights_v(w_h);
+  rmm::device_vector<int> result_v(cluster_id);
+
+  cugraph::GraphCSRView<int, int, float> G(
+    offsets_v.data().get(), indices_v.data().get(), weights_v.data().get(), num_verts, num_edges);
+
+  int num_clusters{4};
+  int num_eigenvectors{4};
+  float evs_tolerance{.00001};
+  float kmean_tolerance{.00001};
+  int evs_max_iter{100};
+  int kmean_max_iter{100};
+  float score;
+
+  cugraph::ext_raft::balancedCutClustering(G,
+                                           num_clusters,
+                                           num_eigenvectors,
+                                           evs_tolerance,
+                                           evs_max_iter,
+                                           kmean_tolerance,
+                                           kmean_max_iter,
+                                           result_v.data().get());
+  cugraph::ext_raft::analyzeClustering_edge_cut(G, num_clusters, result_v.data().get(), &score);
+
+  std::cout << "score = " << score << std::endl;
+  ASSERT_LT(score, float{55.0});
+}
+
 CUGRAPH_TEST_PROGRAM_MAIN()

--- a/python/cugraph/centrality/betweenness_centrality.py
+++ b/python/cugraph/centrality/betweenness_centrality.py
@@ -229,8 +229,8 @@ def edge_betweenness_centrality(
     )
 
     if G.renumbered:
-        df = G.unrenumber(df, "src")
-        df = G.unrenumber(df, "dst")
+        df = G.unrenumber(df, "src", preserve_order=True)
+        df = G.unrenumber(df, "dst", preserve_order=True)
 
     return df
 
@@ -272,4 +272,5 @@ def _initialize_vertices_from_identifiers_list(G, identifiers):
         ).to_array()
 
     k = len(vertices)
+
     return vertices, k

--- a/python/cugraph/community/ecg.py
+++ b/python/cugraph/community/ecg.py
@@ -66,6 +66,6 @@ def ecg(input_graph, min_weight=0.05, ensemble_size=16):
     parts = ecg_wrapper.ecg(input_graph, min_weight, ensemble_size)
 
     if input_graph.renumbered:
-        parts = input_graph.unrenumber(parts, "vertex")
+        parts = input_graph.unrenumber(parts, "vertex", preserve_order=True)
 
     return parts

--- a/python/cugraph/community/spectral_clustering.py
+++ b/python/cugraph/community/spectral_clustering.py
@@ -81,8 +81,6 @@ def spectralBalancedCutClustering(
         kmean_max_iter,
     )
 
-    print('unrenumbered result =\n', df)
-
     if G.renumbered:
         df = G.unrenumber(df, "vertex")
 
@@ -259,8 +257,6 @@ def analyzeClustering_edge_cut(G, n_clusters, clustering,
                                               drop=True)
 
     clustering = clustering.sort_values(vertex_col_name).reset_index(drop=True)
-
-    print('before analyze edge cut, clustering =\n', clustering)
 
     score = spectral_clustering_wrapper.analyzeClustering_edge_cut(
         G, n_clusters, clustering[cluster_col_name]

--- a/python/cugraph/community/spectral_clustering_wrapper.pyx
+++ b/python/cugraph/community/spectral_clustering_wrapper.pyx
@@ -262,6 +262,7 @@ def analyzeClustering_edge_cut(input_graph, n_clusters, clustering):
         graph_float = GraphCSRView[int,int,float](<int*>c_offsets, <int*>c_indices,
                                               <float*>c_weights, num_verts, num_edges)
 
+#### THIS Breaks with renumbering.....
         c_analyze_clustering_edge_cut(graph_float,
                                       n_clusters,
                                       <int*> c_cluster,

--- a/python/cugraph/dask/traversal/bfs.py
+++ b/python/cugraph/dask/traversal/bfs.py
@@ -92,6 +92,8 @@ def bfs(graph,
         start = graph.lookup_internal_vertex_id(cudf.Series([start])).compute()
         start = start.iloc[0]
 
+    print('start = ', start)
+
     result = dict([(data.worker_info[wf[0]]["rank"],
                     client.submit(
             call_bfs,
@@ -105,6 +107,8 @@ def bfs(graph,
     wait(result)
 
     df = result[0].result()
+
+    print('df = \n', df)
 
     if graph.renumbered:
         df = graph.unrenumber(df, 'vertex').compute()

--- a/python/cugraph/structure/number_map.py
+++ b/python/cugraph/structure/number_map.py
@@ -885,7 +885,6 @@ class NumberMap:
             index_name = NumberMap.generate_unused_column_name(df)
             df[index_name] = df.index
 
-        print('in unrenumber, calling from_internal_vertex_id\n')
         df = self.from_internal_vertex_id(df, column_name, drop=True)
 
         if preserve_order:

--- a/python/cugraph/tests/dask/test_mg_bfs.py
+++ b/python/cugraph/tests/dask/test_mg_bfs.py
@@ -15,17 +15,28 @@ import cugraph.dask as dcg
 import cugraph.comms as Comms
 from dask.distributed import Client
 import gc
+import pytest
 import cugraph
 import dask_cudf
 import cudf
 from dask_cuda import LocalCUDACluster
 
 
-def test_dask_bfs():
-    gc.collect()
+@pytest.fixture
+def client_connection():
     cluster = LocalCUDACluster()
     client = Client(cluster)
     Comms.initialize()
+
+    yield client
+
+    Comms.destroy()
+    client.close()
+    cluster.close()
+
+
+def test_dask_bfs(client_connection):
+    gc.collect()
 
     input_data_path = r"../datasets/netscience.csv"
     chunksize = dcg.get_chunksize(input_data_path)
@@ -60,7 +71,3 @@ def test_dask_bfs():
                 compare_dist['distance_dask'].iloc[i]):
             err = err + 1
     assert err == 0
-
-    Comms.destroy()
-    client.close()
-    cluster.close()

--- a/python/cugraph/tests/dask/test_mg_comms.py
+++ b/python/cugraph/tests/dask/test_mg_comms.py
@@ -53,8 +53,7 @@ def test_dask_pagerank(client_connection):
                               dtype=['int32', 'int32', 'float32'])
 
     dg1 = cugraph.DiGraph()
-    dg1.from_dask_cudf_edgelist(ddf1, 'src', 'dst')
-    result_pr1 = dcg.pagerank(dg1)
+    dg1.from_dask_cudf_edgelist(ddf1, 'src', 'dst', store_row_major=False)
 
     ddf2 = dask_cudf.read_csv(input_data_path2, chunksize=chunksize2,
                               delimiter=' ',
@@ -62,7 +61,7 @@ def test_dask_pagerank(client_connection):
                               dtype=['int32', 'int32', 'float32'])
 
     dg2 = cugraph.DiGraph()
-    dg2.from_dask_cudf_edgelist(ddf2, 'src', 'dst')
+    dg2.from_dask_cudf_edgelist(ddf2, 'src', 'dst', store_row_major=False)
     result_pr2 = dcg.pagerank(dg2)
 
     # Calculate single GPU pagerank for verification of results

--- a/python/cugraph/tests/dask/test_mg_comms.py
+++ b/python/cugraph/tests/dask/test_mg_comms.py
@@ -54,6 +54,7 @@ def test_dask_pagerank(client_connection):
 
     dg1 = cugraph.DiGraph()
     dg1.from_dask_cudf_edgelist(ddf1, 'src', 'dst', store_row_major=False)
+    result_pr1 = dcg.pagerank(dg1)
 
     ddf2 = dask_cudf.read_csv(input_data_path2, chunksize=chunksize2,
                               delimiter=' ',

--- a/python/cugraph/tests/dask/test_mg_renumber.py
+++ b/python/cugraph/tests/dask/test_mg_renumber.py
@@ -175,7 +175,7 @@ def test_dask_pagerank(client_connection):
     g.from_cudf_edgelist(df, 'src', 'dst')
 
     dg = cugraph.DiGraph()
-    dg.from_dask_cudf_edgelist(ddf)
+    dg.from_dask_cudf_edgelist(ddf, 'src', 'dst')
 
     # Pre compute local data
     # dg.compute_local_data(by='dst')

--- a/python/cugraph/tests/test_balanced_cut.py
+++ b/python/cugraph/tests/test_balanced_cut.py
@@ -33,16 +33,19 @@ def cugraph_call(G, partitions):
 def random_call(G, partitions):
     random.seed(0)
     num_verts = G.number_of_vertices()
-    assignment = []
-    for i in range(num_verts):
-        assignment.append(random.randint(0, partitions - 1))
 
-    assignment_cu = cudf.DataFrame(assignment, columns=['cluster'])
-    assignment_cu['vertex'] = assignment_cu.index
+    score = 0.0
+    for repeat in range(10):
+        assignment = []
+        for i in range(num_verts):
+            assignment.append(random.randint(0, partitions - 1))
 
-    print('random call')
-    score = cugraph.analyzeClustering_edge_cut(G, partitions, assignment_cu)
-    return set(range(num_verts)), score
+        assignment_cu = cudf.DataFrame(assignment, columns=['cluster'])
+        assignment_cu['vertex'] = assignment_cu.index
+
+        score += cugraph.analyzeClustering_edge_cut(G, partitions, assignment_cu)
+
+    return set(range(num_verts)), (score / 10.0)
 
 
 PARTITIONS = [2, 4, 8]
@@ -60,14 +63,7 @@ def test_edge_cut_clustering(graph_file, partitions):
     cu_M = utils.read_csv_file(graph_file, read_weights_in_sp=False)
 
     G_edge = cugraph.Graph()
-    #G_edge.from_cudf_edgelist(cu_M, source="0", destination="1", renumber=False)
     G_edge.from_cudf_edgelist(cu_M, source="0", destination="1")
-
-    print('cu_M = \n', cu_M)
-    el = G_edge.add_internal_vertex_id(cu_M, "src", "0")
-    el = G_edge.add_internal_vertex_id(el, "dst", "1")
-    el[["src", "dst", "2"]].to_csv(graph_file + "_" + str(partitions), sep=' ', header=False, index=False)
-    print('el = \n', el)
 
     # Get the edge_cut score for partitioning versus random assignment
     cu_vid, cu_score = cugraph_call(G_edge, partitions)

--- a/python/cugraph/tests/test_betweenness_centrality.py
+++ b/python/cugraph/tests/test_betweenness_centrality.py
@@ -187,6 +187,12 @@ def _calc_bc_subset_fixed(
         seed = 123  # random.seed(None) uses time, but we want same sources
     random.seed(seed)  # It will be called again in cugraph's call
     sources = random.sample(range(G.number_of_vertices()), k)
+
+    if G.renumbered:
+        sources_df = cudf.DataFrame({'src': sources})
+        sources = G.unrenumber(sources_df, 'src')['src'].to_pandas().tolist()
+    
+
     # The first call is going to proceed to the random sampling in the same
     # fashion as the lines above
     df = cugraph.betweenness_centrality(

--- a/python/cugraph/tests/test_ecg.py
+++ b/python/cugraph/tests/test_ecg.py
@@ -23,7 +23,13 @@ def cugraph_call(G, min_weight, ensemble_size):
     df = cugraph.ecg(G, min_weight, ensemble_size)
     df = df.sort_values("vertex")
     num_parts = df["partition"].max() + 1
-    score = cugraph.analyzeClustering_modularity(G, num_parts, df["partition"])
+    num_parts2 = len(df.groupby(['partition']).count())
+    print('num_parts = ', num_parts)
+    print('num_parts2 = ', num_parts2)
+    score = cugraph.analyzeClustering_modularity(G, num_parts, df,
+                                                 'vertex', 'partition')
+
+    print('score = ', score)
     return score, num_parts
 
 

--- a/python/cugraph/tests/test_edge_betweenness_centrality.py
+++ b/python/cugraph/tests/test_edge_betweenness_centrality.py
@@ -42,7 +42,8 @@ DIRECTED_GRAPH_OPTIONS = [False, True]
 NORMALIZED_OPTIONS = [False, True]
 DEFAULT_EPSILON = 0.0001
 
-DATASETS = utils.DATASETS
+DATASETS = ["../datasets/karate.csv", "../datasets/netscience.csv"]
+
 UNRENUMBERED_DATASETS = ["../datasets/karate.csv"]
 
 SUBSET_SIZE_OPTIONS = [4, None]
@@ -106,7 +107,9 @@ def calc_edge_betweenness_centrality(
         The dataframe is expected to be sorted based on 'src' then 'dst',
         so that we can use cupy.isclose to compare the scores.
     """
-    G, Gnx = utils.build_cu_and_nx_graphs(graph_file, directed=directed)
+    G, Gnx = utils.build_cu_and_nx_graphs(graph_file,
+                                          directed=directed) # ,
+                                          # renumber=False)
     calc_func = None
     if k is not None and seed is not None:
         calc_func = _calc_bc_subset
@@ -114,7 +117,6 @@ def calc_edge_betweenness_centrality(
         calc_func = _calc_bc_subset_fixed
     else:  # We processed to a comparison using every sources
         if use_k_full:
-            print("Computing k_full")
             k = Gnx.number_of_nodes()
         calc_func = _calc_bc_full
     sorted_df = calc_func(
@@ -136,6 +138,11 @@ def _calc_bc_subset(G, Gnx, normalized, weight, k, seed, result_dtype):
     # We first mimic acquisition of the nodes to compare with same sources
     random.seed(seed)  # It will be called again in nx's call
     sources = random.sample(Gnx.nodes(), k)
+
+    # NOTE: Since we sampled the Networkx graph, the sources are already
+    # external ids, so we don't need to translate to external ids for
+    # cugraph
+
     df = cugraph.edge_betweenness_centrality(
         G,
         k=sources,
@@ -152,13 +159,11 @@ def _calc_bc_subset(G, Gnx, normalized, weight, k, seed, result_dtype):
         columns={"betweenness_centrality": "ref_bc"}, copy=False
     )
 
-    sorted_df = df.sort_values(["src", "dst"]).rename(
+    merged_df = df.merge(nx_df, on=['src', 'dst']).rename(
         columns={"betweenness_centrality": "cu_bc"}, copy=False
     ).reset_index(drop=True)
 
-    sorted_df = cudf.concat([sorted_df, nx_df["ref_bc"]], axis=1, sort=False)
-
-    return sorted_df
+    return merged_df
 
 
 def _calc_bc_subset_fixed(G, Gnx, normalized, weight, k, seed, result_dtype):
@@ -172,6 +177,11 @@ def _calc_bc_subset_fixed(G, Gnx, normalized, weight, k, seed, result_dtype):
         seed = 123  # random.seed(None) uses time, but we want same sources
     random.seed(seed)  # It will be called again in cugraph's call
     sources = random.sample(range(G.number_of_vertices()), k)
+
+    if G.renumbered:
+        sources_df = cudf.DataFrame({'src': sources})
+        sources = G.unrenumber(sources_df, 'src')['src'].to_pandas().tolist()
+
     # The first call is going to proceed to the random sampling in the same
     # fashion as the lines above
     df = cugraph.edge_betweenness_centrality(
@@ -181,6 +191,8 @@ def _calc_bc_subset_fixed(G, Gnx, normalized, weight, k, seed, result_dtype):
         weight=weight,
         seed=seed,
         result_dtype=result_dtype,
+    ).rename(
+        columns={"betweenness_centrality": "cu_bc"}, copy=False
     )
 
     # The second call is going to process source that were already sampled
@@ -193,20 +205,14 @@ def _calc_bc_subset_fixed(G, Gnx, normalized, weight, k, seed, result_dtype):
         weight=weight,
         seed=None,
         result_dtype=result_dtype,
-    )
-
-    sorted_df = df.sort_values(["src", "dst"]).rename(
-        columns={"betweenness_centrality": "cu_bc"}, copy=False
-    ).reset_index(drop=True)
-    sorted_df2 = df2.sort_values(["src", "dst"]).rename(
+    ).rename(
         columns={"betweenness_centrality": "ref_bc"}, copy=False
     ).reset_index(drop=True)
 
-    sorted_df = cudf.concat(
-        [sorted_df, sorted_df2["ref_bc"]], axis=1, sort=False
-    )
 
-    return sorted_df
+    merged_df = df.merge(df2, on=['src', 'dst']).reset_index(drop=True)
+
+    return merged_df
 
 
 def _calc_bc_full(G, Gnx, normalized, weight, k, seed, result_dtype):
@@ -218,9 +224,11 @@ def _calc_bc_full(G, Gnx, normalized, weight, k, seed, result_dtype):
         seed=seed,
         result_dtype=result_dtype,
     )
+
     assert (
         df["betweenness_centrality"].dtype == result_dtype
     ), "'betweenness_centrality' column has not the expected type"
+
     nx_bc_dict = nx.edge_betweenness_centrality(
         Gnx, k=k, normalized=normalized, seed=seed, weight=weight
     )
@@ -229,12 +237,11 @@ def _calc_bc_full(G, Gnx, normalized, weight, k, seed, result_dtype):
         columns={"betweenness_centrality": "ref_bc"}, copy=False
     )
 
-    sorted_df = df.sort_values(["src", "dst"]).rename(
+    merged_df = df.merge(nx_df, on=['src', 'dst']).rename(
         columns={"betweenness_centrality": "cu_bc"}, copy=False
     ).reset_index(drop=True)
 
-    sorted_df = cudf.concat([sorted_df, nx_df["ref_bc"]], axis=1, sort=False)
-    return sorted_df
+    return merged_df
 
 
 # =============================================================================

--- a/python/cugraph/tests/test_graph.py
+++ b/python/cugraph/tests/test_graph.py
@@ -13,6 +13,8 @@
 
 import gc
 
+import time
+
 import pandas as pd
 import pytest
 
@@ -41,52 +43,13 @@ with warnings.catch_warnings():
 
 
 def compare_series(series_1, series_2):
-    if isinstance(series_1, cudf.Series):
-        series_1 = series_1.values_host
-    if isinstance(series_2, cudf.Series):
-        series_2 = series_2.values_host
-    if len(series_1) != len(series_2):
-        print("Series do not match in length")
-        return 0
-    for i in range(len(series_1)):
-        if series_1[i] != series_2[i]:
-            print(
-                "Series["
-                + str(i)
-                + "] does not match, "
-                + str(series_1[i])
-                + ", "
-                + str(series_2[i])
-            )
-            return 0
-    return True
+    assert len(series_1) == len(series_2)
+    diffs = df.query('series_1 != series_2')
 
+    if len(diffs) > 0:
+        print("diffs:\n", diffs)
 
-def compare_offsets(offset0, offset1):
-    if isinstance(offset0, cudf.Series):
-        offset0 = offset0.values_host
-    if isinstance(offset1, cudf.Series):
-        offset1 = offset1.values_host
-    if not (len(offset0) <= len(offset1)):
-        print(
-            "Mismatched length: "
-            + str(len(offset0))
-            + " != "
-            + str(len(offset1))
-        )
-        return False
-    for i in range(len(offset0)):
-        if offset0[i] != offset1[i]:
-            print(
-                "Series["
-                + str(i)
-                + "]: "
-                + str(offset0[i])
-                + " != "
-                + str(offset1[i])
-            )
-            return False
-    return True
+    assert len(diffs) == 0
 
 
 # This function returns True if two graphs are identical (bijection between the
@@ -116,6 +79,8 @@ def compare_graphs(nx_graph, cu_graph):
     ds0 = pd.Series(list(nx_graph.nodes)).sort_values(ignore_index=True)
     ds1 = pd.Series(list(cu_to_nx_graph.nodes)).sort_values(ignore_index=True)
 
+    #print('compare series from compare_graphs')
+    #compare_series(ds0, ds1)
     if not ds0.equals(ds1):
         print('ds0 != ds1')
         return False
@@ -207,8 +172,8 @@ def test_add_edge_list_to_adj_list(graph_file):
     G = cugraph.DiGraph()
     G.from_cudf_edgelist(cu_M, source="0", destination="1", renumber=False)
     offsets_cu, indices_cu, values_cu = G.view_adj_list()
-    assert compare_offsets(offsets_cu, offsets_exp)
-    assert compare_series(indices_cu, indices_exp)
+    compare_series(offsets_cu, offsets_exp)
+    compare_series(indices_cu, indices_exp)
     assert values_cu is None
 
 
@@ -236,8 +201,8 @@ def test_add_adj_list_to_edge_list(graph_file):
     edgelist = G.view_edge_list()
     sources_cu = edgelist["src"]
     destinations_cu = edgelist["dst"]
-    assert compare_series(sources_cu, sources_exp)
-    assert compare_series(destinations_cu, destinations_exp)
+    compare_series(sources_cu, sources_exp)
+    compare_series(destinations_cu, destinations_exp)
 
 
 # Test
@@ -259,8 +224,8 @@ def test_view_edge_list_from_adj_list(graph_file):
     Mcoo = Mcsr.tocoo()
     src1 = Mcoo.row
     dst1 = Mcoo.col
-    assert compare_series(src1, edgelist_df["src"])
-    assert compare_series(dst1, edgelist_df["dst"])
+    compare_series(src1, edgelist_df["src"])
+    compare_series(dst1, edgelist_df["dst"])
 
 
 # Test
@@ -451,7 +416,11 @@ def test_networkx_compatibility(graph_file):
 
     print('g from gdf = \n', gdf)
     print('nx from df = \n', df)
+
+    t1 = time.time()
     assert compare_graphs(Gnx, G)
+    t2 = time.time() - t1
+    print('compare_graphs time: ', t2)
 
     Gnx.clear()
     G.clear()
@@ -465,7 +434,10 @@ def test_networkx_compatibility(graph_file):
         create_using=cugraph.DiGraph,
     )
 
+    t1 = time.time()
     assert compare_graphs(Gnx, G)
+    t2 = time.time() - t1
+    print('compare_graphs time: ', t2)
 
     Gnx.clear()
     G.clear()
@@ -496,7 +468,11 @@ def test_consolidation(graph_file):
     G = cugraph.from_cudf_edgelist(ddf, source='source', destination='target',
                                    create_using=cugraph.DiGraph)
 
+    t1 = time.time()
     assert compare_graphs(Gnx, G)
+    t2 = time.time() - t1
+    print('compare_graphs time: ', t2)
+
     Gnx.clear()
     G.clear()
     client.close()
@@ -641,11 +617,9 @@ def test_to_directed(graph_file):
     assert DiG.number_of_nodes() == DiGnx.number_of_nodes()
     assert DiG.number_of_edges() == DiGnx.number_of_edges()
 
-    edgelist_df = G.edgelist.edgelist_df
-    for i in range(len(edgelist_df)):
-        assert DiGnx.has_edge(
-            edgelist_df.iloc[i]["src"], edgelist_df.iloc[i]["dst"]
-        )
+    for index, row in cu_M.to_pandas().iterrows():
+        assert G.has_edge(row['0'], row['1'])
+        assert G.has_edge(row['1'], row['0'])
 
 
 # Test
@@ -666,18 +640,19 @@ def test_to_undirected(graph_file):
         M, source="0", target="1", create_using=nx.DiGraph()
     )
 
+    for index, row in cu_M.to_pandas().iterrows():
+        assert DiG.has_edge(row['0'], row['1'])
+        assert DiG.has_edge(row['1'], row['0']) == False
+
     G = DiG.to_undirected()
     Gnx = DiGnx.to_undirected()
 
     assert G.number_of_nodes() == Gnx.number_of_nodes()
     assert G.number_of_edges() == Gnx.number_of_edges()
 
-    edgelist_df = G.edgelist.edgelist_df
-
-    for i in range(len(edgelist_df)):
-        assert Gnx.has_edge(
-            edgelist_df.iloc[i]["src"], edgelist_df.iloc[i]["dst"]
-        )
+    for index, row in cu_M.to_pandas().iterrows():
+        assert G.has_edge(row['0'], row['1'])
+        assert G.has_edge(row['1'], row['0'])
 
 
 # Test
@@ -692,9 +667,9 @@ def test_has_edge(graph_file):
     G = cugraph.Graph()
     G.from_cudf_edgelist(cu_M, source="0", destination="1")
 
-    for i in range(len(cu_M)):
-        assert G.has_edge(cu_M.loc[i][0], cu_M.loc[i][1])
-        assert G.has_edge(cu_M.loc[i][1], cu_M.loc[i][0])
+    for index, row in cu_M.to_pandas().iterrows():
+        assert G.has_edge(row['0'], row['1'])
+        assert G.has_edge(row['1'], row['0'])
 
 
 # Test

--- a/python/cugraph/tests/test_graph.py
+++ b/python/cugraph/tests/test_graph.py
@@ -44,6 +44,7 @@ with warnings.catch_warnings():
 
 def compare_series(series_1, series_2):
     assert len(series_1) == len(series_2)
+    df = cudf.DataFrame({"series_1": series_1, "series_2": series_2})
     diffs = df.query('series_1 != series_2')
 
     if len(diffs) > 0:

--- a/python/cugraph/tests/test_modularity.py
+++ b/python/cugraph/tests/test_modularity.py
@@ -25,7 +25,9 @@ def cugraph_call(G, partitions):
     df = cugraph.spectralModularityMaximizationClustering(
         G, partitions, num_eigen_vects=(partitions - 1)
     )
-    score = cugraph.analyzeClustering_modularity(G, partitions, df["cluster"])
+    score = cugraph.analyzeClustering_modularity(G, partitions, df,
+                                                 'vertex',
+                                                 'cluster')
     return score
 
 
@@ -35,8 +37,14 @@ def random_call(G, partitions):
     assignment = []
     for i in range(num_verts):
         assignment.append(random.randint(0, partitions - 1))
-    assignment_cu = cudf.Series(assignment)
-    score = cugraph.analyzeClustering_modularity(G, partitions, assignment_cu)
+
+    assignment_cu = cudf.DataFrame(assignment, columns=['cluster'])
+    assignment_cu['vertex'] = assignment_cu.index
+
+    score = cugraph.analyzeClustering_modularity(G, partitions,
+                                                 assignment_cu,
+                                                 'vertex',
+                                                 'cluster')
     return score
 
 


### PR DESCRIPTION
This PR modifies the renumbering logic to sort vertices by degree.  The consequence of this will be that the lowest vertex id assigned by each partition will be the highest degree vertex assigned to that partition.

closes #1048

Note, this PR applies the logic to both SNMG and MNMG renumbering.