### PR TITLE
Fix multi-GPU hang on graph generation

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -439,6 +439,7 @@ add_library(cugraph SHARED
     src/experimental/pagerank.cu
     src/experimental/katz_centrality.cu
     src/tree/mst.cu
+    src/utilities/host_barrier.cpp
 )
 
 target_link_directories(cugraph

--- a/cpp/include/patterns/update_frontier_v_push_if_out_nbr.cuh
+++ b/cpp/include/patterns/update_frontier_v_push_if_out_nbr.cuh
@@ -23,6 +23,7 @@
 #include <utilities/dataframe_buffer.cuh>
 #include <utilities/device_comm.cuh>
 #include <utilities/error.hpp>
+#include <utilities/host_barrier.hpp>
 #include <utilities/host_scalar_comm.cuh>
 #include <utilities/shuffle_comm.cuh>
 #include <utilities/thrust_tuple_utils.cuh>
@@ -403,6 +404,21 @@ void update_frontier_v_push_if_out_nbr(
 
   // 1. fill the buffer
 
+  if (GraphViewType::is_multi_gpu) {
+    auto& comm = handle.get_comms();
+
+    // barrier is necessary here to avoid potential overlap (which can leads to deadlock) between
+    // two different communicators (beginning of col_comm)
+#if 1
+    // FIXME: temporary hack till UCC is integrated into RAFT (so we can use UCC barrier with DASK
+    // and MPI barrier with MPI)
+    host_barrier(comm, handle.get_stream_view());
+#else
+    handle.get_stream_view().synchronize();
+    comm.barrier();  // currently, this is ncclAllReduce
+#endif
+  }
+
   rmm::device_uvector<vertex_t> keys(size_t{0}, handle.get_stream());
   auto payload_buffer = allocate_dataframe_buffer<payload_t>(size_t{0}, handle.get_stream());
   rmm::device_scalar<size_t> buffer_idx(size_t{0}, handle.get_stream());
@@ -585,6 +601,21 @@ void update_frontier_v_push_if_out_nbr(
     }
   }
 
+  if (GraphViewType::is_multi_gpu) {
+    auto& comm = handle.get_comms();
+
+    // barrier is necessary here to avoid potential overlap (which can leads to deadlock) between
+    // two different communicators (beginning of col_comm)
+#if 1
+    // FIXME: temporary hack till UCC is integrated into RAFT (so we can use UCC barrier with DASK
+    // and MPI barrier with MPI)
+    host_barrier(comm, handle.get_stream_view());
+#else
+    handle.get_stream_view().synchronize();
+    comm.barrier();  // currently, this is ncclAllReduce
+#endif
+  }
+
   // 2. reduce the buffer
 
   auto num_buffer_elements =
@@ -596,13 +627,21 @@ void update_frontier_v_push_if_out_nbr(
   if (GraphViewType::is_multi_gpu) {
     // FIXME: this step is unnecessary if row_comm_size== 1
     auto& comm               = handle.get_comms();
-    auto const comm_rank     = comm.get_rank();
     auto& row_comm           = handle.get_subcomm(cugraph::partition_2d::key_naming_t().row_name());
-    auto const row_comm_rank = row_comm.get_rank();
     auto const row_comm_size = row_comm.get_size();
     auto& col_comm           = handle.get_subcomm(cugraph::partition_2d::key_naming_t().col_name());
     auto const col_comm_rank = col_comm.get_rank();
-    auto const col_comm_size = col_comm.get_size();
+
+    // barrier is necessary here to avoid potential overlap (which can leads to deadlock) between
+    // two different communicators (beginning of row_comm)
+#if 1
+    // FIXME: temporary hack till UCC is integrated into RAFT (so we can use UCC barrier with DASK
+    // and MPI barrier with MPI)
+    host_barrier(comm, handle.get_stream_view());
+#else
+    handle.get_stream_view().synchronize();
+    comm.barrier();  // currently, this is ncclAllReduce
+#endif
 
     std::vector<vertex_t> h_vertex_lasts(row_comm_size);
     for (size_t i = 0; i < h_vertex_lasts.size(); ++i) {
@@ -649,6 +688,17 @@ void update_frontier_v_push_if_out_nbr(
                                               get_dataframe_buffer_begin<payload_t>(payload_buffer),
                                               keys.size(),
                                               reduce_op);
+
+    // barrier is necessary here to avoid potential overlap (which can leads to deadlock) between
+    // two different communicators (end of row_comm)
+#if 1
+    // FIXME: temporary hack till UCC is integrated into RAFT (so we can use UCC barrier with DASK
+    // and MPI barrier with MPI)
+    host_barrier(comm, handle.get_stream_view());
+#else
+    handle.get_stream_view().synchronize();
+    comm.barrier();  // currently, this is ncclAllReduce
+#endif
   }
 
   // 3. update vertex properties
@@ -753,7 +803,7 @@ void update_frontier_v_push_if_out_nbr(
       }
     }
   }
-}
+}  // namespace experimental
 
 }  // namespace experimental
 }  // namespace cugraph

