### PR TITLE
Update C++ MG PageRank and SG PageRank, Katz Centrality, BFS, and SSSP to use the new R-mat graph generator

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -20,7 +20,10 @@
 # - common test utils -----------------------------------------------------------------------------
 
 add_library(cugraphtestutil STATIC
-            "${CMAKE_CURRENT_SOURCE_DIR}/utilities/test_utilities.cu"
+            "${CMAKE_CURRENT_SOURCE_DIR}/utilities/generate_graph_from_edgelist.cu"
+            "${CMAKE_CURRENT_SOURCE_DIR}/utilities/matrix_market_file_utilities.cu"
+            "${CMAKE_CURRENT_SOURCE_DIR}/utilities/rmat_utilities.cu"
+            "${CMAKE_CURRENT_SOURCE_DIR}/utilities/misc_utilities.cpp"
             "${CMAKE_CURRENT_SOURCE_DIR}/../../thirdparty/mmio/mmio.c")
 
 set_property(TARGET cugraphtestutil PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/cpp/tests/experimental/bfs_test.cpp
+++ b/cpp/tests/experimental/bfs_test.cpp
@@ -73,17 +73,26 @@ void bfs_reference(edge_t const* offsets,
 }
 
 typedef struct BFS_Usecase_t {
-  std::string graph_file_full_path{};
+  cugraph::test::input_graph_specifier_t input_graph_specifier{};
   size_t source{false};
 
   BFS_Usecase_t(std::string const& graph_file_path, size_t source) : source(source)
   {
+    std::string graph_file_full_path{};
     if ((graph_file_path.length() > 0) && (graph_file_path[0] != '/')) {
       graph_file_full_path = cugraph::test::get_rapids_dataset_root_dir() + "/" + graph_file_path;
     } else {
       graph_file_full_path = graph_file_path;
     }
+    input_graph_specifier.tag = cugraph::test::input_graph_specifier_t::MATRIX_MARKET_FILE_PATH;
+    input_graph_specifier.graph_file_full_path = graph_file_full_path;
   };
+
+  BFS_Usecase_t(cugraph::test::rmat_params_t rmat_params, size_t source) : source(source)
+  {
+    input_graph_specifier.tag         = cugraph::test::input_graph_specifier_t::RMAT_PARAMS;
+    input_graph_specifier.rmat_params = rmat_params;
+  }
 } BFS_Usecase;
 
 class Tests_BFS : public ::testing::TestWithParam<BFS_Usecase> {
@@ -104,8 +113,23 @@ class Tests_BFS : public ::testing::TestWithParam<BFS_Usecase> {
 
     cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, false, false> graph(handle);
     std::tie(graph, std::ignore) =
-      cugraph::test::read_graph_from_matrix_market_file<vertex_t, edge_t, weight_t, false, false>(
-        handle, configuration.graph_file_full_path, false, false);
+      configuration.input_graph_specifier.tag ==
+          cugraph::test::input_graph_specifier_t::MATRIX_MARKET_FILE_PATH
+        ? cugraph::test::
+            read_graph_from_matrix_market_file<vertex_t, edge_t, weight_t, false, false>(
+              handle, configuration.input_graph_specifier.graph_file_full_path, false, false)
+        : cugraph::test::generate_graph_from_rmat_params<vertex_t, edge_t, weight_t, false, false>(
+            handle,
+            configuration.input_graph_specifier.rmat_params.scale,
+            configuration.input_graph_specifier.rmat_params.edge_factor,
+            configuration.input_graph_specifier.rmat_params.a,
+            configuration.input_graph_specifier.rmat_params.b,
+            configuration.input_graph_specifier.rmat_params.c,
+            configuration.input_graph_specifier.rmat_params.seed,
+            configuration.input_graph_specifier.rmat_params.undirected,
+            configuration.input_graph_specifier.rmat_params.scramble_vertex_ids,
+            false,
+            false);
     auto graph_view = graph.view();
 
     std::vector<edge_t> h_offsets(graph_view.get_number_of_vertices() + 1);
@@ -193,13 +217,16 @@ class Tests_BFS : public ::testing::TestWithParam<BFS_Usecase> {
 // FIXME: add tests for type combinations
 TEST_P(Tests_BFS, CheckInt32Int32) { run_current_test<int32_t, int32_t>(GetParam()); }
 
-INSTANTIATE_TEST_CASE_P(simple_test,
-                        Tests_BFS,
-                        ::testing::Values(BFS_Usecase("test/datasets/karate.mtx", 0),
-                                          BFS_Usecase("test/datasets/polbooks.mtx", 0),
-                                          BFS_Usecase("test/datasets/netscience.mtx", 0),
-                                          BFS_Usecase("test/datasets/netscience.mtx", 100),
-                                          BFS_Usecase("test/datasets/wiki2003.mtx", 1000),
-                                          BFS_Usecase("test/datasets/wiki-Talk.mtx", 1000)));
+INSTANTIATE_TEST_CASE_P(
+  simple_test,
+  Tests_BFS,
+  ::testing::Values(
+    BFS_Usecase("test/datasets/karate.mtx", 0),
+    BFS_Usecase("test/datasets/polbooks.mtx", 0),
+    BFS_Usecase("test/datasets/netscience.mtx", 0),
+    BFS_Usecase("test/datasets/netscience.mtx", 100),
+    BFS_Usecase("test/datasets/wiki2003.mtx", 1000),
+    BFS_Usecase("test/datasets/wiki-Talk.mtx", 1000),
+    BFS_Usecase(cugraph::test::rmat_params_t{10, 16, 0.57, 0.19, 0.19, 0, false, false}, 0)));
 
 CUGRAPH_TEST_PROGRAM_MAIN()

--- a/cpp/tests/experimental/katz_centrality_test.cpp
+++ b/cpp/tests/experimental/katz_centrality_test.cpp
@@ -89,18 +89,31 @@ void katz_centrality_reference(edge_t const* offsets,
 }
 
 typedef struct KatzCentrality_Usecase_t {
-  std::string graph_file_full_path{};
+  cugraph::test::input_graph_specifier_t input_graph_specifier{};
+
   bool test_weighted{false};
 
   KatzCentrality_Usecase_t(std::string const& graph_file_path, bool test_weighted)
     : test_weighted(test_weighted)
   {
+    std::string graph_file_full_path{};
     if ((graph_file_path.length() > 0) && (graph_file_path[0] != '/')) {
       graph_file_full_path = cugraph::test::get_rapids_dataset_root_dir() + "/" + graph_file_path;
     } else {
       graph_file_full_path = graph_file_path;
     }
+    input_graph_specifier.tag = cugraph::test::input_graph_specifier_t::MATRIX_MARKET_FILE_PATH;
+    input_graph_specifier.graph_file_full_path = graph_file_full_path;
   };
+
+  KatzCentrality_Usecase_t(cugraph::test::rmat_params_t rmat_params,
+                           double personalization_ratio,
+                           bool test_weighted)
+    : test_weighted(test_weighted)
+  {
+    input_graph_specifier.tag         = cugraph::test::input_graph_specifier_t::RMAT_PARAMS;
+    input_graph_specifier.rmat_params = rmat_params;
+  }
 } KatzCentrality_Usecase;
 
 class Tests_KatzCentrality : public ::testing::TestWithParam<KatzCentrality_Usecase> {
@@ -119,8 +132,26 @@ class Tests_KatzCentrality : public ::testing::TestWithParam<KatzCentrality_Usec
 
     cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, true, false> graph(handle);
     std::tie(graph, std::ignore) =
-      cugraph::test::read_graph_from_matrix_market_file<vertex_t, edge_t, weight_t, true, false>(
-        handle, configuration.graph_file_full_path, configuration.test_weighted, false);
+      configuration.input_graph_specifier.tag ==
+          cugraph::test::input_graph_specifier_t::MATRIX_MARKET_FILE_PATH
+        ? cugraph::test::
+            read_graph_from_matrix_market_file<vertex_t, edge_t, weight_t, true, false>(
+              handle,
+              configuration.input_graph_specifier.graph_file_full_path,
+              configuration.test_weighted,
+              false)
+        : cugraph::test::generate_graph_from_rmat_params<vertex_t, edge_t, weight_t, true, false>(
+            handle,
+            configuration.input_graph_specifier.rmat_params.scale,
+            configuration.input_graph_specifier.rmat_params.edge_factor,
+            configuration.input_graph_specifier.rmat_params.a,
+            configuration.input_graph_specifier.rmat_params.b,
+            configuration.input_graph_specifier.rmat_params.c,
+            configuration.input_graph_specifier.rmat_params.seed,
+            configuration.input_graph_specifier.rmat_params.undirected,
+            configuration.input_graph_specifier.rmat_params.scramble_vertex_ids,
+            configuration.test_weighted,
+            false);
     auto graph_view = graph.view();
 
     std::vector<edge_t> h_offsets(graph_view.get_number_of_vertices() + 1);
@@ -220,13 +251,26 @@ TEST_P(Tests_KatzCentrality, CheckInt32Int32FloatFloat)
 INSTANTIATE_TEST_CASE_P(
   simple_test,
   Tests_KatzCentrality,
-  ::testing::Values(KatzCentrality_Usecase("test/datasets/karate.mtx", false),
-                    KatzCentrality_Usecase("test/datasets/karate.mtx", true),
-                    KatzCentrality_Usecase("test/datasets/web-Google.mtx", false),
-                    KatzCentrality_Usecase("test/datasets/web-Google.mtx", true),
-                    KatzCentrality_Usecase("test/datasets/ljournal-2008.mtx", false),
-                    KatzCentrality_Usecase("test/datasets/ljournal-2008.mtx", true),
-                    KatzCentrality_Usecase("test/datasets/webbase-1M.mtx", false),
-                    KatzCentrality_Usecase("test/datasets/webbase-1M.mtx", true)));
+  ::testing::Values(
+    KatzCentrality_Usecase("test/datasets/karate.mtx", false),
+    KatzCentrality_Usecase("test/datasets/karate.mtx", true),
+    KatzCentrality_Usecase("test/datasets/web-Google.mtx", false),
+    KatzCentrality_Usecase("test/datasets/web-Google.mtx", true),
+    KatzCentrality_Usecase("test/datasets/ljournal-2008.mtx", false),
+    KatzCentrality_Usecase("test/datasets/ljournal-2008.mtx", true),
+    KatzCentrality_Usecase("test/datasets/webbase-1M.mtx", false),
+    KatzCentrality_Usecase("test/datasets/webbase-1M.mtx", true),
+    KatzCentrality_Usecase(cugraph::test::rmat_params_t{10, 16, 0.57, 0.19, 0.19, 0, false, false},
+                           0.0,
+                           false),
+    KatzCentrality_Usecase(cugraph::test::rmat_params_t{10, 16, 0.57, 0.19, 0.19, 0, false, false},
+                           0.5,
+                           false),
+    KatzCentrality_Usecase(cugraph::test::rmat_params_t{10, 16, 0.57, 0.19, 0.19, 0, false, false},
+                           0.0,
+                           true),
+    KatzCentrality_Usecase(cugraph::test::rmat_params_t{10, 16, 0.57, 0.19, 0.19, 0, false, false},
+                           0.5,
+                           true)));
 
 CUGRAPH_TEST_PROGRAM_MAIN()

--- a/cpp/tests/experimental/sssp_test.cpp
+++ b/cpp/tests/experimental/sssp_test.cpp
@@ -79,17 +79,26 @@ void sssp_reference(edge_t const* offsets,
 }
 
 typedef struct SSSP_Usecase_t {
-  std::string graph_file_full_path{};
+  cugraph::test::input_graph_specifier_t input_graph_specifier{};
   size_t source{false};
 
   SSSP_Usecase_t(std::string const& graph_file_path, size_t source) : source(source)
   {
+    std::string graph_file_full_path{};
     if ((graph_file_path.length() > 0) && (graph_file_path[0] != '/')) {
       graph_file_full_path = cugraph::test::get_rapids_dataset_root_dir() + "/" + graph_file_path;
     } else {
       graph_file_full_path = graph_file_path;
     }
+    input_graph_specifier.tag = cugraph::test::input_graph_specifier_t::MATRIX_MARKET_FILE_PATH;
+    input_graph_specifier.graph_file_full_path = graph_file_full_path;
   };
+
+  SSSP_Usecase_t(cugraph::test::rmat_params_t rmat_params, size_t source) : source(source)
+  {
+    input_graph_specifier.tag         = cugraph::test::input_graph_specifier_t::RMAT_PARAMS;
+    input_graph_specifier.rmat_params = rmat_params;
+  }
 } SSSP_Usecase;
 
 class Tests_SSSP : public ::testing::TestWithParam<SSSP_Usecase> {
@@ -108,8 +117,23 @@ class Tests_SSSP : public ::testing::TestWithParam<SSSP_Usecase> {
 
     cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, false, false> graph(handle);
     std::tie(graph, std::ignore) =
-      cugraph::test::read_graph_from_matrix_market_file<vertex_t, edge_t, weight_t, false, false>(
-        handle, configuration.graph_file_full_path, true, false);
+      configuration.input_graph_specifier.tag ==
+          cugraph::test::input_graph_specifier_t::MATRIX_MARKET_FILE_PATH
+        ? cugraph::test::
+            read_graph_from_matrix_market_file<vertex_t, edge_t, weight_t, false, false>(
+              handle, configuration.input_graph_specifier.graph_file_full_path, true, false)
+        : cugraph::test::generate_graph_from_rmat_params<vertex_t, edge_t, weight_t, false, false>(
+            handle,
+            configuration.input_graph_specifier.rmat_params.scale,
+            configuration.input_graph_specifier.rmat_params.edge_factor,
+            configuration.input_graph_specifier.rmat_params.a,
+            configuration.input_graph_specifier.rmat_params.b,
+            configuration.input_graph_specifier.rmat_params.c,
+            configuration.input_graph_specifier.rmat_params.seed,
+            configuration.input_graph_specifier.rmat_params.undirected,
+            configuration.input_graph_specifier.rmat_params.scramble_vertex_ids,
+            true,
+            false);
     auto graph_view = graph.view();
 
     std::vector<edge_t> h_offsets(graph_view.get_number_of_vertices() + 1);
@@ -209,16 +233,13 @@ class Tests_SSSP : public ::testing::TestWithParam<SSSP_Usecase> {
 // FIXME: add tests for type combinations
 TEST_P(Tests_SSSP, CheckInt32Int32Float) { run_current_test<int32_t, int32_t, float>(GetParam()); }
 
-#if 0
-INSTANTIATE_TEST_CASE_P(simple_test,
-                        Tests_SSSP,
-                        ::testing::Values(SSSP_Usecase("test/datasets/karate.mtx", 0)));
-#else
-INSTANTIATE_TEST_CASE_P(simple_test,
-                        Tests_SSSP,
-                        ::testing::Values(SSSP_Usecase("test/datasets/karate.mtx", 0),
-                                          SSSP_Usecase("test/datasets/dblp.mtx", 0),
-                                          SSSP_Usecase("test/datasets/wiki2003.mtx", 1000)));
-#endif
+INSTANTIATE_TEST_CASE_P(
+  simple_test,
+  Tests_SSSP,
+  ::testing::Values(
+    SSSP_Usecase("test/datasets/karate.mtx", 0),
+    SSSP_Usecase("test/datasets/dblp.mtx", 0),
+    SSSP_Usecase("test/datasets/wiki2003.mtx", 1000),
+    SSSP_Usecase(cugraph::test::rmat_params_t{10, 16, 0.57, 0.19, 0.19, 0, false, false}, 0)));
 
 CUGRAPH_TEST_PROGRAM_MAIN()

--- a/cpp/tests/utilities/generate_graph_from_edgelist.cu
+++ b/cpp/tests/utilities/generate_graph_from_edgelist.cu
@@ -1,0 +1,526 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <utilities/test_utilities.hpp>
+
+#include <experimental/detail/graph_utils.cuh>
+#include <experimental/graph_functions.hpp>
+#include <utilities/error.hpp>
+
+#include <rmm/thrust_rmm_allocator.h>
+
+#include <thrust/remove.h>
+
+#include <cstdint>
+
+namespace cugraph {
+namespace test {
+
+namespace detail {
+
+template <typename vertex_t,
+          typename edge_t,
+          typename weight_t,
+          bool store_transposed,
+          bool multi_gpu>
+std::enable_if_t<
+  multi_gpu,
+  std::tuple<
+    cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>,
+    rmm::device_uvector<vertex_t>>>
+generate_graph_from_edgelist(raft::handle_t const& handle,
+                             rmm::device_uvector<vertex_t>&& vertices,
+                             rmm::device_uvector<vertex_t>&& edgelist_rows,
+                             rmm::device_uvector<vertex_t>&& edgelist_cols,
+                             rmm::device_uvector<weight_t>&& edgelist_weights,
+                             bool is_symmetric,
+                             bool test_weighted,
+                             bool renumber)
+{
+  CUGRAPH_EXPECTS(renumber, "renumber should be true if multi_gpu is true.");
+
+  auto& comm               = handle.get_comms();
+  auto const comm_size     = comm.get_size();
+  auto const comm_rank     = comm.get_rank();
+  auto& row_comm           = handle.get_subcomm(cugraph::partition_2d::key_naming_t().row_name());
+  auto const row_comm_size = row_comm.get_size();
+  auto& col_comm           = handle.get_subcomm(cugraph::partition_2d::key_naming_t().col_name());
+  auto const col_comm_size = col_comm.get_size();
+
+  vertex_t number_of_vertices = static_cast<vertex_t>(vertices.size());
+
+  auto vertex_key_func =
+    cugraph::experimental::detail::compute_gpu_id_from_vertex_t<vertex_t>{comm_size};
+  vertices.resize(thrust::distance(vertices.begin(),
+                                   thrust::remove_if(
+                                     rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+                                     vertices.begin(),
+                                     vertices.end(),
+                                     [comm_rank, key_func = vertex_key_func] __device__(auto val) {
+                                       return key_func(val) != comm_rank;
+                                     })),
+                  handle.get_stream());
+  vertices.shrink_to_fit(handle.get_stream());
+
+  auto edge_key_func = cugraph::experimental::detail::compute_gpu_id_from_edge_t<vertex_t>{
+    false, comm_size, row_comm_size, col_comm_size};
+  size_t number_of_local_edges{};
+  if (test_weighted) {
+    auto edge_first = thrust::make_zip_iterator(
+      thrust::make_tuple(edgelist_rows.begin(), edgelist_cols.begin(), edgelist_weights.begin()));
+    number_of_local_edges = thrust::distance(
+      edge_first,
+      thrust::remove_if(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+                        edge_first,
+                        edge_first + edgelist_rows.size(),
+                        [comm_rank, key_func = edge_key_func] __device__(auto e) {
+                          auto major = store_transposed ? thrust::get<1>(e) : thrust::get<0>(e);
+                          auto minor = store_transposed ? thrust::get<0>(e) : thrust::get<1>(e);
+                          return key_func(major, minor) != comm_rank;
+                        }));
+  } else {
+    auto edge_first =
+      thrust::make_zip_iterator(thrust::make_tuple(edgelist_rows.begin(), edgelist_cols.begin()));
+    number_of_local_edges = thrust::distance(
+      edge_first,
+      thrust::remove_if(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+                        edge_first,
+                        edge_first + edgelist_rows.size(),
+                        [comm_rank, key_func = edge_key_func] __device__(auto e) {
+                          auto major = store_transposed ? thrust::get<1>(e) : thrust::get<0>(e);
+                          auto minor = store_transposed ? thrust::get<0>(e) : thrust::get<1>(e);
+                          return key_func(major, minor) != comm_rank;
+                        }));
+  }
+
+  edgelist_rows.resize(number_of_local_edges, handle.get_stream());
+  edgelist_rows.shrink_to_fit(handle.get_stream());
+  edgelist_cols.resize(number_of_local_edges, handle.get_stream());
+  edgelist_cols.shrink_to_fit(handle.get_stream());
+  if (test_weighted) {
+    edgelist_weights.resize(number_of_local_edges, handle.get_stream());
+    edgelist_weights.shrink_to_fit(handle.get_stream());
+  }
+
+  // 3. renumber
+
+  rmm::device_uvector<vertex_t> renumber_map_labels(0, handle.get_stream());
+  cugraph::experimental::partition_t<vertex_t> partition{};
+  vertex_t aggregate_number_of_vertices{};
+  edge_t number_of_edges{};
+  // FIXME: set do_expensive_check to false once validated
+  std::tie(renumber_map_labels, partition, aggregate_number_of_vertices, number_of_edges) =
+    cugraph::experimental::renumber_edgelist<vertex_t, edge_t, multi_gpu>(
+      handle,
+      vertices.data(),
+      static_cast<vertex_t>(vertices.size()),
+      store_transposed ? edgelist_cols.data() : edgelist_rows.data(),
+      store_transposed ? edgelist_rows.data() : edgelist_cols.data(),
+      edgelist_rows.size(),
+      false,
+      true);
+  assert(aggregate_number_of_vertices == number_of_vertices);
+
+  // 4. create a graph
+
+  return std::make_tuple(
+    cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>(
+      handle,
+      std::vector<cugraph::experimental::edgelist_t<vertex_t, edge_t, weight_t>>{
+        cugraph::experimental::edgelist_t<vertex_t, edge_t, weight_t>{
+          edgelist_rows.data(),
+          edgelist_cols.data(),
+          test_weighted ? edgelist_weights.data() : nullptr,
+          static_cast<edge_t>(edgelist_rows.size())}},
+      partition,
+      number_of_vertices,
+      number_of_edges,
+      cugraph::experimental::graph_properties_t{is_symmetric, false},
+      true,
+      true),
+    std::move(renumber_map_labels));
+}
+
+template <typename vertex_t,
+          typename edge_t,
+          typename weight_t,
+          bool store_transposed,
+          bool multi_gpu>
+std::enable_if_t<
+  !multi_gpu,
+  std::tuple<
+    cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>,
+    rmm::device_uvector<vertex_t>>>
+generate_graph_from_edgelist(raft::handle_t const& handle,
+                             rmm::device_uvector<vertex_t>&& vertices,
+                             rmm::device_uvector<vertex_t>&& edgelist_rows,
+                             rmm::device_uvector<vertex_t>&& edgelist_cols,
+                             rmm::device_uvector<weight_t>&& edgelist_weights,
+                             bool is_symmetric,
+                             bool test_weighted,
+                             bool renumber)
+{
+  vertex_t number_of_vertices = static_cast<vertex_t>(vertices.size());
+
+  // FIXME: set do_expensive_check to false once validated
+  auto renumber_map_labels =
+    renumber ? cugraph::experimental::renumber_edgelist<vertex_t, edge_t, multi_gpu>(
+                 handle,
+                 vertices.data(),
+                 static_cast<vertex_t>(vertices.size()),
+                 store_transposed ? edgelist_cols.data() : edgelist_rows.data(),
+                 store_transposed ? edgelist_rows.data() : edgelist_cols.data(),
+                 static_cast<edge_t>(edgelist_rows.size()),
+                 true)
+             : rmm::device_uvector<vertex_t>(0, handle.get_stream());
+
+  // FIXME: set do_expensive_check to false once validated
+  return std::make_tuple(
+    cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>(
+      handle,
+      cugraph::experimental::edgelist_t<vertex_t, edge_t, weight_t>{
+        edgelist_rows.data(),
+        edgelist_cols.data(),
+        test_weighted ? edgelist_weights.data() : nullptr,
+        static_cast<edge_t>(edgelist_rows.size())},
+      number_of_vertices,
+      cugraph::experimental::graph_properties_t{is_symmetric, false},
+      renumber ? true : false,
+      true),
+    std::move(renumber_map_labels));
+}
+
+}  // namespace detail
+
+template <typename vertex_t,
+          typename edge_t,
+          typename weight_t,
+          bool store_transposed,
+          bool multi_gpu>
+std::tuple<cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>,
+           rmm::device_uvector<vertex_t>>
+generate_graph_from_edgelist(raft::handle_t const& handle,
+                             rmm::device_uvector<vertex_t>&& vertices,
+                             rmm::device_uvector<vertex_t>&& edgelist_rows,
+                             rmm::device_uvector<vertex_t>&& edgelist_cols,
+                             rmm::device_uvector<weight_t>&& edgelist_weights,
+                             bool is_symmetric,
+                             bool test_weighted,
+                             bool renumber)
+{
+  return detail::
+    generate_graph_from_edgelist<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>(
+      handle,
+      std::move(vertices),
+      std::move(edgelist_rows),
+      std::move(edgelist_cols),
+      std::move(edgelist_weights),
+      is_symmetric,
+      test_weighted,
+      renumber);
+}
+
+// explicit instantiations
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, float, false, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int32_t, float, false, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<float>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, float, false, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int32_t, float, false, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<float>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, float, true, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int32_t, float, true, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<float>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, float, true, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int32_t, float, true, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<float>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, double, false, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int32_t, double, false, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<double>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, double, false, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int32_t, double, false, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<double>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, double, true, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int32_t, double, true, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<double>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, double, true, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int32_t, double, true, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<double>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, float, false, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int64_t, float, false, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<float>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, float, false, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int64_t, float, false, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<float>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, float, true, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int64_t, float, true, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<float>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, float, true, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int64_t, float, true, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<float>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, double, false, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int64_t, double, false, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<double>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, double, false, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int64_t, double, false, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<double>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, double, true, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int64_t, double, true, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<double>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, double, true, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_edgelist<int32_t, int64_t, double, true, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& vertices,
+  rmm::device_uvector<int32_t>&& edgelist_rows,
+  rmm::device_uvector<int32_t>&& edgelist_cols,
+  rmm::device_uvector<double>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, float, false, false>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_edgelist<int64_t, int64_t, float, false, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t>&& vertices,
+  rmm::device_uvector<int64_t>&& edgelist_rows,
+  rmm::device_uvector<int64_t>&& edgelist_cols,
+  rmm::device_uvector<float>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, float, false, true>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_edgelist<int64_t, int64_t, float, false, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t>&& vertices,
+  rmm::device_uvector<int64_t>&& edgelist_rows,
+  rmm::device_uvector<int64_t>&& edgelist_cols,
+  rmm::device_uvector<float>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, float, true, false>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_edgelist<int64_t, int64_t, float, true, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t>&& vertices,
+  rmm::device_uvector<int64_t>&& edgelist_rows,
+  rmm::device_uvector<int64_t>&& edgelist_cols,
+  rmm::device_uvector<float>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, float, true, true>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_edgelist<int64_t, int64_t, float, true, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t>&& vertices,
+  rmm::device_uvector<int64_t>&& edgelist_rows,
+  rmm::device_uvector<int64_t>&& edgelist_cols,
+  rmm::device_uvector<float>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, double, false, false>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_edgelist<int64_t, int64_t, double, false, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t>&& vertices,
+  rmm::device_uvector<int64_t>&& edgelist_rows,
+  rmm::device_uvector<int64_t>&& edgelist_cols,
+  rmm::device_uvector<double>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, double, false, true>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_edgelist<int64_t, int64_t, double, false, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t>&& vertices,
+  rmm::device_uvector<int64_t>&& edgelist_rows,
+  rmm::device_uvector<int64_t>&& edgelist_cols,
+  rmm::device_uvector<double>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, double, true, false>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_edgelist<int64_t, int64_t, double, true, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t>&& vertices,
+  rmm::device_uvector<int64_t>&& edgelist_rows,
+  rmm::device_uvector<int64_t>&& edgelist_cols,
+  rmm::device_uvector<double>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, double, true, true>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_edgelist<int64_t, int64_t, double, true, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t>&& vertices,
+  rmm::device_uvector<int64_t>&& edgelist_rows,
+  rmm::device_uvector<int64_t>&& edgelist_cols,
+  rmm::device_uvector<double>&& edgelist_weights,
+  bool is_symmetric,
+  bool test_weighted,
+  bool renumber);
+
+}  // namespace test
+}  // namespace cugraph

--- a/cpp/tests/utilities/misc_utilities.cpp
+++ b/cpp/tests/utilities/misc_utilities.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <utilities/test_utilities.hpp>
+
+namespace cugraph {
+namespace test {
+
+std::string getFileName(const std::string& s)
+{
+  char sep = '/';
+#ifdef _WIN32
+  sep = '\\';
+#endif
+  size_t i = s.rfind(sep, s.length());
+  if (i != std::string::npos) { return (s.substr(i + 1, s.length() - i)); }
+  return ("");
+}
+
+}  // namespace test
+}  // namespace cugraph

--- a/cpp/tests/utilities/rmat_utilities.cu
+++ b/cpp/tests/utilities/rmat_utilities.cu
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <utilities/test_utilities.hpp>
+
+#include <experimental/graph_generator.hpp>
+#include <utilities/error.hpp>
+
+#include <rmm/thrust_rmm_allocator.h>
+#include <raft/random/rng.cuh>
+
+#include <thrust/sequence.h>
+
+#include <cstdint>
+
+namespace cugraph {
+namespace test {
+
+template <typename vertex_t,
+          typename edge_t,
+          typename weight_t,
+          bool store_transposed,
+          bool multi_gpu>
+std::tuple<cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>,
+           rmm::device_uvector<vertex_t>>
+generate_graph_from_rmat_params(raft::handle_t const& handle,
+                                size_t scale,
+                                size_t edge_factor,
+                                double a,
+                                double b,
+                                double c,
+                                uint64_t seed,
+                                bool undirected,
+                                bool scramble_vertex_ids,
+                                bool test_weighted,
+                                bool renumber)
+{
+  rmm::device_uvector<vertex_t> d_edgelist_rows(0, handle.get_stream());
+  rmm::device_uvector<vertex_t> d_edgelist_cols(0, handle.get_stream());
+  std::tie(d_edgelist_rows, d_edgelist_cols) =
+    cugraph::experimental::generate_rmat_edgelist<vertex_t>(
+      handle, scale, edge_factor, a, b, c, seed, undirected ? true : false, scramble_vertex_ids);
+  if (undirected) {
+    // FIXME: need to symmetrize
+    CUGRAPH_FAIL("unimplemented.");
+  }
+
+  rmm::device_uvector<weight_t> d_edgelist_weights(test_weighted ? d_edgelist_rows.size() : 0,
+                                                   handle.get_stream());
+  if (test_weighted) {
+    raft::random::Rng rng(seed + 1);
+    rng.uniform<weight_t, size_t>(d_edgelist_weights.data(),
+                                  d_edgelist_weights.size(),
+                                  weight_t{0.0},
+                                  weight_t{1.0},
+                                  handle.get_stream());
+  }
+
+  rmm::device_uvector<vertex_t> d_vertices(static_cast<vertex_t>(size_t{1} << scale),
+                                           handle.get_stream());
+  thrust::sequence(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+                   d_vertices.begin(),
+                   d_vertices.end(),
+                   vertex_t{0});
+
+  return generate_graph_from_edgelist<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>(
+    handle,
+    std::move(d_vertices),
+    std::move(d_edgelist_rows),
+    std::move(d_edgelist_cols),
+    std::move(d_edgelist_weights),
+    false,
+    test_weighted,
+    renumber);
+}
+
+// explicit instantiations
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, float, false, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int32_t, float, false, false>(raft::handle_t const& handle,
+                                                                       size_t scale,
+                                                                       size_t edge_factor,
+                                                                       double a,
+                                                                       double b,
+                                                                       double c,
+                                                                       uint64_t seed,
+                                                                       bool undirected,
+                                                                       bool scramble_vertex_ids,
+                                                                       bool test_weighted,
+                                                                       bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, float, false, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int32_t, float, false, true>(raft::handle_t const& handle,
+                                                                      size_t scale,
+                                                                      size_t edge_factor,
+                                                                      double a,
+                                                                      double b,
+                                                                      double c,
+                                                                      uint64_t seed,
+                                                                      bool undirected,
+                                                                      bool scramble_vertex_ids,
+                                                                      bool test_weighted,
+                                                                      bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, float, true, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int32_t, float, true, false>(raft::handle_t const& handle,
+                                                                      size_t scale,
+                                                                      size_t edge_factor,
+                                                                      double a,
+                                                                      double b,
+                                                                      double c,
+                                                                      uint64_t seed,
+                                                                      bool undirected,
+                                                                      bool scramble_vertex_ids,
+                                                                      bool test_weighted,
+                                                                      bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, float, true, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int32_t, float, true, true>(raft::handle_t const& handle,
+                                                                     size_t scale,
+                                                                     size_t edge_factor,
+                                                                     double a,
+                                                                     double b,
+                                                                     double c,
+                                                                     uint64_t seed,
+                                                                     bool undirected,
+                                                                     bool scramble_vertex_ids,
+                                                                     bool test_weighted,
+                                                                     bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, double, false, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int32_t, double, false, false>(
+  raft::handle_t const& handle,
+  size_t scale,
+  size_t edge_factor,
+  double a,
+  double b,
+  double c,
+  uint64_t seed,
+  bool undirected,
+  bool scramble_vertex_ids,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, double, false, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int32_t, double, false, true>(raft::handle_t const& handle,
+                                                                       size_t scale,
+                                                                       size_t edge_factor,
+                                                                       double a,
+                                                                       double b,
+                                                                       double c,
+                                                                       uint64_t seed,
+                                                                       bool undirected,
+                                                                       bool scramble_vertex_ids,
+                                                                       bool test_weighted,
+                                                                       bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, double, true, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int32_t, double, true, false>(raft::handle_t const& handle,
+                                                                       size_t scale,
+                                                                       size_t edge_factor,
+                                                                       double a,
+                                                                       double b,
+                                                                       double c,
+                                                                       uint64_t seed,
+                                                                       bool undirected,
+                                                                       bool scramble_vertex_ids,
+                                                                       bool test_weighted,
+                                                                       bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, double, true, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int32_t, double, true, true>(raft::handle_t const& handle,
+                                                                      size_t scale,
+                                                                      size_t edge_factor,
+                                                                      double a,
+                                                                      double b,
+                                                                      double c,
+                                                                      uint64_t seed,
+                                                                      bool undirected,
+                                                                      bool scramble_vertex_ids,
+                                                                      bool test_weighted,
+                                                                      bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, float, false, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int64_t, float, false, false>(raft::handle_t const& handle,
+                                                                       size_t scale,
+                                                                       size_t edge_factor,
+                                                                       double a,
+                                                                       double b,
+                                                                       double c,
+                                                                       uint64_t seed,
+                                                                       bool undirected,
+                                                                       bool scramble_vertex_ids,
+                                                                       bool test_weighted,
+                                                                       bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, float, false, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int64_t, float, false, true>(raft::handle_t const& handle,
+                                                                      size_t scale,
+                                                                      size_t edge_factor,
+                                                                      double a,
+                                                                      double b,
+                                                                      double c,
+                                                                      uint64_t seed,
+                                                                      bool undirected,
+                                                                      bool scramble_vertex_ids,
+                                                                      bool test_weighted,
+                                                                      bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, float, true, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int64_t, float, true, false>(raft::handle_t const& handle,
+                                                                      size_t scale,
+                                                                      size_t edge_factor,
+                                                                      double a,
+                                                                      double b,
+                                                                      double c,
+                                                                      uint64_t seed,
+                                                                      bool undirected,
+                                                                      bool scramble_vertex_ids,
+                                                                      bool test_weighted,
+                                                                      bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, float, true, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int64_t, float, true, true>(raft::handle_t const& handle,
+                                                                     size_t scale,
+                                                                     size_t edge_factor,
+                                                                     double a,
+                                                                     double b,
+                                                                     double c,
+                                                                     uint64_t seed,
+                                                                     bool undirected,
+                                                                     bool scramble_vertex_ids,
+                                                                     bool test_weighted,
+                                                                     bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, double, false, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int64_t, double, false, false>(
+  raft::handle_t const& handle,
+  size_t scale,
+  size_t edge_factor,
+  double a,
+  double b,
+  double c,
+  uint64_t seed,
+  bool undirected,
+  bool scramble_vertex_ids,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, double, false, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int64_t, double, false, true>(raft::handle_t const& handle,
+                                                                       size_t scale,
+                                                                       size_t edge_factor,
+                                                                       double a,
+                                                                       double b,
+                                                                       double c,
+                                                                       uint64_t seed,
+                                                                       bool undirected,
+                                                                       bool scramble_vertex_ids,
+                                                                       bool test_weighted,
+                                                                       bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, double, true, false>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int64_t, double, true, false>(raft::handle_t const& handle,
+                                                                       size_t scale,
+                                                                       size_t edge_factor,
+                                                                       double a,
+                                                                       double b,
+                                                                       double c,
+                                                                       uint64_t seed,
+                                                                       bool undirected,
+                                                                       bool scramble_vertex_ids,
+                                                                       bool test_weighted,
+                                                                       bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int32_t, int64_t, double, true, true>,
+                    rmm::device_uvector<int32_t>>
+generate_graph_from_rmat_params<int32_t, int64_t, double, true, true>(raft::handle_t const& handle,
+                                                                      size_t scale,
+                                                                      size_t edge_factor,
+                                                                      double a,
+                                                                      double b,
+                                                                      double c,
+                                                                      uint64_t seed,
+                                                                      bool undirected,
+                                                                      bool scramble_vertex_ids,
+                                                                      bool test_weighted,
+                                                                      bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, float, false, false>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_rmat_params<int64_t, int64_t, float, false, false>(raft::handle_t const& handle,
+                                                                       size_t scale,
+                                                                       size_t edge_factor,
+                                                                       double a,
+                                                                       double b,
+                                                                       double c,
+                                                                       uint64_t seed,
+                                                                       bool undirected,
+                                                                       bool scramble_vertex_ids,
+                                                                       bool test_weighted,
+                                                                       bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, float, false, true>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_rmat_params<int64_t, int64_t, float, false, true>(raft::handle_t const& handle,
+                                                                      size_t scale,
+                                                                      size_t edge_factor,
+                                                                      double a,
+                                                                      double b,
+                                                                      double c,
+                                                                      uint64_t seed,
+                                                                      bool undirected,
+                                                                      bool scramble_vertex_ids,
+                                                                      bool test_weighted,
+                                                                      bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, float, true, false>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_rmat_params<int64_t, int64_t, float, true, false>(raft::handle_t const& handle,
+                                                                      size_t scale,
+                                                                      size_t edge_factor,
+                                                                      double a,
+                                                                      double b,
+                                                                      double c,
+                                                                      uint64_t seed,
+                                                                      bool undirected,
+                                                                      bool scramble_vertex_ids,
+                                                                      bool test_weighted,
+                                                                      bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, float, true, true>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_rmat_params<int64_t, int64_t, float, true, true>(raft::handle_t const& handle,
+                                                                     size_t scale,
+                                                                     size_t edge_factor,
+                                                                     double a,
+                                                                     double b,
+                                                                     double c,
+                                                                     uint64_t seed,
+                                                                     bool undirected,
+                                                                     bool scramble_vertex_ids,
+                                                                     bool test_weighted,
+                                                                     bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, double, false, false>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_rmat_params<int64_t, int64_t, double, false, false>(
+  raft::handle_t const& handle,
+  size_t scale,
+  size_t edge_factor,
+  double a,
+  double b,
+  double c,
+  uint64_t seed,
+  bool undirected,
+  bool scramble_vertex_ids,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, double, false, true>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_rmat_params<int64_t, int64_t, double, false, true>(raft::handle_t const& handle,
+                                                                       size_t scale,
+                                                                       size_t edge_factor,
+                                                                       double a,
+                                                                       double b,
+                                                                       double c,
+                                                                       uint64_t seed,
+                                                                       bool undirected,
+                                                                       bool scramble_vertex_ids,
+                                                                       bool test_weighted,
+                                                                       bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, double, true, false>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_rmat_params<int64_t, int64_t, double, true, false>(raft::handle_t const& handle,
+                                                                       size_t scale,
+                                                                       size_t edge_factor,
+                                                                       double a,
+                                                                       double b,
+                                                                       double c,
+                                                                       uint64_t seed,
+                                                                       bool undirected,
+                                                                       bool scramble_vertex_ids,
+                                                                       bool test_weighted,
+                                                                       bool renumber);
+
+template std::tuple<cugraph::experimental::graph_t<int64_t, int64_t, double, true, true>,
+                    rmm::device_uvector<int64_t>>
+generate_graph_from_rmat_params<int64_t, int64_t, double, true, true>(raft::handle_t const& handle,
+                                                                      size_t scale,
+                                                                      size_t edge_factor,
+                                                                      double a,
+                                                                      double b,
+                                                                      double c,
+                                                                      uint64_t seed,
+                                                                      bool undirected,
+                                                                      bool scramble_vertex_ids,
+                                                                      bool test_weighted,
+                                                                      bool renumber);
+
+}  // namespace test
+}  // namespace cugraph

--- a/cpp/tests/utilities/test_utilities.hpp
+++ b/cpp/tests/utilities/test_utilities.hpp
@@ -165,6 +165,23 @@ generate_graph_from_rmat_params(raft::handle_t const& handle,
                                 bool test_weighted,
                                 bool renumber);
 
+struct rmat_params_t {
+  size_t scale{};
+  size_t edge_factor{};
+  double a{};
+  double b{};
+  double c{};
+  uint64_t seed{};
+  bool undirected{};
+  bool scramble_vertex_ids{};
+};
+
+struct input_graph_specifier_t {
+  enum { MATRIX_MARKET_FILE_PATH, RMAT_PARAMS } tag{};
+  std::string graph_file_full_path{};
+  rmat_params_t rmat_params{};
+};
+
 template <typename vertex_t>
 std::enable_if_t<std::is_signed<vertex_t>::value, bool> is_valid_vertex(vertex_t num_vertices,
                                                                         vertex_t v)

--- a/cpp/tests/utilities/test_utilities.hpp
+++ b/cpp/tests/utilities/test_utilities.hpp
@@ -19,8 +19,8 @@
 #include <graph.hpp>
 
 #include <raft/handle.hpp>
+#include <rmm/device_uvector.hpp>
 
-#include <cstdio>
 #include <string>
 #include <vector>
 
@@ -129,6 +129,22 @@ read_graph_from_matrix_market_file(raft::handle_t const& handle,
                                    std::string const& graph_file_full_path,
                                    bool test_weighted,
                                    bool renumber);
+
+template <typename vertex_t,
+          typename edge_t,
+          typename weight_t,
+          bool store_transposed,
+          bool multi_gpu>
+std::tuple<cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>,
+           rmm::device_uvector<vertex_t>>
+generate_graph_from_edgelist(raft::handle_t const& handle,
+                             rmm::device_uvector<vertex_t>&& vertices,
+                             rmm::device_uvector<vertex_t>&& edgelist_rows,
+                             rmm::device_uvector<vertex_t>&& edgelist_cols,
+                             rmm::device_uvector<weight_t>&& edgelist_weights,
+                             bool is_symmetric,
+                             bool test_weighted,
+                             bool renumber);
 
 template <typename vertex_t>
 std::enable_if_t<std::is_signed<vertex_t>::value, bool> is_valid_vertex(vertex_t num_vertices,


### PR DESCRIPTION
- [x] Refactor cuGraph C++ test library
- [x] Add a utility function to create a graph object from the R-mat generator
- [x] Update C++ MG PageRank and SG PageRank, Katz Centrality, BFS, and SSSP tests to use the new R-mat graph generator

This partially addresses https://github.com/rapidsai/cugraph/issues/1382 and is a per-requsite for graph primitives performance optimization.