### PR TITLE
[REVIEW] Add support for shortest_path_length and fix graph vertex checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PR #1274 Add generic from_edgelist() and from_adjlist() APIs
 - PR #1279 Add self loop check variable in graph
 - PR #1277 SciPy sparse matrix input support for WCC, SCC, SSSP, and BFS
+- PR #1278 Add support for shortest_path_length and fix graph vertex checks
 
 ## Improvements
 - PR #1227 Pin cmake policies to cmake 3.17 version

--- a/python/cugraph/__init__.py
+++ b/python/cugraph/__init__.py
@@ -77,6 +77,7 @@ from cugraph.traversal import (
     sssp,
     shortest_path,
     filter_unreachable,
+    shortest_path_length
 )
 
 from cugraph.tree import minimum_spanning_tree, maximum_spanning_tree

--- a/python/cugraph/structure/graph.py
+++ b/python/cugraph/structure/graph.py
@@ -1322,7 +1322,7 @@ class Graph:
             return (ddf == n).any().any().compute()
         if self.renumbered:
             tmp = self.renumber_map.to_internal_vertex_id(cudf.Series([n]))
-            return tmp[0] >= 0
+            return tmp[0] is not cudf.NA and tmp[0] >= 0
         else:
             df = self.edgelist.edgelist_df[["src", "dst"]]
             return (df == n).any().any()

--- a/python/cugraph/tests/test_graph.py
+++ b/python/cugraph/tests/test_graph.py
@@ -606,6 +606,15 @@ def test_has_node(graph_file):
         assert G.has_node(n)
 
 
+def test_invalid_has_node():
+    df = cudf.DataFrame([[1, 2]], columns=["src", "dst"])
+    G = cugraph.Graph()
+    G.from_cudf_edgelist(df, source="src", destination="dst")
+    assert not G.has_node(-1)
+    assert not G.has_node(0)
+    assert not G.has_node(G.number_of_nodes() + 1)
+
+
 @pytest.mark.parametrize('graph_file', utils.DATASETS)
 def test_bipartite_api(graph_file):
     # This test only tests the functionality of adding set of nodes and

--- a/python/cugraph/tests/test_paths.py
+++ b/python/cugraph/tests/test_paths.py
@@ -1,5 +1,7 @@
 import cudf
 import cugraph
+from cupy.sparse import coo_matrix as cupy_coo_matrix
+import cupy
 import networkx as nx
 import pytest
 import sys
@@ -24,82 +26,138 @@ def graphs(request):
         graph_tf.writelines(request.param)
         graph_tf.seek(0)
 
-        nx_graph = nx.read_weighted_edgelist(graph_tf.name, delimiter=',')
-        gpu_df = cudf.read_csv(graph_tf.name, names=["src", "dst", "data"],
-                               delimiter=",", dtype=["int32", "int32", "float64"])
-        gpu_graph = cugraph.Graph()
-        gpu_graph.from_cudf_edgelist(gpu_df, source="src", destination="dst", edge_attr="data")
+        nx_G = nx.read_weighted_edgelist(graph_tf.name, delimiter=',')
+        cudf_df = cudf.read_csv(graph_tf.name, names=["src", "dst", "data"],
+                                delimiter=",", dtype=["int32", "int32", "float64"])
+        cugraph_G = cugraph.Graph()
+        cugraph_G.from_cudf_edgelist(cudf_df, source="src", destination="dst", edge_attr="data")
 
-        yield gpu_graph, nx_graph
+        # construct cupy coo_matrix graph
+        i = []
+        j = []
+        weights = []
+        for index in range(cudf_df.shape[0]):
+            vertex1 = cudf_df.iloc[index]["src"]
+            vertex2 = cudf_df.iloc[index]["dst"]
+            weight = cudf_df.iloc[index]["data"]
+            i += [vertex1, vertex2]
+            j += [vertex2, vertex1]
+            weights += [weight, weight]
+        i = cupy.array(i)
+        j = cupy.array(j)
+        weights = cupy.array(weights)
+        largest_vertex = max(cupy.amax(i), cupy.amax(j))
+        cupy_df = cupy_coo_matrix((weights, (i, j)), shape=(largest_vertex + 1, largest_vertex + 1))
+
+        yield cugraph_G, nx_G, cupy_df
 
 
 @pytest.mark.parametrize("graphs", [CONNECTED_GRAPH], indirect=True)
 def test_connected_graph_shortest_path_length(graphs):
