### PR TITLE
[REVIEW][skip-ci-changelog] Include doxygen for new and clean conda environments

### DIFF
--- a/conda/environments/cugraph_dev_cuda10.1.yml
+++ b/conda/environments/cugraph_dev_cuda10.1.yml
@@ -40,3 +40,4 @@ dependencies:
 - pip
 - libcypher-parser
 - rapids-pytest-benchmark
+- doxygen

--- a/conda/environments/cugraph_dev_cuda10.2.yml
+++ b/conda/environments/cugraph_dev_cuda10.2.yml
@@ -40,3 +40,4 @@ dependencies:
 - pip
 - libcypher-parser
 - rapids-pytest-benchmark
+- doxygen

--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -40,3 +40,4 @@ dependencies:
 - pip
 - libcypher-parser
 - rapids-pytest-benchmark
+- doxygen


### PR DESCRIPTION
Tried building `cugraph` from source today with `./build.sh`. I built my conda environment from `conda/environments/cugraph_dev_cuda11.0.yml`

I ran into docs build target failing because `doxygen` was not in the environment:
```
Scanning dependencies of target docs_cugraph
[100%] Generating CUGRAPH_DOXYGEN
/bin/sh: 1: doxygen: not found
CMakeFiles/docs_cugraph.dir/build.make:79: recipe for target 'CUGRAPH_DOXYGEN' failed
make[3]: *** [CUGRAPH_DOXYGEN] Error 127
CMakeFiles/Makefile2:217: recipe for target 'CMakeFiles/docs_cugraph.dir/all' failed
make[2]: *** [CMakeFiles/docs_cugraph.dir/all] Error 2
CMakeFiles/Makefile2:224: recipe for target 'CMakeFiles/docs_cugraph.dir/rule' failed
make[1]: *** [CMakeFiles/docs_cugraph.dir/rule] Error 2
Makefile:207: recipe for target 'docs_cugraph' failed
``` 