### PR TITLE
Updated NetworkX version to 2.5.1

### DIFF
--- a/conda/environments/cugraph_dev_cuda10.1.yml
+++ b/conda/environments/cugraph_dev_cuda10.1.yml
@@ -18,7 +18,7 @@ dependencies:
 - ucx-py=0.19*
 - ucx-proc=*=gpu
 - scipy
-- networkx
+- networkx>=2.5.1
 - python-louvain
 - cudatoolkit=10.1
 - clang=8.0.1

--- a/conda/environments/cugraph_dev_cuda10.2.yml
+++ b/conda/environments/cugraph_dev_cuda10.2.yml
@@ -18,7 +18,7 @@ dependencies:
 - ucx-py=0.19*
 - ucx-proc=*=gpu
 - scipy
-- networkx
+- networkx>=2.5.1
 - python-louvain
 - cudatoolkit=10.2
 - clang=8.0.1

--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -18,7 +18,7 @@ dependencies:
 - ucx-py=0.19*
 - ucx-proc=*=gpu
 - scipy
-- networkx
+- networkx>=2.5.1
 - python-louvain
 - cudatoolkit=11.0
 - clang=8.0.1


### PR DESCRIPTION
Updated NetworkX version to latest version, which addresses an incompatibility with the latest `decorator` dependency.

Tested by running the BC tests which were previously failing with Nx 2.5