--- a/cpp/include/utilities/host_barrier.hpp
+++ b/cpp/include/utilities/host_barrier.hpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <raft/handle.hpp>
+#include <rmm/cuda_stream_view.hpp>
+
+#include <vector>
+
+namespace cugraph {
+namespace experimental {
+
+// FIXME: a temporary hack till UCC is integrated into RAFT (so we can use UCC barrier for DASK and
+// MPI barrier for MPI)
+void host_barrier(raft::comms::comms_t const& comm, rmm::cuda_stream_view stream_view)
+{
+  stream_view.synchronize();
+
+  auto const comm_size = comm.get_size();
+  auto const comm_rank = comm.get_rank();
+
+  // k-tree barrier
+
+  int constexpr k = 2;
+  static_assert(k >= 2);
+  std::vector<raft::comms::request_t> requests(k - 1);
+  std::vector<std::byte> dummies(k - 1);
+
+  // up
+
+  int mod = 1;
+  while (mod < comm_size) {
+    if (comm_rank % mod == 0) {
+      auto level_rank = comm_rank / mod;
+      if (level_rank % k == 0) {
+        auto num_irecvs = 0;
+        ;
+        for (int i = 1; i < k; ++i) {
+          auto src_rank = (level_rank + i) * mod;
+          if (src_rank < comm_size) {
+            comm.irecv(dummies.data() + (i - 1),
+                       sizeof(std::byte),
+                       src_rank,
+                       int{0} /* tag */,
+                       requests.data() + (i - 1));
+            ++num_irecvs;
+          }
+        }
+        comm.waitall(num_irecvs, requests.data());
+      } else {
+        comm.isend(dummies.data(),
+                   sizeof(std::byte),
+                   (level_rank - (level_rank % k)) * mod,
+                   int{0} /* tag */,
+                   requests.data());
+        comm.waitall(1, requests.data());
+      }
+    }
+    mod *= k;
+  }
+
+  // down
+
+  mod /= k;
+  while (mod >= 1) {
+    if (comm_rank % mod == 0) {
+      auto level_rank = comm_rank / mod;
+      if (level_rank % k == 0) {
+        auto num_isends = 0;
+        for (int i = 1; i < k; ++i) {
+          auto dst_rank = (level_rank + i) * mod;
+          if (dst_rank < comm_size) {
+            comm.isend(dummies.data() + (i - 1),
+                       sizeof(std::byte),
+                       dst_rank,
+                       int{0} /* tag */,
+                       requests.data() + (i - 1));
+            ++num_isends;
+          }
+        }
+        comm.waitall(num_isends, requests.data());
+      } else {
+        comm.irecv(dummies.data(),
+                   sizeof(std::byte),
+                   (level_rank - (level_rank % k)) * mod,
+                   int{0} /* tag */,
+                   requests.data());
+        comm.waitall(1, requests.data());
+      }
+    }
+    mod /= k;
+  }
+}
+
+}  // namespace experimental
+}  // namespace cugraph

--- a/cpp/include/utilities/shuffle_comm.cuh
+++ b/cpp/include/utilities/shuffle_comm.cuh
@@ -73,11 +73,16 @@ compute_tx_rx_counts_offsets_ranks(raft::comms::comms_t const &comm,
                             rx_offsets,
                             rx_src_ranks,
                             stream);
