### PR TITLE
[REVEIW] BLD Installing raft headers under cugraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 - PR #1166 Fix misspelling of function calls in asserts causing debug build to fail
 - PR #1180 BLD Adopt RAFT model for cuhornet dependency
 - PR #1181 Fix notebook error handling in CI
-
+- PR #1186 BLD Installing raft headers under cugraph 
 
 # cuGraph 0.15.0 (26 Aug 2020)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -417,6 +417,8 @@ install(TARGETS cugraph LIBRARY
 install(DIRECTORY include/
     DESTINATION include/cugraph)
 
+install(DIRECTORY ${RAFT_DIR}/cpp/include/raft/
+    DESTINATION include/cugraph/raft)
 ###################################################################################################
 # - make documentation ----------------------------------------------------------------------------
 # requires doxygen and graphviz to be installed


### PR DESCRIPTION
In 0.16, we just include the necessary headers under the cugraph and cuml includes. 
In the 0.17 timeline, we can provide a means to install raft globally, but that will require shipping a new conda package and matching hashes.