### PR TITLE
[REVIEW] Update docs to remove references to master [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - PR #1056 Fix MG BFS performance
 - PR #1062 Compute max_vertex_id in mnmg local data computation
 - PR #1068 Remove unused thirdparty code
+- PR #1105 Update `master` references to `main`
 
 ## Bug Fixes
 - PR #936 Update Force Atlas 2 doc and wrapper

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Read the section on [building cuGraph from source](SOURCEBUILD.md) to validate t
 ```git remote add upstream https://github.com/rapidsai/cugraph.git```
 
 3. Checkout the latest branch
-cuGraph only allows contribution to the current branch and not master or a future branch.  PLease check the [cuGraph](https://github.com/rapidsai/cugraph) page for the name of the current branch.  
+cuGraph only allows contribution to the current branch and not main or a future branch.  Please check the [cuGraph](https://github.com/rapidsai/cugraph) page for the name of the current branch.  
 ```git checkout branch-x.x```
 
 4. Code .....

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The [RAPIDS](https://rapids.ai) cuGraph library is a collection of GPU accelerat
 
  For more project details, see [rapids.ai](https://rapids.ai/).
 
-**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cudf/blob/master/README.md) ensure you are on the latest branch.
+**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/cudf/blob/main/README.md) ensure you are on the latest branch.
 
 
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -239,7 +239,7 @@ set(CUHORNET_INCLUDE_DIR ${CUHORNET_DIR}/src/cuhornet CACHE STRING "Path to cuho
 
 ExternalProject_Add(cuhornet
   GIT_REPOSITORY    https://github.com/rapidsai/cuhornet.git
-  GIT_TAG           master
+  GIT_TAG           main
   PREFIX            ${CUHORNET_DIR}
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""


### PR DESCRIPTION
This PR removes unecessary references to master or updates references to the new main branch in CI scripts and other OPS-owned files.