### PR TITLE
update default path of setup to use the new directory paths in build …

### DIFF
--- a/python/setuputils.py
+++ b/python/setuputils.py
@@ -152,7 +152,7 @@ def clone_repo_if_needed(name, cpp_build_path=None,
         repo_path = (
             _get_repo_path() + '/python/_external_repositories/' + name + '/')
     else:
-        repo_path = os.path.join(cpp_build_path, name + '/src/' + name + '/')
+        repo_path = os.path.join(cpp_build_path, '_deps', name + '-src')
 
     return repo_path, repo_cloned
 


### PR DESCRIPTION
A recent change caused the `setup.py` running in a clean checkout to fail unless either `RAFT_PATH` or `CUGRAPH_BUILD_PATH` were set.  These are typically set if you run the build scripts, but if you try running the build steps individually by hand the script would fail unless you set one of these environment variables correctly.

This PR fixes the default path (if neither environment variable is specified) to construct the proper location for looking up raft.

Closes #1428 