### PR TITLE
[REVIEW] update RAFT git tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ## Bug Fixes
 - PR #1131 Show style checker errors with set +e
+- PR #1150 Update RAFT git tag
 
 # cuGraph 0.15.0 (26 Aug 2020)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -284,7 +284,7 @@ else(DEFINED ENV{RAFT_PATH})
 
   ExternalProject_Add(raft
     GIT_REPOSITORY    https://github.com/rapidsai/raft.git
-    GIT_TAG           099e2b874b05555a78bed1666fa2d22f784e56a7
+    GIT_TAG           516106e3b515b25c863776fcc51fb12df6c0a186
     PREFIX            ${RAFT_DIR}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND     ""


### PR DESCRIPTION
Update RAFT version (to pull the updates removing deprecated RMM calls).

https://github.com/rapidsai/cuhornet/pull/44 needs to be merged first for this to pass CI.