### PR TITLE
Added `uninstall` target which uninstalls libcugraph and cugraph from a prior build/install step

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,11 +19,11 @@ ARGS=$*
 REPODIR=$(cd $(dirname $0); pwd)
 LIBCUGRAPH_BUILD_DIR=${LIBCUGRAPH_BUILD_DIR:=${REPODIR}/cpp/build}
 
-VALIDARGS="clean scrub libcugraph cugraph docs -v -g -n --allgpuarch --buildfaiss --show_depr_warn -h --help"
+VALIDARGS="clean uninstall libcugraph cugraph docs -v -g -n --allgpuarch --buildfaiss --show_depr_warn -h --help"
 HELP="$0 [<target> ...] [<flag> ...]
  where <target> is:
-   clean            - remove build dirs
-   scrub            - remove all existing build artifacts, configuration, and installed files (start over)
+   clean            - remove all existing build artifacts and configuration (start over)
+   uninstall        - uninstall libcugraph and cugraph from a prior build/install (see also -n)
    libcugraph       - build the cugraph C++ code
    cugraph          - build the cugraph Python package
    cpp-mgtests      - build libcugraph mnmg tests. Builds MPI communicator, adding MPI as a dependency.
@@ -31,7 +31,7 @@ HELP="$0 [<target> ...] [<flag> ...]
  and <flag> is:
    -v               - verbose build mode
    -g               - build for debug
-   -n               - no install step
+   -n               - do not install after a successful build
    --allgpuarch     - build for all supported GPU architectures
    --buildfaiss     - build faiss statically into cugraph
    --show_depr_warn - show cmake deprecation warnings
@@ -108,34 +108,35 @@ if hasArg cpp-mgtests; then
     BUILD_CPP_MG_TESTS=ON
 fi
 
-# If clean given, run it prior to any other steps
-if hasArg clean || hasArg scrub; then
-    if hasArg scrub; then
-        # uninstall libcugraph
-        if [[ "$INSTALL_PREFIX" != "" ]]; then
-            rm -rf ${INSTALL_PREFIX}/include/cugraph
-            rm -f ${INSTALL_PREFIX}/lib/libcugraph.so
-        fi
-        # This may be redundant given the above, but can also be used in case
-        # there are other installed files outside of the locations above.
-        if [ -e ${LIBCUGRAPH_BUILD_DIR}/install_manifest.txt ]; then
-            xargs rm -f < ${LIBCUGRAPH_BUILD_DIR}/install_manifest.txt > /dev/null 2>&1
-        fi
-        # remove artifacts generated inplace
-        # FIXME: ideally the "setup.py clean" command would be used for this,
-        # but currently running any setup.py command has side effects
-        # (eg. cloning repos).
-        # (cd ${REPODIR}/python && python setup.py clean)
-        if [[ -d ${REPODIR}/python ]]; then
-            pushd ${REPODIR}/python > /dev/null
-            rm -rf dist dask-worker-space cugraph/raft *.egg-info
-            find . -name "__pycache__" -type d -exec rm -rf {} \; > /dev/null 2>&1
-            find . -name "*.cpp" -type f -delete
-            find . -name "*.cpython*.so" -type f -delete
-            popd > /dev/null
-        fi
-        # uninstall cugraph installed from a prior "setup.py install"
-        pip uninstall -y cugraph
+# If clean or uninstall given, run them prior to any other steps
+if hasArg uninstall; then
+    # uninstall libcugraph
+    if [[ "$INSTALL_PREFIX" != "" ]]; then
+        rm -rf ${INSTALL_PREFIX}/include/cugraph
+        rm -f ${INSTALL_PREFIX}/lib/libcugraph.so
+    fi
+    # This may be redundant given the above, but can also be used in case
+    # there are other installed files outside of the locations above.
+    if [ -e ${LIBCUGRAPH_BUILD_DIR}/install_manifest.txt ]; then
+        xargs rm -f < ${LIBCUGRAPH_BUILD_DIR}/install_manifest.txt > /dev/null 2>&1
+    fi
+    # uninstall cugraph installed from a prior "setup.py install"
+    pip uninstall -y cugraph
+fi
+
+if hasArg clean; then
+    # remove artifacts generated inplace
+    # FIXME: ideally the "setup.py clean" command would be used for this, but
+    # currently running any setup.py command has side effects (eg. cloning
+    # repos).
+    # (cd ${REPODIR}/python && python setup.py clean)
+    if [[ -d ${REPODIR}/python ]]; then
+        pushd ${REPODIR}/python > /dev/null
+        rm -rf dist dask-worker-space cugraph/raft *.egg-info
+        find . -name "__pycache__" -type d -exec rm -rf {} \; > /dev/null 2>&1
+        find . -name "*.cpp" -type f -delete
+        find . -name "*.cpython*.so" -type f -delete
+        popd > /dev/null
     fi
 
     # If the dirs to clean are mounted dirs in a container, the contents should


### PR DESCRIPTION
Added `uninstall` target which uninstalls libcugraph and cugraph from a prior build/install step. Also extended the `clean` target to remove inplace artifacts (mainly cython-generated cpp files and inplace `.so` python extensions built from cython).

NOTE: since targets can be combined on the same command, a user can get the "scrub" behavior by running:
```
./build.sh uninstall clean
```