### PR TITLE
[REVIEW] FIX Fix notebook error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 - PR #1168 Disabled MG tests on single GPU
 - PR #1166 Fix misspelling of function calls in asserts causing debug build to fail
 - PR #1180 BLD Adopt RAFT model for cuhornet dependency
+- PR #1181 Fix notebook error handling in CI
+
 
 # cuGraph 0.15.0 (26 Aug 2020)
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -53,7 +53,7 @@ logger "Check GPU usage..."
 nvidia-smi
 
 logger "Activate conda env..."
-source activate gdf
+source activate rapids
 
 logger "conda install required packages"
 conda install -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge -c defaults \
@@ -98,6 +98,10 @@ fi
 # TEST - Run GoogleTest and py.tests for libcugraph and cuGraph
 ################################################################################
 
+set +e -Eo pipefail
+EXITCODE=0
+trap "EXITCODE=1" ERR
+
 if hasArg --skip-tests; then
     logger "Skipping Tests..."
 else
@@ -122,3 +126,5 @@ else
     ${WORKSPACE}/ci/gpu/test-notebooks.sh 2>&1 | tee nbtest.log
     python ${WORKSPACE}/ci/utils/nbtestlog2junitxml.py nbtest.log
 fi
+
+return ${EXITCODE}


### PR DESCRIPTION
Current functionality does not actually properly handle errors in testing the notebooks.

${WORKSPACE}/ci/gpu/test-notebooks.sh 2>&1 | tee nbtest.log

Will only error if the last command in the pipe errors.

set +e -Eo pipefail will allow us to detect errors earlier in the pipe and hold the EXITCODE till we need it.