### PR TITLE
Remove GIT_SHALLOW from CMakeLists.txt [skip-ci-changelog]

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -217,7 +217,6 @@ FetchContent_Declare(
     cuco
     GIT_REPOSITORY https://github.com/NVIDIA/cuCollections.git
     GIT_TAG        729d07db2e544e173efefdd168db21f7b8adcfaf
-    GIT_SHALLOW    true
 )
 
 FetchContent_GetProperties(cuco)


### PR DESCRIPTION
This PR removes `GIT_SHALLOW` (which is not compatible with commit hashes) from the `cuco` fetch function to prevent build errors from occurring. This is similar to Rick's fix in #1250, but now needs to be backported to `0.16` since Ops needs to re-release `0.16` and this issue is causing build errors.

This fix was confirmed locally.

As outlined in the [CMake docs](https://cmake.org/cmake/help/v3.17/module/ExternalProject.html):

>If GIT_SHALLOW is enabled then GIT_TAG works only with branch names and tags. A commit hash is not allowed.