-    gpu_graph, nx_graph = graphs
+    cugraph_G, nx_G, cupy_df = graphs
 
-    path_1_to_1_length = cugraph.shortest_path_length(gpu_graph, 1, 1)
+    path_1_to_1_length = cugraph.shortest_path_length(cugraph_G, 1, 1)
     assert path_1_to_1_length == 0.0
-    assert path_1_to_1_length == nx.shortest_path_length(nx_graph, "1", target="1", weight="weight")
+    assert path_1_to_1_length == nx.shortest_path_length(nx_G, "1", target="1", weight="weight")
+    assert path_1_to_1_length == cugraph.shortest_path_length(nx_G, "1", "1")
+    assert path_1_to_1_length == cugraph.shortest_path_length(cupy_df, 1, 1)
 
-    path_1_to_5_length = cugraph.shortest_path_length(gpu_graph, 1, 5)
+    path_1_to_5_length = cugraph.shortest_path_length(cugraph_G, 1, 5)
     assert path_1_to_5_length == 2.0
-    assert path_1_to_5_length == nx.shortest_path_length(nx_graph, "1", target="5", weight="weight")
+    assert path_1_to_5_length == nx.shortest_path_length(nx_G, "1", target="5", weight="weight")
+    assert path_1_to_5_length == cugraph.shortest_path_length(nx_G, "1", "5")
+    assert path_1_to_5_length == cugraph.shortest_path_length(cupy_df, 1, 5)
 
-    path_1_to_3_length = cugraph.shortest_path_length(gpu_graph, 1, 3)
+    path_1_to_3_length = cugraph.shortest_path_length(cugraph_G, 1, 3)
     assert path_1_to_3_length == 2.0
-    assert path_1_to_3_length == nx.shortest_path_length(nx_graph, "1", target="3", weight="weight")
+    assert path_1_to_3_length == nx.shortest_path_length(nx_G, "1", target="3", weight="weight")
+    assert path_1_to_3_length == cugraph.shortest_path_length(nx_G, "1", "3")
+    assert path_1_to_3_length == cugraph.shortest_path_length(cupy_df, 1, 3)
 
-    path_1_to_6_length = cugraph.shortest_path_length(gpu_graph, 1, 6)
+    path_1_to_6_length = cugraph.shortest_path_length(cugraph_G, 1, 6)
     assert path_1_to_6_length == 2.0
-    assert path_1_to_6_length == nx.shortest_path_length(nx_graph, "1", target="6", weight="weight")
+    assert path_1_to_6_length == nx.shortest_path_length(nx_G, "1", target="6", weight="weight")
+    assert path_1_to_6_length == cugraph.shortest_path_length(nx_G, "1", "6")
+    assert path_1_to_6_length == cugraph.shortest_path_length(cupy_df, 1, 6)
 
 
 @pytest.mark.parametrize("graphs", [CONNECTED_GRAPH], indirect=True)
 def test_shortest_path_length_invalid_source(graphs):
-    gpu_graph, __ = graphs
+    cugraph_G, nx_G, cupy_df = graphs
 
     with pytest.raises(ValueError):
-        cugraph.shortest_path_length(gpu_graph, 42, 1)
+        cugraph.shortest_path_length(cugraph_G, -1, 1)
+
+    with pytest.raises(ValueError):
+        cugraph.shortest_path_length(nx_G, "-1", "1")
+
+    with pytest.raises(ValueError):
+        cugraph.shortest_path_length(cupy_df, -1, 1)
 
 
-@pytest.mark.parametrize("graphs", [CONNECTED_GRAPH], indirect=True)
+@pytest.mark.parametrize("graphs", [DISCONNECTED_GRAPH], indirect=True)
 def test_shortest_path_length_invalid_target(graphs):
-    gpu_graph, __ = graphs
+    cugraph_G, nx_G, cupy_df = graphs
 
     with pytest.raises(ValueError):
-        cugraph.shortest_path_length(gpu_graph, 1, 42)
+        cugraph.shortest_path_length(cugraph_G, 1, 10)
+
+    with pytest.raises(ValueError):
+        cugraph.shortest_path_length(nx_G, "1", "10")
+
+    with pytest.raises(ValueError):
+        cugraph.shortest_path_length(cupy_df, 1, 10)
 
 
 @pytest.mark.parametrize("graphs", [CONNECTED_GRAPH], indirect=True)
 def test_shortest_path_length_invalid_vertexes(graphs):