+  // FIXME: temporary unverified work-around for a NCCL (2.9.6) bug that causes a hang on DGX1 (due
+  // to remote memory allocation), this synchronization is unnecessary otherwise but seems like
+  // suppress the hange issue. Need to be revisited once NCCL 2.10 is released.
+  CUDA_TRY(cudaDeviceSynchronize());
 
   raft::update_host(tx_counts.data(), d_tx_value_counts.data(), comm_size, stream);
   raft::update_host(rx_counts.data(), d_rx_value_counts.data(), comm_size, stream);
 
   CUDA_TRY(cudaStreamSynchronize(stream));  // rx_counts should be up-to-date
+  host_barrier(comm, stream);
 
   std::partial_sum(tx_counts.begin(), tx_counts.end() - 1, tx_offsets.begin() + 1);
   std::partial_sum(rx_counts.begin(), rx_counts.end() - 1, rx_offsets.begin() + 1);

--- a/cpp/include/utilities/shuffle_comm.cuh
+++ b/cpp/include/utilities/shuffle_comm.cuh
@@ -82,7 +82,6 @@ compute_tx_rx_counts_offsets_ranks(raft::comms::comms_t const &comm,
   raft::update_host(rx_counts.data(), d_rx_value_counts.data(), comm_size, stream);
 
   CUDA_TRY(cudaStreamSynchronize(stream));  // rx_counts should be up-to-date
-  host_barrier(comm, stream);
 
   std::partial_sum(tx_counts.begin(), tx_counts.end() - 1, tx_offsets.begin() + 1);
   std::partial_sum(rx_counts.begin(), rx_counts.end() - 1, rx_offsets.begin() + 1);

--- a/cpp/include/utilities/shuffle_comm.cuh
+++ b/cpp/include/utilities/shuffle_comm.cuh
@@ -201,8 +201,6 @@ auto shuffle_values(raft::comms::comms_t const &comm,
   rmm::device_uvector<size_t> d_tx_value_counts(comm_size, stream);
   raft::update_device(d_tx_value_counts.data(), tx_value_counts.data(), comm_size, stream);
 
-  CUDA_TRY(cudaStreamSynchronize(stream));  // tx_value_counts should be up-to-date
-
   std::vector<size_t> tx_counts{};
   std::vector<size_t> tx_offsets{};
   std::vector<int> tx_dst_ranks{};

--- a/cpp/src/experimental/generate_rmat_edgelist.cu
+++ b/cpp/src/experimental/generate_rmat_edgelist.cu
@@ -137,8 +137,9 @@ generate_rmat_edgelists(raft::handle_t const& handle,
                         bool scramble_vertex_ids)
 {
   CUGRAPH_EXPECTS(min_scale > 0, "minimum graph scale is 1.");
-  CUGRAPH_EXPECTS(size_t{1} << max_scale <= std::numeric_limits<vertex_t>::max(),
-                  "Invalid input argument: scale too large for vertex_t.");
+  CUGRAPH_EXPECTS(
+    size_t{1} << max_scale <= static_cast<size_t>(std::numeric_limits<vertex_t>::max()),
+    "Invalid input argument: scale too large for vertex_t.");
 
   std::vector<std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>>> output{};
   output.reserve(n_edgelists);

--- a/cpp/src/experimental/renumber_edgelist.cu
+++ b/cpp/src/experimental/renumber_edgelist.cu
@@ -21,6 +21,7 @@
 #include <experimental/graph_view.hpp>
 #include <utilities/device_comm.cuh>
 #include <utilities/error.hpp>
+#include <utilities/host_barrier.hpp>
 #include <utilities/host_scalar_comm.cuh>
 #include <utilities/shuffle_comm.cuh>
 
@@ -59,6 +60,22 @@ rmm::device_uvector<vertex_t> compute_renumber_map(
 
   // 1. acquire (unique major label, count) pairs
 
+  if (multi_gpu) {
+    auto& comm = handle.get_comms();
+
+    // barrier is necessary here to avoid potential overlap (which can leads to deadlock) between
+    // two different communicators (beginning of col_comm)
+#if 1
+    // FIXME: temporary hack till UCC is integrated into RAFT (so we can use UCC barrier with DASK
+    // and MPI barrier with MPI)
+    host_barrier(comm, handle.get_stream_view());
+#else
+    handle.get_stream_view().synchronize();
+    ;
+    comm.barrier();  // currently, this is ncclAllReduce
+#endif
+  }
+
   rmm::device_uvector<vertex_t> major_labels(0, handle.get_stream());
   rmm::device_uvector<edge_t> major_counts(0, handle.get_stream());
   for (size_t i = 0; i < edgelist_major_vertices.size(); ++i) {
@@ -71,6 +88,7 @@ rmm::device_uvector<vertex_t> compute_renumber_map(
                    edgelist_major_vertices[i],
                    edgelist_major_vertices[i] + edgelist_edge_counts[i],
                    sorted_major_labels.begin());
+      // FIXME: better refactor this sort-count_if-reduce_by_key routine for reuse
       thrust::sort(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
                    sorted_major_labels.begin(),
                    sorted_major_labels.end());
@@ -98,6 +116,9 @@ rmm::device_uvector<vertex_t> compute_renumber_map(
 
       rmm::device_uvector<vertex_t> rx_major_labels(0, handle.get_stream());
       rmm::device_uvector<edge_t> rx_major_counts(0, handle.get_stream());
+      // FIXME: a temporary workaround for a NCCL (2.9.6) bug that causes a hang on DGX1 (due to
+      // remote memory allocation), this barrier is unnecessary otherwise.
+      col_comm.barrier();
       auto rx_sizes = host_scalar_gather(
         col_comm, tmp_major_labels.size(), static_cast<int>(i), handle.get_stream());
       std::vector<size_t> rx_displs{};
@@ -118,31 +139,38 @@ rmm::device_uvector<vertex_t> compute_renumber_map(
                      static_cast<int>(i),
                      handle.get_stream());
       if (static_cast<int>(i) == col_comm_rank) {
-        thrust::sort_by_key(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
-                            rx_major_labels.begin(),
-                            rx_major_labels.end(),
-                            rx_major_counts.begin());
-        major_labels.resize(rx_major_labels.size(), handle.get_stream());
-        major_counts.resize(major_labels.size(), handle.get_stream());
-        auto pair_it =
-          thrust::reduce_by_key(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
-                                rx_major_labels.begin(),
-                                rx_major_labels.end(),
-                                rx_major_counts.begin(),
-                                major_labels.begin(),
-                                major_counts.begin());
-        major_labels.resize(thrust::distance(major_labels.begin(), thrust::get<0>(pair_it)),
-                            handle.get_stream());
-        major_counts.resize(major_labels.size(), handle.get_stream());
-        major_labels.shrink_to_fit(handle.get_stream());
-        major_counts.shrink_to_fit(handle.get_stream());
+        major_labels = std::move(rx_major_labels);
+        major_counts = std::move(rx_major_counts);
       }
     } else {
-      tmp_major_labels.shrink_to_fit(handle.get_stream());
-      tmp_major_counts.shrink_to_fit(handle.get_stream());
+      assert(i == 0);
       major_labels = std::move(tmp_major_labels);
       major_counts = std::move(tmp_major_counts);
     }
+  }
+  if (multi_gpu) {
+    // FIXME: better refactor this sort-count_if-reduce_by_key routine for reuse
+    thrust::sort_by_key(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+                        major_labels.begin(),
+                        major_labels.end(),
+                        major_counts.begin());
+    auto num_unique_labels =
+      thrust::count_if(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+                       thrust::make_counting_iterator(size_t{0}),
+                       thrust::make_counting_iterator(major_labels.size()),
+                       [labels = major_labels.data()] __device__(auto i) {
+                         return (i == 0) || (labels[i - 1] != labels[i]);
+                       });
+    rmm::device_uvector<vertex_t> tmp_major_labels(num_unique_labels, handle.get_stream());
+    rmm::device_uvector<edge_t> tmp_major_counts(tmp_major_labels.size(), handle.get_stream());
+    thrust::reduce_by_key(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+                          major_labels.begin(),
+                          major_labels.end(),
+                          major_counts.begin(),
+                          tmp_major_labels.begin(),
+                          tmp_major_counts.begin());
+    major_labels = std::move(tmp_major_labels);
+    major_counts = std::move(tmp_major_counts);
   }
 
   // 2. acquire unique minor labels
@@ -168,28 +196,52 @@ rmm::device_uvector<vertex_t> compute_renumber_map(
                                     minor_labels.end())),
     handle.get_stream());
   if (multi_gpu) {
+    auto& comm               = handle.get_comms();
     auto& row_comm           = handle.get_subcomm(cugraph::partition_2d::key_naming_t().row_name());
     auto const row_comm_size = row_comm.get_size();
 
-    rmm::device_uvector<vertex_t> rx_minor_labels(0, handle.get_stream());
-    std::tie(rx_minor_labels, std::ignore) = groupby_gpuid_and_shuffle_values(
-      row_comm,
-      minor_labels.begin(),
-      minor_labels.end(),
-      [key_func = detail::compute_gpu_id_from_vertex_t<vertex_t>{row_comm_size}] __device__(
-        auto val) { return key_func(val); },
-      handle.get_stream());
-    thrust::sort(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
-                 rx_minor_labels.begin(),
-                 rx_minor_labels.end());
-    rx_minor_labels.resize(
-      thrust::distance(
-        rx_minor_labels.begin(),
-        thrust::unique(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
-                       rx_minor_labels.begin(),
-                       rx_minor_labels.end())),
-      handle.get_stream());
-    minor_labels = std::move(rx_minor_labels);
+    // barrier is necessary here to avoid potential overlap (which can leads to deadlock) between
+    // two different communicators (beginning of row_comm)
+#if 1
+    // FIXME: temporary hack till UCC is integrated into RAFT (so we can use UCC barrier with DASK
+    // and MPI barrier with MPI)
+    host_barrier(comm, handle.get_stream_view());
+#else
+    handle.get_stream_view().synchronize();
+    comm.barrier();  // currently, this is ncclAllReduce
+#endif
+
+    if (row_comm_size > 1) {
+      rmm::device_uvector<vertex_t> rx_minor_labels(0, handle.get_stream());
+      std::tie(rx_minor_labels, std::ignore) = groupby_gpuid_and_shuffle_values(
+        row_comm,
+        minor_labels.begin(),
+        minor_labels.end(),
+        [key_func = detail::compute_gpu_id_from_vertex_t<vertex_t>{row_comm_size}] __device__(
+          auto val) { return key_func(val); },
+        handle.get_stream());
+      thrust::sort(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+                   rx_minor_labels.begin(),
+                   rx_minor_labels.end());
+      rx_minor_labels.resize(
+        thrust::distance(
+          rx_minor_labels.begin(),
+          thrust::unique(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+                         rx_minor_labels.begin(),
+                         rx_minor_labels.end())),
+        handle.get_stream());
+      minor_labels = std::move(rx_minor_labels);
+      // barrier is necessary here to avoid potential overlap (which can leads to deadlock) between
+      // two different communicators (end of row_comm)
+#if 1
+      // FIXME: temporary hack till UCC is integrated into RAFT (so we can use UCC barrier with DASK
+      // and MPI barrier with MPI)
+      host_barrier(comm, handle.get_stream_view());
+#else
+      handle.get_stream_view().synchronize();
+      comm.barrier();  // currently, this is ncclAllReduce
+#endif
+    }
   }
   minor_labels.shrink_to_fit(handle.get_stream());
 
@@ -366,6 +418,18 @@ void expensive_check_edgelist(
         auto& row_comm = handle.get_subcomm(cugraph::partition_2d::key_naming_t().row_name());
         auto& col_comm = handle.get_subcomm(cugraph::partition_2d::key_naming_t().col_name());
 
+        // FIXME: this barrier is unnecessary if the above host_scalar_allreduce is a true host
+        // operation (as it serves as a barrier) barrier is necessary here to avoid potential
+        // overlap (which can leads to deadlock) between two different communicators (beginning of
+        // col_comm)
+#if 1
+        // FIXME: temporary hack till UCC is integrated into RAFT (so we can use UCC barrier with
+        // DASK and MPI barrier with MPI)
+        host_barrier(comm, handle.get_stream_view());
+#else
+        handle.get_stream_view().synchronize();
+        comm.barrier();  // currently, this is ncclAllReduce
+#endif
         rmm::device_uvector<vertex_t> sorted_major_vertices(0, handle.get_stream());
         {
           auto recvcounts =
@@ -385,6 +449,16 @@ void expensive_check_edgelist(
                        sorted_major_vertices.end());
         }
 
+        // barrier is necessary here to avoid potential overlap (which can leads to deadlock)
+        // between two different communicators (beginning of row_comm)
+#if 1
+        // FIXME: temporary hack till UCC is integrated into RAFT (so we can use UCC barrier with
+        // DASK and MPI barrier with MPI)
+        host_barrier(comm, handle.get_stream_view());
+#else
+        handle.get_stream_view().synchronize();
+        comm.barrier();  // currently, this is ncclAllReduce
+#endif
         rmm::device_uvector<vertex_t> sorted_minor_vertices(0, handle.get_stream());
         {
           auto recvcounts =
@@ -403,6 +477,16 @@ void expensive_check_edgelist(
                        sorted_minor_vertices.begin(),
                        sorted_minor_vertices.end());
         }
+        // barrier is necessary here to avoid potential overlap (which can leads to deadlock)
+        // between two different communicators (end of row_comm)
+#if 1
+        // FIXME: temporary hack till UCC is integrated into RAFT (so we can use UCC barrier with
+        // DASK and MPI barrier with MPI)
+        host_barrier(comm, handle.get_stream_view());
+#else
+        handle.get_stream_view().synchronize();
+        comm.barrier();  // currently, this is ncclAllReduce
+#endif
 
         auto edge_first = thrust::make_zip_iterator(
           thrust::make_tuple(edgelist_major_vertices[i], edgelist_minor_vertices[i]));
@@ -509,7 +593,6 @@ renumber_edgelist(raft::handle_t const& handle,
                                                               edgelist_const_major_vertices,
                                                               edgelist_const_minor_vertices,
                                                               edgelist_edge_counts);
-
   // 2. initialize partition_t object, number_of_vertices, and number_of_edges for the coarsened
   // graph
 
@@ -535,6 +618,17 @@ renumber_edgelist(raft::handle_t const& handle,
   // FIXME: compare this hash based approach with a binary search based approach in both memory
   // footprint and execution time
 
+  // FIXME: this barrier is unnecessary if the above host_scalar_allgather is a true host operation
+  // (as it serves as a barrier) barrier is necessary here to avoid potential overlap (which can
+  // leads to deadlock) between two different communicators (beginning of col_comm)
+#if 1
+  // FIXME: temporary hack till UCC is integrated into RAFT (so we can use UCC barrier with DASK and
+  // MPI barrier with MPI)
+  host_barrier(comm, handle.get_stream_view());
+#else
+  handle.get_stream_view().synchronize();
+  comm.barrier();  // currently, this is ncclAllReduce
+#endif
   for (size_t i = 0; i < edgelist_major_vertices.size(); ++i) {
     rmm::device_uvector<vertex_t> renumber_map_major_labels(
       col_comm_rank == static_cast<int>(i) ? vertex_t{0}
@@ -571,6 +665,16 @@ renumber_edgelist(raft::handle_t const& handle,
                       edgelist_major_vertices[i]);
   }
 
+  // barrier is necessary here to avoid potential overlap (which can leads to deadlock) between two
+  // different communicators (beginning of row_comm)
+#if 1
+  // FIXME: temporary hack till UCC is integrated into RAFT (so we can use UCC barrier with DASK and
+  // MPI barrier with MPI)
+  host_barrier(comm, handle.get_stream_view());
+#else
+  handle.get_stream_view().synchronize();
+  comm.barrier();  // currently, this is ncclAllReduce
+#endif
   {
     rmm::device_uvector<vertex_t> renumber_map_minor_labels(
       partition.get_matrix_partition_minor_size(), handle.get_stream());
@@ -611,6 +715,16 @@ renumber_edgelist(raft::handle_t const& handle,
                         edgelist_minor_vertices[i]);
     }
   }
+  // barrier is necessary here to avoid potential overlap (which can leads to deadlock) between two
+  // different communicators (end of row_comm)
+#if 1
+  // FIXME: temporary hack till UCC is integrated into RAFT (so we can use UCC barrier with DASK and
+  // MPI barrier with MPI)
+  host_barrier(comm, handle.get_stream_view());
+#else
+  handle.get_stream_view().synchronize();
+  comm.barrier();  // currently, this is ncclAllReduce
+#endif
 
   return std::make_tuple(
     std::move(renumber_map_labels), partition, number_of_vertices, number_of_edges);

--- a/cpp/src/experimental/renumber_edgelist.cu
+++ b/cpp/src/experimental/renumber_edgelist.cu
@@ -432,6 +432,7 @@ void expensive_check_edgelist(
         handle.get_stream_view().synchronize();
         comm.barrier();  // currently, this is ncclAllReduce
 #endif
+
         rmm::device_uvector<vertex_t> sorted_major_vertices(0, handle.get_stream());
         {
           auto recvcounts =
@@ -461,6 +462,7 @@ void expensive_check_edgelist(
         handle.get_stream_view().synchronize();
         comm.barrier();  // currently, this is ncclAllReduce
 #endif
+
         rmm::device_uvector<vertex_t> sorted_minor_vertices(0, handle.get_stream());
         {
           auto recvcounts =
@@ -479,6 +481,7 @@ void expensive_check_edgelist(
                        sorted_minor_vertices.begin(),
                        sorted_minor_vertices.end());
         }
+
         // barrier is necessary here to avoid potential overlap (which can leads to deadlock)
         // between two different communicators (end of row_comm)
 #if 1
@@ -631,6 +634,7 @@ renumber_edgelist(raft::handle_t const& handle,
   handle.get_stream_view().synchronize();
   comm.barrier();  // currently, this is ncclAllReduce
 #endif
+
   for (size_t i = 0; i < edgelist_major_vertices.size(); ++i) {
     rmm::device_uvector<vertex_t> renumber_map_major_labels(
       col_comm_rank == static_cast<int>(i) ? vertex_t{0}

--- a/cpp/src/utilities/host_barrier.cpp
+++ b/cpp/src/utilities/host_barrier.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <utilities/host_barrier.hpp>
+
+#include <vector>
+
+namespace cugraph {
+namespace experimental {
+
+// FIXME: a temporary hack till UCC is integrated into RAFT (so we can use UCC barrier for DASK and
+// MPI barrier for MPI)
+void host_barrier(raft::comms::comms_t const& comm, rmm::cuda_stream_view stream_view)
+{
+  stream_view.synchronize();
+
+  auto const comm_size = comm.get_size();
+  auto const comm_rank = comm.get_rank();
+
+  // k-tree barrier
+
+  int constexpr k = 2;
+  static_assert(k >= 2);
+  std::vector<raft::comms::request_t> requests(k - 1);
+  std::vector<std::byte> dummies(k - 1);
+
+  // up
+
+  int mod = 1;
+  while (mod < comm_size) {
+    if (comm_rank % mod == 0) {
+      auto level_rank = comm_rank / mod;
+      if (level_rank % k == 0) {
+        auto num_irecvs = 0;
+        ;
+        for (int i = 1; i < k; ++i) {
+          auto src_rank = (level_rank + i) * mod;
+          if (src_rank < comm_size) {
+            comm.irecv(dummies.data() + (i - 1),
+                       sizeof(std::byte),
+                       src_rank,
+                       int{0} /* tag */,
+                       requests.data() + (i - 1));
+            ++num_irecvs;
+          }
+        }
+        comm.waitall(num_irecvs, requests.data());
+      } else {
+        comm.isend(dummies.data(),
+                   sizeof(std::byte),
+                   (level_rank - (level_rank % k)) * mod,
+                   int{0} /* tag */,
+                   requests.data());
+        comm.waitall(1, requests.data());
+      }
+    }
+    mod *= k;
+  }
+
+  // down
+
+  mod /= k;
+  while (mod >= 1) {
+    if (comm_rank % mod == 0) {
+      auto level_rank = comm_rank / mod;
+      if (level_rank % k == 0) {
+        auto num_isends = 0;
+        for (int i = 1; i < k; ++i) {
+          auto dst_rank = (level_rank + i) * mod;
+          if (dst_rank < comm_size) {
+            comm.isend(dummies.data() + (i - 1),
+                       sizeof(std::byte),
+                       dst_rank,
+                       int{0} /* tag */,
+                       requests.data() + (i - 1));
+            ++num_isends;
+          }
+        }
+        comm.waitall(num_isends, requests.data());
+      } else {
+        comm.irecv(dummies.data(),
+                   sizeof(std::byte),
+                   (level_rank - (level_rank % k)) * mod,
+                   int{0} /* tag */,
+                   requests.data());
+        comm.waitall(1, requests.data());
+      }
+    }
+    mod /= k;
+  }
+}
+
+}  // namespace experimental
+}  // namespace cugraph


### PR DESCRIPTION
Two bug fixes for multi-GPU graph creation.

- Add barrier to avoid overlap between different communicators
- NCCL bug workaround on DGX1