### PR TITLE
[REVIEW] Updates to support nightly MG test automation

### DIFF
--- a/python/cugraph/dask/common/mg_utils.py
+++ b/python/cugraph/dask/common/mg_utils.py
@@ -62,9 +62,23 @@ def get_visible_devices():
 
 
 def setup_local_dask_cluster(p2p=True):
+    """
+    Performs steps to setup a Dask cluster using LocalCUDACluster and returns
+    the LocalCUDACluster and corresponding client instance.
+    """
     cluster = LocalCUDACluster()
     client = Client(cluster)
     client.wait_for_workers(len(get_visible_devices()))
     Comms.initialize(p2p)
 
-    return (Comms, client, cluster)
+    return (cluster, client)
+
+
+def teardown_local_dask_cluster(cluster, client):
+    """
+    Performs steps to destroy a Dask cluster and a corresponding client
+    instance.
+    """
+    Comms.destroy()
+    client.close()
+    cluster.close()

--- a/python/cugraph/dask/common/mg_utils.py
+++ b/python/cugraph/dask/common/mg_utils.py
@@ -10,8 +10,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from cugraph.raft.dask.common.utils import default_client
+
+import os
+
 import numba.cuda
+
+from dask_cuda import LocalCUDACluster
+from dask.distributed import Client
+
+from cugraph.raft.dask.common.utils import default_client
+import cugraph.comms as Comms
 
 
 # FIXME: We currently look for the default client from dask, as such is the
@@ -41,3 +49,22 @@ def is_single_gpu():
         return False
     else:
         return True
+
+
+def get_visible_devices():
+    _visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if _visible_devices is None:
+        # FIXME: We assume that if the variable is unset there is only one GPU
+        visible_devices = ["0"]
+    else:
+        visible_devices = _visible_devices.strip().split(",")
+    return visible_devices
+
+
+def setup_local_dask_cluster(p2p=True):
+    cluster = LocalCUDACluster()
+    client = Client(cluster)
+    client.wait_for_workers(len(get_visible_devices()))
+    Comms.initialize(p2p)
+
+    return (Comms, client, cluster)

--- a/python/cugraph/tests/dask/mg_context.py
+++ b/python/cugraph/tests/dask/mg_context.py
@@ -12,28 +12,21 @@
 # limitations under the License.
 
 import time
-import os
+
+import pytest
 
 from dask.distributed import Client
+
+from cugraph.dask.common.mg_utils import get_visible_devices
 from dask_cuda import LocalCUDACluster as CUDACluster
 import cugraph.comms as Comms
-import pytest
+
 
 # Maximal number of verifications of the number of workers
 DEFAULT_MAX_ATTEMPT = 100
 
 # Time between each attempt in seconds
 DEFAULT_WAIT_TIME = 0.5
-
-
-def get_visible_devices():
-    _visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
-    if _visible_devices is None:
-        # FIXME: We assume that if the variable is unset there is only one GPU
-        visible_devices = ["0"]
-    else:
-        visible_devices = _visible_devices.strip().split(",")
-    return visible_devices
 
 
 def skip_if_not_enough_devices(required_devices):

--- a/python/cugraph/tests/dask/mg_context.py
+++ b/python/cugraph/tests/dask/mg_context.py
@@ -37,11 +37,12 @@ def get_visible_devices():
 
 
 def skip_if_not_enough_devices(required_devices):
-    visible_devices = get_visible_devices()
-    number_of_visible_devices = len(visible_devices)
-    if required_devices > number_of_visible_devices:
-        pytest.skip("Not enough devices available to "
-                    "test MG({})".format(required_devices))
+    if required_devices is not None:
+        visible_devices = get_visible_devices()
+        number_of_visible_devices = len(visible_devices)
+        if required_devices > number_of_visible_devices:
+            pytest.skip("Not enough devices available to "
+                        "test MG({})".format(required_devices))
 
 
 class MGContext:

