### PR TITLE
Expose dense implementation of Hungarian algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,12 @@ for i in range(len(df_page)):
 |              | Core Number                            | Single-GPU   |                     |
 | Layout       |                                        |              |                     |
 |              | Force Atlas 2                          | Single-GPU   |                     |
+| Linear Assignment|                                    |              |                     |
+|              | Hungarian                              | Single-GPU   | [README](cpp/src/linear_assignment/README-hungarian.md) |
 | Link Analysis|                                        |              |                     |
 |              | Pagerank                               | Multi-GPU    |                     |
 |              | Personal Pagerank                      | Multi-GPU    |                     |
-|              | HITS                      				| Single-GPU   | leverages Gunrock   |
+|              | HITS                                   | Single-GPU   | leverages Gunrock   |
 | Link Prediction |                                     |              |                     |
 |              | Jaccard Similarity                     | Single-GPU   |                     |
 |              | Weighted Jaccard Similarity            | Single-GPU   |                     |

--- a/cpp/src/linear_assignment/README-hungarian.md
+++ b/cpp/src/linear_assignment/README-hungarian.md
@@ -1,0 +1,36 @@
+# LAP
+Implementation of ***O(n^3) Alternating Tree Variant*** of Hungarian Algorithm on NVIDIA CUDA-enabled GPU.
+
+This implementation solves a batch of ***k*** **Linear Assignment Problems (LAP)**, each with ***nxn*** matrix of single floating point cost values. At optimality, the algorithm produces an assignment with ***minimum*** cost.
+
+The API can be used to query optimal primal and dual costs, optimal assignment vector, and optimal row/column dual vectors for each subproblem in the batch.
+
+cuGraph exposes the Hungarian algorithm, the actual implementation is contained in the RAFT library which contains some common tools and kernels shared between cuGraph and cuML.
+
+Following parameters can be used to tune the performance of algorithm:
+
+1. epsilon: (in raft/lap/lap_kernels.cuh) This parameter controls the tolerance on the floating point precision. Setting this too small will result in increased solution time because the algorithm will search for precise solutions. Setting it too high may cause some inaccuracies.
+
+2. BLOCKDIMX, BLOCKDIMY: (in raft/lap/lap_functions.cuh) These parameters control threads_per_block to be used along the given dimension. Set these according to the device specifications and occupancy calculation.
+
+***This library is licensed under Apache License 2.0. Please cite our paper, if this library helps you in your research.***
+
+- Harvard citation style
+
+  Date, K. and Nagi, R., 2016. GPU-accelerated Hungarian algorithms for the Linear Assignment Problem. Parallel Computing, 57, pp.52-72.
+
+- BibTeX Citation block to be used in LaTeX bibliography file:
+
+```
+@article{date2016gpu,
+  title={GPU-accelerated Hungarian algorithms for the Linear Assignment Problem},
+  author={Date, Ketan and Nagi, Rakesh},
+  journal={Parallel Computing},
+  volume={57},
+  pages={52--72},
+  year={2016},
+  publisher={Elsevier}
+}
+```
+
+The paper is available online on [ScienceDirect](https://www.sciencedirect.com/science/article/abs/pii/S016781911630045X).

--- a/python/cugraph/__init__.py
+++ b/python/cugraph/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/__init__.py
+++ b/python/cugraph/__init__.py
@@ -89,7 +89,7 @@ from cugraph.bsp.traversal import bfs_df_pregel
 from cugraph.proto.components import strong_connected_component
 from cugraph.proto.structure import find_bicliques
 
-from cugraph.linear_assignment import hungarian
+from cugraph.linear_assignment import hungarian, dense_hungarian
 from cugraph.layout import force_atlas2
 from cugraph.raft import raft_include_test
 from cugraph.comms import comms

--- a/python/cugraph/linear_assignment/__init__.py
+++ b/python/cugraph/linear_assignment/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/linear_assignment/__init__.py
+++ b/python/cugraph/linear_assignment/__init__.py
@@ -11,4 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cugraph.linear_assignment.lap import hungarian
+from cugraph.linear_assignment.lap import hungarian, dense_hungarian

--- a/python/cugraph/linear_assignment/lap.pxd
+++ b/python/cugraph/linear_assignment/lap.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/linear_assignment/lap.pxd
+++ b/python/cugraph/linear_assignment/lap.pxd
@@ -20,19 +20,19 @@ from cugraph.structure.graph_primtypes cimport *
 
 cdef extern from "algorithms.hpp" namespace "cugraph":
 
-    cdef WT hungarian[VT,ET,WT](
+    cdef weight_t hungarian[vertex_t,edge_t,weight_t](
         const handle_t &handle,
-        const GraphCOOView[VT,ET,WT] &graph,
-        VT num_workers,
-        const VT *workers,
-        VT *assignment) except +
+        const GraphCOOView[vertex_t,edge_t,weight_t] &graph,
+        vertex_t num_workers,
+        const vertex_t *workers,
+        vertex_t *assignment) except +
 
 
 cdef extern from "algorithms.hpp":
 
-    cdef WT dense_hungarian "cugraph::dense::hungarian" [VT,WT](
+    cdef weight_t dense_hungarian "cugraph::dense::hungarian" [vertex_t,weight_t](
         const handle_t &handle,
-        const WT *costs,
-        VT num_rows,
-        VT num_columns,
-        VT *assignment) except +
+        const weight_t *costs,
+        vertex_t num_rows,
+        vertex_t num_columns,
+        vertex_t *assignment) except +

--- a/python/cugraph/linear_assignment/lap.pxd
+++ b/python/cugraph/linear_assignment/lap.pxd
@@ -20,9 +20,19 @@ from cugraph.structure.graph_primtypes cimport *
 
 cdef extern from "algorithms.hpp" namespace "cugraph":
 
-    cdef void hungarian[VT,ET,WT](
+    cdef WT hungarian[VT,ET,WT](
         const handle_t &handle,
         const GraphCOOView[VT,ET,WT] &graph,
         VT num_workers,
         const VT *workers,
+        VT *assignment) except +
+
+
+cdef extern from "algorithms.hpp":
+
+    cdef WT dense_hungarian "cugraph::dense::hungarian" [VT,WT](
+        const handle_t &handle,
+        const WT *costs,
+        VT num_rows,
+        VT num_columns,
         VT *assignment) except +

--- a/python/cugraph/linear_assignment/lap.py
+++ b/python/cugraph/linear_assignment/lap.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/linear_assignment/lap.py
+++ b/python/cugraph/linear_assignment/lap.py
@@ -107,7 +107,7 @@ def dense_hungarian(costs, num_rows, num_columns):
         The cost of the overall assignment
     assignment : cudf.Series
       assignment[i] gives the vertex id of the task assigned to the
-                    worker i     
+                    worker i
 
     FIXME: Update this with a real example...
 

--- a/python/cugraph/linear_assignment/lap.py
+++ b/python/cugraph/linear_assignment/lap.py
@@ -84,6 +84,8 @@ def dense_hungarian(costs, num_rows, num_columns):
     Execute the Hungarian algorithm against a dense bipartite
     graph representation.
 
+    *NOTE*: This API is unstable and subject to change
+
     The Hungarian algorithm identifies the lowest cost matching of vertices
     such that all workers that can be assigned work are assigned exactly
     on job.

--- a/python/cugraph/linear_assignment/lap_wrapper.pyx
+++ b/python/cugraph/linear_assignment/lap_wrapper.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/linear_assignment/lap_wrapper.pyx
+++ b/python/cugraph/linear_assignment/lap_wrapper.pyx
@@ -17,6 +17,7 @@
 # cython: language_level = 3
 
 from cugraph.linear_assignment.lap cimport hungarian as c_hungarian
+from cugraph.linear_assignment.lap cimport dense_hungarian as c_dense_hungarian
 from cugraph.structure.graph_primtypes cimport *
 from cugraph.structure import graph_primtypes_wrapper
 from libc.stdint cimport uintptr_t
@@ -25,7 +26,7 @@ from cugraph.structure.graph import Graph as type_Graph
 import cudf
 import numpy as np
 
-def hungarian(input_graph, workers):
+def sparse_hungarian(input_graph, workers):
     """
     Call the hungarian algorithm
     """
@@ -76,10 +77,37 @@ def hungarian(input_graph, workers):
     if weights.dtype == np.float32:
         g_float = GraphCOOView[int,int,float](<int*>c_src, <int*>c_dst, <float*>c_weights, num_verts, num_edges)
 
-        c_hungarian[int,int,float](handle_[0], g_float, len(workers), <int*>c_workers, <int*>c_assignment)
+        cost = c_hungarian[int,int,float](handle_[0], g_float, len(workers), <int*>c_workers, <int*>c_assignment)
     else:
         g_double = GraphCOOView[int,int,double](<int*>c_src, <int*>c_dst, <double*>c_weights, num_verts, num_edges)
 
-        c_hungarian[int,int,double](handle_[0], g_double, len(workers), <int*>c_workers, <int*>c_assignment)
+        cost = c_hungarian[int,int,double](handle_[0], g_double, len(workers), <int*>c_workers, <int*>c_assignment)
 
-    return df
+    return cost, df
+
+
+def dense_hungarian(costs, num_rows, num_columns):
+    """
+    Call the dense hungarian algorithm
+    """
+    if type(costs) is not cudf.Series:
+        raise("costs must be a cudf.Series")
+
+    cdef unique_ptr[handle_t] handle_ptr
+    handle_ptr.reset(new handle_t())
+    handle_ = handle_ptr.get();
+
+    assignment = cudf.Series(np.zeros(num_rows, dtype=np.int32))
+
+    cdef uintptr_t c_costs = costs.__cuda_array_interface__['data'][0]
+    cdef uintptr_t c_assignment = assignment.__cuda_array_interface__['data'][0]
+
+
+    if costs.dtype == np.float32:
+        cost = c_dense_hungarian[int,float](handle_[0], <float*> c_costs, num_rows, num_columns, <int*> c_assignment)
+    elif costs.dtype == np.float64:
+        cost = c_dense_hungarian[int,double](handle_[0], <double*> c_costs, num_rows, num_columns, <int*> c_assignment)
+    else:
+        raise("unsported type: ", costs.dtype)
+
+    return cost, assignment

--- a/python/cugraph/tests/test_hungarian.py
+++ b/python/cugraph/tests/test_hungarian.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/tests/test_hungarian.py
+++ b/python/cugraph/tests/test_hungarian.py
@@ -80,7 +80,7 @@ def test_hungarian(managed, pool, v1_size, v2_size, weight_limit):
                                        np.float)
 
     start = timer()
-    matching = cugraph.hungarian(g, v1)
+    cugraph_cost, matching = cugraph.hungarian(g, v1)
     end = timer()
 
     print('cugraph time: ', (end - start))
@@ -92,13 +92,6 @@ def test_hungarian(managed, pool, v1_size, v2_size, weight_limit):
     print('scipy time: ', (end - start))
 
     scipy_cost = m[np_matching[0], np_matching[1]].sum()
-
-    cugraph_df = matching.merge(g.edgelist.edgelist_df,
-                                left_on=['vertex', 'assignment'],
-                                right_on=['src', 'dst'],
-                                how='left')
-
-    cugraph_cost = cugraph_df['weights'].sum()
 
     print('scipy_cost = ', scipy_cost)
     print('cugraph_cost = ', cugraph_cost)

--- a/python/cugraph/tests/test_hungarian.py
+++ b/python/cugraph/tests/test_hungarian.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 import gc
-from itertools import product
 from timeit import default_timer as timer
 
 import numpy as np
@@ -61,11 +60,8 @@ def setup_function():
     gc.collect()
 
 
-# Test all combinations of default/managed and pooled/non-pooled allocation
-@pytest.mark.parametrize('managed, pool',
-                         list(product([False, True], [False, True])))
 @pytest.mark.parametrize('v1_size, v2_size, weight_limit', SPARSE_SIZES)
-def test_hungarian(managed, pool, v1_size, v2_size, weight_limit):
+def test_hungarian(v1_size, v2_size, weight_limit):
     v1, g, m = create_random_bipartite(v1_size,
                                        v2_size,
                                        weight_limit,
@@ -88,11 +84,8 @@ def test_hungarian(managed, pool, v1_size, v2_size, weight_limit):
     assert(scipy_cost == cugraph_cost)
 
 
-# Test all combinations of default/managed and pooled/non-pooled allocation
-@pytest.mark.parametrize('managed, pool',
-                         list(product([False, True], [False, True])))
 @pytest.mark.parametrize('n, weight_limit', DENSE_SIZES)
-def test_dense_hungarian(managed, pool, n, weight_limit):
+def test_dense_hungarian(n, weight_limit):
     C = np.random.uniform(
         0, weight_limit, size=(n, n)
     ).round().astype(np.float32)


### PR DESCRIPTION
Expose an API for the dense implementation of the Hungarian algorithm.

The implementation is actually done in dense form, the sparse version (previously exposed) converts to a dense matrix before calling.

This change exposes the dense version directly to python, allowing users with dense matrices to send their data directly to the algorithm without converting it to a sparse representation first.

Also include some documentation updates.
Also modified the python return value to include both the cost and the assignment.