### PR TITLE
[REVIEW] Graph container cleanup, added arg for instantiating legacy types and switch statements to factory function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - PR #1129 Refactored test to use common dataset and added additional doc pages
 - PR #1144 updated documentation and APIs
 - PR #1139 MNMG Louvain Python updates, Cython cleanup
+- PR #1152 graph container cleanup, added arg for instantiating legacy types and switch statements to factory function
 
 ## Bug Fixes
 - PR #1131 Show style checker errors with set +e

--- a/cpp/include/utilities/cython.hpp
+++ b/cpp/include/utilities/cython.hpp
@@ -137,7 +137,9 @@ struct graph_container_t {
 // void* offsets, indices, weights
 //   Pointer to an array of values representing offsets, indices, and weights
 //   respectively. The value types of the array are specified using
-//   numberTypeEnum values separately (see below)
+//   numberTypeEnum values separately (see below). offsets should be size
+//   num_vertices+1, indices should be size num_edges, weights should also be
+//   size num_edges
 //
 // numberTypeEnum offsetType, indexType, weightType
 //   numberTypeEnum enum value describing the data type for the offsets,

--- a/cpp/include/utilities/cython.hpp
+++ b/cpp/include/utilities/cython.hpp
@@ -45,6 +45,9 @@ enum class graphTypeEnum : int {
   graph_view_t_double_mg_transposed
 };
 
+// Enum for the high-level type of GraphC??View* class to instantiate.
+enum class legacyGraphTypeEnum : int { CSR, CSC, COO };
+
 // "container" for a graph type instance which insulates the owner from the
 // specifics of the actual graph type. This is intended to be used in Cython
 // code that only needs to pass a graph object to another wrapped C++ API. This
@@ -54,24 +57,35 @@ struct graph_container_t {
   // FIXME: use std::variant (or a better alternative, ie. type erasure?) instead
   //        of a union if possible
   union graphPtrUnion {
+    ~graphPtrUnion() {}
+
     void* null;
-    GraphCSRView<int, int, float>* GraphCSRViewFloatPtr;
-    GraphCSRView<int, int, double>* GraphCSRViewDoublePtr;
-    GraphCSCView<int, int, float>* GraphCSCViewFloatPtr;
-    GraphCSCView<int, int, double>* GraphCSCViewDoublePtr;
-    GraphCOOView<int, int, float>* GraphCOOViewFloatPtr;
-    GraphCOOView<int, int, double>* GraphCOOViewDoublePtr;
-    experimental::graph_view_t<int, int, float, false, false>* graph_view_t_float_ptr;
-    experimental::graph_view_t<int, int, double, false, false>* graph_view_t_double_ptr;
-    experimental::graph_view_t<int, int, float, false, true>* graph_view_t_float_mg_ptr;
-    experimental::graph_view_t<int, int, double, false, true>* graph_view_t_double_mg_ptr;
-    experimental::graph_view_t<int, int, float, true, false>* graph_view_t_float_transposed_ptr;
-    experimental::graph_view_t<int, int, double, true, false>* graph_view_t_double_transposed_ptr;
-    experimental::graph_view_t<int, int, float, true, true>* graph_view_t_float_mg_transposed_ptr;
-    experimental::graph_view_t<int, int, double, true, true>* graph_view_t_double_mg_transposed_ptr;
+    std::unique_ptr<GraphCSRView<int, int, float>> GraphCSRViewFloatPtr;
+    std::unique_ptr<GraphCSRView<int, int, double>> GraphCSRViewDoublePtr;
+    std::unique_ptr<GraphCSCView<int, int, float>> GraphCSCViewFloatPtr;
+    std::unique_ptr<GraphCSCView<int, int, double>> GraphCSCViewDoublePtr;
+    std::unique_ptr<GraphCOOView<int, int, float>> GraphCOOViewFloatPtr;
+    std::unique_ptr<GraphCOOView<int, int, double>> GraphCOOViewDoublePtr;
+    std::unique_ptr<experimental::graph_view_t<int, int, float, false, false>>
+      graph_view_t_float_ptr;
+    std::unique_ptr<experimental::graph_view_t<int, int, double, false, false>>
+      graph_view_t_double_ptr;
+    std::unique_ptr<experimental::graph_view_t<int, int, float, false, true>>
+      graph_view_t_float_mg_ptr;
+    std::unique_ptr<experimental::graph_view_t<int, int, double, false, true>>
+      graph_view_t_double_mg_ptr;
+    std::unique_ptr<experimental::graph_view_t<int, int, float, true, false>>
+      graph_view_t_float_transposed_ptr;
+    std::unique_ptr<experimental::graph_view_t<int, int, double, true, false>>
+      graph_view_t_double_transposed_ptr;
+    std::unique_ptr<experimental::graph_view_t<int, int, float, true, true>>
+      graph_view_t_float_mg_transposed_ptr;
+    std::unique_ptr<experimental::graph_view_t<int, int, double, true, true>>
+      graph_view_t_double_mg_transposed_ptr;
   };
 
-  inline graph_container_t() : graph_ptr_union{nullptr}, graph_ptr_type{graphTypeEnum::null} {}
+  graph_container_t() : graph_ptr_union{nullptr}, graph_ptr_type{graphTypeEnum::null} {}
+  ~graph_container_t() {}
 
   // The expected usage of a graph_container_t is for it to be created as part
   // of a cython wrapper simply for passing a templated instantiation of a
@@ -81,42 +95,6 @@ struct graph_container_t {
   // to an instance are not supported and these methods are deleted.
   graph_container_t(const graph_container_t&) = delete;
   graph_container_t& operator=(const graph_container_t&) = delete;
-
-  inline ~graph_container_t()
-  {
-    switch (graph_ptr_type) {
-      case graphTypeEnum::GraphCSRViewFloat: delete graph_ptr_union.GraphCSRViewFloatPtr; break;
-      case graphTypeEnum::GraphCSRViewDouble: delete graph_ptr_union.GraphCSRViewDoublePtr; break;
-      case graphTypeEnum::GraphCSCViewFloat: delete graph_ptr_union.GraphCSCViewFloatPtr; break;
-      case graphTypeEnum::GraphCSCViewDouble: delete graph_ptr_union.GraphCSCViewDoublePtr; break;
-      case graphTypeEnum::GraphCOOViewFloat: delete graph_ptr_union.GraphCOOViewFloatPtr; break;
-      case graphTypeEnum::GraphCOOViewDouble: delete graph_ptr_union.GraphCOOViewDoublePtr; break;
-      case graphTypeEnum::graph_view_t_float: delete graph_ptr_union.graph_view_t_float_ptr; break;
-      case graphTypeEnum::graph_view_t_double:
-        delete graph_ptr_union.graph_view_t_double_ptr;
-        break;
-      case graphTypeEnum::graph_view_t_float_mg:
-        delete graph_ptr_union.graph_view_t_float_mg_ptr;
-        break;
-      case graphTypeEnum::graph_view_t_double_mg:
-        delete graph_ptr_union.graph_view_t_double_mg_ptr;
-        break;
-      case graphTypeEnum::graph_view_t_float_transposed:
-        delete graph_ptr_union.graph_view_t_float_transposed_ptr;
-        break;
-      case graphTypeEnum::graph_view_t_double_transposed:
-        delete graph_ptr_union.graph_view_t_double_transposed_ptr;
-        break;
-      case graphTypeEnum::graph_view_t_float_mg_transposed:
-        delete graph_ptr_union.graph_view_t_float_mg_transposed_ptr;
-        break;
-      case graphTypeEnum::graph_view_t_double_mg_transposed:
-        delete graph_ptr_union.graph_view_t_double_mg_transposed_ptr;
-        break;
-      default: break;
-    }
-    graph_ptr_type = graphTypeEnum::null;
-  }
 
   graphPtrUnion graph_ptr_union;
   graphTypeEnum graph_ptr_type;
@@ -130,6 +108,12 @@ struct graph_container_t {
 //   populate. populate_graph_container() can only be called on an "empty"
 //   container (ie. a container that has not been previously populated by
 //   populate_graph_container())
+//
+// legacyGraphTypeEnum legacyType
+//   Specifies the type of graph when instantiating a legacy graph type
+//   (GraphCSRViewFloat, etc.).
+//   NOTE: this parameter will be removed when the transition to exclusinve use
+//   of the new 2D graph classes is complete.
 //
 // raft::handle_t const& handle
 //   Raft handle to be set on the new graph instance in the container
@@ -176,6 +160,7 @@ struct graph_container_t {
 //
 // FIXME: Should local_* values be void* as well?
 void populate_graph_container(graph_container_t& graph_container,
+                              legacyGraphTypeEnum legacyType,
                               raft::handle_t const& handle,
                               void* offsets,
                               void* indices,

--- a/cpp/src/utilities/cython.cpp
+++ b/cpp/src/utilities/cython.cpp
@@ -56,80 +56,86 @@ void populate_graph_container(graph_container_t& graph_container,
   if (weightType == numberTypeEnum::floatType) {
     switch (legacyType) {
       case legacyGraphTypeEnum::CSR: {
-        auto g = new GraphCSRView<int, int, float>(reinterpret_cast<int*>(offsets),
-                                                   reinterpret_cast<int*>(indices),
-                                                   reinterpret_cast<float*>(weights),
-                                                   num_vertices,
-                                                   num_edges);
         graph_container.graph_ptr_union.GraphCSRViewFloatPtr =
-          std::unique_ptr<GraphCSRView<int, int, float>>(g);
+          std::make_unique<GraphCSRView<int, int, float>>(reinterpret_cast<int*>(offsets),
+                                                          reinterpret_cast<int*>(indices),
+                                                          reinterpret_cast<float*>(weights),
+                                                          num_vertices,
+                                                          num_edges);
         graph_container.graph_ptr_type = graphTypeEnum::GraphCSRViewFloat;
-        g->set_local_data(local_vertices, local_edges, local_offsets);
-        g->set_handle(const_cast<raft::handle_t*>(&handle));
+        (graph_container.graph_ptr_union.GraphCSRViewFloatPtr)
+          ->set_local_data(local_vertices, local_edges, local_offsets);
+        (graph_container.graph_ptr_union.GraphCSRViewFloatPtr)
+          ->set_handle(const_cast<raft::handle_t*>(&handle));
       } break;
       case legacyGraphTypeEnum::CSC: {
-        auto g = new GraphCSCView<int, int, float>(reinterpret_cast<int*>(offsets),
-                                                   reinterpret_cast<int*>(indices),
-                                                   reinterpret_cast<float*>(weights),
-                                                   num_vertices,
-                                                   num_edges);
         graph_container.graph_ptr_union.GraphCSCViewFloatPtr =
-          std::unique_ptr<GraphCSCView<int, int, float>>(g);
+          std::make_unique<GraphCSCView<int, int, float>>(reinterpret_cast<int*>(offsets),
+                                                          reinterpret_cast<int*>(indices),
+                                                          reinterpret_cast<float*>(weights),
+                                                          num_vertices,
+                                                          num_edges);
         graph_container.graph_ptr_type = graphTypeEnum::GraphCSCViewFloat;
-        g->set_local_data(local_vertices, local_edges, local_offsets);
-        g->set_handle(const_cast<raft::handle_t*>(&handle));
+        (graph_container.graph_ptr_union.GraphCSCViewFloatPtr)
+          ->set_local_data(local_vertices, local_edges, local_offsets);
+        (graph_container.graph_ptr_union.GraphCSCViewFloatPtr)
+          ->set_handle(const_cast<raft::handle_t*>(&handle));
       } break;
       case legacyGraphTypeEnum::COO: {
-        auto g = new GraphCOOView<int, int, float>(reinterpret_cast<int*>(offsets),
-                                                   reinterpret_cast<int*>(indices),
-                                                   reinterpret_cast<float*>(weights),
-                                                   num_vertices,
-                                                   num_edges);
         graph_container.graph_ptr_union.GraphCOOViewFloatPtr =
-          std::unique_ptr<GraphCOOView<int, int, float>>(g);
+          std::make_unique<GraphCOOView<int, int, float>>(reinterpret_cast<int*>(offsets),
+                                                          reinterpret_cast<int*>(indices),
+                                                          reinterpret_cast<float*>(weights),
+                                                          num_vertices,
+                                                          num_edges);
         graph_container.graph_ptr_type = graphTypeEnum::GraphCOOViewFloat;
-        g->set_local_data(local_vertices, local_edges, local_offsets);
-        g->set_handle(const_cast<raft::handle_t*>(&handle));
+        (graph_container.graph_ptr_union.GraphCOOViewFloatPtr)
+          ->set_local_data(local_vertices, local_edges, local_offsets);
+        (graph_container.graph_ptr_union.GraphCOOViewFloatPtr)
+          ->set_handle(const_cast<raft::handle_t*>(&handle));
       } break;
     }
 
   } else {
     switch (legacyType) {
       case legacyGraphTypeEnum::CSR: {
-        auto g = new GraphCSRView<int, int, double>(reinterpret_cast<int*>(offsets),
-                                                    reinterpret_cast<int*>(indices),
-                                                    reinterpret_cast<double*>(weights),
-                                                    num_vertices,
-                                                    num_edges);
         graph_container.graph_ptr_union.GraphCSRViewDoublePtr =
-          std::unique_ptr<GraphCSRView<int, int, double>>(g);
+          std::make_unique<GraphCSRView<int, int, double>>(reinterpret_cast<int*>(offsets),
+                                                           reinterpret_cast<int*>(indices),
+                                                           reinterpret_cast<double*>(weights),
+                                                           num_vertices,
+                                                           num_edges);
         graph_container.graph_ptr_type = graphTypeEnum::GraphCSRViewDouble;
-        g->set_local_data(local_vertices, local_edges, local_offsets);
-        g->set_handle(const_cast<raft::handle_t*>(&handle));
+        (graph_container.graph_ptr_union.GraphCSRViewDoublePtr)
+          ->set_local_data(local_vertices, local_edges, local_offsets);
+        (graph_container.graph_ptr_union.GraphCSRViewDoublePtr)
+          ->set_handle(const_cast<raft::handle_t*>(&handle));
       } break;
       case legacyGraphTypeEnum::CSC: {
-        auto g = new GraphCSCView<int, int, double>(reinterpret_cast<int*>(offsets),
-                                                    reinterpret_cast<int*>(indices),
-                                                    reinterpret_cast<double*>(weights),
-                                                    num_vertices,
-                                                    num_edges);
         graph_container.graph_ptr_union.GraphCSCViewDoublePtr =
-          std::unique_ptr<GraphCSCView<int, int, double>>(g);
+          std::make_unique<GraphCSCView<int, int, double>>(reinterpret_cast<int*>(offsets),
+                                                           reinterpret_cast<int*>(indices),
+                                                           reinterpret_cast<double*>(weights),
+                                                           num_vertices,
+                                                           num_edges);
         graph_container.graph_ptr_type = graphTypeEnum::GraphCSCViewDouble;
-        g->set_local_data(local_vertices, local_edges, local_offsets);
-        g->set_handle(const_cast<raft::handle_t*>(&handle));
+        (graph_container.graph_ptr_union.GraphCSCViewDoublePtr)
+          ->set_local_data(local_vertices, local_edges, local_offsets);
+        (graph_container.graph_ptr_union.GraphCSCViewDoublePtr)
+          ->set_handle(const_cast<raft::handle_t*>(&handle));
       } break;
       case legacyGraphTypeEnum::COO: {
-        auto g = new GraphCOOView<int, int, double>(reinterpret_cast<int*>(offsets),
-                                                    reinterpret_cast<int*>(indices),
-                                                    reinterpret_cast<double*>(weights),
-                                                    num_vertices,
-                                                    num_edges);
         graph_container.graph_ptr_union.GraphCOOViewDoublePtr =
-          std::unique_ptr<GraphCOOView<int, int, double>>(g);
+          std::make_unique<GraphCOOView<int, int, double>>(reinterpret_cast<int*>(offsets),
+                                                           reinterpret_cast<int*>(indices),
+                                                           reinterpret_cast<double*>(weights),
+                                                           num_vertices,
+                                                           num_edges);
         graph_container.graph_ptr_type = graphTypeEnum::GraphCOOViewDouble;
-        g->set_local_data(local_vertices, local_edges, local_offsets);
-        g->set_handle(const_cast<raft::handle_t*>(&handle));
+        (graph_container.graph_ptr_union.GraphCOOViewDoublePtr)
+          ->set_local_data(local_vertices, local_edges, local_offsets);
+        (graph_container.graph_ptr_union.GraphCOOViewDoublePtr)
+          ->set_handle(const_cast<raft::handle_t*>(&handle));
       } break;
     }
   }

--- a/cpp/src/utilities/cython.cpp
+++ b/cpp/src/utilities/cython.cpp
@@ -243,7 +243,7 @@ weight_t call_louvain(raft::handle_t const& handle,
   if (graph_container.graph_ptr_type == graphTypeEnum::GraphCSRViewFloat) {
     std::pair<size_t, float> results =
       louvain(handle,
-              *(graph_container.graph_ptr_union.GraphCSRViewFloatPtr.get()),
+              *(graph_container.graph_ptr_union.GraphCSRViewFloatPtr),
               reinterpret_cast<int*>(parts),
               max_level,
               static_cast<float>(resolution));
@@ -251,7 +251,7 @@ weight_t call_louvain(raft::handle_t const& handle,
   } else {
     std::pair<size_t, double> results =
       louvain(handle,
-              *(graph_container.graph_ptr_union.GraphCSRViewDoublePtr.get()),
+              *(graph_container.graph_ptr_union.GraphCSRViewDoublePtr),
               reinterpret_cast<int*>(parts),
               max_level,
               static_cast<double>(resolution));

--- a/python/cugraph/community/subgraph_extraction_wrapper.pyx
+++ b/python/cugraph/community/subgraph_extraction_wrapper.pyx
@@ -75,7 +75,7 @@ def subgraph(input_graph, vertices):
     vertices_df['v'] = vertices
     vertices_df = vertices_df.reset_index(drop=True).reset_index()
 
-    df = df.merge(vertices_df, left_on='src', right_on='index', how='left').drop(['src', 'index']).rename(columns={'v': 'src'}, copy=False)
-    df = df.merge(vertices_df, left_on='dst', right_on='index', how='left').drop(['dst', 'index']).rename(columns={'v': 'dst'}, copy=False)
+    df = df.merge(vertices_df, left_on='src', right_on='index', how='left').drop(columns=['src', 'index']).rename(columns={'v': 'src'}, copy=False)
+    df = df.merge(vertices_df, left_on='dst', right_on='index', how='left').drop(columns=['dst', 'index']).rename(columns={'v': 'dst'}, copy=False)
 
     return df

--- a/python/cugraph/dask/community/louvain_wrapper.pyx
+++ b/python/cugraph/dask/community/louvain_wrapper.pyx
@@ -99,7 +99,9 @@ def louvain(input_df, local_data, rank, handle, max_level, resolution):
     # FIXME: The excessive casting for the enum arg is needed to make cython
     #        understand how to pass the enum value (this is the same pattern
     #        used by cudf). This will not be needed with Cython 3.0
-    populate_graph_container(graph_container, handle_[0],
+    populate_graph_container(graph_container,
+                             <legacyGraphTypeEnum>(<int>(legacyGraphTypeEnum.CSR)),
+                             handle_[0],
                              <void*>c_offsets, <void*>c_indices, <void*>c_weights,
                              <numberTypeEnum>(<int>(numberTypeEnum.intType)),
                              <numberTypeEnum>(<int>(numberTypeEnum.intType)),

--- a/python/cugraph/structure/graph_primtypes.pxd
+++ b/python/cugraph/structure/graph_primtypes.pxd
@@ -200,11 +200,17 @@ cdef extern from "utilities/cython.hpp" namespace "cugraph::cython":
         floatType "cugraph::cython::numberTypeEnum::floatType"
         doubleType "cugraph::cython::numberTypeEnum::doubleType"
 
+    ctypedef enum legacyGraphTypeEnum:
+        CSR "cugraph::cython::legacyGraphTypeEnum::CSR"
+        CSC "cugraph::cython::legacyGraphTypeEnum::CSC"
+        COO "cugraph::cython::legacyGraphTypeEnum::COO"
+
     cdef struct graph_container_t:
         pass
 
     cdef void populate_graph_container(
         graph_container_t &graph_container,
+        legacyGraphTypeEnum legacyType,
         const handle_t &handle,
         void *offsets,
         void *indices,

--- a/python/cugraph/structure/hypergraph.py
+++ b/python/cugraph/structure/hypergraph.py
@@ -311,11 +311,11 @@ def _create_hyper_nodes(
 ):
     nodes = events.copy(deep=False)
     if NODEID in nodes:
-        nodes.drop([NODEID], inplace=True)
+        nodes.drop(columns=[NODEID], inplace=True)
     if NODETYPE in nodes:
-        nodes.drop([NODETYPE], inplace=True)
+        nodes.drop(columns=[NODETYPE], inplace=True)
     if CATEGORY in nodes:
-        nodes.drop([CATEGORY], inplace=True)
+        nodes.drop(columns=[CATEGORY], inplace=True)
     nodes[NODETYPE] = EVENTID if not categorical_metadata \
         else _str_scalar_to_category(len(nodes), EVENTID)
     nodes[CATEGORY] = "event" if not categorical_metadata \


### PR DESCRIPTION
Refactored the graph container to use `unique_ptr`s instead of raw pointers after conversation with @aschaffer , added additional legacy graph types to the factory function which will be needed for MG Pagerank.