-    gpu_graph, __ = graphs
+    cugraph_G, nx_G, cupy_df = graphs
 
     with pytest.raises(ValueError):
-        cugraph.shortest_path_length(gpu_graph, 42, 42)
+        cugraph.shortest_path_length(cugraph_G, 0, 42)
+
+    with pytest.raises(ValueError):
+        cugraph.shortest_path_length(nx_G, "0", "42")
+
+    with pytest.raises(ValueError):
+        cugraph.shortest_path_length(cupy_df, 0, 42)
 
 
 @pytest.mark.parametrize("graphs", [DISCONNECTED_GRAPH], indirect=True)
 def test_shortest_path_length_no_path(graphs):
-    gpu_graph, __ = graphs
+    cugraph_G, nx_G, cupy_df = graphs
 
-    path_1_to_8 = cugraph.shortest_path_length(gpu_graph, 1, 8)
+    path_1_to_8 = cugraph.shortest_path_length(cugraph_G, 1, 8)
     assert path_1_to_8 == sys.float_info.max
+    assert path_1_to_8 == cugraph.shortest_path_length(nx_G, "1", "8")
+    assert path_1_to_8 == cugraph.shortest_path_length(cupy_df, 1, 8)
 
 
 @pytest.mark.parametrize("graphs", [DISCONNECTED_GRAPH], indirect=True)
 def test_shortest_path_length_no_target(graphs):
-    gpu_graph, nx_graph = graphs
+    cugraph_G, nx_G, cupy_df = graphs
 
-    gpu_path_1_to_all = cugraph.shortest_path_length(gpu_graph, 1)
-    nx_path_1_to_all = nx.shortest_path_length(nx_graph, source="1", weight="weight")
-    assert gpu_path_1_to_all.shape[0] == len(nx_path_1_to_all) + 2
+    cugraph_path_1_to_all = cugraph.shortest_path_length(cugraph_G, 1)
+    nx_path_1_to_all = nx.shortest_path_length(nx_G, source="1", weight="weight")
+    nx_gpu_path_1_to_all = cugraph.shortest_path_length(nx_G, "1")
+    cupy_path_1_to_all = cugraph.shortest_path_length(cupy_df, 1)
 
-    for index in range(gpu_path_1_to_all.shape[0]):
+    assert nx_gpu_path_1_to_all == nx_gpu_path_1_to_all
 
-        vertex = str(gpu_path_1_to_all["vertex"][index].item())
-        distance = gpu_path_1_to_all["distance"][index].item()
+    assert cugraph_path_1_to_all.shape[0] == len(nx_path_1_to_all) + 2  # results for vertex 8 and 9 are not returned
+    assert cugraph_path_1_to_all.shape[0] == len(cupy_path_1_to_all[0])
 
+    for index in range(cugraph_path_1_to_all.shape[0]):
+
+        vertex = str(cugraph_path_1_to_all["vertex"][index].item())
+        distance = cugraph_path_1_to_all["distance"][index].item()
+
+        # verify cugraph against networkx
         if vertex in {'8', '9'}:
+            # Networkx does not return distances for these vertexes.
             assert distance == sys.float_info.max
         else:
             assert distance == nx_path_1_to_all[vertex]
+
+        # verify cugraph against cupy graph
+        assert distance == cupy_path_1_to_all[0][int(vertex) - 1].item()

--- a/python/cugraph/tests/test_paths.py
+++ b/python/cugraph/tests/test_paths.py
@@ -27,10 +27,14 @@ def graphs(request):
         graph_tf.seek(0)
 
         nx_G = nx.read_weighted_edgelist(graph_tf.name, delimiter=',')
-        cudf_df = cudf.read_csv(graph_tf.name, names=["src", "dst", "data"],
-                                delimiter=",", dtype=["int32", "int32", "float64"])
+        cudf_df = cudf.read_csv(graph_tf.name,
+                                names=["src", "dst", "data"],
+                                delimiter=",",
+                                dtype=["int32", "int32", "float64"])
         cugraph_G = cugraph.Graph()
-        cugraph_G.from_cudf_edgelist(cudf_df, source="src", destination="dst", edge_attr="data")
+        cugraph_G.from_cudf_edgelist(
+                                    cudf_df, source="src",
+                                    destination="dst", edge_attr="data")
 
         # construct cupy coo_matrix graph
         i = []
@@ -47,7 +51,9 @@ def graphs(request):
         j = cupy.array(j)
         weights = cupy.array(weights)
         largest_vertex = max(cupy.amax(i), cupy.amax(j))
