### PR TITLE
[BUG] Removed unnecessary device-to-host copy which caused a performance regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - PR #1069 Fixed CUDA 11 Pagerank crash, by replacing CUB's SpMV with raft's.
 - PR #1083 Fix NBs to run in nightly test run, update renumbering text, cleanup
 - PR #1087 Updated benchmarks README to better describe how to get plugin, added rapids-pytest-benchmark plugin to conda dev environments
+- PR #1101 Removed unnecessary device-to-host copy which caused a performance regression
 
 # cuGraph 0.14.0 (03 Jun 2020)
 

--- a/cpp/src/centrality/betweenness_centrality.cu
+++ b/cpp/src/centrality/betweenness_centrality.cu
@@ -335,12 +335,6 @@ void BC<vertex_t, edge_t, weight_t, result_t>::add_reached_endpoints_to_source_b
 template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
 void BC<vertex_t, edge_t, weight_t, result_t>::add_vertices_dependencies_to_betweenness()
 {
-  thrust::host_vector<result_t> h_betweenness(number_of_vertices_, 0);
-  CUDA_TRY(cudaMemcpyAsync(h_betweenness.data(),
-                           betweenness_,
-                           number_of_vertices_ * sizeof(result_t),
-                           cudaMemcpyDeviceToHost,
-                           handle_.get_stream()));
   thrust::transform(rmm::exec_policy(handle_.get_stream())->on(handle_.get_stream()),
                     deltas_,
                     deltas_ + number_of_vertices_,

--- a/cpp/tests/centrality/betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/betweenness_centrality_test.cu
@@ -267,7 +267,7 @@ typedef struct BC_Usecase_t {
   BC_Usecase_t(const std::string &config, int number_of_sources)
     : config_(config), number_of_sources_(number_of_sources)
   {
-    // assume relative paths are relative to RAPIDS_DATASedge_t_ROOT_DIR
+    // assume relative paths are relative to RAPIDS_DATASET_ROOT_DIR
     // FIXME: Use platform independent stuff from c++14/17 on compiler update
     const std::string &rapidsDatasetRootDir = cugraph::test::get_rapids_dataset_root_dir();
     if ((config_ != "") && (config_[0] != '/')) {

--- a/cpp/tests/centrality/edge_betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/edge_betweenness_centrality_test.cu
@@ -204,7 +204,7 @@ typedef struct EdgeBC_Usecase_t {
   EdgeBC_Usecase_t(const std::string &config, int number_of_sources)
     : config_(config), number_of_sources_(number_of_sources)
   {
-    // assume relative paths are relative to RAPIDS_DATASedge_t_ROOT_DIR
+    // assume relative paths are relative to RAPIDS_DATASET_ROOT_DIR
     // FIXME: Use platform independent stuff from c++14/17 on compiler update
     const std::string &rapidsDatasetRootDir = cugraph::test::get_rapids_dataset_root_dir();
     if ((config_ != "") && (config_[0] != '/')) {

--- a/python/cugraph/centrality/betweenness_centrality.py
+++ b/python/cugraph/centrality/betweenness_centrality.py
@@ -49,6 +49,8 @@ def betweenness_centrality(
         values give better approximation
         If k is a list, use the content of the list for estimation: the list
         should contain vertices identifiers.
+        If k is None (the default), all the vertices are used to estimate
+        betweenness.
         Vertices obtained through sampling or defined as a list will be used as
         sources for traversals inside the algorithm.
 


### PR DESCRIPTION
* Removed unnecessary device-to-host copy which caused a performance regression
* Fixed some search-and-replace errors in comments
* Added more detail about `k` to the BC docstring

Verified performance regression was gone using the benchmarks:
```
> pytest -v bench_algos.py::bench_betweenness_centrality[ds=../datasets/csv/directed/cit-Patents.csv,mm=True,pa=True] --benchmark-autosave --benchmark-compare=0001

-------------------------------------------------------------------------------------------------------------------- benchmark: 2 tests ---------------------------------------------------------
Name (time in ms)                                                                                                Min                Max               Mean            StdDev            Outliers
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_betweenness_centrality[ds=../datasets/csv/directed/cit-Patents.csv,mm=True,pa=True] (NOW)              30.3700 (1.0)      30.6144 (1.0)      30.4473 (1.0)      0.0798 (1.0)           5;0
bench_betweenness_centrality[ds=../datasets/csv/directed/cit-Patents.csv,mm=True,pa=True] (0001_c90f5dc)     89.8043 (2.96)     90.5968 (2.96)     90.4228 (2.97)     0.2045 (2.56)          1;1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
