### PR TITLE
[gpuCI] Auto-merge branch-0.16 to branch-0.17 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 - PR #1166 Fix misspelling of function calls in asserts causing debug build to fail
 - PR #1180 BLD Adopt RAFT model for cuhornet dependency
 - PR #1181 Fix notebook error handling in CI
-
+- PR #1186 BLD Installing raft headers under cugraph 
 
 # cuGraph 0.15.0 (26 Aug 2020)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -417,6 +417,8 @@ install(TARGETS cugraph LIBRARY
 install(DIRECTORY include/
     DESTINATION include/cugraph)
 
+install(DIRECTORY ${RAFT_DIR}/cpp/include/raft/
+    DESTINATION include/cugraph/raft)
 ###################################################################################################
 # - make documentation ----------------------------------------------------------------------------
 # requires doxygen and graphviz to be installed


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.16` that creates a PR to keep `branch-0.17` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.