### PR TITLE
Update docs and remove all warnings [skip-ci]

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -192,7 +192,7 @@ Pagerank
     :undoc-members:
 
 Pagerank (MG)
----------
+-------------
 
 .. automodule:: cugraph.dask.link_analysis.pagerank
     :members: pagerank
@@ -236,7 +236,7 @@ Breadth-first-search
     :undoc-members:
 
 Breadth-first-search (MG)
---------------------
+-------------------------
 
 .. automodule:: cugraph.dask.traversal.bfs
     :members:
@@ -250,9 +250,16 @@ Single-source-shortest-path
     :undoc-members:
 
 Single-source-shortest-path (MG)
----------------------------
+--------------------------------
 
 .. automodule:: cugraph.dask.traversal.sssp
+    :members:
+    :undoc-members:
+
+Traveling-salesperson-problem
+-----------------------------
+
+.. automodule:: cugraph.traversal.traveling_salesperson
     :members:
     :undoc-members:
 
@@ -264,27 +271,25 @@ Minimum Spanning Tree
 ---------------------
 
 .. automodule:: cugraph.tree.minimum_spanning_tree
-    :members:
+    :members: minimum_spanning_tree
     :undoc-members:
 
 Maximum Spanning Tree
 ---------------------
 
-.. automodule:: cugraph.tree.maximum_spanning_tree
-    :members:
+.. automodule:: cugraph.tree.minimum_spanning_tree
+    :members: maximum_spanning_tree
     :undoc-members:
+    :noindex:
 
 
-DASK MG Helper functions 
+DASK MG Helper functions
 ===========================
 
 .. automodule:: cugraph.comms.comms
-    :members: initialize
+    :members: initialize, destroy
     :undoc-members:
-
-.. automodule:: cugraph.comms.comms
-    :members: destroy
-    :undoc-members:
+    :member-order: bysource
 
 .. automodule:: cugraph.dask.common.read_utils
     :members: get_chunksize

