### PR TITLE
Added cmake function and .hpp template for generating version_config.hpp file.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,6 +18,10 @@ cmake_minimum_required(VERSION 3.18...3.18 FATAL_ERROR)
 
 project(CUGRAPH VERSION 0.19.0 LANGUAGES C CXX CUDA)
 
+# Write the version header
+include(cmake/Modules/Version.cmake)
+write_version()
+
 ###################################################################################################
 # - build type ------------------------------------------------------------------------------------
 
@@ -559,6 +563,9 @@ install(TARGETS cugraph LIBRARY
 
 install(DIRECTORY include/
     DESTINATION include/cugraph)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/cugraph/version_config.hpp
+        DESTINATION include/cugraph)
 
 install(DIRECTORY ${RAFT_DIR}/cpp/include/raft/
     DESTINATION include/cugraph/raft)

--- a/cpp/cmake/Modules/Version.cmake
+++ b/cpp/cmake/Modules/Version.cmake
@@ -1,0 +1,18 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+# Generate version_config.hpp from the version found in CMakeLists.txt
+function(write_version)
+  message(STATUS "CUGRAPH VERSION: ${CUGRAPH_VERSION}")
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version_config.hpp.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/include/cugraph/version_config.hpp @ONLY)
+endfunction(write_version)

--- a/cpp/cmake/version_config.hpp.in
+++ b/cpp/cmake/version_config.hpp.in
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#define CUGRAPH_VERSION_MAJOR @CUGRAPH_VERSION_MAJOR@
+#define CUGRAPH_VERSION_MINOR @CUGRAPH_VERSION_MINOR@
+#define CUGRAPH_VERSION_PATCH @CUGRAPH_VERSION_PATCH@


### PR DESCRIPTION
Adds cmake function and .hpp template for generating a `version_config.hpp` file, similar to RMM's file of the same name.  This allows C++ clients to include the file from the libcugraph install to query version information for reporting, checking compatibility, etc.

Tested by building and installing libcugraph and checking that `version_config.hpp` was present in the conda environment and contained the correct information.

closes #1472 

FYI @anaruse
