### PR TITLE
[REVIEW] FIX Set bash trap after PATH is updated [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## Improvements
 
 ## Bug Fixes
+- PR #1321 Fix benchmark script trap setup to come after the PATH variable update
 
 # cuGraph 0.17.0 (10 Dec 2020)
 ## New Features

--- a/ci/benchmark/build.sh
+++ b/ci/benchmark/build.sh
@@ -20,17 +20,17 @@ function cleanup {
   rm -f testoutput.txt
 }
 
-# Set cleanup trap for Jenkins
-if [ ! -z "$JENKINS_HOME" ] ; then
-  gpuci_logger "Jenkins environment detected, setting cleanup trap"
-  trap cleanup EXIT
-fi
-
 # Set path, build parallel level, and CUDA version
 cd $WORKSPACE
 export PATH=/opt/conda/bin:/usr/local/cuda/bin:$PATH
 export PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 export CUDA_REL=${CUDA_VERSION%.*}
+
+# Set cleanup trap for Jenkins
+if [ ! -z "$JENKINS_HOME" ] ; then
+  gpuci_logger "Jenkins environment detected, setting cleanup trap"
+  trap cleanup EXIT
+fi
 
 # Set home
 export HOME=$WORKSPACE


### PR DESCRIPTION
Benchmark builds were failing after recent CI updates with the following error:

```
ci/benchmark/build.sh: line 25: gpuci_logger: command not found
```

This fix moves the `PATH` variable update above the trap setup, which should provide access to our conda installed gpuCI tools, including `gpuci_logger`.