### PR TITLE
Auto-label PRs based on their content [skip-ci]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -23,7 +23,7 @@ CMake:
   - '**/CMakeLists.txt'
   - '**/cmake/**'
 
-ci:
+gpuCI:
    - 'ci/**'
 
 conda:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,6 +18,10 @@ datasets:
   
 cuGraph:
   - 'cpp/**'
+  
+CMake:
+  - '**/CMakeLists.txt'
+  - '**/cmake/**'
 
 gpuCI:
    - 'ci/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,6 +5,8 @@
 python:
   - 'python/**'
   - 'notebooks/**'
+
+benchmarks:
   - 'benchmarks/**'
   
 doc:
@@ -20,11 +22,12 @@ cuGraph:
 CMake:
   - '**/CMakeLists.txt'
   - '**/cmake/**'
+
+ci:
+   - 'ci/**'
+
+conda:
+  - 'conda/**'
   
 Ops:
   - '.github/**'
-  - 'ci/**'
-  - 'conda/**'
-  - '**/Dockerfile'
-  - '**/.dockerignore'
-  - 'docker/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,10 +19,6 @@ datasets:
 cuGraph:
   - 'cpp/**'
 
-CMake:
-  - '**/CMakeLists.txt'
-  - '**/cmake/**'
-
 gpuCI:
    - 'ci/**'
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,6 +12,13 @@ benchmarks:
 doc:
   - 'docs/**'
   - '**/*.md'
+  - 'datasets/**'
+  - 'notebooks/**'
+  - '**/*.txt'
+  - '**/*.rst'
+  - '**/*.ipynb'
+  - '**/*.pdf'
+  - '**/*.png'
   
 datasets:
   - 'datasets/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,6 +28,3 @@ ci:
 
 conda:
   - 'conda/**'
-  
-Ops:
-  - '.github/**'


### PR DESCRIPTION
This PR adds the GitHub action [PR Labeler](https://github.com/actions/labeler) to auto-label PRs based on their content. 

Labeling is managed with a configuration file `.github/labeler.yml` using the following [options](https://github.com/actions/labeler#usage).