### PR TITLE
[REVIEW] FIX Move codecov upload to gpu build script

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -127,4 +127,8 @@ else
     python ${WORKSPACE}/ci/utils/nbtestlog2junitxml.py nbtest.log
 fi
 
+if [ -n "\${CODECOV_TOKEN}" ]; then
+    codecov -t \$CODECOV_TOKEN
+fi
+
 return ${EXITCODE}


### PR DESCRIPTION
This moves a block from the Jenkins build into the build script. Simplifies the Jenkins builds slightly and fixes a very rare case where tests may error and not be properly caught due to EXITCODE intricacies.