### PR TITLE
Update to make notebook_list.py compatible with numba 0.53

### DIFF
--- a/ci/gpu/notebook_list.py
+++ b/ci/gpu/notebook_list.py
@@ -24,7 +24,9 @@ from numba import cuda
 pascal = False
 
 device = cuda.get_current_device()
-cc = getattr(device, 'COMPUTE_CAPABILITY')
+# check for the attribute using both pre and post numba 0.53 names
+cc = getattr(device, 'COMPUTE_CAPABILITY', None) or \
+     getattr(device, 'compute_capability')
 if (cc[0] < 7):
     pascal = True
 


### PR DESCRIPTION
A recent update to numba 0.53 in CI broke this script and caused CI failures. This makes the script compatible with both pre and post numba 0.53 versions.

Tested in a local env with numba 0.53 installed.