-        cupy_df = cupy_coo_matrix((weights, (i, j)), shape=(largest_vertex + 1, largest_vertex + 1))
+        cupy_df = cupy_coo_matrix(
+            (weights, (i, j)),
+            shape=(largest_vertex + 1, largest_vertex + 1))
 
         yield cugraph_G, nx_G, cupy_df
 
@@ -58,25 +64,29 @@ def test_connected_graph_shortest_path_length(graphs):
 
     path_1_to_1_length = cugraph.shortest_path_length(cugraph_G, 1, 1)
     assert path_1_to_1_length == 0.0
-    assert path_1_to_1_length == nx.shortest_path_length(nx_G, "1", target="1", weight="weight")
+    assert path_1_to_1_length == nx.shortest_path_length(
+        nx_G, "1", target="1", weight="weight")
     assert path_1_to_1_length == cugraph.shortest_path_length(nx_G, "1", "1")
     assert path_1_to_1_length == cugraph.shortest_path_length(cupy_df, 1, 1)
 
     path_1_to_5_length = cugraph.shortest_path_length(cugraph_G, 1, 5)
     assert path_1_to_5_length == 2.0
-    assert path_1_to_5_length == nx.shortest_path_length(nx_G, "1", target="5", weight="weight")
+    assert path_1_to_5_length == nx.shortest_path_length(
+        nx_G, "1", target="5", weight="weight")
     assert path_1_to_5_length == cugraph.shortest_path_length(nx_G, "1", "5")
     assert path_1_to_5_length == cugraph.shortest_path_length(cupy_df, 1, 5)
 
     path_1_to_3_length = cugraph.shortest_path_length(cugraph_G, 1, 3)
     assert path_1_to_3_length == 2.0
-    assert path_1_to_3_length == nx.shortest_path_length(nx_G, "1", target="3", weight="weight")
+    assert path_1_to_3_length == nx.shortest_path_length(
+        nx_G, "1", target="3", weight="weight")
     assert path_1_to_3_length == cugraph.shortest_path_length(nx_G, "1", "3")
     assert path_1_to_3_length == cugraph.shortest_path_length(cupy_df, 1, 3)
 
     path_1_to_6_length = cugraph.shortest_path_length(cugraph_G, 1, 6)
     assert path_1_to_6_length == 2.0
-    assert path_1_to_6_length == nx.shortest_path_length(nx_G, "1", target="6", weight="weight")
+    assert path_1_to_6_length == nx.shortest_path_length(
+        nx_G, "1", target="6", weight="weight")
     assert path_1_to_6_length == cugraph.shortest_path_length(nx_G, "1", "6")
     assert path_1_to_6_length == cugraph.shortest_path_length(cupy_df, 1, 6)
 
@@ -138,17 +148,21 @@ def test_shortest_path_length_no_target(graphs):
     cugraph_G, nx_G, cupy_df = graphs
 
     cugraph_path_1_to_all = cugraph.shortest_path_length(cugraph_G, 1)
-    nx_path_1_to_all = nx.shortest_path_length(nx_G, source="1", weight="weight")
+    nx_path_1_to_all = nx.shortest_path_length(
+        nx_G, source="1", weight="weight")
     nx_gpu_path_1_to_all = cugraph.shortest_path_length(nx_G, "1")
     cupy_path_1_to_all = cugraph.shortest_path_length(cupy_df, 1)
 
     # Cast networkx graph on cugraph vertex column type from str to int.
     # SSSP preserves vertex type, convert for comparison
-    nx_gpu_path_1_to_all["vertex"] = nx_gpu_path_1_to_all["vertex"].astype("int32")
+    nx_gpu_path_1_to_all["vertex"] = \
+        nx_gpu_path_1_to_all["vertex"].astype("int32")
 
     assert cugraph_path_1_to_all == nx_gpu_path_1_to_all
     assert cugraph_path_1_to_all == cupy_path_1_to_all
-    assert cugraph_path_1_to_all.shape[0] == len(nx_path_1_to_all) + 2  # results for vertex 8 and 9 are not returned
+
+    # results for vertex 8 and 9 are not returned
+    assert cugraph_path_1_to_all.shape[0] == len(nx_path_1_to_all) + 2
 
     for index in range(cugraph_path_1_to_all.shape[0]):
 