--- a/python/cugraph/centrality/katz_centrality.py
+++ b/python/cugraph/centrality/katz_centrality.py
@@ -39,14 +39,16 @@ def katz_centrality(
         Attenuation factor defaulted to None. If alpha is not specified then
         it is internally calculated as 1/(degree_max) where degree_max is the
         maximum out degree.
-        NOTE : The maximum acceptable value of alpha for convergence
-        alpha_max = 1/(lambda_max) where lambda_max is the largest eigenvalue
-        of the graph.
-        Since lambda_max is always lesser than or equal to degree_max for a
-        graph, alpha_max will always be greater than or equal to
-        (1/degree_max). Therefore, setting alpha to (1/degree_max) will
-        guarantee that it will never exceed alpha_max thus in turn fulfilling
-        the requirement for convergence.
+
+        NOTE
+            The maximum acceptable value of alpha for convergence
+            alpha_max = 1/(lambda_max) where lambda_max is the largest eigenvalue
+            of the graph.
+            Since lambda_max is always lesser than or equal to degree_max for a
+            graph, alpha_max will always be greater than or equal to
+            (1/degree_max). Therefore, setting alpha to (1/degree_max) will
+            guarantee that it will never exceed alpha_max thus in turn fulfilling
+            the requirement for convergence.
     beta : None
         A weight scalar - currently Not Supported
     max_iter : int

--- a/python/cugraph/components/connectivity.py
+++ b/python/cugraph/components/connectivity.py
@@ -138,8 +138,10 @@ def weakly_connected_components(G,
 
     directed : bool, optional
 
-        NOTE: For non-Graph-type (eg. sparse matrix) values of G only. Raises
-              TypeError if used with a Graph object.
+        NOTE
+            For non-Graph-type (eg. sparse matrix) values of G only. 
+            Raises TypeError if used with a Graph object.
+
         If True (default), then convert the input matrix to a cugraph.DiGraph
         and only move from point i to point j along paths csgraph[i, j]. If
         False, then find the shortest path on an undirected graph: the
@@ -154,8 +156,10 @@ def weakly_connected_components(G,
 
     return_labels : bool, optional
 
-        NOTE: For non-Graph-type (eg. sparse matrix) values of G only. Raises
-              TypeError if used with a Graph object.
+        NOTE
+            For non-Graph-type (eg. sparse matrix) values of G only. Raises
+            TypeError if used with a Graph object.
+
         If True (default), then return the labels for each of the connected
         components.
 
@@ -231,8 +235,10 @@ def strongly_connected_components(G,
 
     directed : bool, optional
 
-        NOTE: For non-Graph-type (eg. sparse matrix) values of G only. Raises
-              TypeError if used with a Graph object.
+        NOTE
+            For non-Graph-type (eg. sparse matrix) values of G only.
+            Raises TypeError if used with a Graph object.
+
         If True (default), then convert the input matrix to a cugraph.DiGraph
         and only move from point i to point j along paths csgraph[i, j]. If
         False, then find the shortest path on an undirected graph: the
@@ -247,8 +253,10 @@ def strongly_connected_components(G,
 
     return_labels : bool, optional
 
-        NOTE: For non-Graph-type (eg. sparse matrix) values of G only. Raises
-              TypeError if used with a Graph object.
+        NOTE
+            For non-Graph-type (eg. sparse matrix) values of G only. Raises
+            TypeError if used with a Graph object.
+
         If True (default), then return the labels for each of the connected
         components.
 
@@ -325,8 +333,10 @@ def connected_components(G,
 
     directed : bool, optional
 
-        NOTE: For non-Graph-type (eg. sparse matrix) values of G only. Raises
-              TypeError if used with a Graph object.
+        NOTE
+            For non-Graph-type (eg. sparse matrix) values of G only. Raises
+            TypeError if used with a Graph object.
+
         If True (default), then convert the input matrix to a cugraph.DiGraph
         and only move from point i to point j along paths csgraph[i, j]. If
         False, then find the shortest path on an undirected graph: the
@@ -340,8 +350,10 @@ def connected_components(G,
 
     return_labels : bool, optional
 
-        NOTE: For non-Graph-type (eg. sparse matrix) values of G only. Raises
-              TypeError if used with a Graph object.
+        NOTE
+            For non-Graph-type (eg. sparse matrix) values of G only. Raises
+            TypeError if used with a Graph object.
+
         If True (default), then return the labels for each of the connected
         components.
 

--- a/python/cugraph/dask/centrality/katz_centrality.py
+++ b/python/cugraph/dask/centrality/katz_centrality.py
@@ -68,14 +68,16 @@ def katz_centrality(input_graph,
         Attenuation factor defaulted to None. If alpha is not specified then
         it is internally calculated as 1/(degree_max) where degree_max is the
         maximum out degree.
-        NOTE : The maximum acceptable value of alpha for convergence
-        alpha_max = 1/(lambda_max) where lambda_max is the largest eigenvalue
-        of the graph.
-        Since lambda_max is always lesser than or equal to degree_max for a
-        graph, alpha_max will always be greater than or equal to
-        (1/degree_max). Therefore, setting alpha to (1/degree_max) will
-        guarantee that it will never exceed alpha_max thus in turn fulfilling
-        the requirement for convergence.
+
+        NOTE
+            The maximum acceptable value of alpha for convergence
+            alpha_max = 1/(lambda_max) where lambda_max is the largest eigenvalue
+            of the graph.
+            Since lambda_max is always lesser than or equal to degree_max for a
+            graph, alpha_max will always be greater than or equal to
+            (1/degree_max). Therefore, setting alpha to (1/degree_max) will
+            guarantee that it will never exceed alpha_max thus in turn fulfilling
+            the requirement for convergence.
     beta : None
         A weight scalar - currently Not Supported
     max_iter : int
@@ -94,6 +96,7 @@ def katz_centrality(input_graph,
         acceptable.
     nstart : dask_cudf.Dataframe
         GPU Dataframe containing the initial guess for katz centrality
+
         nstart['vertex'] : dask_cudf.Series
             Contains the vertex identifiers
         nstart['values'] : dask_cudf.Series

--- a/python/cugraph/dask/link_analysis/pagerank.py
+++ b/python/cugraph/dask/link_analysis/pagerank.py
@@ -73,6 +73,7 @@ def pagerank(input_graph,
     personalization : cudf.Dataframe
         GPU Dataframe containing the personalization information.
         Currently not supported.
+
         personalization['vertex'] : cudf.Series
             Subset of vertices of graph for personalization
         personalization['values'] : cudf.Series
@@ -91,6 +92,7 @@ def pagerank(input_graph,
         acceptable.
     nstart : not supported
         initial guess for pagerank
+
     Returns
     -------
     PageRank : dask_cudf.DataFrame

--- a/python/cugraph/link_analysis/pagerank.py
+++ b/python/cugraph/link_analysis/pagerank.py
@@ -46,7 +46,6 @@ def pagerank(
             Subset of vertices of graph for personalization
         personalization['values'] : cudf.Series
             Personalization values for vertices
-
     max_iter : int
         The maximum number of iterations before an answer is returned. This can
         be used to limit the execution time and do an early exit before the

--- a/python/cugraph/structure/symmetrize.py
+++ b/python/cugraph/structure/symmetrize.py
@@ -32,6 +32,7 @@ def symmetrize_df(df, src_name, dst_name, multi=False, symmetrize=True):
     != data2 then this code will arbitrarily pick the smaller data
     element to keep, if this is not desired then the caller should
     should correct the data prior to calling symmetrize.
+
     Parameters
     ----------
     df : cudf.DataFrame

--- a/python/cugraph/traversal/bfs.py
+++ b/python/cugraph/traversal/bfs.py
@@ -136,8 +136,10 @@ def bfs(G,
         can be set, not both.
 
     directed : bool, optional
-        NOTE: For non-Graph-type (eg. sparse matrix) values of G only. Raises
-              TypeError if used with a Graph object.
+        NOTE
+            For non-Graph-type (eg. sparse matrix) values of G only. Raises
+            TypeError if used with a Graph object.
+
         If True (default), then convert the input matrix to a cugraph.DiGraph,
         otherwise a cugraph.Graph object will be used.
 

--- a/python/cugraph/traversal/traveling_salesperson.py
+++ b/python/cugraph/traversal/traveling_salesperson.py
@@ -29,6 +29,7 @@ def traveling_salesperson(pos_list,
     optimization.
 
     The current implementation does not support a weighted graph.
+
     Parameters
     ----------
     pos_list: cudf.DataFrame


### PR DESCRIPTION
This pr fixes the following 
- Add traveling salesperson problem to the docs
- Update docs to address all build warnings


To remove some warnings. updated the use of `NOTE:` in cases like the one shown below.

| Old  | New |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/19949207/113936070-283a2380-97ac-11eb-9705-9f261c965fa9.png) | ![image](https://user-images.githubusercontent.com/19949207/113935703-b06bf900-97ab-11eb-93a4-7df2f711c1aa.png)  |



