### PR TITLE
Fix MNMG Louvain tests on Pascal architecture

### DIFF
--- a/python/cugraph/dask/common/mg_utils.py
+++ b/python/cugraph/dask/common/mg_utils.py
@@ -19,10 +19,12 @@ from dask_cuda import LocalCUDACluster
 from dask.distributed import Client
 
 from cugraph.raft.dask.common.utils import default_client
-# FIXME: cugraph/__init__.py also imports the comms module, but depending on the
-# import environment, cugraph/comms/__init__.py may be imported instead. The
-# following imports the comms.py module directly
+# FIXME: cugraph/__init__.py also imports the comms module, but
+# depending on the import environment, cugraph/comms/__init__.py
+# may be imported instead. The following imports the comms.py
+# module directly
 from cugraph.comms import comms as Comms
+
 
 # FIXME: We currently look for the default client from dask, as such is the
 # if there is a dask client running without any GPU we will still try

--- a/python/cugraph/dask/common/mg_utils.py
+++ b/python/cugraph/dask/common/mg_utils.py
@@ -19,8 +19,10 @@ from dask_cuda import LocalCUDACluster
 from dask.distributed import Client
 
 from cugraph.raft.dask.common.utils import default_client
-import cugraph.comms as Comms
-
+# FIXME: cugraph/__init__.py also imports the comms module, but depending on the
+# import environment, cugraph/comms/__init__.py may be imported instead. The
+# following imports the comms.py module directly
+from cugraph.comms import comms as Comms
 
 # FIXME: We currently look for the default client from dask, as such is the
 # if there is a dask client running without any GPU we will still try
@@ -69,7 +71,7 @@ def setup_local_dask_cluster(p2p=True):
     cluster = LocalCUDACluster()
     client = Client(cluster)
     client.wait_for_workers(len(get_visible_devices()))
-    Comms.initialize(p2p)
+    Comms.initialize(p2p=p2p)
 
     return (cluster, client)
 

--- a/python/cugraph/tests/dask/test_mg_louvain.py
+++ b/python/cugraph/tests/dask/test_mg_louvain.py
@@ -17,6 +17,7 @@ import cugraph.dask as dcg
 import cugraph
 import dask_cudf
 from cugraph.tests import utils
+from cugraph.utilities.utils import is_device_version_less_than
 from cugraph.dask.common.mg_utils import (is_single_gpu,
                                           setup_local_dask_cluster,
                                           teardown_local_dask_cluster)
@@ -84,11 +85,15 @@ def test_mg_louvain_with_edgevals(daskGraphFromDataset):
     # FIXME: daskGraphFromDataset returns a DiGraph, which Louvain is currently
     # accepting. In the future, an MNMG symmeterize will need to be called to
     # create a Graph for Louvain.
-    parts, mod = dcg.louvain(daskGraphFromDataset)
+    if is_device_version_less_than((7, 0)):
+        with pytest.raises(RuntimeError):
+            parts, mod = dcg.louvain(daskGraphFromDataset)
+    else:
+        parts, mod = dcg.louvain(daskGraphFromDataset)
 
-    # FIXME: either call Nx with the same dataset and compare results, or
-    # hadcode golden results to compare to.
-    print()
-    print(parts.compute())
-    print(mod)
-    print()
+        # FIXME: either call Nx with the same dataset and compare results, or
+        # hardcode golden results to compare to.
+        print()
+        print(parts.compute())
+        print(mod)
+        print()

--- a/python/cugraph/utilities/utils.py
+++ b/python/cugraph/utilities/utils.py
@@ -14,6 +14,11 @@
 from numba import cuda
 
 import cudf
+from rmm._cuda.gpu import (
+    getDeviceAttribute,
+    cudaDeviceAttr,
+)
+
 
 # optional dependencies
 try:
@@ -178,6 +183,25 @@ def is_cuda_version_less_than(min_version=(10, 2)):
     if this_cuda_ver[0] < min_version[0]:
         return True
     if this_cuda_ver[1] < min_version[1]:
+        return True
+    return False
+
+
+def is_device_version_less_than(min_version=(7, 0)):
+    """
+    Returns True if the version of CUDA being used is less than min_version
+    """
+    major_version = getDeviceAttribute(
+        cudaDeviceAttr.cudaDevAttrComputeCapabilityMajor, 0
+    )
+    minor_version = getDeviceAttribute(
+        cudaDeviceAttr.cudaDevAttrComputeCapabilityMinor, 0
+    )
+    if major_version > min_version[0]:
+        return False
+    if major_version < min_version[0]:
+        return True
+    if minor_version < min_version[1]:
         return True
     return False
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -105,11 +105,11 @@ EXTENSIONS = [
                             "../thirdparty/cub",
                             raft_include_dir,
                             os.path.join(
-                                conda_include_dir, "libcudf", "libcudacxx"),
+                                conda_include_dir, "libcudacxx"),
                             cuda_include_dir],
               library_dirs=[get_python_lib()],
               runtime_library_dirs=[conda_lib_dir],
-              libraries=['cugraph', 'cudf', 'nccl'],
+              libraries=['cugraph', 'nccl'],
               language='c++',
               extra_compile_args=['-std=c++14'])
 ]


### PR DESCRIPTION
MNMG Louvain uses a feature not supported on Pascal.  This PR updates the python unit tests so that it expects an exception to be raised if running on a Pascal GPU.