### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -275,7 +275,7 @@ message("set LIBCUDACXX_INCLUDE_DIR to: ${LIBCUDACXX_INCLUDE_DIR}")
 FetchContent_Declare(
     cuhornet
     GIT_REPOSITORY    https://github.com/rapidsai/cuhornet.git
-    GIT_TAG           9cb8e8803852bd895a9c95c0fe778ad6eeefa7ad
+    GIT_TAG           e58d0ecdbc270fc28867d66c965787a62a7a882c
     GIT_SHALLOW       true
     SOURCE_SUBDIR     hornet
 )

--- a/cpp/tests/traversal/tsp_test.cu
+++ b/cpp/tests/traversal/tsp_test.cu
@@ -133,10 +133,11 @@ class Tests_Tsp : public ::testing::TestWithParam<Tsp_Usecase> {
 
     // Device alloc
     raft::handle_t const handle;
-    rmm::device_uvector<int> vertices(static_cast<size_t>(nodes), nullptr);
-    rmm::device_uvector<int> route(static_cast<size_t>(nodes), nullptr);
-    rmm::device_uvector<float> x_pos(static_cast<size_t>(nodes), nullptr);
-    rmm::device_uvector<float> y_pos(static_cast<size_t>(nodes), nullptr);
+    auto stream = handle.get_stream();
+    rmm::device_uvector<int> vertices(static_cast<size_t>(nodes), stream);
+    rmm::device_uvector<int> route(static_cast<size_t>(nodes), stream);
+    rmm::device_uvector<float> x_pos(static_cast<size_t>(nodes), stream);
+    rmm::device_uvector<float> y_pos(static_cast<size_t>(nodes), stream);
 
     int* vtx_ptr   = vertices.data();
     int* d_route   = route.data();


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.