### PR TITLE
ENH Update conda recipes pinning of repo dependencies

### DIFF
--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -25,13 +25,13 @@ requirements:
   build:
     - python x.x
     - cython>=0.29,<0.30
-    - libcugraph={{ version }}
+    - libcugraph={{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
     - cudf={{ minor_version }}
     - ucx-py {{ minor_version }}
     - ucx-proc=*=gpu
   run:
     - python x.x
-    - libcugraph={{ version }}
+    - libcugraph={{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
     - cudf={{ minor_version }}
     - dask-cudf {{ minor_version }}
     - dask-cuda {{ minor_version }}


### PR DESCRIPTION
Ensure all conda packages created in this repo that depend on other packages are all version pinned to the same build number. This way it prevents a conda solve from picking mismatched versions of `cugraph` and `libcugraph` that can break this repo during builds and testing.