--- a/python/cugraph/tests/test_paths.py
+++ b/python/cugraph/tests/test_paths.py
@@ -1,0 +1,105 @@
+import cudf
+import cugraph
+import networkx as nx
+import pytest
+import sys
+from tempfile import NamedTemporaryFile
+
+CONNECTED_GRAPH = """1,5,3
+1,4,1
+1,2,1
+1,6,2
+1,7,2
+4,5,1
+2,3,1
+7,6,2
+"""
+
+DISCONNECTED_GRAPH = CONNECTED_GRAPH + "8,9,4"
+
+
+@pytest.fixture
+def graphs(request):
+    with NamedTemporaryFile(mode="w+", suffix=".csv") as graph_tf:
+        graph_tf.writelines(request.param)
+        graph_tf.seek(0)
+
+        nx_graph = nx.read_weighted_edgelist(graph_tf.name, delimiter=',')
+        gpu_df = cudf.read_csv(graph_tf.name, names=["src", "dst", "data"],
+                               delimiter=",", dtype=["int32", "int32", "float64"])
+        gpu_graph = cugraph.Graph()
+        gpu_graph.from_cudf_edgelist(gpu_df, source="src", destination="dst", edge_attr="data")
+
+        yield gpu_graph, nx_graph
+
+
+@pytest.mark.parametrize("graphs", [CONNECTED_GRAPH], indirect=True)
+def test_connected_graph_shortest_path_length(graphs):
+    gpu_graph, nx_graph = graphs
+
+    path_1_to_1_length = cugraph.shortest_path_length(gpu_graph, 1, 1)
+    assert path_1_to_1_length == 0.0
+    assert path_1_to_1_length == nx.shortest_path_length(nx_graph, "1", target="1", weight="weight")
+
+    path_1_to_5_length = cugraph.shortest_path_length(gpu_graph, 1, 5)
+    assert path_1_to_5_length == 2.0
+    assert path_1_to_5_length == nx.shortest_path_length(nx_graph, "1", target="5", weight="weight")
+
+    path_1_to_3_length = cugraph.shortest_path_length(gpu_graph, 1, 3)
+    assert path_1_to_3_length == 2.0
+    assert path_1_to_3_length == nx.shortest_path_length(nx_graph, "1", target="3", weight="weight")
+
+    path_1_to_6_length = cugraph.shortest_path_length(gpu_graph, 1, 6)
+    assert path_1_to_6_length == 2.0
+    assert path_1_to_6_length == nx.shortest_path_length(nx_graph, "1", target="6", weight="weight")
+
+
+@pytest.mark.parametrize("graphs", [CONNECTED_GRAPH], indirect=True)
+def test_shortest_path_length_invalid_source(graphs):
+    gpu_graph, __ = graphs
+
+    with pytest.raises(ValueError):
+        cugraph.shortest_path_length(gpu_graph, 42, 1)
+
+
+@pytest.mark.parametrize("graphs", [CONNECTED_GRAPH], indirect=True)
+def test_shortest_path_length_invalid_target(graphs):
+    gpu_graph, __ = graphs
+
+    with pytest.raises(ValueError):
+        cugraph.shortest_path_length(gpu_graph, 1, 42)
+
+
+@pytest.mark.parametrize("graphs", [CONNECTED_GRAPH], indirect=True)
+def test_shortest_path_length_invalid_vertexes(graphs):
+    gpu_graph, __ = graphs
+
+    with pytest.raises(ValueError):
+        cugraph.shortest_path_length(gpu_graph, 42, 42)
+
+
+@pytest.mark.parametrize("graphs", [DISCONNECTED_GRAPH], indirect=True)
+def test_shortest_path_length_no_path(graphs):
+    gpu_graph, __ = graphs
+
+    path_1_to_8 = cugraph.shortest_path_length(gpu_graph, 1, 8)
+    assert path_1_to_8 == sys.float_info.max
+
+
+@pytest.mark.parametrize("graphs", [DISCONNECTED_GRAPH], indirect=True)
+def test_shortest_path_length_no_target(graphs):
+    gpu_graph, nx_graph = graphs
+
+    gpu_path_1_to_all = cugraph.shortest_path_length(gpu_graph, 1)
+    nx_path_1_to_all = nx.shortest_path_length(nx_graph, source="1", weight="weight")
+    assert gpu_path_1_to_all.shape[0] == len(nx_path_1_to_all) + 2
+
+    for index in range(gpu_path_1_to_all.shape[0]):
+
+        vertex = str(gpu_path_1_to_all["vertex"][index].item())
+        distance = gpu_path_1_to_all["distance"][index].item()
+
+        if vertex in {'8', '9'}:
+            assert distance == sys.float_info.max
+        else:
+            assert distance == nx_path_1_to_all[vertex]

