### PR TITLE
Update Changelog Link [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # cuGraph 0.19.0 (Date TBD)
 
-Please see https://github.com/rapidsai/cugraph/releases/tag/branch-0.19-latest for the latest changes to this development branch.
+Please see https://github.com/rapidsai/cugraph/releases/tag/v0.19.0a for the latest changes to this development branch.
 
 # cuGraph 0.18.0 (24 Feb 2021)
 


### PR DESCRIPTION
The tag used for pre-releases was recently changed, so this PR updates the link in the changelog.