### PR TITLE
[gpuCI] Auto-merge branch-0.16 to branch-0.17 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - PR #1198 Remove deprecated call to from_gpu_matrix
 - PR #1174 Fix bugs in MNMG pattern accelerators and pattern accelerator based implementations of MNMG PageRank, BFS, and SSSP
 - PR #1233 Temporarily disabling C++ tests for 0.16
+- PR #1240 Require `ucx-proc=*=gpu`
 
 
 # cuGraph 0.15.0 (26 Aug 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@
 - PR #1217 NetworkX Transition doc
 - PR #1223 Update mnmg docs
 
-
 ## Bug Fixes
 - PR #1131 Show style checker errors with set +e
 - PR #1150 Update RAFT git tag
@@ -53,7 +52,7 @@
 - PR #1196 Move subcomms init outside of individual algorithm functions
 - PR #1198 Remove deprecated call to from_gpu_matrix
 - PR #1174 Fix bugs in MNMG pattern accelerators and pattern accelerator based implementations of MNMG PageRank, BFS, and SSSP
-
+- PR #1233 Temporarily disabling C++ tests for 0.16
 
 
 # cuGraph 0.15.0 (26 Aug 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# cuGraph 0.16.0 (Date TBD)
+# cuGraph 0.16.0 (21 Oct 2020)
 
 ## New Features
 - PR #1098 Add new graph classes to support 2D partitioning

--- a/ci/benchmark/build.sh
+++ b/ci/benchmark/build.sh
@@ -71,6 +71,7 @@ conda install -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge -c defaul
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \
       "ucx-py=${MINOR_VERSION}" \
+      "ucx-proc=*=gpu" \
       "rapids-build-env=${MINOR_VERSION}" \
       rapids-pytest-benchmark
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -65,6 +65,7 @@ conda install -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge -c defaul
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \
       "ucx-py=${MINOR_VERSION}" \
+      "ucx-proc=*=gpu" \
       "rapids-build-env=$MINOR_VERSION.*" \
       "rapids-notebook-env=$MINOR_VERSION.*" \
       rapids-pytest-benchmark

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -64,12 +64,16 @@ else
     cd $WORKSPACE/ci/artifacts/cugraph/cpu/conda_work/cpp/build
 fi
 
-for gt in gtests/*; do
-    test_name=$(basename $gt)
-    echo "Running GoogleTest $test_name"
-    ${gt} ${GTEST_FILTER} ${GTEST_ARGS}
-    ERRORCODE=$((ERRORCODE | $?))
-done
+# FIXME: temporarily disabling all C++ tests for 0.16 due to intermittent
+# failures from what appears to be an issue with Thrust (which does not appear
+# to affect the Python API or notebooks). Re-enable once this issue is resolved
+# in 0.17.
+# for gt in gtests/*; do
+#     test_name=$(basename $gt)
+#     echo "Running GoogleTest $test_name"
+#     ${gt} ${GTEST_FILTER} ${GTEST_ARGS}
+#     ERRORCODE=$((ERRORCODE | $?))
+# done
 
 if [[ "$PROJECT_FLASH" == "1" ]]; then
     echo "Installing libcugraph..."

--- a/conda/environments/cugraph_dev_cuda10.1.yml
+++ b/conda/environments/cugraph_dev_cuda10.1.yml
@@ -15,6 +15,7 @@ dependencies:
 - dask-cudf=0.16*
 - nccl>=2.7
 - ucx-py=0.16*
+- ucx-proc=*=gpu
 - scipy
 - networkx
 - python-louvain

--- a/conda/environments/cugraph_dev_cuda10.2.yml
+++ b/conda/environments/cugraph_dev_cuda10.2.yml
@@ -15,6 +15,7 @@ dependencies:
 - dask-cudf=0.16*
 - nccl>=2.7
 - ucx-py=0.16*
+- ucx-proc=*=gpu
 - scipy
 - networkx
 - python-louvain

--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -15,6 +15,7 @@ dependencies:
 - dask-cudf=0.16*
 - nccl>=2.7
 - ucx-py=0.16*
+- ucx-proc=*=gpu
 - scipy
 - networkx
 - python-louvain

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - libcugraph={{ version }}
     - cudf={{ minor_version }}
     - ucx-py {{ minor_version }}
+    - ucx-proc=*=gpu
   run:
     - python x.x
     - libcugraph={{ version }}
@@ -38,6 +39,7 @@ requirements:
     - distributed>=2.12.0
     - nccl>=2.7
     - ucx-py {{ minor_version }}
+    - ucx-proc=*=gpu
 
 #test:
 #  commands:

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -31,11 +31,13 @@ requirements:
     - libcypher-parser
     - nccl>=2.7
     - ucx-py {{ minor_version }}
+    - ucx-proc=*=gpu
   run:
     - libcudf={{ minor_version }}
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
     - nccl>=2.7
     - ucx-py {{ minor_version }}
+    - ucx-proc=*=gpu
 
 #test:
 #  commands:


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.16` that creates a PR to keep `branch-0.17` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.