--- a/python/cugraph/tests/test_paths.py
+++ b/python/cugraph/tests/test_paths.py
@@ -142,10 +142,13 @@ def test_shortest_path_length_no_target(graphs):
     nx_gpu_path_1_to_all = cugraph.shortest_path_length(nx_G, "1")
     cupy_path_1_to_all = cugraph.shortest_path_length(cupy_df, 1)
 
-    assert nx_gpu_path_1_to_all == nx_gpu_path_1_to_all
+    # Cast networkx graph on cugraph vertex column type from str to int.
+    # SSSP preserves vertex type, convert for comparison
+    nx_gpu_path_1_to_all["vertex"] = nx_gpu_path_1_to_all["vertex"].astype("int32")
 
+    assert cugraph_path_1_to_all == nx_gpu_path_1_to_all
+    assert cugraph_path_1_to_all == cupy_path_1_to_all
     assert cugraph_path_1_to_all.shape[0] == len(nx_path_1_to_all) + 2  # results for vertex 8 and 9 are not returned
-    assert cugraph_path_1_to_all.shape[0] == len(cupy_path_1_to_all[0])
 
     for index in range(cugraph_path_1_to_all.shape[0]):
 
@@ -158,6 +161,3 @@ def test_shortest_path_length_no_target(graphs):
             assert distance == sys.float_info.max
         else:
             assert distance == nx_path_1_to_all[vertex]
-
-        # verify cugraph against cupy graph
-        assert distance == cupy_path_1_to_all[0][int(vertex) - 1].item()

--- a/python/cugraph/traversal/__init__.py
+++ b/python/cugraph/traversal/__init__.py
@@ -11,8 +11,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import cudf
 from cugraph.traversal.bfs import bfs
 from cugraph.traversal.bfs import bfs_edges
-from cugraph.traversal.sssp import sssp
-from cugraph.traversal.sssp import shortest_path
-from cugraph.traversal.sssp import filter_unreachable
+from cugraph.traversal.sssp import (
+    sssp,
+    shortest_path,
+    filter_unreachable
+)
+
+
+# TODO: need to add docs, test with cupy matrix and networkx graphs
+def shortest_path_length(G, source, target=None):
+    df = sssp(G, source)
+    if target is not None:
+        if not G.has_node(target):
+            raise ValueError("Graph does not contain target vertex")
+        target_distance = df.loc[df["vertex"] == target]
+        return target_distance.iloc[0]["distance"]
+    else:
+        results = cudf.DataFrame()
+        results["vertex"] = df["vertex"]
+        results["distance"] = df["distance"]
+        return results
+
+
+__all__ = [
+    "bfs",
+    "bfs_edges",
+    "sssp",
+    "shortest_path",
+    "shortest_path_length",
+    "filter_unreachable"
+]

--- a/python/cugraph/traversal/__init__.py
+++ b/python/cugraph/traversal/__init__.py
@@ -11,53 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cudf
 from cugraph.traversal.bfs import bfs
 from cugraph.traversal.bfs import bfs_edges
 from cugraph.traversal.sssp import (
     sssp,
     shortest_path,
-    filter_unreachable
+    filter_unreachable,
+    shortest_path_length
 )
-
-
-# TODO: need to add docs
-def shortest_path_length(G, source, target=None):
-
-    # verify target is in graph before traversing
-    if target is not None:
-        if not hasattr(G, "has_node"):
-            # G is a cupy coo_matrix. Extract maximum possible vertex value
-            as_matrix = G.toarray()
-            if target < 0 or target >= max(as_matrix.shape[0], as_matrix.shape[1]):
-                raise ValueError("Graph does not contain target vertex")
-        elif not G.has_node(target):
-            # G is an instance of cugraph or networkx graph
-            raise ValueError("Graph does not contain target vertex")
-
-    df = sssp(G, source)
-
-    if isinstance(df, tuple):
-        # cupy path, df is tuple of (distance, predecessor)
-        if target:
-            return df[0][target-1]
-        return df
-    else:
-        if target:
-            target_distance = df.loc[df["vertex"] == target]
-            return target_distance.iloc[0]["distance"]
-        else:
-            results = cudf.DataFrame()
-            results["vertex"] = df["vertex"]
-            results["distance"] = df["distance"]
-            return results
-
-
-__all__ = [
-    "bfs",
-    "bfs_edges",
-    "sssp",
-    "shortest_path",
-    "shortest_path_length",
-    "filter_unreachable"
-]

