### PR TITLE
[REVIEW] BUG fix misspelling of function calls in asserts causing debug build to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - PR #1150 Update RAFT git tag
 - PR #1155 Remove RMM library dependency and CXX11 ABI handling
 - PR #1158 Pass size_t* & size_t* instead of size_t[] & int[] for raft allgatherv's input parameters recvcounts & displs
+- PR #1166 Fix misspelling of function calls in asserts causing debug build to fail
 
 
 # cuGraph 0.15.0 (26 Aug 2020)

--- a/cpp/include/patterns/any_of_adj_matrix_row.cuh
+++ b/cpp/include/patterns/any_of_adj_matrix_row.cuh
@@ -43,9 +43,9 @@ namespace experimental {
  * @param adj_matrix_row_value_input_first Iterator pointing to the adjacency matrix row properties
  * for the first (inclusive) row (assigned to this process in multi-GPU).
  * `adj_matrix_row_value_input_last` (exclusive) is deduced as @p adj_matrix_row_value_input_first +
- * @p graph_view.get_number_of_adj_matrix_local_rows().
+ * @p graph_view.get_number_of_local_adj_matrix_partition_rows().
  * @param row_op Unary predicate operator that takes *(@p adj_matrix_row_value_input_first + i)
- * (where i = [0, @p graph_view.get_number_of_adj_matrix_local_rows()) and returns either
+ * (where i = [0, @p graph_view.get_number_of_local_adj_matrix_partition_rows()) and returns either
  * true or false.
  * @return true If the predicate returns true at least once (in any process in multi-GPU).
  * @return false If the predicate never returns true (in any process in multi-GPU).

--- a/cpp/include/patterns/copy_to_adj_matrix_col.cuh
+++ b/cpp/include/patterns/copy_to_adj_matrix_col.cuh
@@ -48,7 +48,7 @@ namespace experimental {
  * @param adj_matrix_col_value_output_first Iterator pointing to the adjacency matrix column output
  * property variables for the first (inclusive) column (assigned to this process in multi-GPU).
  * `adj_matrix_col_value_output_last` (exclusive) is deduced as @p adj_matrix_col_value_output_first
- * + @p graph_view.get_number_of_adj_matrix_local_cols().
+ * + @p graph_view.get_number_of_local_adj_matrix_partition_cols().
  */
 template <typename GraphViewType,
           typename VertexValueInputIterator,
@@ -62,7 +62,7 @@ void copy_to_adj_matrix_col(raft::handle_t const& handle,
     CUGRAPH_FAIL("unimplemented.");
   } else {
     assert(graph_view.get_number_of_local_vertices() ==
-           graph_view.get_number_of_adj_matrix_local_cols());
+           graph_view.get_number_of_local_adj_matrix_partition_cols());
     thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
                  vertex_value_input_first,
                  vertex_value_input_first + graph_view.get_number_of_local_vertices(),
@@ -96,7 +96,7 @@ void copy_to_adj_matrix_col(raft::handle_t const& handle,
  * @param adj_matrix_col_value_output_first Iterator pointing to the adjacency matrix column output
  * property variables for the first (inclusive) column (assigned to this process in multi-GPU).
  * `adj_matrix_col_value_output_last` (exclusive) is deduced as @p adj_matrix_col_value_output_first
- * + @p graph_view.get_number_of_adj_matrix_local_cols().
+ * + @p graph_view.get_number_of_local_adj_matrix_partition_cols().
  */
 template <typename GraphViewType,
           typename VertexIterator,
@@ -113,7 +113,7 @@ void copy_to_adj_matrix_col(raft::handle_t const& handle,
     CUGRAPH_FAIL("unimplemented.");
   } else {
     assert(graph_view.get_number_of_local_vertices() ==
-           graph_view.get_number_of_adj_matrix_local_cols());
+           graph_view.get_number_of_local_adj_matrix_partition_cols());
     auto val_first = thrust::make_permutation_iterator(vertex_value_input_first, vertex_first);
     thrust::scatter(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
                     val_first,

--- a/cpp/include/patterns/copy_to_adj_matrix_row.cuh
+++ b/cpp/include/patterns/copy_to_adj_matrix_row.cuh
@@ -48,7 +48,7 @@ namespace experimental {
  * @param adj_matrix_row_value_output_first Iterator pointing to the adjacency matrix row output
  * property variables for the first (inclusive) row (assigned to this process in multi-GPU).
  * `adj_matrix_row_value_output_last` (exclusive) is deduced as @p adj_matrix_row_value_output_first
- * + @p graph_view.get_number_of_adj_matrix_local_rows().
+ * + @p graph_view.get_number_of_local_adj_matrix_partition_rows().
  */
 template <typename GraphViewType,
           typename VertexValueInputIterator,
@@ -62,7 +62,7 @@ void copy_to_adj_matrix_row(raft::handle_t const& handle,
     CUGRAPH_FAIL("unimplemented.");
   } else {
     assert(graph_view.get_number_of_local_vertices() ==
-           graph_view.get_number_of_adj_matrix_local_rows());
+           graph_view.get_number_of_local_adj_matrix_partition_rows());
     thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
                  vertex_value_input_first,
                  vertex_value_input_first + graph_view.get_number_of_local_vertices(),
@@ -96,7 +96,7 @@ void copy_to_adj_matrix_row(raft::handle_t const& handle,
  * @param adj_matrix_row_value_output_first Iterator pointing to the adjacency matrix row output
  * property variables for the first (inclusive) row (assigned to this process in multi-GPU).
  * `adj_matrix_row_value_output_last` (exclusive) is deduced as @p adj_matrix_row_value_output_first
- * + @p graph_view.get_number_of_adj_matrix_local_rows().
+ * + @p graph_view.get_number_of_local_adj_matrix_partition_rows().
  */
 template <typename GraphViewType,
           typename VertexIterator,
@@ -113,7 +113,7 @@ void copy_to_adj_matrix_row(raft::handle_t const& handle,
     CUGRAPH_FAIL("unimplemented.");
   } else {
     assert(graph_view.get_number_of_local_vertices() ==
-           graph_view.get_number_of_adj_matrix_local_rows());
+           graph_view.get_number_of_local_adj_matrix_partition_rows());
     auto val_first = thrust::make_permutation_iterator(vertex_value_input_first, vertex_first);
     thrust::scatter(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
                     val_first,

--- a/cpp/include/patterns/copy_v_transform_reduce_nbr.cuh
+++ b/cpp/include/patterns/copy_v_transform_reduce_nbr.cuh
@@ -200,11 +200,11 @@ __global__ void for_all_major_for_all_nbr_low_out_degree(
  * @param adj_matrix_row_value_input_first Iterator pointing to the adjacency matrix row input
  * properties for the first (inclusive) row (assigned to this process in multi-GPU).
  * `adj_matrix_row_value_input_last` (exclusive) is deduced as @p adj_matrix_row_value_input_first +
- * @p graph_view.get_number_of_adj_matrix_local_rows().
+ * @p graph_view.get_number_of_local_adj_matrix_partition_rows().
  * @param adj_matrix_col_value_input_first Iterator pointing to the adjacency matrix column input
  * properties for the first (inclusive) column (assigned to this process in multi-GPU).
  * `adj_matrix_col_value_output_last` (exclusive) is deduced as @p adj_matrix_col_value_output_first
- * + @p graph_view.get_number_of_adj_matrix_local_cols().
+ * + @p graph_view.get_number_of_local_adj_matrix_partition_cols().
  * @param e_op Quaternary (or quinary) operator takes edge source, edge destination, (optional edge
  * weight), *(@p adj_matrix_row_value_input_first + i), and *(@p adj_matrix_col_value_input_first +
  * j) (where i is in [0, graph_view.get_number_of_local_adj_matrix_partition_rows()) and j is in [0,
@@ -249,9 +249,9 @@ void copy_v_transform_reduce_in_nbr(raft::handle_t const& handle,
     }
 
     assert(graph_view.get_number_of_local_vertices() ==
-           graph_view.get_number_of_adj_matrix_local_rows());
+           graph_view.get_number_of_local_adj_matrix_partition_rows());
     assert(graph_view.get_number_of_local_vertices() ==
-           graph_view.get_number_of_adj_matrix_local_cols());
+           graph_view.get_number_of_local_adj_matrix_partition_cols());
     detail::for_all_major_for_all_nbr_low_out_degree<GraphViewType::is_adj_matrix_transposed>
       <<<update_grid.num_blocks, update_grid.block_size, 0, handle.get_stream()>>>(
         matrix_partition,
@@ -283,11 +283,11 @@ void copy_v_transform_reduce_in_nbr(raft::handle_t const& handle,
  * @param adj_matrix_row_value_input_first Iterator pointing to the adjacency matrix row input
  * properties for the first (inclusive) row (assigned to this process in multi-GPU).
  * `adj_matrix_row_value_input_last` (exclusive) is deduced as @p adj_matrix_row_value_input_first +
- * @p graph_view.get_number_of_adj_matrix_local_rows().
+ * @p graph_view.get_number_of_local_adj_matrix_partition_rows().
  * @param adj_matrix_col_value_input_first Iterator pointing to the adjacency matrix column input
  * properties for the first (inclusive) column (assigned to this process in multi-GPU).
  * `adj_matrix_col_value_output_last` (exclusive) is deduced as @p adj_matrix_col_value_output_first
- * + @p graph_view.get_number_of_adj_matrix_local_cols().
+ * + @p graph_view.get_number_of_local_adj_matrix_partition_cols().
  * @param e_op Quaternary (or quinary) operator takes edge source, edge destination, (optional edge
  * weight), *(@p adj_matrix_row_value_input_first + i), and *(@p adj_matrix_col_value_input_first +
  * j) (where i is in [0, graph_view.get_number_of_local_adj_matrix_partition_rows()) and j is in [0,

--- a/cpp/include/patterns/count_if_e.cuh
+++ b/cpp/include/patterns/count_if_e.cuh
@@ -157,11 +157,11 @@ __global__ void for_all_major_for_all_nbr_low_out_degree(
  * @param adj_matrix_row_value_input_first Iterator pointing to the adjacency matrix row input
  * properties for the first (inclusive) row (assigned to this process in multi-GPU).
  * `adj_matrix_row_value_input_last` (exclusive) is deduced as @p adj_matrix_row_value_input_first +
- * @p graph_view.get_number_of_adj_matrix_local_rows().
+ * @p graph_view.get_number_of_local_adj_matrix_partition_rows().
  * @param adj_matrix_col_value_input_first Iterator pointing to the adjacency matrix column input
  * properties for the first (inclusive) column (assigned to this process in multi-GPU).
  * `adj_matrix_col_value_output_last` (exclusive) is deduced as @p adj_matrix_col_value_output_first
- * + @p graph_view.get_number_of_adj_matrix_local_cols().
+ * + @p graph_view.get_number_of_local_adj_matrix_partition_cols().
  * @param e_op Quaternary (or quinary) operator takes edge source, edge destination, (optional edge
  * weight), *(@p adj_matrix_row_value_input_first + i), and *(@p adj_matrix_col_value_input_first +
  * j) (where i is in [0, graph_view.get_number_of_local_adj_matrix_partition_rows()) and j is in [0,

--- a/cpp/include/patterns/transform_reduce_e.cuh
+++ b/cpp/include/patterns/transform_reduce_e.cuh
@@ -180,11 +180,11 @@ __global__ void for_all_major_for_all_nbr_low_out_degree(
  * @param adj_matrix_row_value_input_first Iterator pointing to the adjacency matrix row input
  * properties for the first (inclusive) row (assigned to this process in multi-GPU).
  * `adj_matrix_row_value_input_last` (exclusive) is deduced as @p adj_matrix_row_value_input_first +
- * @p graph_view.get_number_of_adj_matrix_local_rows().
+ * @p graph_view.get_number_of_local_adj_matrix_partition_rows().
  * @param adj_matrix_col_value_input_first Iterator pointing to the adjacency matrix column input
  * properties for the first (inclusive) column (assigned to this process in multi-GPU).
  * `adj_matrix_col_value_output_last` (exclusive) is deduced as @p adj_matrix_col_value_output_first
- * + @p graph_view.get_number_of_adj_matrix_local_cols().
+ * + @p graph_view.get_number_of_local_adj_matrix_partition_cols().
  * @param e_op Quaternary (or quinary) operator takes edge source, edge destination, (optional edge
  * weight), *(@p adj_matrix_row_value_input_first + i), and *(@p adj_matrix_col_value_input_first +
  * j) (where i is in [0, graph_view.get_number_of_local_adj_matrix_partition_rows()) and j is in [0,

--- a/cpp/include/patterns/transform_reduce_v_with_adj_matrix_row.cuh
+++ b/cpp/include/patterns/transform_reduce_v_with_adj_matrix_row.cuh
@@ -49,7 +49,7 @@ namespace experimental {
  * @param adj_matrix_row_value_input_first Iterator pointing to the adjacency matrix row input
  * properties for the first (inclusive) row (assigned to this process in multi-GPU).
  * `adj_matrix_row_value_input_last` (exclusive) is deduced as @p adj_matrix_row_value_input_first +
- * @p graph_view.get_number_of_adj_matrix_local_rows().
+ * @p graph_view.get_number_of_local_adj_matrix_partition_rows().
  * @param v_op Binary operator takes *(@p vertex_value_input_first + i) and *(@p
  * adj_matrix_row_value_input_first + j) (where i and j are set for a vertex and the matching row)
  * and returns a transformed value to be reduced.
@@ -73,7 +73,7 @@ T transform_reduce_v_with_adj_matrix_row(
     CUGRAPH_FAIL("unimplemented.");
   } else {
     assert(graph_view.get_number_of_local_vertices() ==
-           graph_view.get_number_of_adj_matrix_local_rows());
+           graph_view.get_number_of_local_adj_matrix_partition_rows());
     auto input_first = thrust::make_zip_iterator(
       thrust::make_tuple(vertex_value_input_first, adj_matrix_row_value_input_first));
     auto v_op_wrapper = [v_op] __device__(auto v_and_row_val) {

--- a/cpp/include/patterns/update_frontier_v_push_if_out_nbr.cuh
+++ b/cpp/include/patterns/update_frontier_v_push_if_out_nbr.cuh
@@ -278,11 +278,11 @@ __global__ void update_frontier_and_vertex_output_values(
  * @param adj_matrix_row_value_input_first Iterator pointing to the adjacency matrix row input
  * properties for the first (inclusive) row (assigned to this process in multi-GPU).
  * `adj_matrix_row_value_input_last` (exclusive) is deduced as @p adj_matrix_row_value_input_first +
- * @p graph_view.get_number_of_adj_matrix_local_rows().
+ * @p graph_view.get_number_of_local_adj_matrix_partition_rows().
  * @param adj_matrix_col_value_input_first Iterator pointing to the adjacency matrix column input
  * properties for the first (inclusive) column (assigned to this process in multi-GPU).
  * `adj_matrix_col_value_output_last` (exclusive) is deduced as @p adj_matrix_col_value_output_first
- * + @p graph_view.get_number_of_adj_matrix_local_cols().
+ * + @p graph_view.get_number_of_local_adj_matrix_partition_cols().
  * @param e_op Quaternary (or quinary) operator takes edge source, edge destination, (optional edge
  * weight), *(@p adj_matrix_row_value_input_first + i), and *(@p adj_matrix_col_value_input_first +
  * j) (where i is in [0, graph_view.get_number_of_local_adj_matrix_partition_rows()) and j is in [0,


### PR DESCRIPTION
Some of the pattern accelerator calls have the misspelled calls in assert messages.