### PR TITLE
FIX Update change log check

### DIFF
--- a/ci/checks/changelog.sh
+++ b/ci/checks/changelog.sh
@@ -5,10 +5,10 @@
 ############################
 
 # Checkout main for comparison
-git checkout --quiet main
+git checkout --force --quiet main
 
 # Switch back to tip of PR branch
-git checkout --quiet current-pr-branch
+git checkout --force --quiet current-pr-branch
 
 # Ignore errors during searching
 set +e


### PR DESCRIPTION
The change log check was updated in branch-0.15 but both master and main have an older version of the ci/checks/changelog.sh. Without the forced checkout this will break and not complete the check successfully.