### PR TITLE
[REVIEW] Force local install of conda artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #1251 Changed the MG context testing class to use updated parameters passed in from the individual tests
 - PR #1253 MG test fixes: updated additional comms.initialize() calls, fixed dask DataFrame comparisons
 - PR #1270 Raise exception for p2p, disable bottom up approach for bfs
+- PR #1275 Force local artifact conda install
 
 # cuGraph 0.16.0 (21 Oct 2020)
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -72,8 +72,12 @@ for gt in gtests/*; do
 done
 
 if [[ "$PROJECT_FLASH" == "1" ]]; then
-    echo "Installing libcugraph..."
-    conda install -c $WORKSPACE/ci/artifacts/cugraph/cpu/conda-bld/ libcugraph
+    CONDA_FILE=`find $WORKSPACE/ci/artifacts/cugraph/cpu/conda-bld/ -name "libcugraph*.tar.bz2"`
+    CONDA_FILE=`basename "$CONDA_FILE" .tar.bz2` #get filename without extension
+    CONDA_FILE=${CONDA_FILE//-/=} #convert to conda install
+    echo "Installing $CONDA_FILE"
+    conda install -c $WORKSPACE/ci/artifacts/cugraph/cpu/conda-bld/ "$CONDA_FILE"
+
     export LIBCUGRAPH_BUILD_DIR="$WORKSPACE/ci/artifacts/cugraph/cpu/conda_work/cpp/build"
     echo "Build cugraph..."
     $WORKSPACE/build.sh cugraph


### PR DESCRIPTION
This forces the `ci/gpu/build.sh` script to install the local conda package artifact from the CUDA build. This is achieved by specifying the exact version and build string of the artifact.