--- a/python/cugraph/tests/dask/test_mg_batch_betweenness_centrality.py
+++ b/python/cugraph/tests/dask/test_mg_batch_betweenness_centrality.py
@@ -37,8 +37,11 @@ from cugraph.tests.test_betweenness_centrality import (
 # Parameters
 # =============================================================================
 DATASETS = ["../datasets/karate.csv"]
-MG_DEVICE_COUNT_OPTIONS = [1, 2, 3, 4]
-MG_DEVICE_COUNT_OPTIONS = [None]
+MG_DEVICE_COUNT_OPTIONS = [pytest.param(1, marks=pytest.mark.preset_gpu_count),
+                           pytest.param(2, marks=pytest.mark.preset_gpu_count),
+                           pytest.param(3, marks=pytest.mark.preset_gpu_count),
+                           pytest.param(4, marks=pytest.mark.preset_gpu_count),
+                           None]
 RESULT_DTYPE_OPTIONS = [np.float64]
 
 

--- a/python/cugraph/tests/dask/test_mg_batch_betweenness_centrality.py
+++ b/python/cugraph/tests/dask/test_mg_batch_betweenness_centrality.py
@@ -38,6 +38,7 @@ from cugraph.tests.test_betweenness_centrality import (
 # =============================================================================
 DATASETS = ["../datasets/karate.csv"]
 MG_DEVICE_COUNT_OPTIONS = [1, 2, 3, 4]
+MG_DEVICE_COUNT_OPTIONS = [None]
 RESULT_DTYPE_OPTIONS = [np.float64]
 
 

--- a/python/cugraph/tests/dask/test_mg_batch_edge_betweenness_centrality.py
+++ b/python/cugraph/tests/dask/test_mg_batch_edge_betweenness_centrality.py
@@ -37,8 +37,11 @@ from cugraph.tests.test_edge_betweenness_centrality import (
 # Parameters
 # =============================================================================
 DATASETS = ["../datasets/karate.csv"]
-MG_DEVICE_COUNT_OPTIONS = [1, 2, 4]
-MG_DEVICE_COUNT_OPTIONS = [None]
+MG_DEVICE_COUNT_OPTIONS = [pytest.param(1, marks=pytest.mark.preset_gpu_count),
+                           pytest.param(2, marks=pytest.mark.preset_gpu_count),
+                           pytest.param(3, marks=pytest.mark.preset_gpu_count),
+                           pytest.param(4, marks=pytest.mark.preset_gpu_count),
+                           None]
 RESULT_DTYPE_OPTIONS = [np.float64]
 
 

--- a/python/cugraph/tests/dask/test_mg_batch_edge_betweenness_centrality.py
+++ b/python/cugraph/tests/dask/test_mg_batch_edge_betweenness_centrality.py
@@ -38,6 +38,7 @@ from cugraph.tests.test_edge_betweenness_centrality import (
 # =============================================================================
 DATASETS = ["../datasets/karate.csv"]
 MG_DEVICE_COUNT_OPTIONS = [1, 2, 4]
+MG_DEVICE_COUNT_OPTIONS = [None]
 RESULT_DTYPE_OPTIONS = [np.float64]
 
 

--- a/python/cugraph/tests/dask/test_mg_bfs.py
+++ b/python/cugraph/tests/dask/test_mg_bfs.py
@@ -27,6 +27,7 @@ from cugraph.dask.common.mg_utils import is_single_gpu
 def client_connection():
     cluster = LocalCUDACluster()
     client = Client(cluster)
+    client.wait_for_workers(None)  # number of devices None = all vsble devices
     Comms.initialize(p2p=True)
 
     yield client

--- a/python/cugraph/tests/dask/test_mg_bfs.py
+++ b/python/cugraph/tests/dask/test_mg_bfs.py
@@ -18,20 +18,15 @@ import cugraph
 import dask_cudf
 import cudf
 from cugraph.dask.common.mg_utils import (is_single_gpu,
-                                          setup_local_dask_cluster)
+                                          setup_local_dask_cluster,
+                                          teardown_local_dask_cluster)
 
 
 @pytest.fixture(scope="module")
 def client_connection():
-    # setup
-    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
-
+    (cluster, client) = setup_local_dask_cluster(p2p=True)
     yield client
-
-    # teardown
-    comms.destroy()
-    client.close()
-    cluster.close()
+    teardown_local_dask_cluster(cluster, client)
 
 
 @pytest.mark.skipif(

--- a/python/cugraph/tests/dask/test_mg_bfs.py
+++ b/python/cugraph/tests/dask/test_mg_bfs.py
@@ -12,27 +12,24 @@
 # limitations under the License.
 
 import cugraph.dask as dcg
-import cugraph.comms as Comms
-from dask.distributed import Client
 import gc
 import pytest
 import cugraph
 import dask_cudf
 import cudf
-from dask_cuda import LocalCUDACluster
-from cugraph.dask.common.mg_utils import is_single_gpu
+from cugraph.dask.common.mg_utils import (is_single_gpu,
+                                          setup_local_dask_cluster)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def client_connection():
-    cluster = LocalCUDACluster()
-    client = Client(cluster)
-    client.wait_for_workers(None)  # number of devices None = all vsble devices
-    Comms.initialize(p2p=True)
+    # setup
+    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
 
     yield client
 
-    Comms.destroy()
+    # teardown
+    comms.destroy()
     client.close()
     cluster.close()
 

--- a/python/cugraph/tests/dask/test_mg_comms.py
+++ b/python/cugraph/tests/dask/test_mg_comms.py
@@ -27,6 +27,7 @@ from cugraph.dask.common.mg_utils import is_single_gpu
 def client_connection():
     cluster = LocalCUDACluster()
     client = Client(cluster)
+    client.wait_for_workers(None)  # number of devices None = all vsble devices
     Comms.initialize(p2p=True)
 
     yield client

--- a/python/cugraph/tests/dask/test_mg_comms.py
+++ b/python/cugraph/tests/dask/test_mg_comms.py
@@ -18,20 +18,15 @@ import cugraph
 import dask_cudf
 import cudf
 from cugraph.dask.common.mg_utils import (is_single_gpu,
-                                          setup_local_dask_cluster)
+                                          setup_local_dask_cluster,
+                                          teardown_local_dask_cluster)
 
 
 @pytest.fixture(scope="module")
 def client_connection():
-    # setup
-    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
-
+    (cluster, client) = setup_local_dask_cluster(p2p=True)
     yield client
-
-    # teardown
-    comms.destroy()
-    client.close()
-    cluster.close()
+    teardown_local_dask_cluster(cluster, client)
 
 
 @pytest.mark.skipif(

--- a/python/cugraph/tests/dask/test_mg_comms.py
+++ b/python/cugraph/tests/dask/test_mg_comms.py
@@ -12,27 +12,24 @@
 # limitations under the License.
 
 import cugraph.dask as dcg
-import cugraph.comms as Comms
-from dask.distributed import Client
 import gc
 import pytest
 import cugraph
 import dask_cudf
 import cudf
-from dask_cuda import LocalCUDACluster
-from cugraph.dask.common.mg_utils import is_single_gpu
+from cugraph.dask.common.mg_utils import (is_single_gpu,
+                                          setup_local_dask_cluster)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def client_connection():
-    cluster = LocalCUDACluster()
-    client = Client(cluster)
-    client.wait_for_workers(None)  # number of devices None = all vsble devices
-    Comms.initialize(p2p=True)
+    # setup
+    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
 
     yield client
 
-    Comms.destroy()
+    # teardown
+    comms.destroy()
     client.close()
     cluster.close()
 

--- a/python/cugraph/tests/dask/test_mg_degree.py
+++ b/python/cugraph/tests/dask/test_mg_degree.py
@@ -11,29 +11,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dask.distributed import Client
 import gc
 import pytest
 import cudf
-import cugraph.comms as Comms
 import cugraph
 import dask_cudf
-from cugraph.dask.common.mg_utils import is_single_gpu
-
-# Move to conftest
-from dask_cuda import LocalCUDACluster
+from cugraph.dask.common.mg_utils import (is_single_gpu,
+                                          setup_local_dask_cluster)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def client_connection():
-    cluster = LocalCUDACluster()
-    client = Client(cluster)
-    client.wait_for_workers(None)  # number of devices None = all vsble devices
-    Comms.initialize(p2p=True)
+    # setup
+    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
 
     yield client
 
-    Comms.destroy()
+    # teardown
+    comms.destroy()
     client.close()
     cluster.close()
 

--- a/python/cugraph/tests/dask/test_mg_degree.py
+++ b/python/cugraph/tests/dask/test_mg_degree.py
@@ -17,20 +17,15 @@ import cudf
 import cugraph
 import dask_cudf
 from cugraph.dask.common.mg_utils import (is_single_gpu,
-                                          setup_local_dask_cluster)
+                                          setup_local_dask_cluster,
+                                          teardown_local_dask_cluster)
 
 
 @pytest.fixture(scope="module")
 def client_connection():
-    # setup
-    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
-
+    (cluster, client) = setup_local_dask_cluster(p2p=True)
     yield client
-
-    # teardown
-    comms.destroy()
-    client.close()
-    cluster.close()
+    teardown_local_dask_cluster(cluster, client)
 
 
 @pytest.mark.skipif(

--- a/python/cugraph/tests/dask/test_mg_degree.py
+++ b/python/cugraph/tests/dask/test_mg_degree.py
@@ -28,6 +28,7 @@ from dask_cuda import LocalCUDACluster
 def client_connection():
     cluster = LocalCUDACluster()
     client = Client(cluster)
+    client.wait_for_workers(None)  # number of devices None = all vsble devices
     Comms.initialize(p2p=True)
 
     yield client

--- a/python/cugraph/tests/dask/test_mg_katz_centrality.py
+++ b/python/cugraph/tests/dask/test_mg_katz_centrality.py
@@ -31,6 +31,7 @@ from cugraph.dask.common.mg_utils import is_single_gpu
 def client_connection():
     cluster = LocalCUDACluster()
     client = Client(cluster)
+    client.wait_for_workers(None)  # number of devices None = all vsble devices
     Comms.initialize(p2p=True)
 
     yield client

--- a/python/cugraph/tests/dask/test_mg_katz_centrality.py
+++ b/python/cugraph/tests/dask/test_mg_katz_centrality.py
@@ -14,29 +14,23 @@
 # import numpy as np
 import pytest
 import cugraph.dask as dcg
-import cugraph.comms as Comms
-from dask.distributed import Client
 import gc
 import cugraph
 import dask_cudf
 import cudf
-from dask_cuda import LocalCUDACluster
-from cugraph.dask.common.mg_utils import is_single_gpu
-
-# The function selects personalization_perc% of accessible vertices in graph M
-# and randomly assigns them personalization values
+from cugraph.dask.common.mg_utils import (is_single_gpu,
+                                          setup_local_dask_cluster)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def client_connection():
-    cluster = LocalCUDACluster()
-    client = Client(cluster)
-    client.wait_for_workers(None)  # number of devices None = all vsble devices
-    Comms.initialize(p2p=True)
+    # setup
+    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
 
     yield client
 
-    Comms.destroy()
+    # teardown
+    comms.destroy()
     client.close()
     cluster.close()
 

--- a/python/cugraph/tests/dask/test_mg_katz_centrality.py
+++ b/python/cugraph/tests/dask/test_mg_katz_centrality.py
@@ -19,20 +19,15 @@ import cugraph
 import dask_cudf
 import cudf
 from cugraph.dask.common.mg_utils import (is_single_gpu,
-                                          setup_local_dask_cluster)
+                                          setup_local_dask_cluster,
+                                          teardown_local_dask_cluster)
 
 
 @pytest.fixture(scope="module")
 def client_connection():
-    # setup
-    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
-
+    (cluster, client) = setup_local_dask_cluster(p2p=True)
     yield client
-
-    # teardown
-    comms.destroy()
-    client.close()
-    cluster.close()
+    teardown_local_dask_cluster(cluster, client)
 
 
 @pytest.mark.skipif(

--- a/python/cugraph/tests/dask/test_mg_louvain.py
+++ b/python/cugraph/tests/dask/test_mg_louvain.py
@@ -14,13 +14,11 @@
 import pytest
 
 import cugraph.dask as dcg
-import cugraph.comms as Comms
-from dask.distributed import Client
 import cugraph
 import dask_cudf
-from dask_cuda import LocalCUDACluster
 from cugraph.tests import utils
-from cugraph.dask.common.mg_utils import is_single_gpu
+from cugraph.dask.common.mg_utils import (is_single_gpu,
+                                          setup_local_dask_cluster)
 
 try:
     from rapids_pytest_benchmark import setFixtureParamNames
@@ -45,15 +43,12 @@ except ImportError:
 @pytest.fixture(scope="module")
 def client_connection():
     # setup
-    cluster = LocalCUDACluster()
-    client = Client(cluster)
-    client.wait_for_workers(None)  # number of devices None = all vsble devices
-    Comms.initialize(p2p=True)
+    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
 
     yield client
 
     # teardown
-    Comms.destroy()
+    comms.destroy()
     client.close()
     cluster.close()
 

--- a/python/cugraph/tests/dask/test_mg_louvain.py
+++ b/python/cugraph/tests/dask/test_mg_louvain.py
@@ -18,7 +18,8 @@ import cugraph
 import dask_cudf
 from cugraph.tests import utils
 from cugraph.dask.common.mg_utils import (is_single_gpu,
-                                          setup_local_dask_cluster)
+                                          setup_local_dask_cluster,
+                                          teardown_local_dask_cluster)
 
 try:
     from rapids_pytest_benchmark import setFixtureParamNames
@@ -42,15 +43,9 @@ except ImportError:
 # Fixtures
 @pytest.fixture(scope="module")
 def client_connection():
-    # setup
-    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
-
+    (cluster, client) = setup_local_dask_cluster(p2p=True)
     yield client
-
-    # teardown
-    comms.destroy()
-    client.close()
-    cluster.close()
+    teardown_local_dask_cluster(cluster, client)
 
 
 @pytest.mark.skipif(

--- a/python/cugraph/tests/dask/test_mg_louvain.py
+++ b/python/cugraph/tests/dask/test_mg_louvain.py
@@ -47,6 +47,7 @@ def client_connection():
     # setup
     cluster = LocalCUDACluster()
     client = Client(cluster)
+    client.wait_for_workers(None)  # number of devices None = all vsble devices
     Comms.initialize(p2p=True)
 
     yield client

--- a/python/cugraph/tests/dask/test_mg_pagerank.py
+++ b/python/cugraph/tests/dask/test_mg_pagerank.py
@@ -56,6 +56,7 @@ PERSONALIZATION_PERC = [0, 10, 50]
 def client_connection():
     cluster = LocalCUDACluster()
     client = Client(cluster)
+    client.wait_for_workers(None)  # number of devices None = all vsble devices
     Comms.initialize(p2p=True)
 
     yield client

--- a/python/cugraph/tests/dask/test_mg_pagerank.py
+++ b/python/cugraph/tests/dask/test_mg_pagerank.py
@@ -18,7 +18,8 @@ import cugraph
 import dask_cudf
 import cudf
 from cugraph.dask.common.mg_utils import (is_single_gpu,
-                                          setup_local_dask_cluster)
+                                          setup_local_dask_cluster,
+                                          teardown_local_dask_cluster)
 
 
 # The function selects personalization_perc% of accessible vertices in graph M
@@ -52,15 +53,9 @@ PERSONALIZATION_PERC = [0, 10, 50]
 
 @pytest.fixture(scope="module")
 def client_connection():
-    # setup
-    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
-
+    (cluster, client) = setup_local_dask_cluster(p2p=True)
     yield client
-
-    # teardown
-    comms.destroy()
-    client.close()
-    cluster.close()
+    teardown_local_dask_cluster(cluster, client)
 
 
 @pytest.mark.skipif(

--- a/python/cugraph/tests/dask/test_mg_pagerank.py
+++ b/python/cugraph/tests/dask/test_mg_pagerank.py
@@ -13,18 +13,16 @@
 import numpy as np
 import pytest
 import cugraph.dask as dcg
-import cugraph.comms as Comms
-from dask.distributed import Client
 import gc
 import cugraph
 import dask_cudf
 import cudf
-from dask_cuda import LocalCUDACluster
-from cugraph.dask.common.mg_utils import is_single_gpu
+from cugraph.dask.common.mg_utils import (is_single_gpu,
+                                          setup_local_dask_cluster)
+
 
 # The function selects personalization_perc% of accessible vertices in graph M
 # and randomly assigns them personalization values
-
 
 def personalize(vertices, personalization_perc):
     personalization = None
@@ -52,16 +50,15 @@ def personalize(vertices, personalization_perc):
 PERSONALIZATION_PERC = [0, 10, 50]
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def client_connection():
-    cluster = LocalCUDACluster()
-    client = Client(cluster)
-    client.wait_for_workers(None)  # number of devices None = all vsble devices
-    Comms.initialize(p2p=True)
+    # setup
+    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
 
     yield client
 
-    Comms.destroy()
+    # teardown
+    comms.destroy()
     client.close()
     cluster.close()
 

--- a/python/cugraph/tests/dask/test_mg_renumber.py
+++ b/python/cugraph/tests/dask/test_mg_renumber.py
@@ -20,28 +20,25 @@ import pandas
 import numpy as np
 
 import cugraph.dask as dcg
-import cugraph.comms as Comms
-from dask.distributed import Client
 import cugraph
 import dask_cudf
 import dask
 import cudf
-from dask_cuda import LocalCUDACluster
 from cugraph.tests import utils
 from cugraph.structure.number_map import NumberMap
-from cugraph.dask.common.mg_utils import is_single_gpu
+from cugraph.dask.common.mg_utils import (is_single_gpu,
+                                          setup_local_dask_cluster)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def client_connection():
-    cluster = LocalCUDACluster()
-    client = Client(cluster)
-    client.wait_for_workers(None)  # number of devices None = all vsble devices
-    Comms.initialize(p2p=True)
+    # setup
+    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
 
     yield client
 
-    Comms.destroy()
+    # teardown
+    comms.destroy()
     client.close()
     cluster.close()
 

--- a/python/cugraph/tests/dask/test_mg_renumber.py
+++ b/python/cugraph/tests/dask/test_mg_renumber.py
@@ -27,20 +27,15 @@ import cudf
 from cugraph.tests import utils
 from cugraph.structure.number_map import NumberMap
 from cugraph.dask.common.mg_utils import (is_single_gpu,
-                                          setup_local_dask_cluster)
+                                          setup_local_dask_cluster,
+                                          teardown_local_dask_cluster)
 
 
 @pytest.fixture(scope="module")
 def client_connection():
-    # setup
-    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
-
+    (cluster, client) = setup_local_dask_cluster(p2p=True)
     yield client
-
-    # teardown
-    comms.destroy()
-    client.close()
-    cluster.close()
+    teardown_local_dask_cluster(cluster, client)
 
 
 # Test all combinations of default/managed and pooled/non-pooled allocation

--- a/python/cugraph/tests/dask/test_mg_renumber.py
+++ b/python/cugraph/tests/dask/test_mg_renumber.py
@@ -36,6 +36,7 @@ from cugraph.dask.common.mg_utils import is_single_gpu
 def client_connection():
     cluster = LocalCUDACluster()
     client = Client(cluster)
+    client.wait_for_workers(None)  # number of devices None = all vsble devices
     Comms.initialize(p2p=True)
 
     yield client

--- a/python/cugraph/tests/dask/test_mg_replication.py
+++ b/python/cugraph/tests/dask/test_mg_replication.py
@@ -24,9 +24,11 @@ import cugraph.tests.utils as utils
 
 DATASETS_OPTIONS = utils.DATASETS_SMALL
 DIRECTED_GRAPH_OPTIONS = [False, True]
-MG_DEVICE_COUNT_OPTIONS = [1, 2, 3, 4]
-MG_DEVICE_COUNT_OPTIONS = [None]
-
+MG_DEVICE_COUNT_OPTIONS = [pytest.param(1, marks=pytest.mark.preset_gpu_count),
+                           pytest.param(2, marks=pytest.mark.preset_gpu_count),
+                           pytest.param(3, marks=pytest.mark.preset_gpu_count),
+                           pytest.param(4, marks=pytest.mark.preset_gpu_count),
+                           None]
 
 @pytest.mark.skipif(
     is_single_gpu(), reason="skipping MG testing on Single GPU system"

--- a/python/cugraph/tests/dask/test_mg_replication.py
+++ b/python/cugraph/tests/dask/test_mg_replication.py
@@ -24,8 +24,8 @@ import cugraph.tests.utils as utils
 
 DATASETS_OPTIONS = utils.DATASETS_SMALL
 DIRECTED_GRAPH_OPTIONS = [False, True]
-# MG_DEVICE_COUNT_OPTIONS = [1, 2, 3, 4]
-MG_DEVICE_COUNT_OPTIONS = [1]
+MG_DEVICE_COUNT_OPTIONS = [1, 2, 3, 4]
+MG_DEVICE_COUNT_OPTIONS = [None]
 
 
 @pytest.mark.skipif(

--- a/python/cugraph/tests/dask/test_mg_replication.py
+++ b/python/cugraph/tests/dask/test_mg_replication.py
@@ -30,6 +30,7 @@ MG_DEVICE_COUNT_OPTIONS = [pytest.param(1, marks=pytest.mark.preset_gpu_count),
                            pytest.param(4, marks=pytest.mark.preset_gpu_count),
                            None]
 
+
 @pytest.mark.skipif(
     is_single_gpu(), reason="skipping MG testing on Single GPU system"
 )

--- a/python/cugraph/tests/dask/test_mg_sssp.py
+++ b/python/cugraph/tests/dask/test_mg_sssp.py
@@ -27,6 +27,7 @@ from cugraph.dask.common.mg_utils import is_single_gpu
 def client_connection():
     cluster = LocalCUDACluster()
     client = Client(cluster)
+    client.wait_for_workers(None)  # number of devices None = all vsble devices
     Comms.initialize(p2p=True)
 
     yield client

--- a/python/cugraph/tests/dask/test_mg_sssp.py
+++ b/python/cugraph/tests/dask/test_mg_sssp.py
@@ -18,20 +18,15 @@ import cugraph
 import dask_cudf
 import cudf
 from cugraph.dask.common.mg_utils import (is_single_gpu,
-                                          setup_local_dask_cluster)
+                                          setup_local_dask_cluster,
+                                          teardown_local_dask_cluster)
 
 
 @pytest.fixture(scope="module")
 def client_connection():
-    # setup
-    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
-
+    (cluster, client) = setup_local_dask_cluster(p2p=True)
     yield client
-
-    # teardown
-    comms.destroy()
-    client.close()
-    cluster.close()
+    teardown_local_dask_cluster(cluster, client)
 
 
 @pytest.mark.skipif(

--- a/python/cugraph/tests/dask/test_mg_sssp.py
+++ b/python/cugraph/tests/dask/test_mg_sssp.py
@@ -12,27 +12,24 @@
 # limitations under the License.
 
 import cugraph.dask as dcg
-import cugraph.comms as Comms
-from dask.distributed import Client
 import gc
 import pytest
 import cugraph
 import dask_cudf
 import cudf
-from dask_cuda import LocalCUDACluster
-from cugraph.dask.common.mg_utils import is_single_gpu
+from cugraph.dask.common.mg_utils import (is_single_gpu,
+                                          setup_local_dask_cluster)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def client_connection():
-    cluster = LocalCUDACluster()
-    client = Client(cluster)
-    client.wait_for_workers(None)  # number of devices None = all vsble devices
-    Comms.initialize(p2p=True)
+    # setup
+    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
 
     yield client
 
-    Comms.destroy()
+    # teardown
+    comms.destroy()
     client.close()
     cluster.close()
 

--- a/python/cugraph/tests/dask/test_mg_utility.py
+++ b/python/cugraph/tests/dask/test_mg_utility.py
@@ -39,6 +39,7 @@ def setup_function():
 def client_connection():
     cluster = LocalCUDACluster()
     client = Client(cluster)
+    client.wait_for_workers(None)  # number of devices None = all vsble devices
     Comms.initialize(p2p=True)
 
     yield client

--- a/python/cugraph/tests/dask/test_mg_utility.py
+++ b/python/cugraph/tests/dask/test_mg_utility.py
@@ -21,7 +21,8 @@ import pytest
 from cugraph.dask.common.part_utils import concat_within_workers
 from cugraph.dask.common.read_utils import get_n_workers
 from cugraph.dask.common.mg_utils import (is_single_gpu,
-                                          setup_local_dask_cluster)
+                                          setup_local_dask_cluster,
+                                          teardown_local_dask_cluster)
 import os
 import time
 import numpy as np
@@ -37,15 +38,9 @@ def setup_function():
 
 @pytest.fixture(scope="module")
 def client_connection():
-    # setup
-    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
-
+    (cluster, client) = setup_local_dask_cluster(p2p=True)
     yield client
-
-    # teardown
-    comms.destroy()
-    client.close()
-    cluster.close()
+    teardown_local_dask_cluster(cluster, client)
 
 
 @pytest.mark.skipif(

--- a/python/cugraph/tests/test_symmetrize.py
+++ b/python/cugraph/tests/test_symmetrize.py
@@ -20,7 +20,8 @@ import cudf
 import cugraph
 from cugraph.tests import utils
 from cugraph.dask.common.mg_utils import (is_single_gpu,
-                                          setup_local_dask_cluster)
+                                          setup_local_dask_cluster,
+                                          teardown_local_dask_cluster)
 
 
 def test_version():
@@ -188,15 +189,9 @@ def test_symmetrize_weighted(graph_file):
 
 @pytest.fixture(scope="module")
 def client_connection():
-    # setup
-    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
-
+    (cluster, client) = setup_local_dask_cluster(p2p=True)
     yield client
-
-    # teardown
-    comms.destroy()
-    client.close()
-    cluster.close()
+    teardown_local_dask_cluster(cluster, client)
 
 
 @pytest.mark.skipif(

--- a/python/cugraph/tests/test_symmetrize.py
+++ b/python/cugraph/tests/test_symmetrize.py
@@ -19,10 +19,8 @@ import pandas as pd
 import cudf
 import cugraph
 from cugraph.tests import utils
-import cugraph.comms as Comms
-from dask.distributed import Client
-from dask_cuda import LocalCUDACluster
-from cugraph.dask.common.mg_utils import is_single_gpu
+from cugraph.dask.common.mg_utils import (is_single_gpu,
+                                          setup_local_dask_cluster)
 
 
 def test_version():
@@ -188,15 +186,15 @@ def test_symmetrize_weighted(graph_file):
     compare(cu_M["0"], cu_M["1"], cu_M["2"], sym_src, sym_dst, sym_w)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def client_connection():
-    cluster = LocalCUDACluster()
-    client = Client(cluster)
-    Comms.initialize(p2p=True)
+    # setup
+    (comms, client, cluster) = setup_local_dask_cluster(p2p=True)
 
     yield client
 
-    Comms.destroy()
+    # teardown
+    comms.destroy()
     client.close()
     cluster.close()
 

--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -11,6 +11,7 @@ markers =
           managedmem_off: RMM managed memory disabled
           poolallocator_on: RMM pool allocator enabled
           poolallocator_off: RMM pool allocator disabled
+          preset_gpu_count: Use a hard-coded number of GPUs for specific MG tests
           ETL: benchmarks for ETL steps
           small: small datasets
           tiny: tiny datasets


### PR DESCRIPTION
This PR includes various updates to support nightly automated MG test runs, including:
* Adding a marker which nightly scripts use to run on all visible GPUs instead of a hardcoded number of GPUs, since the scripts rely on knowing the number of GPUs being used in the tests by setting the `CUDA_VISIBLE_DEVICES` env var.
  * In the nightly scripts, the marker is used like so: `pytest -m "not preset_gpu_count" ...`
* Added a `client.wait_for_workers()` call to various setups to both match the approach taken by the `MGContext` class, and to ensure workers are running. This seemed to increase reliability in the test runs. 
  * _side note: we should decide to use only the `MGContext` class or the `client_connection` pytest fixture in these tests, since they both aim to accomplish the same thing._
