### PR TITLE
[gpuCI] Auto-merge branch-0.17 to branch-0.18 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - PR #1273 Update Force Atlas 2 notebook, wrapper and coding style
 - PR #1289 Update api.rst for MST
 - PR #1281 Update README
+- PR #1293: Updating RAFT to latest
 
 ## Bug Fixes
 - PR #1237 update tests for assymetric graphs, enable personalization pagerank

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -316,7 +316,7 @@ else(DEFINED ENV{RAFT_PATH})
 
   ExternalProject_Add(raft
     GIT_REPOSITORY    https://github.com/rapidsai/raft.git
-    GIT_TAG           315de02f8e2304e078e5e0f6df23c6a6799e23f4
+    GIT_TAG           f75d7b437bf1da3df749108161b8a0505fb6b7b3
     PREFIX            ${RAFT_DIR}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND     ""


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.17` that creates a PR to keep `branch-0.18` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.