### PR TITLE
[REVIEW] BUG Updated cuco commit hash to latest as of 2020-10-30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## Bug Fixes
 - PR #1242 Calling gunrock cmake using explicit -D options, re-enabling C++ tests
-- PR #1250 Updated cuco commit hash to latest as of 2020-10-30
+- PR #1250 Updated cuco commit hash to latest as of 2020-10-30 and removed unneeded GIT_SHALLOW param
 
 
 # cuGraph 0.16.0 (21 Oct 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Bug Fixes
 - PR #1242 Calling gunrock cmake using explicit -D options, re-enabling C++ tests
+- PR #1250 Updated cuco commit hash to latest as of 2020-10-30
 
 
 # cuGraph 0.16.0 (21 Oct 2020)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -225,7 +225,7 @@ message("Fetching cuco")
 FetchContent_Declare(
     cuco
     GIT_REPOSITORY https://github.com/NVIDIA/cuCollections.git
-    GIT_TAG        729d07db2e544e173efefdd168db21f7b8adcfaf
+    GIT_TAG        5f94cdd3b3df0e5f79c47fb772497d6e42455414
     GIT_SHALLOW    true
 )
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -226,7 +226,6 @@ FetchContent_Declare(
     cuco
     GIT_REPOSITORY https://github.com/NVIDIA/cuCollections.git
     GIT_TAG        5f94cdd3b3df0e5f79c47fb772497d6e42455414
-    GIT_SHALLOW    true
 )
 
 FetchContent_GetProperties(cuco)


### PR DESCRIPTION
Updated cuco commit hash to latest as of 2020-10-30.  This fixes build breakages as reported here: https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cugraph/job/branches/job/cugraph-cpu-branch-build/5381/console

Update: removing the `GIT_SHALLOW` param is the actual fix (thanks to @ChuckHastings), since its use is only supported when a branch or tag are specified (not a hash): https://cmake.org/cmake/help/latest/module/ExternalProject.html
I'll keep the change to update the hash though since it's just a README change and might help future debugging efforts by being of a more recent date (fewer commits to bisect)
