### PR TITLE
[REVIEW] BUG Remove deprecated call to from_gpu_matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - PR #1186 BLD Installing raft headers under cugraph
 - PR #1192 Fix benchmark notes and documentation issues in graph.py
 - PR #1196 Move subcomms init outside of individual algorithm functions
+- PR #1198 Remove deprecated call to from_gpu_matrix
 
 # cuGraph 0.15.0 (26 Aug 2020)
 

--- a/python/cugraph/layout/force_atlas2_wrapper.pyx
+++ b/python/cugraph/layout/force_atlas2_wrapper.pyx
@@ -127,7 +127,7 @@ def force_atlas2(input_graph,
                 <bool> verbose,
                 <GraphBasedDimRedCallback*>callback_ptr)
 
-        pos_df = cudf.DataFrame.from_gpu_matrix(pos, columns=['x', 'y'])
+        pos_df = cudf.DataFrame(pos, columns=['x', 'y'])
         df['x'] = pos_df['x']
         df['y'] = pos_df['y']
     else:
@@ -159,7 +159,7 @@ def force_atlas2(input_graph,
                 <bool> verbose,
                 <GraphBasedDimRedCallback*>callback_ptr)
 
-        pos_df = cudf.DataFrame.from_gpu_matrix(pos, columns=['x', 'y'])
+        pos_df = cudf.DataFrame(pos, columns=['x', 'y'])
         df['x'] = pos_df['x']
         df['y'] = pos_df['y']
 


### PR DESCRIPTION
This PR removes deprecated method `DataFrame.from_gpu_matrix`
Fixes: https://github.com/rapidsai/cugraph/issues/1191