### PR TITLE
Replace rmm::device_vector & thrust::host_vector with rmm::device_uvector & std::vector, respectively.

### DIFF
--- a/cpp/include/compute_partition.cuh
+++ b/cpp/include/compute_partition.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/compute_partition.cuh
+++ b/cpp/include/compute_partition.cuh
@@ -65,7 +65,6 @@ class compute_partition_t {
                         vertex_partition_offsets.data(),
                         vertex_partition_offsets.size(),
                         handle.get_stream());
-    CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
   }
 
  public:

--- a/cpp/include/compute_partition.cuh
+++ b/cpp/include/compute_partition.cuh
@@ -39,27 +39,33 @@ class compute_partition_t {
   using graph_view_t = graph_view_type;
   using vertex_t     = typename graph_view_type::vertex_type;
 
-  compute_partition_t(graph_view_t const &graph_view)
+  compute_partition_t(raft::handle_t const &handle, graph_view_t const &graph_view)
+    : vertex_partition_offsets_v_(0, handle.get_stream())
   {
-    init<graph_view_t::is_multi_gpu>(graph_view);
+    init<graph_view_t::is_multi_gpu>(handle, graph_view);
   }
 
  private:
   template <bool is_multi_gpu, typename std::enable_if_t<!is_multi_gpu> * = nullptr>
-  void init(graph_view_t const &graph_view)
+  void init(raft::handle_t const &handle, graph_view_t const &graph_view)
   {
   }
 
   template <bool is_multi_gpu, typename std::enable_if_t<is_multi_gpu> * = nullptr>
-  void init(graph_view_t const &graph_view)
+  void init(raft::handle_t const &handle, graph_view_t const &graph_view)
   {
     auto partition = graph_view.get_partition();
     row_size_      = partition.get_row_size();
     col_size_      = partition.get_col_size();
     size_          = row_size_ * col_size_;
 
-    vertex_partition_offsets_v_.resize(size_ + 1);
-    vertex_partition_offsets_v_ = partition.get_vertex_partition_offsets();
+    vertex_partition_offsets_v_.resize(size_ + 1, handle.get_stream());
+    auto vertex_partition_offsets = partition.get_vertex_partition_offsets();
+    raft::update_device(vertex_partition_offsets_v_.data(),
+                        vertex_partition_offsets.data(),
+                        vertex_partition_offsets.size(),
+                        handle.get_stream());
+    CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
   }
 
  public:
@@ -166,7 +172,7 @@ class compute_partition_t {
    */
   vertex_device_view_t vertex_device_view() const
   {
-    return vertex_device_view_t(vertex_partition_offsets_v_.data().get(), size_);
+    return vertex_device_view_t(vertex_partition_offsets_v_.data(), size_);
   }
 
   /**
@@ -176,12 +182,11 @@ class compute_partition_t {
    */
   edge_device_view_t edge_device_view() const
   {
-    return edge_device_view_t(
-      vertex_partition_offsets_v_.data().get(), row_size_, col_size_, size_);
+    return edge_device_view_t(vertex_partition_offsets_v_.data(), row_size_, col_size_, size_);
   }
 
  private:
-  rmm::device_vector<vertex_t> vertex_partition_offsets_v_{};
+  rmm::device_uvector<vertex_t> vertex_partition_offsets_v_;
   int row_size_{1};
   int col_size_{1};
   int size_{1};

--- a/cpp/include/patterns/count_if_e.cuh
+++ b/cpp/include/patterns/count_if_e.cuh
@@ -201,7 +201,7 @@ typename GraphViewType::edge_type count_if_e(
                                          detail::count_if_e_for_all_block_size,
                                          handle.get_device_properties().maxGridSize[0]);
 
-      rmm::device_vector<edge_t> block_counts(update_grid.num_blocks);
+      rmm::device_uvector<edge_t> block_counts(update_grid.num_blocks, handle.get_stream());
 
       detail::for_all_major_for_all_nbr_low_degree<<<update_grid.num_blocks,
                                                      update_grid.block_size,
@@ -210,7 +210,7 @@ typename GraphViewType::edge_type count_if_e(
         matrix_partition,
         adj_matrix_row_value_input_first + row_value_input_offset,
         adj_matrix_col_value_input_first + col_value_input_offset,
-        block_counts.data().get(),
+        block_counts.data(),
         e_op);
 
       // FIXME: we have several options to implement this. With cooperative group support

--- a/cpp/include/patterns/vertex_frontier.cuh
+++ b/cpp/include/patterns/vertex_frontier.cuh
@@ -157,7 +157,7 @@ class Bucket {
 
   void insert(vertex_t v)
   {
-    *thrust::device_ptr<vertex_t>(elements_.data() + size_) = v;
+    raft::update_device(elements_.data() + size_, &v, 1, handle_ptr_->get_stream());
     ++size_;
   }
 

--- a/cpp/include/patterns/vertex_frontier.cuh
+++ b/cpp/include/patterns/vertex_frontier.cuh
@@ -147,13 +147,17 @@ template <typename vertex_t, bool is_multi_gpu = false>
 class Bucket {
  public:
   Bucket(raft::handle_t const& handle, size_t capacity)
-    : handle_ptr_(&handle), elements_(capacity, invalid_vertex_id<vertex_t>::value)
+    : handle_ptr_(&handle), elements_(capacity, handle.get_stream())
   {
+    thrust::fill(rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+                 elements_.begin(),
+                 elements_.end(),
+                 invalid_vertex_id<vertex_t>::value);
   }
 
   void insert(vertex_t v)
   {
-    elements_[size_] = v;
+    *thrust::device_ptr<vertex_t>(elements_.data() + size_) = v;
     ++size_;
   }
 
@@ -177,9 +181,9 @@ class Bucket {
 
   size_t capacity() const { return elements_.size(); }
 
-  auto const data() const { return elements_.data().get(); }
+  auto const data() const { return elements_.data(); }
 
-  auto data() { return elements_.data().get(); }
+  auto data() { return elements_.data(); }
 
   auto const begin() const { return elements_.begin(); }
 
@@ -191,7 +195,7 @@ class Bucket {
 
  private:
   raft::handle_t const* handle_ptr_{nullptr};
-  rmm::device_vector<vertex_t> elements_{};
+  rmm::device_uvector<vertex_t> elements_;
   size_t size_{0};
 };
 
@@ -206,13 +210,21 @@ class VertexFrontier {
 
   VertexFrontier(raft::handle_t const& handle, std::vector<size_t> bucket_capacities)
     : handle_ptr_(&handle),
-      tmp_bucket_ptrs_(num_buckets, nullptr),
-      tmp_bucket_sizes_(num_buckets, 0),
+      tmp_bucket_ptrs_(num_buckets, handle.get_stream()),
+      tmp_bucket_sizes_(num_buckets, handle.get_stream()),
       buffer_ptrs_(kReduceInputTupleSize + 1 /* to store destination column number */, nullptr),
       buffer_idx_(0, handle_ptr_->get_stream())
   {
     CUGRAPH_EXPECTS(bucket_capacities.size() == num_buckets,
                     "invalid input argument bucket_capacities (size mismatch)");
+    thrust::fill(rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+                 tmp_bucket_ptrs_.begin(),
+                 tmp_bucket_ptrs_.end(),
+                 static_cast<vertex_t*>(nullptr));
+    thrust::fill(rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+                 tmp_bucket_sizes_.begin(),
+                 tmp_bucket_sizes_.end(),
+                 size_t{0});
     for (size_t i = 0; i < num_buckets; ++i) {
       buckets_.emplace_back(handle, bucket_capacities[i]);
     }
@@ -251,8 +263,8 @@ class VertexFrontier {
            0,
            handle_ptr_->get_stream()>>>(this_bucket.begin(),
                                         this_bucket.end(),
-                                        std::get<0>(bucket_and_bucket_size_device_ptrs).get(),
-                                        std::get<1>(bucket_and_bucket_size_device_ptrs).get(),
+                                        std::get<0>(bucket_and_bucket_size_device_ptrs),
+                                        std::get<1>(bucket_and_bucket_size_device_ptrs),
                                         bucket_idx,
                                         kInvalidBucketIdx,
                                         invalid_vertex,
@@ -269,8 +281,10 @@ class VertexFrontier {
                         [] __device__(auto value) { return value == invalid_vertex; });
 
     auto bucket_sizes_device_ptr = std::get<1>(bucket_and_bucket_size_device_ptrs);
-    thrust::host_vector<size_t> bucket_sizes(bucket_sizes_device_ptr,
-                                             bucket_sizes_device_ptr + kNumBuckets);
+    std::vector<size_t> bucket_sizes(kNumBuckets);
+    raft::update_host(
+      bucket_sizes.data(), bucket_sizes_device_ptr, kNumBuckets, handle_ptr_->get_stream());
+    CUDA_TRY(cudaStreamSynchronize(handle_ptr_->get_stream()));
     for (size_t i = 0; i < kNumBuckets; ++i) {
       if (i != bucket_idx) { get_bucket(i).set_size(bucket_sizes[i]); }
     }
@@ -283,14 +297,17 @@ class VertexFrontier {
 
   auto get_bucket_and_bucket_size_device_pointers()
   {
-    thrust::host_vector<vertex_t*> tmp_ptrs(buckets_.size(), nullptr);
-    thrust::host_vector<size_t> tmp_sizes(buckets_.size(), 0);
+    std::vector<vertex_t*> tmp_ptrs(buckets_.size(), nullptr);
+    std::vector<size_t> tmp_sizes(buckets_.size(), 0);
     for (size_t i = 0; i < buckets_.size(); ++i) {
       tmp_ptrs[i]  = get_bucket(i).data();
       tmp_sizes[i] = get_bucket(i).size();
     }
-    tmp_bucket_ptrs_  = tmp_ptrs;
-    tmp_bucket_sizes_ = tmp_sizes;
+    raft::update_device(
+      tmp_bucket_ptrs_.data(), tmp_ptrs.data(), tmp_ptrs.size(), handle_ptr_->get_stream());
+    raft::update_device(
+      tmp_bucket_sizes_.data(), tmp_sizes.data(), tmp_sizes.size(), handle_ptr_->get_stream());
+    CUDA_TRY(cudaStreamSynchronize(handle_ptr_->get_stream()));
     return std::make_tuple(tmp_bucket_ptrs_.data(), tmp_bucket_sizes_.data());
   }
 
@@ -345,8 +362,8 @@ class VertexFrontier {
 
   raft::handle_t const* handle_ptr_{nullptr};
   std::vector<Bucket<vertex_t, is_multi_gpu>> buckets_{};
-  rmm::device_vector<vertex_t*> tmp_bucket_ptrs_{};
-  rmm::device_vector<size_t> tmp_bucket_sizes_{};
+  rmm::device_uvector<vertex_t*> tmp_bucket_ptrs_;
+  rmm::device_uvector<size_t> tmp_bucket_sizes_;
 
   std::array<size_t, kReduceInputTupleSize> tuple_element_sizes_ =
     compute_thrust_tuple_element_sizes<ReduceInputTupleType>()();

--- a/cpp/src/experimental/louvain.cuh
+++ b/cpp/src/experimental/louvain.cuh
@@ -405,7 +405,7 @@ class Louvain {
       handle_(handle),
       dendrogram_(std::make_unique<Dendrogram<vertex_t>>()),
       current_graph_view_(graph_view),
-      compute_partition_(graph_view),
+      compute_partition_(handle, graph_view),
       local_num_vertices_(graph_view.get_number_of_local_vertices()),
       local_num_rows_(graph_view.get_number_of_local_adj_matrix_partition_rows()),
       local_num_cols_(graph_view.get_number_of_local_adj_matrix_partition_cols()),


### PR DESCRIPTION
- [x] Replace rmm::device_vector with rmm::device_uvector for better concurrency in multi-stream executions
- [x] Replace thrust::host_vector with std::vector

This PR partially addresses https://github.com/rapidsai/cugraph/issues/1390