### PR TITLE
Removed GIT_SHALLOW for cuHornet FetchContent since a specific commit must now be used

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -277,7 +277,6 @@ FetchContent_Declare(
     cuhornet
     GIT_REPOSITORY    https://github.com/rapidsai/cuhornet.git
     GIT_TAG           e58d0ecdbc270fc28867d66c965787a62a7a882c
-    GIT_SHALLOW       true
     SOURCE_SUBDIR     hornet
 )
 


### PR DESCRIPTION
Removed `GIT_SHALLOW` for cuHornet `FetchContent` since a specific commit must now be used.