### PR TITLE
[REVIEW] Use latest Gunrock, update HITS implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Bug Fixes
 - PR #1242 Calling gunrock cmake using explicit -D options, re-enabling C++ tests
+- PR #1246 Use latest Gunrock, update HITS implementation
 
 
 # cuGraph 0.16.0 (21 Oct 2020)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -278,13 +278,13 @@ ExternalProject_Add(cuhornet
 )
 
 # - GUNROCK
-set(CUGUNROCK_DIR ${CMAKE_CURRENT_BINARY_DIR}/cugunrock CACHE STRING
-  "Path to cugunrock repo")
+set(GUNROCK_DIR ${CMAKE_CURRENT_BINARY_DIR}/gunrock CACHE STRING "Path to gunrock repo")
+set(GUNROCK_INCLUDE_DIR ${GUNROCK_DIR}/src/gunrock_ext CACHE STRING "Path to gunrock includes")
 
-ExternalProject_Add(cugunrock
-  GIT_REPOSITORY    https://github.com/rapidsai/cugunrock.git
-  GIT_TAG           0b92fae6ee9026188a811b4d08915779e7c97178
-  PREFIX            ${CUGUNROCK_DIR}
+ExternalProject_Add(gunrock_ext
+  GIT_REPOSITORY    https://github.com/gunrock/gunrock.git
+  GIT_TAG           dev
+  PREFIX            ${GUNROCK_DIR}
   CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                     -DGUNROCK_BUILD_SHARED_LIBS=OFF
                     -DGUNROCK_BUILD_TESTS=OFF
@@ -296,14 +296,15 @@ ExternalProject_Add(cugunrock
                     -DGUNROCK_GENCODE_SM75=${GUNROCK_GENCODE_SM75}
                     -DGUNROCK_GENCODE_SM80=${GUNROCK_GENCODE_SM80}
                     ${GUNROCK_GENCODE}
-  BUILD_BYPRODUCTS  ${CUGUNROCK_DIR}/lib/libgunrock.a
+  BUILD_BYPRODUCTS  ${GUNROCK_DIR}/src/gunrock_ext-build/lib/libgunrock.a
+  INSTALL_COMMAND   ""
 )
 
 add_library(gunrock STATIC IMPORTED)
 
-add_dependencies(gunrock cugunrock)
+add_dependencies(gunrock gunrock_ext)
 
-set_property(TARGET gunrock PROPERTY IMPORTED_LOCATION ${CUGUNROCK_DIR}/lib/libgunrock.a)
+set_property(TARGET gunrock PROPERTY IMPORTED_LOCATION ${GUNROCK_DIR}/src/gunrock_ext-build/lib/libgunrock.a)
 
 # - NCCL
 if(NOT NCCL_PATH)
@@ -399,7 +400,7 @@ add_library(cugraph SHARED
 # NOTE:  This dependency will force the building of cugraph to
 #        wait until after cugunrock is constructed.
 #
-add_dependencies(cugraph cugunrock)
+add_dependencies(cugraph gunrock_ext)
 add_dependencies(cugraph raft)
 
 ###################################################################################################
@@ -419,7 +420,7 @@ target_include_directories(cugraph
     "${CUHORNET_INCLUDE_DIR}/xlib/include"
     "${CUHORNET_INCLUDE_DIR}/primitives"
     "${CMAKE_CURRENT_SOURCE_DIR}/src"
-    "${CUGUNROCK_DIR}/include"
+    "${GUNROCK_INCLUDE_DIR}"
     "${NCCL_INCLUDE_DIRS}"
     "${RAFT_DIR}/cpp/include"
     PUBLIC

--- a/cpp/src/link_analysis/gunrock_hits.cpp
+++ b/cpp/src/link_analysis/gunrock_hits.cpp
@@ -30,6 +30,9 @@ namespace cugraph {
 
 namespace gunrock {
 
+const int HOST{1};  // gunrock should expose the device constant at the API level.
+const int DEVICE{2};  // gunrock should expose the device constant at the API level.
+
 template <typename vertex_t, typename edge_t, typename weight_t>
 void hits(cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
           int max_iter,
@@ -44,49 +47,18 @@ void hits(cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                   "Invalid API parameter: authorities array should be of size V");
 
   //
-  //  NOTE:  gunrock doesn't support tolerance parameter
-  //         gunrock doesn't support passing a starting value
-  //         gunrock doesn't support the normalized parameter
+  //  NOTE:  gunrock doesn't support passing a starting value
   //
-  //  FIXME: gunrock uses a 2-norm, while networkx uses a 1-norm.
-  //         They will add a parameter to allow us to specify
-  //         which norm to use.
-  //
-  std::vector<edge_t> local_offsets(graph.number_of_vertices + 1);
-  std::vector<vertex_t> local_indices(graph.number_of_edges);
-  std::vector<weight_t> local_hubs(graph.number_of_vertices);
-  std::vector<weight_t> local_authorities(graph.number_of_vertices);
-
-  //    Ideally:
-  //
-  //::hits(graph.number_of_vertices, graph.number_of_edges, graph.offsets, graph.indices,
-  //       max_iter, hubs, authorities, DEVICE);
-  //
-  //    For now, the following:
-
-  CUDA_TRY(cudaMemcpy(local_offsets.data(),
-                      graph.offsets,
-                      (graph.number_of_vertices + 1) * sizeof(edge_t),
-                      cudaMemcpyDeviceToHost));
-  CUDA_TRY(cudaMemcpy(local_indices.data(),
-                      graph.indices,
-                      graph.number_of_edges * sizeof(vertex_t),
-                      cudaMemcpyDeviceToHost));
-
   ::hits(graph.number_of_vertices,
          graph.number_of_edges,
-         local_offsets.data(),
-         local_indices.data(),
+         graph.offsets,
+         graph.indices,
          max_iter,
-         local_hubs.data(),
-         local_authorities.data());
-
-  CUDA_TRY(cudaMemcpy(
-    hubs, local_hubs.data(), graph.number_of_vertices * sizeof(weight_t), cudaMemcpyHostToDevice));
-  CUDA_TRY(cudaMemcpy(authorities,
-                      local_authorities.data(),
-                      graph.number_of_vertices * sizeof(weight_t),
-                      cudaMemcpyHostToDevice));
+         tolerance,
+         HITS_NORMALIZATION_METHOD_1,
+         hubs,
+         authorities,
+         DEVICE);
 }
 
 template void hits(cugraph::GraphCSRView<int32_t, int32_t, float> const &,
@@ -98,5 +70,4 @@ template void hits(cugraph::GraphCSRView<int32_t, int32_t, float> const &,
                    float *);
 
 }  // namespace gunrock
-
 }  // namespace cugraph

--- a/cpp/src/link_analysis/gunrock_hits.cpp
+++ b/cpp/src/link_analysis/gunrock_hits.cpp
@@ -30,7 +30,7 @@ namespace cugraph {
 
 namespace gunrock {
 
-const int HOST{1};  // gunrock should expose the device constant at the API level.
+const int HOST{1};    // gunrock should expose the device constant at the API level.
 const int DEVICE{2};  // gunrock should expose the device constant at the API level.
 
 template <typename vertex_t, typename edge_t, typename weight_t>

--- a/python/cugraph/tests/test_hits.py
+++ b/python/cugraph/tests/test_hits.py
@@ -37,16 +37,6 @@ with warnings.catch_warnings():
 print("Networkx version : {} ".format(nx.__version__))
 
 
-def cudify(d):
-    if d is None:
-        return None
-
-    k = np.fromiter(d.keys(), dtype="int32")
-    v = np.fromiter(d.values(), dtype="float32")
-    cuD = cudf.DataFrame({"vertex": k, "values": v})
-    return cuD
-
-
 def cugraph_call(cu_M, max_iter, tol):
     # cugraph hits Call
 
@@ -78,20 +68,16 @@ def networkx_call(M, max_iter, tol):
     )
 
     # same parameters as in NVGRAPH
-    pr = nx.hits(Gnx, max_iter, tol, normalized=True)
+    nx_hits = nx.hits(Gnx, max_iter, tol, normalized=True)
     t2 = time.time() - t1
 
     print("Networkx Time : " + str(t2))
 
-    return pr
+    return nx_hits
 
 
 MAX_ITERATIONS = [50]
 TOLERANCE = [1.0e-06]
-
-
-# Test all combinations of default/managed and pooled/non-pooled allocation
-
 
 @pytest.mark.parametrize("graph_file", utils.DATASETS_UNDIRECTED)
 @pytest.mark.parametrize("max_iter", MAX_ITERATIONS)
@@ -105,52 +91,19 @@ def test_hits(graph_file, max_iter, tol):
     cu_M = utils.read_csv_file(graph_file)
     cugraph_hits = cugraph_call(cu_M, max_iter, tol)
 
-    # Calculating mismatch
-    # hubs = sorted(hubs.items(), key=lambda x: x[0])
-    # print("hubs = ", hubs)
-
-    #
-    #  Scores don't match.  Networkx uses the 1-norm,
-    #  gunrock uses a 2-norm.  Eventually we'll add that
-    #  as a parameter. For now, let's check the order
-    #  which should match.  We'll allow 6 digits to right
-    #  of decimal point accuracy
-    #
     pdf = pd.DataFrame.from_dict(hubs, orient="index").sort_index()
-    pdf = pdf.multiply(1000000).floordiv(1)
     cugraph_hits["nx_hubs"] = cudf.Series.from_pandas(pdf[0])
 
     pdf = pd.DataFrame.from_dict(authorities, orient="index").sort_index()
-    pdf = pdf.multiply(1000000).floordiv(1)
     cugraph_hits["nx_authorities"] = cudf.Series.from_pandas(pdf[0])
 
-    #
-    #  Sort by hubs (cugraph) in descending order.  Then we'll
-    #  check to make sure all scores are in descending order.
-    #
-    cugraph_hits = cugraph_hits.sort_values("hubs", ascending=False)
+    hubs_diffs1 = cugraph_hits.query('hubs - nx_hubs > 0.00001')
+    hubs_diffs2 = cugraph_hits.query('hubs - nx_hubs < -0.00001')
+    authorities_diffs1 = cugraph_hits.query('authorities - nx_authorities > 0.0001')
+    authorities_diffs2 = cugraph_hits.query('authorities - nx_authorities < -0.0001')
 
-    assert cugraph_hits["hubs"].is_monotonic_decreasing
-    assert cugraph_hits["nx_hubs"].is_monotonic_decreasing
+    assert len(hubs_diffs1) == 0
+    assert len(hubs_diffs2) == 0
+    assert len(authorities_diffs1) == 0
+    assert len(authorities_diffs2) == 0
 
-    cugraph_hits = cugraph_hits.sort_values("authorities", ascending=False)
-
-    assert cugraph_hits["authorities"].is_monotonic_decreasing
-    assert cugraph_hits["nx_authorities"].is_monotonic_decreasing
-
-
-@pytest.mark.parametrize("graph_file", utils.DATASETS_UNDIRECTED)
-@pytest.mark.parametrize("max_iter", MAX_ITERATIONS)
-@pytest.mark.parametrize("tol", TOLERANCE)
-def test_hits_nx(graph_file, max_iter, tol):
-    gc.collect()
-
-    M = utils.read_csv_for_nx(graph_file)
-    Gnx = nx.from_pandas_edgelist(
-        M, source="0", target="1", create_using=nx.DiGraph()
-    )
-    nx_hubs, nx_authorities = nx.hits(Gnx, max_iter, tol, normalized=True)
-    cg_hubs, cg_authorities = cugraph.hits(Gnx, max_iter, tol, normalized=True)
-
-    # assert nx_hubs == cg_hubs
-    # assert nx_authorities == cg_authorities

--- a/python/cugraph/tests/test_hits.py
+++ b/python/cugraph/tests/test_hits.py
@@ -13,7 +13,6 @@
 
 import gc
 import time
-import numpy as np
 import pandas as pd
 
 import pytest
@@ -79,6 +78,7 @@ def networkx_call(M, max_iter, tol):
 MAX_ITERATIONS = [50]
 TOLERANCE = [1.0e-06]
 
+
 @pytest.mark.parametrize("graph_file", utils.DATASETS_UNDIRECTED)
 @pytest.mark.parametrize("max_iter", MAX_ITERATIONS)
 @pytest.mark.parametrize("tol", TOLERANCE)
@@ -99,11 +99,12 @@ def test_hits(graph_file, max_iter, tol):
 
     hubs_diffs1 = cugraph_hits.query('hubs - nx_hubs > 0.00001')
     hubs_diffs2 = cugraph_hits.query('hubs - nx_hubs < -0.00001')
-    authorities_diffs1 = cugraph_hits.query('authorities - nx_authorities > 0.0001')
-    authorities_diffs2 = cugraph_hits.query('authorities - nx_authorities < -0.0001')
+    authorities_diffs1 = cugraph_hits.query(
+        'authorities - nx_authorities > 0.0001')
+    authorities_diffs2 = cugraph_hits.query(
+        'authorities - nx_authorities < -0.0001')
 
     assert len(hubs_diffs1) == 0
     assert len(hubs_diffs2) == 0
     assert len(authorities_diffs1) == 0
     assert len(authorities_diffs2) == 0
-


### PR DESCRIPTION
Closes #1154 

This PR makes the following changes to our gunrock integration:
1. Update the CMake files to point directly to the gunrock repository instead of cugunrock.  This makes it easier to integrate their changes.
1. Latest repo adds features to allow the HITS function to accept data already on device memory and to accept a tolerance parameter and to select which normalization function to use (networkx uses the L1 norm gunrock was using the L2 norm, now we can specify which one that gunrock should use
1. With the updated HITS we can now compare results to networkx, so updated the python test to compare results to networkx.
