### PR TITLE
[REVIEW] pass size_t* instead of int_t[] for raft allgatherv's input parameter displs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #1131 Show style checker errors with set +e
 - PR #1150 Update RAFT git tag
 - PR #1155 Remove RMM library dependency and CXX11 ABI handling
+- PR #1158 Pass size_t[] instead of int[] for raft allgatherv's input parameter displs
 
 
 # cuGraph 0.15.0 (26 Aug 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - PR #1131 Show style checker errors with set +e
 - PR #1150 Update RAFT git tag
 - PR #1155 Remove RMM library dependency and CXX11 ABI handling
-- PR #1158 Pass size_t[] instead of int[] for raft allgatherv's input parameter displs
+- PR #1158 Pass size_t* & size_t* instead of size_t[] & int[] for raft allgatherv's input parameters recvcounts & displs
 
 
 # cuGraph 0.15.0 (26 Aug 2020)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -250,7 +250,7 @@ else(DEFINED ENV{RAFT_PATH})
 
   ExternalProject_Add(raft
     GIT_REPOSITORY    https://github.com/rapidsai/raft.git
-    GIT_TAG           516106e3b515b25c863776fcc51fb12df6c0a186
+    GIT_TAG           53c1e2dde4045f386f9cc4bb7d3dc99d5690b886
     PREFIX            ${RAFT_DIR}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND     ""

--- a/cpp/src/traversal/mg/common_utils.cuh
+++ b/cpp/src/traversal/mg/common_utils.cuh
@@ -184,7 +184,7 @@ return_t collect_vectors(raft::handle_t const &handle,
   // h_buffer_offsets has to be int because raft allgatherv expects
   // int array for displacement vector. This should be changed in
   // raft so that the displacement is templated
-  thrust::host_vector<int> h_buffer_offsets(h_buffer_len.size());
+  thrust::host_vector<size_t> h_buffer_offsets(h_buffer_len.size());
 
   thrust::exclusive_scan(
     thrust::host, h_buffer_len.begin(), h_buffer_len.end(), h_buffer_offsets.begin());

--- a/cpp/src/utilities/spmv_1D.cu
+++ b/cpp/src/utilities/spmv_1D.cu
@@ -75,8 +75,10 @@ void MGcsrmv<vertex_t, edge_t, weight_t>::run(weight_t *x)
   auto const &comm{handle_.get_comms()};  // local
 
   std::vector<size_t> recvbuf(comm.get_size());
+  std::vector<size_t> displs(comm.get_size());
   std::copy(local_vertices_, local_vertices_ + comm.get_size(), recvbuf.begin());
-  comm.allgatherv(y_loc_.data().get(), x, recvbuf.data(), part_off_, stream);
+  std::copy(part_off_, part_off_ + comm.get_size(), displs.begin());
+  comm.allgatherv(y_loc_.data().get(), x, recvbuf.data(), displs.data(), stream);
 }
 
 template class MGcsrmv<int32_t, int32_t, double>;


### PR DESCRIPTION
RAFT allgatherv is updated to take size_t* instead of int_t[] for displs, cuGraph needs to updated accordingly.