### PR TITLE
Updated git utils used by copyright.py for compatibility with current CI env

### DIFF
--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018-2020, NVIDIA CORPORATION.
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
 ########################
 # cuGraph Style Tester #
 ########################

--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -52,13 +52,14 @@ COPYRIGHT=`env PYTHONPATH=ci/utils python ci/checks/copyright.py --git-modified-
 CR_RETVAL=$?
 ERRORCODE=$((ERRORCODE | ${CR_RETVAL}))
 
-# Output results if failure otherwise show pass
 if [ "$CR_RETVAL" != "0" ]; then
   echo -e "\n\n>>>> FAILED: copyright check; begin output\n\n"
   echo -e "$COPYRIGHT"
   echo -e "\n\n>>>> FAILED: copyright check; end output\n\n"
 else
-  echo -e "\n\n>>>> PASSED: copyright check\n\n"
+  echo -e "\n\n>>>> PASSED: copyright check; begin debug output\n\n"
+  echo -e "$COPYRIGHT"
+  echo -e "\n\n>>>> PASSED: copyright check; end debug output\n\n"
 fi
 
 exit ${ERRORCODE}

--- a/ci/utils/git_helpers.py
+++ b/ci/utils/git_helpers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ci/utils/git_helpers.py
+++ b/ci/utils/git_helpers.py
@@ -59,20 +59,21 @@ def uncommittedFiles():
     return ret
 
 
-def changedFilesBetween(base, branch, commitHash):
+def changedFilesBetween(baseName, branchName, commitHash):
     """
-    Returns a list of files changed between branches base and latest commit of
-    branch.
+    Returns a list of files changed between branches baseName and latest commit
+    of branchName.
     """
     current = branch()
     # checkout "base" branch
-    __git("checkout", "--force", base)
+    __git("checkout", "--force", baseName)
     # checkout branch for comparing
-    __git("checkout", "--force", branch)
+    __git("checkout", "--force", branchName)
     # checkout latest commit from branch
     __git("checkout", "-fq", commitHash)
 
-    files = __gitdiff("--name-only", "--ignore-submodules", f"{base}..{branch}")
+    files = __gitdiff("--name-only", "--ignore-submodules",
+                      f"{baseName}..{branchName}")
 
     # restore the original branch
     __git("checkout", "--force", current)

--- a/ci/utils/git_helpers.py
+++ b/ci/utils/git_helpers.py
@@ -60,8 +60,8 @@ def uncommittedFiles():
 
 
 def changedFilesFromBase(base):
-    """Returns a list of files changed between the current branch and base"""
-    files = __gitdiff("--name-only", "--ignore-submodules", f"{base}...")
+    """Returns a list of files changed between base and HEAD"""
+    files = __gitdiff("--name-only", "--ignore-submodules", f"{base}...HEAD")
     return files.splitlines()
 
 

--- a/ci/utils/git_helpers.py
+++ b/ci/utils/git_helpers.py
@@ -87,9 +87,9 @@ def changesInFileBetween(file, b1, b2, pathFilter=None):
 
 def modifiedFiles(pathFilter=None):
     """
-    If inside a CI-env (ie. TARGET_BRANCH and SOURCE_BRANCH are defined), then
-    lists out all files modified between these 2 branches. Else, lists out all
-    the uncommitted files in the current branch.
+    If inside a CI-env (ie. TARGET_BRANCH is defined and current branch is
+    HEAD), then lists out all files modified between these 2 branches. Else,
+    lists out all the uncommitted files in the current branch.
 
     Such utility function is helpful while putting checker scripts as part of
     cmake, as well as CI process. This way, during development, only the files
@@ -98,16 +98,17 @@ def modifiedFiles(pathFilter=None):
     checked. This happens, all the while using the same script.
     """
     targetBranch = os.environ.get("TARGET_BRANCH")
-    sourceBranch = os.environ.get("SOURCE_BRANCH")
-    if targetBranch and sourceBranch:
-        print("   [DEBUG] Assuming a CI environment: ", end="")
+    currentBranch = branch()
+    if targetBranch and (currentBranch == "HEAD"):
+        print("   [DEBUG] Assuming a CI environment: "
+              f"TARGET_BRANCH={targetBranch}, currentBranch={currentBranch}")
         allFiles = changedFilesBetween(os.environ["TARGET_BRANCH"],
-                                       os.environ["SOURCE_BRANCH"])
+                                       currentBranch)
     else:
-        print("   [DEBUG] Did not detect CI environment: ", end="")
+        print("   [DEBUG] Did not detect CI environment: "
+              f"TARGET_BRANCH={targetBranch}, currentBranch={currentBranch}")
         allFiles = uncommittedFiles()
 
-    print(f"TARGET_BRANCH={targetBranch}, SOURCE_BRANCH={sourceBranch}")
     files = []
     for f in allFiles:
         if pathFilter is None or pathFilter(f):

--- a/ci/utils/git_helpers.py
+++ b/ci/utils/git_helpers.py
@@ -59,6 +59,12 @@ def uncommittedFiles():
     return ret
 
 
+def changedFilesFromBase(base):
+    """Returns a list of files changed between the current branch and base"""
+    files = __gitdiff("--name-only", "--ignore-submodules", f"{base}...")
+    return files.splitlines()
+
+
 def changedFilesBetween(b1, b2):
     """Returns a list of files changed between branches b1 and b2"""
     current = branch()
@@ -87,9 +93,9 @@ def changesInFileBetween(file, b1, b2, pathFilter=None):
 
 def modifiedFiles(pathFilter=None):
     """
-    If inside a CI-env (ie. TARGET_BRANCH is defined and current branch is
-    HEAD), then lists out all files modified between these 2 branches. Else,
-    lists out all the uncommitted files in the current branch.
+    If inside a CI-env (ie. TARGET_BRANCH is defined), then lists out all files
+    modified between these 2 branches. Else, lists out all the uncommitted files
+    in the current branch.
 
     Such utility function is helpful while putting checker scripts as part of
     cmake, as well as CI process. This way, during development, only the files
@@ -98,15 +104,13 @@ def modifiedFiles(pathFilter=None):
     checked. This happens, all the while using the same script.
     """
     targetBranch = os.environ.get("TARGET_BRANCH")
-    currentBranch = branch()
-    if targetBranch and (currentBranch == "HEAD"):
+    if targetBranch:
         print("   [DEBUG] Assuming a CI environment: "
-              f"TARGET_BRANCH={targetBranch}, currentBranch={currentBranch}")
-        allFiles = changedFilesBetween(os.environ["TARGET_BRANCH"],
-                                       currentBranch)
+              f"TARGET_BRANCH={targetBranch}")
+        allFiles = changedFilesFromBase(base=targetBranch)
     else:
         print("   [DEBUG] Did not detect CI environment: "
-              f"TARGET_BRANCH={targetBranch}, currentBranch={currentBranch}")
+              f"TARGET_BRANCH={targetBranch}")
         allFiles = uncommittedFiles()
 
     files = []

--- a/ci/utils/git_helpers.py
+++ b/ci/utils/git_helpers.py
@@ -87,10 +87,9 @@ def changesInFileBetween(file, b1, b2, pathFilter=None):
 
 def modifiedFiles(pathFilter=None):
     """
-    If inside a CI-env (ie. currentBranch=current-pr-branch and the env-var
-    PR_TARGET_BRANCH is defined), then lists out all files modified between
-    these 2 branches. Else, lists out all the uncommitted files in the current
-    branch.
+    If inside a CI-env (ie. TARGET_BRANCH and SOURCE_BRANCH are defined), then
+    lists out all files modified between these 2 branches. Else, lists out all
+    the uncommitted files in the current branch.
 
     Such utility function is helpful while putting checker scripts as part of
     cmake, as well as CI process. This way, during development, only the files
@@ -98,15 +97,24 @@ def modifiedFiles(pathFilter=None):
     process ALL files modified by the dev, as submiited in the PR, will be
     checked. This happens, all the while using the same script.
     """
-    if "PR_TARGET_BRANCH" in os.environ and branch() == "current-pr-branch":
-        allFiles = changedFilesBetween(os.environ["PR_TARGET_BRANCH"],
-                                       branch())
+    targetBranch = os.environ.get("TARGET_BRANCH")
+    sourceBranch = os.environ.get("SOURCE_BRANCH")
+    if targetBranch and sourceBranch:
+        print("   [DEBUG] Assuming a CI environment: ", end="")
+        allFiles = changedFilesBetween(os.environ["TARGET_BRANCH"],
+                                       os.environ["SOURCE_BRANCH"])
     else:
+        print("   [DEBUG] Did not detect CI environment: ", end="")
         allFiles = uncommittedFiles()
+
+    print(f"TARGET_BRANCH={targetBranch}, SOURCE_BRANCH={sourceBranch}")
     files = []
     for f in allFiles:
         if pathFilter is None or pathFilter(f):
             files.append(f)
+
+    filesToCheckString = "\n\t".join(files) if files else "<None>"
+    print(f"   [DEBUG] Found files to check:\n\t{filesToCheckString}\n")
     return files
 
 


### PR DESCRIPTION
Updated git utils used by copyright.py for compatibility with current CI env, added debug prints.

<s>NOTE: I'm intentionally not updating the copyright date on the changed file to test that the check is working in the actual CI environment here.  Once verified, I'll change it from a draft PR and mark it ready for review.</s> _verified_