### PR TITLE
Disabling shallow fetch for cuhornet

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -273,7 +273,6 @@ FetchContent_Declare(
     cuhornet
     GIT_REPOSITORY    https://github.com/rapidsai/cuhornet.git
     GIT_TAG           9cb8e8803852bd895a9c95c0fe778ad6eeefa7ad
-    GIT_SHALLOW       true
     SOURCE_SUBDIR     hornet
 )
 


### PR DESCRIPTION
Got rid of the GIT_SHALLOW setting since it should not be enabled by default.