### PR TITLE
Removed unused dependencies from libcugraph recipe, moved non-test script code from test script to gpu build script

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -61,30 +61,6 @@ else
     cd $WORKSPACE/ci/artifacts/cugraph/cpu/conda_work/cpp/build
 fi
 
-# FIXME: if possible, any install and build steps should be moved outside this
-# script since a failing install/build step is treated as a failing test command
-# and will not stop the script. This script is also only expected to run tests
-# in a preconfigured environment, and install/build steps are unexpected side
-# effects.
-if [[ "$PROJECT_FLASH" == "1" ]]; then
-    export LIBCUGRAPH_BUILD_DIR="$WORKSPACE/ci/artifacts/cugraph/cpu/conda_work/cpp/build"
-
-    # Faiss patch
-    echo "Update libcugraph.so"
-    cd $LIBCUGRAPH_BUILD_DIR
-    chrpath -d libcugraph.so
-    patchelf --replace-needed `patchelf --print-needed libcugraph.so | grep faiss` libfaiss.so libcugraph.so
-
-    CONDA_FILE=`find $WORKSPACE/ci/artifacts/cugraph/cpu/conda-bld/ -name "libcugraph*.tar.bz2"`
-    CONDA_FILE=`basename "$CONDA_FILE" .tar.bz2` #get filename without extension
-    CONDA_FILE=${CONDA_FILE//-/=} #convert to conda install
-    echo "Installing $CONDA_FILE"
-    conda install -c $WORKSPACE/ci/artifacts/cugraph/cpu/conda-bld/ "$CONDA_FILE"
-
-    echo "Build cugraph..."
-    $WORKSPACE/build.sh cugraph
-fi
-
 # Do not abort the script on error from this point on. This allows all tests to
 # run regardless of pass/fail, but relies on the ERR trap above to manage the
 # EXITCODE for the script.

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -32,30 +32,21 @@ build:
 requirements:
   build:
     - cmake>=3.12.4
-    - libcudf={{ minor_version }}
     - cudatoolkit {{ cuda_version }}.*
+    - librmm {{ minor_version }}.*
     - boost-cpp>=1.66
-    - libcypher-parser
     - nccl>=2.8.4
-    - ucx-py {{ minor_version }}
     - ucx-proc=*=gpu
     - gtest
+    - gmock
     - faiss-proc=*=cuda
     - conda-forge::libfaiss=1.7.0
-    - gmock
   run:
-    - libcudf={{ minor_version }}
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
     - nccl>=2.8.4
-    - ucx-py {{ minor_version }}
     - ucx-proc=*=gpu
     - faiss-proc=*=cuda
     - conda-forge::libfaiss=1.7.0
-
-#test:
-#  commands:
-#    - test -f $PREFIX/include/cugraph.h
-
 
 about:
   home: http://rapids.ai/

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -91,7 +91,6 @@ function(ConfigureTest CMAKE_TEST_NAME CMAKE_TEST_SRC)
         cugraph
         GTest::GTest
         GTest::Main
-        ${CUDF_LIBRARY}
         ${NCCL_LIBRARIES}
         cudart
         cuda


### PR DESCRIPTION
* Removed unused dependencies from the `libcugraph` recipe.  This is motivated by the CuPy project to integrate `libcugraph` as the graph analytics backend with minimal extra dependencies ( https://github.com/cupy/cupy/issues/4219, https://github.com/cupy/cupy/issues/2431, https://github.com/cupy/cupy/pull/4054 )
* Moved non-test script code from test script to gpu build script. The `FIXME` addressed for this was added after discussing with @raydouglass earlier, and will allow any Project Flash failures to fail the build immediately instead of attempting to then run tests.
* Removed unused cudf lib reference from test cmake file.

Tested by doing a successful local `conda build` of the recipe.