### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/conda/environments/cugraph_dev_cuda10.1.yml
+++ b/conda/environments/cugraph_dev_cuda10.1.yml
@@ -18,7 +18,7 @@ dependencies:
 - ucx-py=0.19*
 - ucx-proc=*=gpu
 - scipy
-- networkx
+- networkx>=2.5.1
 - python-louvain
 - cudatoolkit=10.1
 - clang=8.0.1

--- a/conda/environments/cugraph_dev_cuda10.2.yml
+++ b/conda/environments/cugraph_dev_cuda10.2.yml
@@ -18,7 +18,7 @@ dependencies:
 - ucx-py=0.19*
 - ucx-proc=*=gpu
 - scipy
-- networkx
+- networkx>=2.5.1
 - python-louvain
 - cudatoolkit=10.2
 - clang=8.0.1

--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -18,7 +18,7 @@ dependencies:
 - ucx-py=0.19*
 - ucx-proc=*=gpu
 - scipy
-- networkx
+- networkx>=2.5.1
 - python-louvain
 - cudatoolkit=11.0
 - clang=8.0.1


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.