### PR TITLE
[gpuCI] Auto-merge branch-0.16 to branch-0.17 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - PR #1169 Added RAPIDS cpp packages to cugraph dev env
 - PR #1165 updated remaining algorithms to be NetworkX compatible
 - PR #1176 Update ci/local/README.md
+- PR #1184 BLD getting latest tags
 
 ## Bug Fixes
 - PR #1131 Show style checker errors with set +e

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -185,7 +185,7 @@ set(CUHORNET_INCLUDE_DIR ${CUHORNET_DIR}/src/cuhornet CACHE STRING "Path to cuho
 
 ExternalProject_Add(cuhornet
   GIT_REPOSITORY    https://github.com/rapidsai/cuhornet.git
-  GIT_TAG           7e8be7e439c2765384c40b004806aabae2d74666
+  GIT_TAG           9cb8e8803852bd895a9c95c0fe778ad6eeefa7ad
   PREFIX            ${CUHORNET_DIR}
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.16` that creates a PR to keep `branch-0.17` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.