### PR TITLE
Fix #1340 - Use generic from_edgelist() methods

### DIFF
--- a/notebooks/link_analysis/Pagerank.ipynb
+++ b/notebooks/link_analysis/Pagerank.ipynb
@@ -11,7 +11,7 @@
     "Notebook Credits\n",
     "* Original Authors: Bradley Rees and James Wyles\n",
     "* Created:   08/13/2019\n",
-    "* Updated:   08/16/2020\n",
+    "* Updated:   01/17/2022\n",
     "\n",
     "RAPIDS Versions: 0.14    \n",
     "\n",

--- a/notebooks/link_analysis/Pagerank.ipynb
+++ b/notebooks/link_analysis/Pagerank.ipynb
@@ -11,7 +11,7 @@
     "Notebook Credits\n",
     "* Original Authors: Bradley Rees and James Wyles\n",
     "* Created:   08/13/2019\n",
-    "* Updated:   01/17/2022\n",
+    "* Updated:   01/17/2021\n",
     "\n",
     "RAPIDS Versions: 0.14    \n",
     "\n",

--- a/notebooks/link_analysis/Pagerank.ipynb
+++ b/notebooks/link_analysis/Pagerank.ipynb
@@ -190,7 +190,7 @@
    "metadata": {},
    "source": [
     "### Read in the data - GPU\n",
-    "cuGraph depends on cuDF for data loading and the initial Dataframe creation\n",
+    "cuGraph graphs can be created from cuDF, dask_cuDF and Pandas dataframes\n",
     "\n",
     "The data file contains an edge list, which represents the connection of a vertex to another.  The `source` to `destination` pairs is in what is known as Coordinate Format (COO).  In this test case, the data is just two columns.  However a third, `weight`, column is also possible"
    ]
@@ -219,8 +219,7 @@
    "outputs": [],
    "source": [
     "# create a Graph using the source (src) and destination (dst) vertex pairs from the Dataframe \n",
-    "G = cugraph.Graph()\n",
-    "G.from_cudf_edgelist(gdf, source='src', destination='dst')"
+    "G = cugraph.from_edgelist(gdf, source='src', destination='dst')"
    ]
   },
   {


### PR DESCRIPTION
Hi!

I have updated this notebook to make use of the new generic from_edgelist() methods. I have also updated the notebook to mention that graphs can be created from cudf, dask_cudf and Pandas dataframes.

Hope it helps!

Regards,
Miguel

closes #1340