--- a/python/cugraph/traversal/__init__.py
+++ b/python/cugraph/traversal/__init__.py
@@ -21,19 +21,36 @@ from cugraph.traversal.sssp import (
 )
 
 
-# TODO: need to add docs, test with cupy matrix and networkx graphs
+# TODO: need to add docs
 def shortest_path_length(G, source, target=None):
-    df = sssp(G, source)
+
+    # verify target is in graph before traversing
     if target is not None:
-        if not G.has_node(target):
+        if not hasattr(G, "has_node"):
+            # G is a cupy coo_matrix. Extract maximum possible vertex value
+            as_matrix = G.toarray()
+            if target < 0 or target >= max(as_matrix.shape[0], as_matrix.shape[1]):
+                raise ValueError("Graph does not contain target vertex")
+        elif not G.has_node(target):
+            # G is an instance of cugraph or networkx graph
             raise ValueError("Graph does not contain target vertex")
-        target_distance = df.loc[df["vertex"] == target]
-        return target_distance.iloc[0]["distance"]
+
+    df = sssp(G, source)
+
+    if isinstance(df, tuple):
+        # cupy path, df is tuple of (distance, predecessor)
+        if target:
+            return df[0][target-1]
+        return df
     else:
-        results = cudf.DataFrame()
-        results["vertex"] = df["vertex"]
-        results["distance"] = df["distance"]
-        return results
+        if target:
+            target_distance = df.loc[df["vertex"] == target]
+            return target_distance.iloc[0]["distance"]
+        else:
+            results = cudf.DataFrame()
+            results["vertex"] = df["vertex"]
+            results["distance"] = df["distance"]
+            return results
 
 
 __all__ = [

--- a/python/cugraph/traversal/sssp.py
+++ b/python/cugraph/traversal/sssp.py
@@ -229,7 +229,8 @@ def sssp(G,
         source = G.lookup_internal_vertex_id(cudf.Series([source]))[0]
 
     if source is cudf.NA:
-        raise ValueError("Starting vertex should be between 0 to number of vertices")
+        raise ValueError(
+            "Starting vertex should be between 0 to number of vertices")
 
     df = sssp_wrapper.sssp(G, source)
 
@@ -337,7 +338,8 @@ def shortest_path_length(G, source, target=None):
         if not hasattr(G, "has_node"):
             # G is a cupy coo_matrix. Extract maximum possible vertex value
             as_matrix = G.toarray()
-            if target < 0 or target >= max(as_matrix.shape[0], as_matrix.shape[1]):
+            if target < 0 or target >= max(as_matrix.shape[0],
+                                           as_matrix.shape[1]):
                 raise ValueError("Graph does not contain target vertex")
         elif not G.has_node(target):
             # G is an instance of cugraph or networkx graph

--- a/python/cugraph/traversal/sssp.py
+++ b/python/cugraph/traversal/sssp.py
@@ -156,12 +156,26 @@ def sssp(G,
 
     Parameters
     ----------
+<<<<<<< HEAD
     graph : cugraph.Graph, networkx.Graph, CuPy or SciPy sparse matrix Graph or
         matrix object, which should contain the connectivity information. Edge
         weights, if present, should be single or double precision floating
         point values.
     source : int
         Index of the source vertex.
+=======
+    graph : cuGraph.Graph, NetworkX.Graph, or CuPy sparse COO matrix
+        cuGraph graph descriptor with connectivity information. Edge weights,
+        if present, should be single or double precision floating point values.
+
+    source : Dependant on graph type. Index of the source vertex.
+
+    If graph is an instance of cuGraph.Graph or CuPy sparse COO matrix:
+        int
+
+    If graph is an instance of a NetworkX.Graph:
+        str
+>>>>>>> Document shortest_path_length and sssp behavior
 
     Returns
     -------
@@ -213,6 +227,9 @@ def sssp(G,
 
     if G.renumbered:
         source = G.lookup_internal_vertex_id(cudf.Series([source]))[0]
+
+    if source is cudf.NA:
+        raise ValueError("Starting vertex should be between 0 to number of vertices")
 
     df = sssp_wrapper.sssp(G, source)
 
@@ -268,3 +285,82 @@ def shortest_path(G,
     """
     return sssp(G, source, method, directed, return_predecessors,
                 unweighted, overwrite, indices)
+
+
+def shortest_path_length(G, source, target=None):
+    """
+    Compute the distance from a source vertex to one or all vertexes in graph.
+    Uses Single Source Shortest Path (SSSP).
+
+    Parameters
+    ----------
+    graph : cuGraph.Graph, NetworkX.Graph, or CuPy sparse COO matrix
+        cuGraph graph descriptor with connectivity information. Edge weights,
+        if present, should be single or double precision floating point values.
+
+    source : Dependant on graph type. Index of the source vertex.
+
+    If graph is an instance of cuGraph.Graph or CuPy sparse COO matrix:
+        int
+
+    If graph is an instance of a NetworkX.Graph:
+        str
+
+    target: Dependant on graph type. Vertex to find distance to.
+
+    If graph is an instance of cuGraph.Graph or CuPy sparse COO matrix:
+        int
+
+    If graph is an instance of a NetworkX.Graph:
+        str
+
+    Returns
+    -------
+    Return value type is based on the input type.
+
+    If target is None, returns:
+
+        cudf.DataFrame
+            df['vertex']
+                vertex id
+
+            df['distance']
+                gives the path distance from the starting vertex
+
+    If target is not None, returns:
+
+        Distance from source to target vertex.
+    """
+
+    # verify target is in graph before traversing
+    if target is not None:
+        if not hasattr(G, "has_node"):
+            # G is a cupy coo_matrix. Extract maximum possible vertex value
+            as_matrix = G.toarray()
+            if target < 0 or target >= max(as_matrix.shape[0], as_matrix.shape[1]):
+                raise ValueError("Graph does not contain target vertex")
+        elif not G.has_node(target):
+            # G is an instance of cugraph or networkx graph
+            raise ValueError("Graph does not contain target vertex")
+
+    df = sssp(G, source)
+
+    if isinstance(df, tuple):
+        # cupy path, df is tuple of (distance, predecessor)
+        if target:
+            return df[0][target-1]
+        results = cudf.DataFrame()
+        results["vertex"] = range(df[0].shape[0])
+        results["distance"] = df[0]
+        return results
+
+    else:
+        # cugraph and networkx path
+        if target:
+            target_distance = df.loc[df["vertex"] == target]
+            return target_distance.iloc[0]["distance"]
+
+        results = cudf.DataFrame()
+        results["vertex"] = df["vertex"]
+        results["distance"] = df["distance"]
+        return results

--- a/python/cugraph/traversal/sssp_wrapper.pyx
+++ b/python/cugraph/traversal/sssp_wrapper.pyx
@@ -84,7 +84,7 @@ def sssp(input_graph, source):
     num_edges = input_graph.number_of_edges(directed_edges=True)
 
     # Step 5: Check if source index is valid
-    if source is cudf.NA or 0 > source or num_verts <= source:
+    if not 0 <= source < num_verts:
         raise ValueError("Starting vertex should be between 0 to number of vertices")
 
     # Step 6: Generation of the result cudf.DataFrame

--- a/python/cugraph/traversal/sssp_wrapper.pyx
+++ b/python/cugraph/traversal/sssp_wrapper.pyx
@@ -84,7 +84,7 @@ def sssp(input_graph, source):
     num_edges = input_graph.number_of_edges(directed_edges=True)
 
     # Step 5: Check if source index is valid
-    if not 0 <= source < num_verts:
+    if source is cudf.NA or 0 > source or num_verts <= source:
         raise ValueError("Starting vertex should be between 0 to number of vertices")
 
     # Step 6: Generation of the result cudf.DataFrame


### PR DESCRIPTION
Adds the ability to get the length/cost of path from source to destination(s). Closely follows [`networkx.shortest_path_length`](https://networkx.org/documentation/latest/reference/algorithms/generated/networkx.algorithms.shortest_paths.generic.shortest_path_length.html#networkx.algorithms.shortest_paths.generic.shortest_path_length). 


Similarities:
1) Takes an optional target vertex
2) If only source is provided, a `cudf` dataframe is returned with columns: `[vertex, distance]` (similar to `networkx` dictionary return)
3) If source and target are specified the exact length is returned or `sys.float_info.max` if the vertex is not reachable. 


Differences:
1) Requires that source be provided, as apposed to `networkx`
2) Nethod of graph traversal is not an option. 

Fixes:
1) Fixes #806 
2) `sssp` and `cugraph.Graph.has_node` vertex checks. Added support for checking for vertexes that are not apart of the graph. in the past, `TypeError` was raised when doing a comparison check (as apposed to `ValueError`) 