### PR TITLE
[REVIEW] BUG Calling gunrock cmake using explicit -D options, re-enabling C++ tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 ## Improvements
 
 ## Bug Fixes
+- PR #1242 Calling gunrock cmake using explicit -D options, re-enabling C++ tests
 
 
-# cuGraph 0.16.0 (Date TBD)
+# cuGraph 0.16.0 (21 Oct 2020)
 
 ## New Features
 - PR #1098 Add new graph classes to support 2D partitioning

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -64,16 +64,12 @@ else
     cd $WORKSPACE/ci/artifacts/cugraph/cpu/conda_work/cpp/build
 fi
 
-# FIXME: temporarily disabling all C++ tests for 0.16 due to intermittent
-# failures from what appears to be an issue with Thrust (which does not appear
-# to affect the Python API or notebooks). Re-enable once this issue is resolved
-# in 0.17.
-# for gt in gtests/*; do
-#     test_name=$(basename $gt)
-#     echo "Running GoogleTest $test_name"
-#     ${gt} ${GTEST_FILTER} ${GTEST_ARGS}
-#     ERRORCODE=$((ERRORCODE | $?))
-# done
+for gt in gtests/*; do
+    test_name=$(basename $gt)
+    echo "Running GoogleTest $test_name"
+    ${gt} ${GTEST_FILTER} ${GTEST_ARGS}
+    ERRORCODE=$((ERRORCODE | $?))
+done
 
 if [[ "$PROJECT_FLASH" == "1" ]]; then
     echo "Installing libcugraph..."

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -50,6 +50,14 @@ endif(CMAKE_COMPILER_IS_GNUCXX)
 
 find_package(CUDA)
 
+# Configure GPU arch to build
+set(GUNROCK_GENCODE_SM60 "OFF")
+set(GUNROCK_GENCODE_SM61 "OFF")
+set(GUNROCK_GENCODE_SM70 "OFF")
+set(GUNROCK_GENCODE_SM72 "OFF")
+set(GUNROCK_GENCODE_SM75 "OFF")
+set(GUNROCK_GENCODE_SM80 "OFF")
+
 # Check for aarch64 vs workstation architectures
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
   message(STATUS "CMAKE Detected aarch64 CPU architecture, selecting appropriate gencodes")
@@ -57,12 +65,13 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
   set(GPU_ARCHS "62") # Default minimum CUDA GenCode - not supported by gunrock
   if(CUDA_VERSION_MAJOR GREATER_EQUAL 9)
     set(GPU_ARCHS "${GPU_ARCHS};72")
-    set(GUNROCK_GENCODE "-DGUNROCK_GENCODE_SM72=TRUE")
+    set(GUNROCK_GENCODE_SM72 "ON")
   endif()
   if(CUDA_VERSION_MAJOR GREATER_EQUAL 11)
     # This is probably for SBSA CUDA, or a next gen Jetson
     set(GPU_ARCHS "${GPU_ARCHS};75;80")
-    set(GUNROCK_GENCODE "${GUNROCK_GENCODE} -DGUNROCK_GENCODE_SM75=TRUE -DGUNROCK_GENCODE_SM80=TRUE ")
+    set(GUNROCK_GENCODE_SM75 "ON")
+    set(GUNROCK_GENCODE_SM80 "ON")
   endif()
 
 else()
@@ -70,20 +79,19 @@ else()
   # System architecture was not aarch64,
   # this is datacenter or workstation class hardware
   set(GPU_ARCHS "60") # Default minimum supported CUDA gencode
-  set(GUNROCK_GENCODE "-DGUNROCK_GENCODE_SM60=TRUE")
+  set(GUNROCK_GENCODE_SM60 "ON")
   if(CUDA_VERSION_MAJOR GREATER_EQUAL 9)
     set(GPU_ARCHS "${GPU_ARCHS};70")
-    set(GUNROCK_GENCODE "${GUNROCK_GENCODE} -DGUNROCK_GENCODE_SM70=TRUE")
+    set(GUNROCK_GENCODE_SM70 "ON")
   endif()
   if(CUDA_VERSION_MAJOR GREATER_EQUAL 10)
     set(GPU_ARCHS "${GPU_ARCHS};75")
-    set(GUNROCK_GENCODE "${GUNROCK_GENCODE} -DGUNROCK_GENCODE_SM75=TRUE")
+    set(GUNROCK_GENCODE_SM75 "ON")
   endif()
   if(CUDA_VERSION_MAJOR GREATER_EQUAL 11)
     set(GPU_ARCHS "${GPU_ARCHS};80")
-    set(GUNROCK_GENCODE "${GUNROCK_GENCODE} -DGUNROCK_GENCODE_SM80=TRUE")
+    set(GUNROCK_GENCODE_SM80 "ON")
   endif()
-
 endif()
 
 message("-- Building for GPU_ARCHS = ${GPU_ARCHS}")
@@ -97,6 +105,7 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode arch=compute_${ptx},code=comp
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror=cross-execution-space-call -Wno-deprecated-declarations -Xptxas --disable-warnings")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wall,-Wno-error=sign-compare,-Wno-error=unused-but-set-variable")
+
 
 # Option to enable line info in CUDA device compilation to allow introspection when profiling /
 # memchecking
@@ -248,7 +257,6 @@ set(LIBCUDACXX_INCLUDE_DIR "${libcudacxx_SOURCE_DIR}/include")
 message("set LIBCUDACXX_INCLUDE_DIR to: ${LIBCUDACXX_INCLUDE_DIR}")
 
 
-
 ###################################################################################################
 # - External Projects -----------------------------------------------------------------------------
 
@@ -280,7 +288,13 @@ ExternalProject_Add(cugunrock
   CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                     -DGUNROCK_BUILD_SHARED_LIBS=OFF
                     -DGUNROCK_BUILD_TESTS=OFF
-                    -DCUDA_AUTODETECT_GENCODE=FALSE
+                    -DCUDA_AUTODETECT_GENCODE=OFF
+                    -DGUNROCK_GENCODE_SM60=${GUNROCK_GENCODE_SM60}
+                    -DGUNROCK_GENCODE_SM61=${GUNROCK_GENCODE_SM61}
+                    -DGUNROCK_GENCODE_SM70=${GUNROCK_GENCODE_SM70}
+                    -DGUNROCK_GENCODE_SM72=${GUNROCK_GENCODE_SM72}
+                    -DGUNROCK_GENCODE_SM75=${GUNROCK_GENCODE_SM75}
+                    -DGUNROCK_GENCODE_SM80=${GUNROCK_GENCODE_SM80}
                     ${GUNROCK_GENCODE}
   BUILD_BYPRODUCTS  ${CUGUNROCK_DIR}/lib/libgunrock.a
 )

--- a/cpp/tests/traversal/sssp_test.cu
+++ b/cpp/tests/traversal/sssp_test.cu
@@ -425,10 +425,7 @@ TEST_P(Tests_SSSP, CheckFP64_RANDOM_DIST_PREDS)
 
 // --gtest_filter=*simple_test*
 
-// FIXME: Enable this for 0.17. Temporarily disabled due to sporadic error hard
-// to reproduce: "transform: failed to synchronize: cudaErrorIllegalAddress: an
-// illegal memory access was encountered" thrown in the test body.
-INSTANTIATE_TEST_CASE_P(DISABLED_simple_test,
+INSTANTIATE_TEST_CASE_P(simple_test,
                         Tests_SSSP,
                         ::testing::Values(SSSP_Usecase(MTX, "test/datasets/dblp.mtx", 100),
                                           SSSP_Usecase(MTX, "test/datasets/wiki2003.mtx", 100000),


### PR DESCRIPTION
* Changes to call gunrock cmake using explicit -D options for each arch, similar to a prior version of the CMakeLists.txt, since the update to expand a variable into the arch options was being expanded as a single quoted value with spaces that wasn't recognized, resulting in gunrock being built for only compute 60 support. This caused C++ test crashes.
* Re-enabled C++ tests.

This was tested by building cugraph with this change and running the Pagerank C++ test 1000 times without failures/crashes.  Prior to this, the Pagerank C++ test (and others) would crash after 1-50 test run iterations.

The issue and corresponding fix was verified with a standalone reproducer, which can be seen here: https://github.com/rlratzel/cugraph_build_problem