### PR TITLE
Update stale GHA with exemptions & new labels [skip-ci]

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,65 +1,57 @@
-name: Mark stale and rotten issues and pull requests
+name: Mark inactive issues and pull requests
 
 on:
   schedule:
     - cron: "0 * * * *"
 
 jobs:
-  mark-stale-issues:
+  mark-inactive-30d:
     runs-on: ubuntu-latest
     steps:
-      - name: Mark Issues as Stale
+      - name: Mark 30 day inactive issues and pull requests
         uses: actions/stale@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: >
-            This issue has been marked stale due to no recent activity in the past 30d.
+            This issue has been labeled `inactive-30d` due to no recent activity in the past 30 days.
             Please close this issue if no further response or action is needed.
             Otherwise, please respond with a comment indicating any updates or changes to the original issue and/or confirm this issue still needs to be addressed.
-            This issue will be marked rotten if there is no activity in the next 60d.
-          stale-issue-label: "stale"
+            This issue will be labeled `inactive-90d` if there is no activity in the next 60 days.
+          stale-issue-label: "inactive-30d"
+          exempt-issue-labels: "0 - Blocked,0 - Backlog,good first issue"
           days-before-issue-stale: 30
           days-before-issue-close: -1
-  mark-stale-prs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Mark PRs as Stale
-        uses: actions/stale@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: >
-            This PR has been marked stale due to no recent activity in the past 30d.
+            This PR has been labeled `inactive-30d` due to no recent activity in the past 30 days.
             Please close this PR if it is no longer required.
             Otherwise, please respond with a comment indicating any updates.
-            This PR will be marked rotten if there is no activity in the next 60d.
-          stale-pr-label: "stale"
+            This PR will be labeled `inactive-90d` if there is no activity in the next 60 days.
+          stale-pr-label: "inactive-30d"
+          exempt-pr-labels: "0 - Blocked,0 - Backlog,good first issue"
           days-before-pr-stale: 30
           days-before-pr-close: -1
-  mark-rotten-issues:
+          operations-per-run: 50
+  mark-inactive-90d:
     runs-on: ubuntu-latest
     steps:
-      - name: Mark Issues as Rotten
+      - name: Mark 90 day inactive issues and pull requests
         uses: actions/stale@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: >
-            This issue has been marked rotten due to no recent activity in the past 90d.
+            This issue has been labeled `inactive-90d` due to no recent activity in the past 90 days.
             Please close this issue if no further response or action is needed.
             Otherwise, please respond with a comment indicating any updates or changes to the original issue and/or confirm this issue still needs to be addressed.
-          stale-issue-label: "rotten"
+          stale-issue-label: "inactive-90d"
+          exempt-issue-labels: "0 - Blocked,0 - Backlog,good first issue"
           days-before-issue-stale: 90
           days-before-issue-close: -1
-  mark-rotten-prs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Mark PRs as Rotten
-        uses: actions/stale@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: >
-            This PR has been marked rotten due to no recent activity in the past 90d.
+            This PR has been labeled `inactive-90d` due to no recent activity in the past 90 days.
             Please close this PR if it is no longer required.
             Otherwise, please respond with a comment indicating any updates.
-          stale-pr-label: "rotten"
+          stale-pr-label: "inactive-90d"
+          exempt-pr-labels: "0 - Blocked,0 - Backlog,good first issue"
           days-before-pr-stale: 90
           days-before-pr-close: -1
+          operations-per-run: 50


### PR DESCRIPTION
Follows #1408 

Updates the stale GHA with the following changes:

- [x] Uses `inactive-30d` and `inactive-90d` labels instead of `stale` and `rotten`
- [x] Updates comments to reflect changes in labels
- [x] Exempts the following labels from being marked `inactive-30d` or `inactive-90d`
  - `0 - Blocked`
  - `0 - Backlog`
  - `good first issue`