### PR TITLE
Remove erroneous escape character from CI scripts

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018-2020, NVIDIA CORPORATION.
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
 ##########################################
 # cuGraph GPU build & testscript for CI  #
 ##########################################

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -127,8 +127,8 @@ else
     python ${WORKSPACE}/ci/utils/nbtestlog2junitxml.py nbtest.log
 fi
 
-if [ -n "\${CODECOV_TOKEN}" ]; then
-    codecov -t \$CODECOV_TOKEN
+if [ -n "${CODECOV_TOKEN}" ]; then
+    codecov -t $CODECOV_TOKEN
 fi
 
 return ${EXITCODE}


### PR DESCRIPTION
This PR removes an erroneous escape character in `ci/gpu/build.sh`.