### PR TITLE
[BUG] Updated benchmarks README to better describe how to get plugin, added rapids-pytest-benchmark plugin to conda dev environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - PR #1066 Update cugunrock to not build for unsupported CUDA architectures
 - PR #1069 Fixed CUDA 11 Pagerank crash, by replacing CUB's SpMV with raft's.
 - PR #1083 Fix NBs to run in nightly test run, update renumbering text, cleanup
+- PR #1087 Updated benchmarks README to better describe how to get plugin, added rapids-pytest-benchmark plugin to conda dev environments
 
 # cuGraph 0.14.0 (03 Jun 2020)
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -15,10 +15,8 @@ directory under the root of the `cuGraph` source tree.
 * cugraph built and installed (or `cugraph` sources and built C++ extensions
   available on `PYTHONPATH`)
 
-* rapids-pytest-benchmark pytest plugin (`conda install -c rlratzel
+* rapids-pytest-benchmark pytest plugin (`conda install -c rapidsai
   rapids-pytest-benchmark`)
-  * NOTE: the `rlratzel` channel is temporary! This plugin will eventually be
-    moved to a more standard channel
 
 * The benchmark datasets downloaded and installed in <cugraph>/datasets. Run the
 script below from the <cugraph>/datasets directory:
@@ -37,6 +35,7 @@ cd <cugraph>/datasets
 
 ## Examples
 ### Python
+_**NOTE: these commands must be run from the `<cugraph_root>/benchmarks` directory.**_
 * Run all the benchmarks and print their names on a separate line (`-v`), and generate a report to stdout
 ```
 (rapids) user@machine:/cugraph/benchmarks> pytest -v

--- a/conda/environments/cugraph_dev_cuda10.1.yml
+++ b/conda/environments/cugraph_dev_cuda10.1.yml
@@ -36,3 +36,4 @@ dependencies:
 - recommonmark
 - pip
 - libcypher-parser
+- rapids-pytest-benchmark

--- a/conda/environments/cugraph_dev_cuda10.2.yml
+++ b/conda/environments/cugraph_dev_cuda10.2.yml
@@ -36,3 +36,4 @@ dependencies:
 - recommonmark
 - pip
 - libcypher-parser
+- rapids-pytest-benchmark

--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -36,3 +36,4 @@ dependencies:
 - recommonmark
 - pip
 - libcypher-parser
+- rapids-pytest-benchmark


### PR DESCRIPTION
Updated benchmarks README to better describe how to get plugin, added rapids-pytest-benchmark plugin to conda dev environments.

Thanks to @aschaffer and @seunghwak for testing the conda environments.

closes #1086 