### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -25,13 +25,13 @@ requirements:
   build:
     - python x.x
     - cython>=0.29,<0.30
-    - libcugraph={{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - libcugraph={{ version }}
     - cudf={{ minor_version }}
     - ucx-py {{ minor_version }}
     - ucx-proc=*=gpu
   run:
     - python x.x
-    - libcugraph={{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - libcugraph={{ version }}
     - cudf={{ minor_version }}
     - dask-cudf {{ minor_version }}
     - dask-cuda {{ minor_version }}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.