### PR TITLE
Remove conda & pip installs from doc script

### DIFF
--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -28,9 +28,6 @@ gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 
-# TODO: Move installs to docs-build-env meta package
-gpuci_conda_retry install -c anaconda markdown beautifulsoup4 jq
-pip install sphinx-markdown-tables
 
 
 gpuci_logger "Check versions"

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 #################################
 # cuGraph Docs build script for CI #
 #################################
@@ -27,8 +27,6 @@ nvidia-smi
 gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
-
-
 
 gpuci_logger "Check versions"
 python --version


### PR DESCRIPTION
This PR removes the conda & pip installs from the doc build script since they're already included in our environment at build time.
