### PR TITLE
[gpuCI] Auto-merge branch-0.15 to branch-0.16 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@
 - PR #1087 Updated benchmarks README to better describe how to get plugin, added rapids-pytest-benchmark plugin to conda dev environments
 - PR #1101 Removed unnecessary device-to-host copy which caused a performance regression
 - PR #1106 Added new release.ipynb to notebook test skip list
+- PR #1125 Patch Thrust to workaround `CUDA_CUB_RET_IF_FAIL` macro clearing CUDA errors
+
 
 # cuGraph 0.14.0 (03 Jun 2020)
 
@@ -167,6 +169,7 @@
 - PR #928 Fix scikit learn test install to work with libgcc-ng 7.3
 - PR 935 Merge
 - PR #956 Use new gpuCI image in local build script
+
 
 # cuGraph 0.13.0 (31 Mar 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# cuGraph 0.15.0 (Date TBD)
+# cuGraph 0.15.0 (26 Aug 2020)
 
 ## New Features
 - PR #940 Add MG Batch BC

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -214,6 +214,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/thrust/thrust.git
     GIT_TAG        1.9.10
     GIT_SHALLOW    true
+    PATCH_COMMAND COMMAND patch -p1 < "${CMAKE_CURRENT_SOURCE_DIR}/cmake/thrust-ret-if-fail.patch"
 )
 
 FetchContent_GetProperties(thrust)

--- a/cpp/cmake/thrust-ret-if-fail.patch
+++ b/cpp/cmake/thrust-ret-if-fail.patch
@@ -1,0 +1,16 @@
+diff --git a/thrust/system/cuda/detail/core/util.h b/thrust/system/cuda/detail/core/util.h
+index a2c87772..ea4ed640 100644
+--- a/thrust/system/cuda/detail/core/util.h
++++ b/thrust/system/cuda/detail/core/util.h
+@@ -652,7 +652,10 @@ namespace core {
+   }
+ 
+ #define CUDA_CUB_RET_IF_FAIL(e) \
+-  if (cub::Debug((e), __FILE__, __LINE__)) return e;
++  {                             \
++    auto const error = (e);     \
++    if (cub::Debug(error, __FILE__, __LINE__)) return error; \
++  }
+ 
+   // uninitialized
+   // -------


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.15` that creates a PR to keep `branch-0.16` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.