### PR TITLE
Fix EXPERIMENTAL_LOUVAIN_TEST on Pascal

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -91,7 +91,7 @@ conda list --show-channel-urls
 
 if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
   gpuci_logger "Build from source"
-  $WORKSPACE/build.sh -v clean libcugraph cugraph --allgpuarch
+  $WORKSPACE/build.sh -v clean libcugraph cugraph
 fi
 
 ################################################################################

--- a/cpp/src/community/louvain.cu
+++ b/cpp/src/community/louvain.cu
@@ -15,18 +15,8 @@
  */
 
 #include <community/louvain.cuh>
-
-// "FIXME": remove the guards after support for Pascal is dropped
-//
-// Disable louvain(experimental::graph_view_t,...)
-// versions for GPU architectures < 700
-// (cuco/static_map.cuh depends on features not supported on or before Pascal)
-//
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700
 #include <experimental/graph.hpp>
-#else
 #include <experimental/louvain.cuh>
-#endif
 
 namespace cugraph {
 
@@ -69,12 +59,9 @@ std::pair<size_t, weight_t> louvain(
   if (device_prop.major < 7) {
     CUGRAPH_FAIL("Louvain not supported on Pascal and older architectures");
   } else {
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700
-#else
     experimental::Louvain<experimental::graph_view_t<vertex_t, edge_t, weight_t, false, multi_gpu>>
       runner(handle, graph_view);
     return runner(clustering, max_level, resolution);
-#endif
   }
 }
 

--- a/cpp/src/community/louvain.cu
+++ b/cpp/src/community/louvain.cu
@@ -16,7 +16,7 @@
 
 #include <community/louvain.cuh>
 
-// "FIXME": remove this check
+// "FIXME": remove the guards after support for Pascal is dropped
 //
 // Disable louvain(experimental::graph_view_t,...)
 // versions for GPU architectures < 700
@@ -57,7 +57,7 @@ std::pair<size_t, weight_t> louvain(
 {
   CUGRAPH_EXPECTS(clustering != nullptr, "Invalid input argument: clustering is null");
 
-  // "FIXME": remove this check
+  // "FIXME": remove this check and the guards below
   //
   // Disable louvain(experimental::graph_view_t,...)
   // versions for GPU architectures < 700
@@ -70,7 +70,6 @@ std::pair<size_t, weight_t> louvain(
     CUGRAPH_FAIL("Louvain not supported on Pascal and older architectures");
   } else {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700
-    CUGRAPH_FAIL("Louvain not supported on Pascal and older architectures");
 #else
     experimental::Louvain<experimental::graph_view_t<vertex_t, edge_t, weight_t, false, multi_gpu>>
       runner(handle, graph_view);
@@ -90,11 +89,7 @@ std::pair<size_t, typename graph_t::weight_type> louvain(raft::handle_t const &h
 {
   CUGRAPH_EXPECTS(clustering != nullptr, "Invalid input argument: clustering is null");
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700
-  CUGRAPH_FAIL("Louvain not supported on Pascal and older architectures");
-#else
   return detail::louvain(handle, graph, clustering, max_level, resolution);
-#endif
 }
 
 // Explicit template instantations

--- a/cpp/src/experimental/louvain.cuh
+++ b/cpp/src/experimental/louvain.cuh
@@ -32,6 +32,17 @@
 #include <patterns/transform_reduce_e.cuh>
 #include <patterns/transform_reduce_v.cuh>
 
+// "FIXME": remove the guards below and references to CUCO_STATIC_MAP_DEFINED
+//
+// cuco/static_map.cuh depends on features not supported on or before Pascal.
+//
+// If we build for sm_60 or before, the inclusion of cuco/static_map.cuh wil
+// result in compilation errors.
+//
+// If we're Pascal or before we do nothing here and will suppress including
+// some code below.  If we are later than Pascal we define CUCO_STATIC_MAP_DEFINED
+// which will result in the full implementation being pulled in.
+//
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700
 #else
 #define CUCO_STATIC_MAP_DEFINED

--- a/cpp/src/experimental/louvain.cuh
+++ b/cpp/src/experimental/louvain.cuh
@@ -21,7 +21,6 @@
 
 #include <rmm/thrust_rmm_allocator.h>
 #include <compute_partition.cuh>
-#include <cuco/static_map.cuh>
 #include <experimental/shuffle.cuh>
 #include <utilities/comm_utils.cuh>
 #include <utilities/graph_utils.cuh>
@@ -32,6 +31,13 @@
 #include <patterns/copy_v_transform_reduce_in_out_nbr.cuh>
 #include <patterns/transform_reduce_e.cuh>
 #include <patterns/transform_reduce_v.cuh>
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700
+#else
+#define CUCO_STATIC_MAP_DEFINED
+#include <cuco/static_map.cuh>
+#endif
+
 
 //#define TIMING
 
@@ -44,6 +50,7 @@ namespace experimental {
 
 namespace detail {
 
+#ifdef CUCO_STATIC_MAP_DEFINED
 template <typename data_t>
 struct create_cuco_pair_t {
   cuco::pair_type<data_t, data_t> __device__ operator()(data_t data)
@@ -54,6 +61,7 @@ struct create_cuco_pair_t {
     return tmp;
   }
 };
+#endif
 
 //
 // These classes should allow cuco::static_map to generate hash tables of
@@ -443,7 +451,9 @@ class Louvain {
                                                  weight_t resolution)
   {
     size_t num_level{0};
+    weight_t best_modularity = weight_t{-1};
 
+#ifdef CUCO_STATIC_MAP_DEFINED
     weight_t total_edge_weight;
     total_edge_weight = experimental::transform_reduce_e(
       handle_,
@@ -452,8 +462,6 @@ class Louvain {
       thrust::make_constant_iterator(0),
       [] __device__(auto, auto, weight_t wt, auto, auto) { return wt; },
       weight_t{0});
-
-    weight_t best_modularity = weight_t{-1};
 
     //
     //  Initialize every cluster to reference each vertex to itself
@@ -480,6 +488,7 @@ class Louvain {
     }
 
     timer_display(std::cout);
+#endif
 
     return std::make_pair(num_level, best_modularity);
   }
@@ -593,6 +602,7 @@ class Louvain {
     }
   }
 
+#ifdef CUCO_STATIC_MAP_DEFINED
   virtual weight_t update_clustering(weight_t total_edge_weight, weight_t resolution)
   {
     timer_start("update_clustering");
@@ -1616,6 +1626,7 @@ class Louvain {
     cugraph::detail::offsets_to_indices(
       current_graph_view_.offsets(), local_num_rows_, src_indices_v_.data().get());
   }
+#endif
 
   std::
     tuple<rmm::device_vector<vertex_t>, rmm::device_vector<vertex_t>, rmm::device_vector<weight_t>>

--- a/cpp/src/experimental/louvain.cuh
+++ b/cpp/src/experimental/louvain.cuh
@@ -38,7 +38,6 @@
 #include <cuco/static_map.cuh>
 #endif
 
-
 //#define TIMING
 
 #ifdef TIMING

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -302,12 +302,11 @@ ConfigureTest(EXPERIMENTAL_PAGERANK_TEST "${EXPERIMENTAL_PAGERANK_TEST_SRCS}" ""
 ###################################################################################################
 # - Experimental LOUVAIN tests -------------------------------------------------------------------
 
-# FIXME: Re-enable once failures are fixed
-#set(EXPERIMENTAL_LOUVAIN_TEST_SRCS
-#    "${CMAKE_SOURCE_DIR}/../thirdparty/mmio/mmio.c"
-#    "${CMAKE_CURRENT_SOURCE_DIR}/experimental/louvain_test.cu")
-#
-#ConfigureTest(EXPERIMENTAL_LOUVAIN_TEST "${EXPERIMENTAL_LOUVAIN_TEST_SRCS}" "")
+set(EXPERIMENTAL_LOUVAIN_TEST_SRCS
+    "${CMAKE_SOURCE_DIR}/../thirdparty/mmio/mmio.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/experimental/louvain_test.cu")
+
+ConfigureTest(EXPERIMENTAL_LOUVAIN_TEST "${EXPERIMENTAL_LOUVAIN_TEST_SRCS}" "")
 
 ###################################################################################################
 # - Experimental KATZ_CENTRALITY tests ------------------------------------------------------------

--- a/cpp/tests/experimental/louvain_test.cu
+++ b/cpp/tests/experimental/louvain_test.cu
@@ -84,7 +84,20 @@ class Tests_Louvain : public ::testing::TestWithParam<Louvain_Usecase> {
 
     auto graph_view = graph.view();
 
-    louvain(graph_view);
+    // "FIXME": remove this check
+    //
+    // Disable louvain(experimental::graph_view_t,...)
+    // versions for GPU architectures < 700
+    // (cuco/static_map.cuh depends on features not supported on or before Pascal)
+    //
+    cudaDeviceProp device_prop;
+    CUDA_CHECK(cudaGetDeviceProperties(&device_prop, 0));
+
+    if (device_prop.major < 7) {
+      EXPECT_THROW(louvain(graph_view), cugraph::logic_error);
+    } else {
+      louvain(graph_view);
+    }
   }
 
   template <typename graph_t>

--- a/cpp/tests/experimental/louvain_test.cu
+++ b/cpp/tests/experimental/louvain_test.cu
@@ -21,17 +21,8 @@
 #include <raft/handle.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 
-// "FIXME": remove this check
-//
-// Disable louvain(experimental::graph_view_t,...)
-// versions for GPU architectures < 700
-// (cuco/static_map.cuh depends on features not supported on or before Pascal)
-//
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700
 #include <experimental/graph.hpp>
-#else
 #include <experimental/louvain.cuh>
-#endif
 
 #include <algorithms.hpp>
 
@@ -84,11 +75,10 @@ class Tests_Louvain : public ::testing::TestWithParam<Louvain_Usecase> {
 
     auto graph_view = graph.view();
 
-    // "FIXME": remove this check
+    // "FIXME": remove this check once we drop support for Pascal
     //
-    // Disable louvain(experimental::graph_view_t,...)
-    // versions for GPU architectures < 700
-    // (cuco/static_map.cuh depends on features not supported on or before Pascal)
+    // Calling louvain on Pascal will throw an exception, we'll check that
+    // this is the behavior while we still support Pascal (device_prop.major < 7)
     //
     cudaDeviceProp device_prop;
     CUDA_CHECK(cudaGetDeviceProperties(&device_prop, 0));


### PR DESCRIPTION
`experimental::louvain` uses a `coco::static_map` which is not supported on Pascal and earlier GPUs.

The first attempt at implementing checks for Pascal attempted to exclusively use preprocessor directives to control building the executable and deciding whether to run it or not.  However, nvcc uses the preprocessor to create different files to be compiled for host, and each combination of devices being compiled.  Exclusively using preprocessor directives created a library that didn't have all of the host and device code necessary to run.

This PR adds a runtime check to raise an exception if running on Pascal, but it will still compile all of the necessary host and device code for other architectures.