### PR TITLE
Move the utility function to gather distributed vectors from tests/community to tests/utilities and update MG tests

### DIFF
--- a/cpp/include/cugraph/experimental/graph_functions.hpp
+++ b/cpp/include/cugraph/experimental/graph_functions.hpp
@@ -284,7 +284,7 @@ void unrenumber_int_vertices(raft::handle_t const& handle,
                              vertex_t const* renumber_map_labels,
                              vertex_t local_int_vertex_first,
                              vertex_t local_int_vertex_last,
-                             std::vector<vertex_t>& vertex_partition_lasts,
+                             std::vector<vertex_t> const& vertex_partition_lasts,
                              bool do_expensive_check = false);
 
 /**

--- a/cpp/include/cugraph/utilities/host_scalar_comm.cuh
+++ b/cpp/include/cugraph/utilities/host_scalar_comm.cuh
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/thrust_tuple_utils.cuh>
 
 #include <raft/handle.hpp>

--- a/cpp/src/experimental/renumber_utils.cu
+++ b/cpp/src/experimental/renumber_utils.cu
@@ -214,7 +214,7 @@ void unrenumber_int_vertices(raft::handle_t const& handle,
                              vertex_t const* renumber_map_labels,
                              vertex_t local_int_vertex_first,
                              vertex_t local_int_vertex_last,
-                             std::vector<vertex_t>& vertex_partition_lasts,
+                             std::vector<vertex_t> const& vertex_partition_lasts,
                              bool do_expensive_check)
 {
   double constexpr load_factor = 0.7;
@@ -385,41 +385,45 @@ template void unrenumber_local_int_vertices<int64_t>(raft::handle_t const& handl
                                                      int64_t local_int_vertex_last,
                                                      bool do_expensive_check);
 
-template void unrenumber_int_vertices<int32_t, false>(raft::handle_t const& handle,
-                                                      int32_t* vertices,
-                                                      size_t num_vertices,
-                                                      int32_t const* renumber_map_labels,
-                                                      int32_t local_int_vertex_first,
-                                                      int32_t local_int_vertex_last,
-                                                      std::vector<int32_t>& vertex_partition_lasts,
-                                                      bool do_expensive_check);
+template void unrenumber_int_vertices<int32_t, false>(
+  raft::handle_t const& handle,
+  int32_t* vertices,
+  size_t num_vertices,
+  int32_t const* renumber_map_labels,
+  int32_t local_int_vertex_first,
+  int32_t local_int_vertex_last,
+  std::vector<int32_t> const& vertex_partition_lasts,
+  bool do_expensive_check);
 
-template void unrenumber_int_vertices<int32_t, true>(raft::handle_t const& handle,
-                                                     int32_t* vertices,
-                                                     size_t num_vertices,
-                                                     int32_t const* renumber_map_labels,
-                                                     int32_t local_int_vertex_first,
-                                                     int32_t local_int_vertex_last,
-                                                     std::vector<int32_t>& vertex_partition_lasts,
-                                                     bool do_expensive_check);
+template void unrenumber_int_vertices<int32_t, true>(
+  raft::handle_t const& handle,
+  int32_t* vertices,
+  size_t num_vertices,
+  int32_t const* renumber_map_labels,
+  int32_t local_int_vertex_first,
+  int32_t local_int_vertex_last,
+  std::vector<int32_t> const& vertex_partition_lasts,
+  bool do_expensive_check);
 
-template void unrenumber_int_vertices<int64_t, false>(raft::handle_t const& handle,
-                                                      int64_t* vertices,
-                                                      size_t num_vertices,
-                                                      int64_t const* renumber_map_labels,
-                                                      int64_t local_int_vertex_first,
-                                                      int64_t local_int_vertex_last,
-                                                      std::vector<int64_t>& vertex_partition_lasts,
-                                                      bool do_expensive_check);
+template void unrenumber_int_vertices<int64_t, false>(
+  raft::handle_t const& handle,
+  int64_t* vertices,
+  size_t num_vertices,
+  int64_t const* renumber_map_labels,
+  int64_t local_int_vertex_first,
+  int64_t local_int_vertex_last,
+  std::vector<int64_t> const& vertex_partition_lasts,
+  bool do_expensive_check);
 
-template void unrenumber_int_vertices<int64_t, true>(raft::handle_t const& handle,
-                                                     int64_t* vertices,
-                                                     size_t num_vertices,
-                                                     int64_t const* renumber_map_labels,
-                                                     int64_t local_int_vertex_first,
-                                                     int64_t local_int_vertex_last,
-                                                     std::vector<int64_t>& vertex_partition_lasts,
-                                                     bool do_expensive_check);
+template void unrenumber_int_vertices<int64_t, true>(
+  raft::handle_t const& handle,
+  int64_t* vertices,
+  size_t num_vertices,
+  int64_t const* renumber_map_labels,
+  int64_t local_int_vertex_first,
+  int64_t local_int_vertex_last,
+  std::vector<int64_t> const& vertex_partition_lasts,
+  bool do_expensive_check);
 
 }  // namespace experimental
 }  // namespace cugraph

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -58,6 +58,39 @@ target_link_libraries(cugraphtestutil cugraph)
 set_target_properties(cugraphtestutil PROPERTIES
         CUDA_ARCHITECTURES OFF)
 
+add_library(cugraphmgtestutil STATIC
+            "${CMAKE_CURRENT_SOURCE_DIR}/utilities/device_comm_wrapper.cu")
+
+set_property(TARGET cugraphmgtestutil PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+target_include_directories(cugraphmgtestutil
+    PRIVATE
+    "${CUB_INCLUDE_DIR}"
+    "${THRUST_INCLUDE_DIR}"
+    "${CUCO_INCLUDE_DIR}"
+    "${LIBCUDACXX_INCLUDE_DIR}"
+    "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
+    "${RMM_INCLUDE}"
+    "${NCCL_INCLUDE_DIRS}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../thirdparty/mmio"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${RAFT_DIR}/cpp/include"
+)
+
+target_link_libraries(cugraphmgtestutil cugraph)
+
+# CUDA_ARCHITECTURES=OFF implies cmake will not pass arch flags to the
+# compiler. CUDA_ARCHITECTURES must be set to a non-empty value to prevent
+# cmake warnings about policy CMP0104. With this setting, arch flags must be
+# manually set! ("evaluate_gpu_archs(GPU_ARCHS)" is the current mechanism
+# used in cpp/CMakeLists.txt for setting arch options).
+# Run "cmake --help-policy CMP0104" for policy details.
+# NOTE: the CUDA_ARCHITECTURES=OFF setting may be removed after migrating to
+# the findcudatoolkit features in cmake 3.17+
+set_target_properties(cugraphmgtestutil PROPERTIES
+        CUDA_ARCHITECTURES OFF)
+
 ###################################################################################################
 # - compiler function -----------------------------------------------------------------------------
 
@@ -194,6 +227,7 @@ function(ConfigureTestMG CMAKE_TEST_NAME CMAKE_TEST_SRC)
 
     target_link_libraries(${CMAKE_TEST_NAME}
         PRIVATE
+        cugraphmgtestutil
         cugraphtestutil
         cugraph
         GTest::GTest

--- a/cpp/tests/community/mg_louvain_helper.cu
+++ b/cpp/tests/community/mg_louvain_helper.cu
@@ -31,36 +31,6 @@
 namespace cugraph {
 namespace test {
 
-template <typename T>
-rmm::device_uvector<T> gather_distributed_vector(raft::handle_t const &handle,
-                                                 T const *d_input,
-                                                 size_t size)
-{
-  auto rx_sizes =
-    cugraph::experimental::host_scalar_gather(handle.get_comms(), size, 0, handle.get_stream());
-  std::vector<size_t> rx_displs(static_cast<size_t>(handle.get_comms().get_rank()) == 0
-                                  ? handle.get_comms().get_size()
-                                  : int{0},
-                                size_t{0});
-  if (static_cast<size_t>(handle.get_comms().get_rank()) == 0) {
-    std::partial_sum(rx_sizes.begin(), rx_sizes.end() - 1, rx_displs.begin() + 1);
-  }
-
-  auto total_size = thrust::reduce(thrust::host, rx_sizes.begin(), rx_sizes.end());
-  rmm::device_uvector<T> gathered_v(total_size, handle.get_stream());
-
-  cugraph::experimental::device_gatherv(handle.get_comms(),
-                                        d_input,
-                                        gathered_v.data(),
-                                        size,
-                                        rx_sizes,
-                                        rx_displs,
-                                        0,
-                                        handle.get_stream());
-
-  return gathered_v;
-}
-
 template <typename vertex_t>
 bool compare_renumbered_vectors(raft::handle_t const &handle,
                                 rmm::device_uvector<vertex_t> const &v1,
@@ -335,10 +305,6 @@ template void single_gpu_renumber_edgelist_given_number_map(
   rmm::device_uvector<int> &d_edgelist_rows,
   rmm::device_uvector<int> &d_edgelist_cols,
   rmm::device_uvector<int> &d_renumber_map_gathered_v);
-
-template rmm::device_uvector<int> gather_distributed_vector(raft::handle_t const &handle,
-                                                            int const *d_input,
-                                                            size_t size);
 
 template bool compare_renumbered_vectors(raft::handle_t const &handle,
                                          rmm::device_uvector<int> const &v1,

--- a/cpp/tests/community/mg_louvain_helper.hpp
+++ b/cpp/tests/community/mg_louvain_helper.hpp
@@ -24,11 +24,6 @@
 namespace cugraph {
 namespace test {
 
-template <typename T>
-rmm::device_uvector<T> gather_distributed_vector(raft::handle_t const &handle,
-                                                 T const *d_input,
-                                                 size_t size);
-
 template <typename vertex_t>
 bool compare_renumbered_vectors(raft::handle_t const &handle,
                                 rmm::device_uvector<vertex_t> const &v1,

--- a/cpp/tests/community/mg_louvain_test.cpp
+++ b/cpp/tests/community/mg_louvain_test.cpp
@@ -17,6 +17,7 @@
 #include "mg_louvain_helper.hpp"
 
 #include <utilities/base_fixture.hpp>
+#include <utilities/device_comm_wrapper.hpp>
 #include <utilities/test_utilities.hpp>
 
 #include <cugraph/algorithms.hpp>
@@ -144,7 +145,7 @@ class Louvain_MG_Testfixture : public ::testing::TestWithParam<Louvain_Usecase> 
       thrust::make_counting_iterator<size_t>(dendrogram.num_levels()),
       [&dendrogram, &sg_graph, &d_clustering_v, &sg_modularity, &handle, resolution, rank](
         size_t i) {
-        auto d_dendrogram_gathered_v = cugraph::test::gather_distributed_vector(
+        auto d_dendrogram_gathered_v = cugraph::test::device_gatherv(
           handle, dendrogram.get_level_ptr_nocheck(i), dendrogram.get_level_size_nocheck(i));
 
         if (rank == 0) {
@@ -207,7 +208,7 @@ class Louvain_MG_Testfixture : public ::testing::TestWithParam<Louvain_Usecase> 
 
     SCOPED_TRACE("compare modularity input: " + param.graph_file_full_path);
 
-    auto d_renumber_map_gathered_v = cugraph::test::gather_distributed_vector(
+    auto d_renumber_map_gathered_v = cugraph::test::device_gatherv(
       handle, d_renumber_map_labels.data(), d_renumber_map_labels.size());
 
     compare_sg_results<vertex_t, edge_t, weight_t>(handle,

--- a/cpp/tests/experimental/bfs_test.cpp
+++ b/cpp/tests/experimental/bfs_test.cpp
@@ -212,12 +212,15 @@ class Tests_BFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, input_
                                                              graph_view.get_number_of_vertices(),
                                                              true);
 
-        auto d_unrenumbered_distances = cugraph::test::sort_by_key(
+        rmm::device_uvector<vertex_t> d_unrenumbered_distances(size_t{0}, handle.get_stream());
+        std::tie(std::ignore, d_unrenumbered_distances) = cugraph::test::sort_by_key(
           handle, d_renumber_map_labels.data(), d_distances.data(), d_renumber_map_labels.size());
-        auto d_unrenumbered_predecessors = cugraph::test::sort_by_key(handle,
-                                                                      d_renumber_map_labels.data(),
-                                                                      d_predecessors.data(),
-                                                                      d_renumber_map_labels.size());
+        rmm::device_uvector<vertex_t> d_unrenumbered_predecessors(size_t{0}, handle.get_stream());
+        std::tie(std::ignore, d_unrenumbered_predecessors) =
+          cugraph::test::sort_by_key(handle,
+                                     d_renumber_map_labels.data(),
+                                     d_predecessors.data(),
+                                     d_renumber_map_labels.size());
         raft::update_host(h_cugraph_distances.data(),
                           d_unrenumbered_distances.data(),
                           d_unrenumbered_distances.size(),

--- a/cpp/tests/experimental/katz_centrality_test.cpp
+++ b/cpp/tests/experimental/katz_centrality_test.cpp
@@ -225,7 +225,9 @@ class Tests_KatzCentrality
 
       std::vector<result_t> h_cugraph_katz_centralities(graph_view.get_number_of_vertices());
       if (renumber) {
-        auto d_unrenumbered_katz_centralities =
+        rmm::device_uvector<result_t> d_unrenumbered_katz_centralities(size_t{0},
+                                                                       handle.get_stream());
+        std::tie(std::ignore, d_unrenumbered_katz_centralities) =
           cugraph::test::sort_by_key(handle,
                                      d_renumber_map_labels.data(),
                                      d_katz_centralities.data(),

--- a/cpp/tests/experimental/mg_bfs_test.cpp
+++ b/cpp/tests/experimental/mg_bfs_test.cpp
@@ -81,6 +81,7 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       hr_clock.start();
     }
 
@@ -92,6 +93,7 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "MG construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -112,6 +114,7 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       hr_clock.start();
     }
 
@@ -125,6 +128,7 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "MG BFS took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/experimental/mg_bfs_test.cpp
+++ b/cpp/tests/experimental/mg_bfs_test.cpp
@@ -16,6 +16,7 @@
 
 #include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/device_comm_wrapper.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>
 
@@ -82,6 +83,7 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
+
     cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, false, true> mg_graph(handle);
     rmm::device_uvector<vertex_t> d_mg_renumber_map_labels(0, handle.get_stream());
     std::tie(mg_graph, d_mg_renumber_map_labels) =
@@ -128,121 +130,132 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
       std::cout << "MG BFS took " << elapsed_time * 1e-6 << " s.\n";
     }
 
-    // 5. compare SG & MG results
+    // 4. compare SG & MG results
 
     if (bfs_usecase.check_correctness) {
-      // 5-1. create SG graph
+      // 4-1. aggregate MG results
 
-      cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, false, false> sg_graph(handle);
-      std::tie(sg_graph, std::ignore) =
-        input_usecase.template construct_graph<vertex_t, edge_t, weight_t, false, false>(
-          handle, false, false);
+      auto d_mg_aggregate_renumber_map_labels = cugraph::test::device_gatherv(
+        handle, d_mg_renumber_map_labels.data(), d_mg_renumber_map_labels.size());
+      auto d_mg_aggregate_distances =
+        cugraph::test::device_gatherv(handle, d_mg_distances.data(), d_mg_distances.size());
+      auto d_mg_aggregate_predecessors =
+        cugraph::test::device_gatherv(handle, d_mg_predecessors.data(), d_mg_predecessors.size());
 
-      auto sg_graph_view = sg_graph.view();
+      if (handle.get_comms().get_rank() == int{0}) {
+        // 4-2. unrenumbr MG results
 
-      std::vector<vertex_t> vertex_partition_lasts(comm_size);
-      for (size_t i = 0; i < vertex_partition_lasts.size(); ++i) {
-        vertex_partition_lasts[i] = mg_graph_view.get_vertex_partition_last(i);
-      }
+        cugraph::experimental::unrenumber_int_vertices<vertex_t, false>(
+          handle,
+          d_mg_aggregate_predecessors.data(),
+          d_mg_aggregate_predecessors.size(),
+          d_mg_aggregate_renumber_map_labels.data(),
+          vertex_t{0},
+          mg_graph_view.get_number_of_vertices(),
+          std::vector<vertex_t>{mg_graph_view.get_number_of_vertices()});
 
-      rmm::device_scalar<vertex_t> d_source(static_cast<vertex_t>(bfs_usecase.source),
-                                            handle.get_stream());
-      cugraph::experimental::unrenumber_int_vertices<vertex_t, true>(
-        handle,
-        d_source.data(),
-        size_t{1},
-        d_mg_renumber_map_labels.data(),
-        mg_graph_view.get_local_vertex_first(),
-        mg_graph_view.get_local_vertex_last(),
-        vertex_partition_lasts,
-        true);
-      auto unrenumbered_source = d_source.value(handle.get_stream());
+        std::tie(std::ignore, d_mg_aggregate_distances) =
+          cugraph::test::sort_by_key(handle,
+                                     d_mg_aggregate_renumber_map_labels.data(),
+                                     d_mg_aggregate_distances.data(),
+                                     d_mg_aggregate_renumber_map_labels.size());
+        std::tie(std::ignore, d_mg_aggregate_predecessors) =
+          cugraph::test::sort_by_key(handle,
+                                     d_mg_aggregate_renumber_map_labels.data(),
+                                     d_mg_aggregate_predecessors.data(),
+                                     d_mg_aggregate_renumber_map_labels.size());
 
-      // 5-2. run SG BFS
+        // 4-3. create SG graph
 
-      rmm::device_uvector<vertex_t> d_sg_distances(sg_graph_view.get_number_of_local_vertices(),
-                                                   handle.get_stream());
-      rmm::device_uvector<vertex_t> d_sg_predecessors(sg_graph_view.get_number_of_local_vertices(),
-                                                      handle.get_stream());
+        cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, false, false> sg_graph(handle);
+        std::tie(sg_graph, std::ignore) =
+          input_usecase.template construct_graph<vertex_t, edge_t, weight_t, false, false>(
+            handle, false, false);
 
-      cugraph::experimental::bfs(handle,
-                                 sg_graph_view,
-                                 d_sg_distances.data(),
-                                 d_sg_predecessors.data(),
-                                 unrenumbered_source,
-                                 false,
-                                 std::numeric_limits<vertex_t>::max());
+        auto sg_graph_view = sg_graph.view();
 
-      // 5-3. compare
+        ASSERT_TRUE(mg_graph_view.get_number_of_vertices() ==
+                    sg_graph_view.get_number_of_vertices());
 
-      std::vector<edge_t> h_sg_offsets(sg_graph_view.get_number_of_vertices() + 1);
-      std::vector<vertex_t> h_sg_indices(sg_graph_view.get_number_of_edges());
-      raft::update_host(h_sg_offsets.data(),
-                        sg_graph_view.offsets(),
-                        sg_graph_view.get_number_of_vertices() + 1,
-                        handle.get_stream());
-      raft::update_host(h_sg_indices.data(),
-                        sg_graph_view.indices(),
-                        sg_graph_view.get_number_of_edges(),
-                        handle.get_stream());
+        // 4-4. run SG BFS
 
-      std::vector<vertex_t> h_sg_distances(sg_graph_view.get_number_of_vertices());
-      std::vector<vertex_t> h_sg_predecessors(sg_graph_view.get_number_of_vertices());
-      raft::update_host(
-        h_sg_distances.data(), d_sg_distances.data(), d_sg_distances.size(), handle.get_stream());
-      raft::update_host(h_sg_predecessors.data(),
-                        d_sg_predecessors.data(),
-                        d_sg_predecessors.size(),
-                        handle.get_stream());
+        rmm::device_uvector<vertex_t> d_sg_distances(sg_graph_view.get_number_of_vertices(),
+                                                     handle.get_stream());
+        rmm::device_uvector<vertex_t> d_sg_predecessors(
+          sg_graph_view.get_number_of_local_vertices(), handle.get_stream());
 
-      std::vector<vertex_t> h_mg_distances(mg_graph_view.get_number_of_local_vertices());
-      std::vector<vertex_t> h_mg_predecessors(mg_graph_view.get_number_of_local_vertices());
-      raft::update_host(
-        h_mg_distances.data(), d_mg_distances.data(), d_mg_distances.size(), handle.get_stream());
-      cugraph::experimental::unrenumber_int_vertices<vertex_t, true>(
-        handle,
-        d_mg_predecessors.data(),
-        d_mg_predecessors.size(),
-        d_mg_renumber_map_labels.data(),
-        mg_graph_view.get_local_vertex_first(),
-        mg_graph_view.get_local_vertex_last(),
-        vertex_partition_lasts,
-        true);
-      raft::update_host(h_mg_predecessors.data(),
-                        d_mg_predecessors.data(),
-                        d_mg_predecessors.size(),
-                        handle.get_stream());
+        vertex_t unrenumbered_source{};
+        raft::update_host(&unrenumbered_source,
+                          d_mg_aggregate_renumber_map_labels.data() + bfs_usecase.source,
+                          size_t{1},
+                          handle.get_stream());
+        handle.get_stream_view().synchronize();
 
-      std::vector<vertex_t> h_mg_renumber_map_labels(d_mg_renumber_map_labels.size());
-      raft::update_host(h_mg_renumber_map_labels.data(),
-                        d_mg_renumber_map_labels.data(),
-                        d_mg_renumber_map_labels.size(),
-                        handle.get_stream());
+        cugraph::experimental::bfs(handle,
+                                   sg_graph_view,
+                                   d_sg_distances.data(),
+                                   d_sg_predecessors.data(),
+                                   unrenumbered_source,
+                                   false,
+                                   std::numeric_limits<vertex_t>::max());
+        // 4-5. compare
 
-      handle.get_stream_view().synchronize();
+        std::vector<edge_t> h_sg_offsets(sg_graph_view.get_number_of_vertices() + 1);
+        std::vector<vertex_t> h_sg_indices(sg_graph_view.get_number_of_edges());
+        raft::update_host(h_sg_offsets.data(),
+                          sg_graph_view.offsets(),
+                          sg_graph_view.get_number_of_vertices() + 1,
+                          handle.get_stream());
+        raft::update_host(h_sg_indices.data(),
+                          sg_graph_view.indices(),
+                          sg_graph_view.get_number_of_edges(),
+                          handle.get_stream());
 
-      for (vertex_t i = 0; i < mg_graph_view.get_number_of_local_vertices(); ++i) {
-        auto mapped_vertex = h_mg_renumber_map_labels[i];
-        ASSERT_TRUE(h_mg_distances[i] == h_sg_distances[mapped_vertex])
-          << "MG BFS distance for vertex: " << mapped_vertex << " in rank: " << comm_rank
-          << " has value: " << h_mg_distances[i]
-          << " different from the corresponding SG value: " << h_sg_distances[mapped_vertex];
-        if (h_mg_predecessors[i] == cugraph::invalid_vertex_id<vertex_t>::value) {
-          ASSERT_TRUE(h_sg_predecessors[mapped_vertex] == h_mg_predecessors[i])
-            << "vertex reachability does not match with the SG result.";
-        } else {
-          ASSERT_TRUE(h_sg_distances[h_mg_predecessors[i]] + 1 == h_sg_distances[mapped_vertex])
-            << "distances to this vertex != distances to the predecessor vertex + 1.";
-          bool found{false};
-          for (auto j = h_sg_offsets[h_mg_predecessors[i]];
-               j < h_sg_offsets[h_mg_predecessors[i] + 1];
-               ++j) {
-            if (h_sg_indices[j] == mapped_vertex) {
-              found = true;
-              break;
+        std::vector<vertex_t> h_mg_aggregate_distances(mg_graph_view.get_number_of_vertices());
+        std::vector<vertex_t> h_mg_aggregate_predecessors(mg_graph_view.get_number_of_vertices());
+
+        raft::update_host(h_mg_aggregate_distances.data(),
+                          d_mg_aggregate_distances.data(),
+                          d_mg_aggregate_distances.size(),
+                          handle.get_stream());
+        raft::update_host(h_mg_aggregate_predecessors.data(),
+                          d_mg_aggregate_predecessors.data(),
+                          d_mg_aggregate_predecessors.size(),
+                          handle.get_stream());
+
+        std::vector<vertex_t> h_sg_distances(sg_graph_view.get_number_of_vertices());
+        std::vector<vertex_t> h_sg_predecessors(sg_graph_view.get_number_of_vertices());
+
+        raft::update_host(
+          h_sg_distances.data(), d_sg_distances.data(), d_sg_distances.size(), handle.get_stream());
+        raft::update_host(h_sg_predecessors.data(),
+                          d_sg_predecessors.data(),
+                          d_sg_predecessors.size(),
+                          handle.get_stream());
+
+        handle.get_stream_view().synchronize();
+
+        ASSERT_TRUE(std::equal(h_mg_aggregate_distances.begin(),
+                               h_mg_aggregate_distances.end(),
+                               h_sg_distances.begin()));
+        for (size_t i = 0; i < h_mg_aggregate_predecessors.size(); ++i) {
+          if (h_mg_aggregate_predecessors[i] == cugraph::invalid_vertex_id<vertex_t>::value) {
+            ASSERT_TRUE(h_sg_predecessors[i] == h_mg_aggregate_predecessors[i])
+              << "vertex reachability does not match with the SG result.";
+          } else {
+            ASSERT_TRUE(h_sg_distances[h_mg_aggregate_predecessors[i]] + 1 == h_sg_distances[i])
+              << "distances to this vertex != distances to the predecessor vertex + 1.";
+            bool found{false};
+            for (auto j = h_sg_offsets[h_mg_aggregate_predecessors[i]];
+                 j < h_sg_offsets[h_mg_aggregate_predecessors[i] + 1];
+                 ++j) {
+              if (h_sg_indices[j] == i) {
+                found = true;
+                break;
+              }
             }
+            ASSERT_TRUE(found) << "no edge from the predecessor vertex to this vertex.";
           }
-          ASSERT_TRUE(found) << "no edge from the predecessor vertex to this vertex.";
         }
       }
     }

--- a/cpp/tests/experimental/mg_katz_centrality_test.cpp
+++ b/cpp/tests/experimental/mg_katz_centrality_test.cpp
@@ -78,6 +78,7 @@ class Tests_MGKatzCentrality
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       hr_clock.start();
     }
     cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, true, true> mg_graph(handle);
@@ -88,6 +89,7 @@ class Tests_MGKatzCentrality
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "MG construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -110,6 +112,7 @@ class Tests_MGKatzCentrality
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       hr_clock.start();
     }
 
@@ -125,6 +128,7 @@ class Tests_MGKatzCentrality
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "MG Katz Centrality took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/experimental/mg_katz_centrality_test.cpp
+++ b/cpp/tests/experimental/mg_katz_centrality_test.cpp
@@ -16,6 +16,7 @@
 
 #include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/device_comm_wrapper.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>
 
@@ -132,68 +133,81 @@ class Tests_MGKatzCentrality
     // 5. copmare SG & MG results
 
     if (katz_usecase.check_correctness) {
-      // 5-1. create SG graph
+      // 5-1. aggregate MG results
 
-      cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, true, false> sg_graph(handle);
-      std::tie(sg_graph, std::ignore) =
-        input_usecase.template construct_graph<vertex_t, edge_t, weight_t, true, false>(
-          handle, true, false);
+      auto d_mg_aggregate_renumber_map_labels = cugraph::test::device_gatherv(
+        handle, d_mg_renumber_map_labels.data(), d_mg_renumber_map_labels.size());
+      auto d_mg_aggregate_katz_centralities = cugraph::test::device_gatherv(
+        handle, d_mg_katz_centralities.data(), d_mg_katz_centralities.size());
 
-      auto sg_graph_view = sg_graph.view();
+      if (handle.get_comms().get_rank() == int{0}) {
+        // 5-2. unrenumbr MG results
 
-      // 5-3. run SG Katz Centrality
+        std::tie(std::ignore, d_mg_aggregate_katz_centralities) =
+          cugraph::test::sort_by_key(handle,
+                                     d_mg_aggregate_renumber_map_labels.data(),
+                                     d_mg_aggregate_katz_centralities.data(),
+                                     d_mg_aggregate_renumber_map_labels.size());
 
-      rmm::device_uvector<result_t> d_sg_katz_centralities(sg_graph_view.get_number_of_vertices(),
-                                                           handle.get_stream());
+        // 5-3. create SG graph
 
-      cugraph::experimental::katz_centrality(handle,
-                                             sg_graph_view,
-                                             static_cast<result_t *>(nullptr),
-                                             d_sg_katz_centralities.data(),
-                                             alpha,
-                                             beta,
-                                             epsilon,
-                                             std::numeric_limits<size_t>::max(),  // max_iterations
-                                             false);
+        cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, true, false> sg_graph(handle);
+        std::tie(sg_graph, std::ignore) =
+          input_usecase.template construct_graph<vertex_t, edge_t, weight_t, true, false>(
+            handle, true, false);
 
-      // 5-4. compare
+        auto sg_graph_view = sg_graph.view();
 
-      std::vector<result_t> h_sg_katz_centralities(sg_graph_view.get_number_of_vertices());
-      raft::update_host(h_sg_katz_centralities.data(),
-                        d_sg_katz_centralities.data(),
-                        d_sg_katz_centralities.size(),
-                        handle.get_stream());
+        ASSERT_TRUE(mg_graph_view.get_number_of_vertices() ==
+                    sg_graph_view.get_number_of_vertices());
 
-      std::vector<result_t> h_mg_katz_centralities(mg_graph_view.get_number_of_local_vertices());
-      raft::update_host(h_mg_katz_centralities.data(),
-                        d_mg_katz_centralities.data(),
-                        d_mg_katz_centralities.size(),
-                        handle.get_stream());
+        // 5-4. run SG Katz Centrality
 
-      std::vector<vertex_t> h_mg_renumber_map_labels(d_mg_renumber_map_labels.size());
-      raft::update_host(h_mg_renumber_map_labels.data(),
-                        d_mg_renumber_map_labels.data(),
-                        d_mg_renumber_map_labels.size(),
-                        handle.get_stream());
+        rmm::device_uvector<result_t> d_sg_katz_centralities(sg_graph_view.get_number_of_vertices(),
+                                                             handle.get_stream());
 
-      handle.get_stream_view().synchronize();
+        cugraph::experimental::katz_centrality(
+          handle,
+          sg_graph_view,
+          static_cast<result_t *>(nullptr),
+          d_sg_katz_centralities.data(),
+          alpha,
+          beta,
+          epsilon,
+          std::numeric_limits<size_t>::max(),  // max_iterations
+          false);
 
-      auto threshold_ratio = 1e-3;
-      auto threshold_magnitude =
-        (1.0 / static_cast<result_t>(mg_graph_view.get_number_of_vertices())) *
-        threshold_ratio;  // skip comparison for low KatzCentrality verties (lowly ranked vertices)
-      auto nearly_equal = [threshold_ratio, threshold_magnitude](auto lhs, auto rhs) {
-        return std::abs(lhs - rhs) <
-               std::max(std::max(lhs, rhs) * threshold_ratio, threshold_magnitude);
-      };
+        // 5-5. compare
 
-      for (vertex_t i = 0; i < mg_graph_view.get_number_of_local_vertices(); ++i) {
-        auto mapped_vertex = h_mg_renumber_map_labels[i];
-        ASSERT_TRUE(nearly_equal(h_mg_katz_centralities[i], h_sg_katz_centralities[mapped_vertex]))
-          << "MG KatzCentrality value for vertex: " << mapped_vertex << " in rank: " << comm_rank
-          << " has value: " << h_mg_katz_centralities[i]
-          << " which exceeds the error margin for comparing to SG value: "
-          << h_sg_katz_centralities[mapped_vertex];
+        std::vector<result_t> h_mg_aggregate_katz_centralities(
+          mg_graph_view.get_number_of_vertices());
+        raft::update_host(h_mg_aggregate_katz_centralities.data(),
+                          d_mg_aggregate_katz_centralities.data(),
+                          d_mg_aggregate_katz_centralities.size(),
+                          handle.get_stream());
+
+        std::vector<result_t> h_sg_katz_centralities(sg_graph_view.get_number_of_vertices());
+        raft::update_host(h_sg_katz_centralities.data(),
+                          d_sg_katz_centralities.data(),
+                          d_sg_katz_centralities.size(),
+                          handle.get_stream());
+
+        handle.get_stream_view().synchronize();
+
+        auto threshold_ratio = 1e-3;
+        auto threshold_magnitude =
+          (1.0 / static_cast<result_t>(mg_graph_view.get_number_of_vertices())) *
+          threshold_ratio;  // skip comparison for low KatzCentrality verties (lowly ranked
+                            // vertices)
+        auto nearly_equal = [threshold_ratio, threshold_magnitude](auto lhs, auto rhs) {
+          return std::abs(lhs - rhs) <
+                 std::max(std::max(lhs, rhs) * threshold_ratio, threshold_magnitude);
+        };
+
+        ASSERT_TRUE(std::equal(h_mg_aggregate_katz_centralities.begin(),
+                               h_mg_aggregate_katz_centralities.end(),
+                               h_sg_katz_centralities.begin(),
+                               nearly_equal));
       }
     }
   }

--- a/cpp/tests/experimental/mg_sssp_test.cpp
+++ b/cpp/tests/experimental/mg_sssp_test.cpp
@@ -16,6 +16,7 @@
 
 #include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/device_comm_wrapper.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>
 
@@ -110,7 +111,6 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
       hr_clock.start();
     }
 
-    // FIXME: disable do_expensive_check
     cugraph::experimental::sssp(handle,
                                 mg_graph_view,
                                 d_mg_distances.data(),
@@ -125,132 +125,144 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
       std::cout << "MG SSSP took " << elapsed_time * 1e-6 << " s.\n";
     }
 
-    // 5. copmare SG & MG results
+    // 4. copmare SG & MG results
 
     if (sssp_usecase.check_correctness) {
-      // 5-1. create SG graph
+      // 4-1. aggregate MG results
 
-      cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, false, false> sg_graph(handle);
-      std::tie(sg_graph, std::ignore) =
-        input_usecase.template construct_graph<vertex_t, edge_t, weight_t, false, false>(
-          handle, true, false);
+      auto d_mg_aggregate_renumber_map_labels = cugraph::test::device_gatherv(
+        handle, d_mg_renumber_map_labels.data(), d_mg_renumber_map_labels.size());
+      auto d_mg_aggregate_distances =
+        cugraph::test::device_gatherv(handle, d_mg_distances.data(), d_mg_distances.size());
+      auto d_mg_aggregate_predecessors =
+        cugraph::test::device_gatherv(handle, d_mg_predecessors.data(), d_mg_predecessors.size());
 
-      auto sg_graph_view = sg_graph.view();
+      if (handle.get_comms().get_rank() == int{0}) {
+        // 4-2. unrenumber MG results
 
-      std::vector<vertex_t> vertex_partition_lasts(comm_size);
-      for (size_t i = 0; i < vertex_partition_lasts.size(); ++i) {
-        vertex_partition_lasts[i] = mg_graph_view.get_vertex_partition_last(i);
-      }
+        cugraph::experimental::unrenumber_int_vertices<vertex_t, false>(
+          handle,
+          d_mg_aggregate_predecessors.data(),
+          d_mg_aggregate_predecessors.size(),
+          d_mg_aggregate_renumber_map_labels.data(),
+          vertex_t{0},
+          mg_graph_view.get_number_of_vertices(),
+          std::vector<vertex_t>{mg_graph_view.get_number_of_vertices()});
 
-      rmm::device_scalar<vertex_t> d_source(static_cast<vertex_t>(sssp_usecase.source),
-                                            handle.get_stream());
-      cugraph::experimental::unrenumber_int_vertices<vertex_t, true>(
-        handle,
-        d_source.data(),
-        size_t{1},
-        d_mg_renumber_map_labels.data(),
-        mg_graph_view.get_local_vertex_first(),
-        mg_graph_view.get_local_vertex_last(),
-        vertex_partition_lasts,
-        true);
-      auto unrenumbered_source = d_source.value(handle.get_stream());
+        std::tie(std::ignore, d_mg_aggregate_distances) =
+          cugraph::test::sort_by_key(handle,
+                                     d_mg_aggregate_renumber_map_labels.data(),
+                                     d_mg_aggregate_distances.data(),
+                                     d_mg_aggregate_renumber_map_labels.size());
+        std::tie(std::ignore, d_mg_aggregate_predecessors) =
+          cugraph::test::sort_by_key(handle,
+                                     d_mg_aggregate_renumber_map_labels.data(),
+                                     d_mg_aggregate_predecessors.data(),
+                                     d_mg_aggregate_renumber_map_labels.size());
 
-      // 5-2. run SG SSSP
+        // 4-3. create SG graph
 
-      rmm::device_uvector<weight_t> d_sg_distances(sg_graph_view.get_number_of_local_vertices(),
-                                                   handle.get_stream());
-      rmm::device_uvector<vertex_t> d_sg_predecessors(sg_graph_view.get_number_of_local_vertices(),
-                                                      handle.get_stream());
+        cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, false, false> sg_graph(handle);
+        std::tie(sg_graph, std::ignore) =
+          input_usecase.template construct_graph<vertex_t, edge_t, weight_t, false, false>(
+            handle, true, false);
 
-      // FIXME: disable do_expensive_check
-      cugraph::experimental::sssp(handle,
-                                  sg_graph_view,
-                                  d_sg_distances.data(),
-                                  d_sg_predecessors.data(),
-                                  unrenumbered_source,
-                                  std::numeric_limits<weight_t>::max());
+        auto sg_graph_view = sg_graph.view();
 
-      // 5-3. compare
+        ASSERT_TRUE(mg_graph_view.get_number_of_vertices() ==
+                    sg_graph_view.get_number_of_vertices());
 
-      std::vector<edge_t> h_sg_offsets(sg_graph_view.get_number_of_vertices() + 1);
-      std::vector<vertex_t> h_sg_indices(sg_graph_view.get_number_of_edges());
-      std::vector<weight_t> h_sg_weights(sg_graph_view.get_number_of_edges());
-      raft::update_host(h_sg_offsets.data(),
-                        sg_graph_view.offsets(),
-                        sg_graph_view.get_number_of_vertices() + 1,
-                        handle.get_stream());
-      raft::update_host(h_sg_indices.data(),
-                        sg_graph_view.indices(),
-                        sg_graph_view.get_number_of_edges(),
-                        handle.get_stream());
-      raft::update_host(h_sg_weights.data(),
-                        sg_graph_view.weights(),
-                        sg_graph_view.get_number_of_edges(),
-                        handle.get_stream());
+        // 4-4. run SG SSSP
 
-      std::vector<weight_t> h_sg_distances(sg_graph_view.get_number_of_vertices());
-      std::vector<vertex_t> h_sg_predecessors(sg_graph_view.get_number_of_vertices());
-      raft::update_host(
-        h_sg_distances.data(), d_sg_distances.data(), d_sg_distances.size(), handle.get_stream());
-      raft::update_host(h_sg_predecessors.data(),
-                        d_sg_predecessors.data(),
-                        d_sg_predecessors.size(),
-                        handle.get_stream());
+        rmm::device_uvector<weight_t> d_sg_distances(sg_graph_view.get_number_of_local_vertices(),
+                                                     handle.get_stream());
+        rmm::device_uvector<vertex_t> d_sg_predecessors(
+          sg_graph_view.get_number_of_local_vertices(), handle.get_stream());
+        vertex_t unrenumbered_source{};
+        raft::update_host(&unrenumbered_source,
+                          d_mg_aggregate_renumber_map_labels.data() + sssp_usecase.source,
+                          size_t{1},
+                          handle.get_stream());
+        handle.get_stream_view().synchronize();
 
-      std::vector<weight_t> h_mg_distances(mg_graph_view.get_number_of_local_vertices());
-      std::vector<vertex_t> h_mg_predecessors(mg_graph_view.get_number_of_local_vertices());
-      raft::update_host(
-        h_mg_distances.data(), d_mg_distances.data(), d_mg_distances.size(), handle.get_stream());
-      cugraph::experimental::unrenumber_int_vertices<vertex_t, true>(
-        handle,
-        d_mg_predecessors.data(),
-        d_mg_predecessors.size(),
-        d_mg_renumber_map_labels.data(),
-        mg_graph_view.get_local_vertex_first(),
-        mg_graph_view.get_local_vertex_last(),
-        vertex_partition_lasts,
-        true);
-      raft::update_host(h_mg_predecessors.data(),
-                        d_mg_predecessors.data(),
-                        d_mg_predecessors.size(),
-                        handle.get_stream());
+        cugraph::experimental::sssp(handle,
+                                    sg_graph_view,
+                                    d_sg_distances.data(),
+                                    d_sg_predecessors.data(),
+                                    unrenumbered_source,
+                                    std::numeric_limits<weight_t>::max());
 
-      std::vector<vertex_t> h_mg_renumber_map_labels(d_mg_renumber_map_labels.size());
-      raft::update_host(h_mg_renumber_map_labels.data(),
-                        d_mg_renumber_map_labels.data(),
-                        d_mg_renumber_map_labels.size(),
-                        handle.get_stream());
+        // 4-5. compare
 
-      handle.get_stream_view().synchronize();
+        std::vector<edge_t> h_sg_offsets(sg_graph_view.get_number_of_vertices() + 1);
+        std::vector<vertex_t> h_sg_indices(sg_graph_view.get_number_of_edges());
+        std::vector<weight_t> h_sg_weights(sg_graph_view.get_number_of_edges());
+        raft::update_host(h_sg_offsets.data(),
+                          sg_graph_view.offsets(),
+                          sg_graph_view.get_number_of_vertices() + 1,
+                          handle.get_stream());
+        raft::update_host(h_sg_indices.data(),
+                          sg_graph_view.indices(),
+                          sg_graph_view.get_number_of_edges(),
+                          handle.get_stream());
+        raft::update_host(h_sg_weights.data(),
+                          sg_graph_view.weights(),
+                          sg_graph_view.get_number_of_edges(),
+                          handle.get_stream());
 
-      auto max_weight_element = std::max_element(h_sg_weights.begin(), h_sg_weights.end());
-      auto epsilon            = *max_weight_element * weight_t{1e-6};
-      auto nearly_equal = [epsilon](auto lhs, auto rhs) { return std::fabs(lhs - rhs) < epsilon; };
+        std::vector<weight_t> h_mg_aggregate_distances(mg_graph_view.get_number_of_vertices());
+        std::vector<vertex_t> h_mg_aggregate_predecessors(mg_graph_view.get_number_of_vertices());
+        raft::update_host(h_mg_aggregate_distances.data(),
+                          d_mg_aggregate_distances.data(),
+                          d_mg_aggregate_distances.size(),
+                          handle.get_stream());
+        raft::update_host(h_mg_aggregate_predecessors.data(),
+                          d_mg_aggregate_predecessors.data(),
+                          d_mg_aggregate_predecessors.size(),
+                          handle.get_stream());
 
-      for (vertex_t i = 0; i < mg_graph_view.get_number_of_local_vertices(); ++i) {
-        auto mapped_vertex = h_mg_renumber_map_labels[i];
-        ASSERT_TRUE(nearly_equal(h_mg_distances[i], h_sg_distances[mapped_vertex]))
-          << "MG SSSP distance for vertex: " << mapped_vertex << " in rank: " << comm_rank
-          << " has value: " << h_mg_distances[i]
-          << " different from the corresponding SG value: " << h_sg_distances[mapped_vertex];
-        if (h_mg_predecessors[i] == cugraph::invalid_vertex_id<vertex_t>::value) {
-          ASSERT_TRUE(h_sg_predecessors[mapped_vertex] == h_mg_predecessors[i])
-            << "vertex reachability does not match with the SG result.";
-        } else {
-          auto pred_distance = h_sg_distances[h_mg_predecessors[i]];
-          bool found{false};
-          for (auto j = h_sg_offsets[h_mg_predecessors[i]];
-               j < h_sg_offsets[h_mg_predecessors[i] + 1];
-               ++j) {
-            if (h_sg_indices[j] == mapped_vertex) {
-              if (nearly_equal(pred_distance + h_sg_weights[j], h_sg_distances[mapped_vertex])) {
-                found = true;
-                break;
+        std::vector<weight_t> h_sg_distances(sg_graph_view.get_number_of_vertices());
+        std::vector<vertex_t> h_sg_predecessors(sg_graph_view.get_number_of_vertices());
+        raft::update_host(
+          h_sg_distances.data(), d_sg_distances.data(), d_sg_distances.size(), handle.get_stream());
+        raft::update_host(h_sg_predecessors.data(),
+                          d_sg_predecessors.data(),
+                          d_sg_predecessors.size(),
+                          handle.get_stream());
+
+        handle.get_stream_view().synchronize();
+
+        auto max_weight_element = std::max_element(h_sg_weights.begin(), h_sg_weights.end());
+        auto epsilon            = *max_weight_element * weight_t{1e-6};
+        auto nearly_equal       = [epsilon](auto lhs, auto rhs) {
+          return std::fabs(lhs - rhs) < epsilon;
+        };
+
+        ASSERT_TRUE(std::equal(h_mg_aggregate_distances.begin(),
+                               h_mg_aggregate_distances.end(),
+                               h_sg_distances.begin(),
+                               nearly_equal));
+
+        for (size_t i = 0; i < h_mg_aggregate_predecessors.size(); ++i) {
+          if (h_mg_aggregate_predecessors[i] == cugraph::invalid_vertex_id<vertex_t>::value) {
+            ASSERT_TRUE(h_sg_predecessors[i] == h_mg_aggregate_predecessors[i])
+              << "vertex reachability does not match with the SG result.";
+          } else {
+            auto pred_distance = h_sg_distances[h_mg_aggregate_predecessors[i]];
+            bool found{false};
+            for (auto j = h_sg_offsets[h_mg_aggregate_predecessors[i]];
+                 j < h_sg_offsets[h_mg_aggregate_predecessors[i] + 1];
+                 ++j) {
+              if (h_sg_indices[j] == i) {
+                if (nearly_equal(pred_distance + h_sg_weights[j], h_sg_distances[i])) {
+                  found = true;
+                  break;
+                }
               }
             }
+            ASSERT_TRUE(found)
+              << "no edge from the predecessor vertex to this vertex with the matching weight.";
           }
-          ASSERT_TRUE(found)
-            << "no edge from the predecessor vertex to this vertex with the matching weight.";
         }
       }
     }
@@ -288,7 +300,7 @@ INSTANTIATE_TEST_SUITE_P(
   ::testing::Values(
     // enable correctness checks
     std::make_tuple(SSSP_Usecase{0},
-                    cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false))));
+                    cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false, true))));
 
 INSTANTIATE_TEST_SUITE_P(
   rmat_large_test,
@@ -296,6 +308,6 @@ INSTANTIATE_TEST_SUITE_P(
   ::testing::Values(
     // disable correctness checks for large graphs
     std::make_tuple(SSSP_Usecase{0, false},
-                    cugraph::test::Rmat_Usecase(20, 32, 0.57, 0.19, 0.19, 0, false, false))));
+                    cugraph::test::Rmat_Usecase(20, 32, 0.57, 0.19, 0.19, 0, false, false, true))));
 
 CUGRAPH_MG_TEST_PROGRAM_MAIN()

--- a/cpp/tests/experimental/mg_sssp_test.cpp
+++ b/cpp/tests/experimental/mg_sssp_test.cpp
@@ -78,6 +78,7 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       hr_clock.start();
     }
     cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, false, true> mg_graph(handle);
@@ -88,6 +89,7 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "MG construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -108,6 +110,7 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       hr_clock.start();
     }
 
@@ -120,6 +123,7 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "MG SSSP took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/experimental/pagerank_test.cpp
+++ b/cpp/tests/experimental/pagerank_test.cpp
@@ -303,10 +303,11 @@ class Tests_PageRank
           d_renumber_map_labels.data(),
           vertex_t{0},
           graph_view.get_number_of_vertices());
-        cugraph::test::sort_by_key(handle,
-                                   d_unrenumbered_personalization_vertices.data(),
-                                   d_unrenumbered_personalization_values.data(),
-                                   d_unrenumbered_personalization_vertices.size());
+        std::tie(d_unrenumbered_personalization_vertices, d_unrenumbered_personalization_values) =
+          cugraph::test::sort_by_key(handle,
+                                     d_unrenumbered_personalization_vertices.data(),
+                                     d_unrenumbered_personalization_values.data(),
+                                     d_unrenumbered_personalization_vertices.size());
 
         raft::update_host(h_unrenumbered_personalization_vertices.data(),
                           d_unrenumbered_personalization_vertices.data(),
@@ -346,7 +347,8 @@ class Tests_PageRank
 
       std::vector<result_t> h_cugraph_pageranks(graph_view.get_number_of_vertices());
       if (renumber) {
-        auto d_unrenumbered_pageranks = cugraph::test::sort_by_key(
+        rmm::device_uvector<result_t> d_unrenumbered_pageranks(size_t{0}, handle.get_stream());
+        std::tie(std::ignore, d_unrenumbered_pageranks) = cugraph::test::sort_by_key(
           handle, d_renumber_map_labels.data(), d_pageranks.data(), d_renumber_map_labels.size());
         raft::update_host(h_cugraph_pageranks.data(),
                           d_unrenumbered_pageranks.data(),

--- a/cpp/tests/experimental/sssp_test.cpp
+++ b/cpp/tests/experimental/sssp_test.cpp
@@ -220,12 +220,15 @@ class Tests_SSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, inpu
                                                              graph_view.get_number_of_vertices(),
                                                              true);
 
-        auto d_unrenumbered_distances = cugraph::test::sort_by_key(
+        rmm::device_uvector<weight_t> d_unrenumbered_distances(size_t{0}, handle.get_stream());
+        std::tie(std::ignore, d_unrenumbered_distances) = cugraph::test::sort_by_key(
           handle, d_renumber_map_labels.data(), d_distances.data(), d_renumber_map_labels.size());
-        auto d_unrenumbered_predecessors = cugraph::test::sort_by_key(handle,
-                                                                      d_renumber_map_labels.data(),
-                                                                      d_predecessors.data(),
-                                                                      d_renumber_map_labels.size());
+        rmm::device_uvector<vertex_t> d_unrenumbered_predecessors(size_t{0}, handle.get_stream());
+        std::tie(std::ignore, d_unrenumbered_predecessors) =
+          cugraph::test::sort_by_key(handle,
+                                     d_renumber_map_labels.data(),
+                                     d_predecessors.data(),
+                                     d_renumber_map_labels.size());
 
         raft::update_host(h_cugraph_distances.data(),
                           d_unrenumbered_distances.data(),

--- a/cpp/tests/pagerank/mg_pagerank_test.cpp
+++ b/cpp/tests/pagerank/mg_pagerank_test.cpp
@@ -16,6 +16,7 @@
 
 #include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/device_comm_wrapper.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>
 
@@ -171,135 +172,96 @@ class Tests_MGPageRank
     // 5. copmare SG & MG results
 
     if (pagerank_usecase.check_correctness) {
-      // 5-1. create SG graph
+      // 5-1. aggregate MG results
 
-      cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, true, false> sg_graph(handle);
-      std::tie(sg_graph, std::ignore) =
-        input_usecase.template construct_graph<vertex_t, edge_t, weight_t, true, false>(
-          handle, true, false);
+      auto d_mg_aggregate_renumber_map_labels = cugraph::test::device_gatherv(
+        handle, d_mg_renumber_map_labels.data(), d_mg_renumber_map_labels.size());
+      auto d_mg_aggregate_personalization_vertices = cugraph::test::device_gatherv(
+        handle, d_mg_personalization_vertices.data(), d_mg_personalization_vertices.size());
+      auto d_mg_aggregate_personalization_values = cugraph::test::device_gatherv(
+        handle, d_mg_personalization_values.data(), d_mg_personalization_values.size());
+      auto d_mg_aggregate_pageranks =
+        cugraph::test::device_gatherv(handle, d_mg_pageranks.data(), d_mg_pageranks.size());
 
-      auto sg_graph_view = sg_graph.view();
+      if (handle.get_comms().get_rank() == int{0}) {
+        // 5-2. unrenumbr MG results
 
-      // 5-2. collect personalization vertex/value pairs
-
-      rmm::device_uvector<vertex_t> d_sg_personalization_vertices(0, handle.get_stream());
-      rmm::device_uvector<result_t> d_sg_personalization_values(0, handle.get_stream());
-      if (pagerank_usecase.personalization_ratio > 0.0) {
-        rmm::device_uvector<vertex_t> d_unrenumbered_personalization_vertices(
-          d_mg_personalization_vertices.size(), handle.get_stream());
-        rmm::device_uvector<result_t> d_unrenumbered_personalization_values(
-          d_unrenumbered_personalization_vertices.size(), handle.get_stream());
-        raft::copy_async(d_unrenumbered_personalization_vertices.data(),
-                         d_mg_personalization_vertices.data(),
-                         d_mg_personalization_vertices.size(),
-                         handle.get_stream());
-        raft::copy_async(d_unrenumbered_personalization_values.data(),
-                         d_mg_personalization_values.data(),
-                         d_mg_personalization_values.size(),
-                         handle.get_stream());
-
-        std::vector<vertex_t> vertex_partition_lasts(comm_size);
-        for (size_t i = 0; i < vertex_partition_lasts.size(); ++i) {
-          vertex_partition_lasts[i] = mg_graph_view.get_vertex_partition_last(i);
-        }
-        cugraph::experimental::unrenumber_int_vertices<vertex_t, true>(
+        cugraph::experimental::unrenumber_int_vertices<vertex_t, false>(
           handle,
-          d_unrenumbered_personalization_vertices.data(),
-          d_unrenumbered_personalization_vertices.size(),
-          d_mg_renumber_map_labels.data(),
-          mg_graph_view.get_local_vertex_first(),
-          mg_graph_view.get_local_vertex_last(),
-          vertex_partition_lasts,
-          handle.get_stream());
-
-        rmm::device_scalar<size_t> d_local_personalization_vector_size(
-          d_unrenumbered_personalization_vertices.size(), handle.get_stream());
-        rmm::device_uvector<size_t> d_recvcounts(comm_size, handle.get_stream());
-        comm.allgather(
-          d_local_personalization_vector_size.data(), d_recvcounts.data(), 1, handle.get_stream());
-        std::vector<size_t> recvcounts(d_recvcounts.size());
-        raft::update_host(
-          recvcounts.data(), d_recvcounts.data(), d_recvcounts.size(), handle.get_stream());
-        auto status = comm.sync_stream(handle.get_stream());
-        ASSERT_EQ(status, raft::comms::status_t::SUCCESS);
-
-        std::vector<size_t> displacements(recvcounts.size(), size_t{0});
-        std::partial_sum(recvcounts.begin(), recvcounts.end() - 1, displacements.begin() + 1);
-
-        d_sg_personalization_vertices.resize(displacements.back() + recvcounts.back(),
-                                             handle.get_stream());
-        d_sg_personalization_values.resize(d_sg_personalization_vertices.size(),
-                                           handle.get_stream());
-
-        comm.allgatherv(d_unrenumbered_personalization_vertices.data(),
-                        d_sg_personalization_vertices.data(),
-                        recvcounts.data(),
-                        displacements.data(),
-                        handle.get_stream());
-        comm.allgatherv(d_unrenumbered_personalization_values.data(),
-                        d_sg_personalization_values.data(),
-                        recvcounts.data(),
-                        displacements.data(),
-                        handle.get_stream());
-
-        std::tie(d_unrenumbered_personalization_vertices, d_unrenumbered_personalization_values) =
+          d_mg_aggregate_personalization_vertices.data(),
+          d_mg_aggregate_personalization_vertices.size(),
+          d_mg_aggregate_renumber_map_labels.data(),
+          vertex_t{0},
+          mg_graph_view.get_number_of_vertices(),
+          std::vector<vertex_t>{mg_graph_view.get_number_of_vertices()});
+        std::tie(d_mg_aggregate_personalization_vertices, d_mg_aggregate_personalization_values) =
           cugraph::test::sort_by_key(handle,
-                                     d_unrenumbered_personalization_vertices.data(),
-                                     d_unrenumbered_personalization_values.data(),
-                                     d_unrenumbered_personalization_vertices.size());
-      }
+                                     d_mg_aggregate_personalization_vertices.data(),
+                                     d_mg_aggregate_personalization_values.data(),
+                                     d_mg_aggregate_personalization_vertices.size());
+        std::tie(std::ignore, d_mg_aggregate_pageranks) =
+          cugraph::test::sort_by_key(handle,
+                                     d_mg_aggregate_renumber_map_labels.data(),
+                                     d_mg_aggregate_pageranks.data(),
+                                     d_mg_aggregate_renumber_map_labels.size());
 
-      // 5-3. run SG PageRank
+        // 5-3. create SG graph
 
-      rmm::device_uvector<result_t> d_sg_pageranks(sg_graph_view.get_number_of_vertices(),
-                                                   handle.get_stream());
+        cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, true, false> sg_graph(handle);
+        std::tie(sg_graph, std::ignore) =
+          input_usecase.template construct_graph<vertex_t, edge_t, weight_t, true, false>(
+            handle, true, false);
 
-      cugraph::experimental::pagerank(handle,
-                                      sg_graph_view,
-                                      static_cast<weight_t*>(nullptr),
-                                      d_sg_personalization_vertices.data(),
-                                      d_sg_personalization_values.data(),
-                                      static_cast<vertex_t>(d_sg_personalization_vertices.size()),
-                                      d_sg_pageranks.data(),
-                                      alpha,
-                                      epsilon,
-                                      std::numeric_limits<size_t>::max(),  // max_iterations
-                                      false);
+        auto sg_graph_view = sg_graph.view();
 
-      // 5-4. compare
+        ASSERT_TRUE(mg_graph_view.get_number_of_vertices() ==
+                    sg_graph_view.get_number_of_vertices());
 
-      std::vector<result_t> h_sg_pageranks(sg_graph_view.get_number_of_vertices());
-      raft::update_host(
-        h_sg_pageranks.data(), d_sg_pageranks.data(), d_sg_pageranks.size(), handle.get_stream());
+        // 5-4. run SG PageRank
 
-      std::vector<result_t> h_mg_pageranks(mg_graph_view.get_number_of_local_vertices());
-      raft::update_host(
-        h_mg_pageranks.data(), d_mg_pageranks.data(), d_mg_pageranks.size(), handle.get_stream());
+        rmm::device_uvector<result_t> d_sg_pageranks(sg_graph_view.get_number_of_vertices(),
+                                                     handle.get_stream());
 
-      std::vector<vertex_t> h_mg_renumber_map_labels(d_mg_renumber_map_labels.size());
-      raft::update_host(h_mg_renumber_map_labels.data(),
-                        d_mg_renumber_map_labels.data(),
-                        d_mg_renumber_map_labels.size(),
-                        handle.get_stream());
+        cugraph::experimental::pagerank(
+          handle,
+          sg_graph_view,
+          static_cast<weight_t*>(nullptr),
+          d_mg_aggregate_personalization_vertices.data(),
+          d_mg_aggregate_personalization_values.data(),
+          static_cast<vertex_t>(d_mg_aggregate_personalization_vertices.size()),
+          d_sg_pageranks.data(),
+          alpha,
+          epsilon,
+          std::numeric_limits<size_t>::max(),  // max_iterations
+          false);
 
-      handle.get_stream_view().synchronize();
+        // 5-4. compare
 
-      auto threshold_ratio = 1e-3;
-      auto threshold_magnitude =
-        (1.0 / static_cast<result_t>(mg_graph_view.get_number_of_vertices())) *
-        threshold_ratio;  // skip comparison for low PageRank verties (lowly ranked vertices)
-      auto nearly_equal = [threshold_ratio, threshold_magnitude](auto lhs, auto rhs) {
-        return std::abs(lhs - rhs) <
-               std::max(std::max(lhs, rhs) * threshold_ratio, threshold_magnitude);
-      };
+        std::vector<result_t> h_mg_aggregate_pageranks(mg_graph_view.get_number_of_vertices());
+        raft::update_host(h_mg_aggregate_pageranks.data(),
+                          d_mg_aggregate_pageranks.data(),
+                          d_mg_aggregate_pageranks.size(),
+                          handle.get_stream());
 
-      for (vertex_t i = 0; i < mg_graph_view.get_number_of_local_vertices(); ++i) {
-        auto mapped_vertex = h_mg_renumber_map_labels[i];
-        ASSERT_TRUE(nearly_equal(h_mg_pageranks[i], h_sg_pageranks[mapped_vertex]))
-          << "MG PageRank value for vertex: " << mapped_vertex << " in rank: " << comm_rank
-          << " has value: " << h_mg_pageranks[i]
-          << " which exceeds the error margin for comparing to SG value: "
-          << h_sg_pageranks[mapped_vertex];
+        std::vector<result_t> h_sg_pageranks(sg_graph_view.get_number_of_vertices());
+        raft::update_host(
+          h_sg_pageranks.data(), d_sg_pageranks.data(), d_sg_pageranks.size(), handle.get_stream());
+
+        handle.get_stream_view().synchronize();
+
+        auto threshold_ratio = 1e-3;
+        auto threshold_magnitude =
+          (1.0 / static_cast<result_t>(mg_graph_view.get_number_of_vertices())) *
+          threshold_ratio;  // skip comparison for low PageRank verties (lowly ranked vertices)
+        auto nearly_equal = [threshold_ratio, threshold_magnitude](auto lhs, auto rhs) {
+          return std::abs(lhs - rhs) <
+                 std::max(std::max(lhs, rhs) * threshold_ratio, threshold_magnitude);
+        };
+
+        ASSERT_TRUE(std::equal(h_mg_aggregate_pageranks.begin(),
+                               h_mg_aggregate_pageranks.end(),
+                               h_sg_pageranks.begin(),
+                               nearly_equal));
       }
     }
   }

--- a/cpp/tests/pagerank/mg_pagerank_test.cpp
+++ b/cpp/tests/pagerank/mg_pagerank_test.cpp
@@ -242,10 +242,11 @@ class Tests_MGPageRank
                         displacements.data(),
                         handle.get_stream());
 
-        cugraph::test::sort_by_key(handle,
-                                   d_unrenumbered_personalization_vertices.data(),
-                                   d_unrenumbered_personalization_values.data(),
-                                   d_unrenumbered_personalization_vertices.size());
+        std::tie(d_unrenumbered_personalization_vertices, d_unrenumbered_personalization_values) =
+          cugraph::test::sort_by_key(handle,
+                                     d_unrenumbered_personalization_vertices.data(),
+                                     d_unrenumbered_personalization_values.data(),
+                                     d_unrenumbered_personalization_vertices.size());
       }
 
       // 5-3. run SG PageRank

--- a/cpp/tests/pagerank/mg_pagerank_test.cpp
+++ b/cpp/tests/pagerank/mg_pagerank_test.cpp
@@ -81,6 +81,7 @@ class Tests_MGPageRank
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       hr_clock.start();
     }
     cugraph::experimental::graph_t<vertex_t, edge_t, weight_t, true, true> mg_graph(handle);
@@ -90,6 +91,7 @@ class Tests_MGPageRank
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "MG construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -147,6 +149,7 @@ class Tests_MGPageRank
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       hr_clock.start();
     }
 
@@ -164,6 +167,7 @@ class Tests_MGPageRank
 
     if (PERF) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "MG PageRank took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/utilities/device_comm_wrapper.cu
+++ b/cpp/tests/utilities/device_comm_wrapper.cu
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "device_comm_wrapper.hpp"
+
+#include <cugraph/utilities/device_comm.cuh>
+#include <cugraph/utilities/host_scalar_comm.cuh>
+
+#include <numeric>
+#include <vector>
+
+namespace cugraph {
+namespace test {
+
+template <typename T>
+rmm::device_uvector<T> device_gatherv(raft::handle_t const &handle, T const *d_input, size_t size)
+{
+  bool is_root  = handle.get_comms().get_rank() == int{0};
+  auto rx_sizes = cugraph::experimental::host_scalar_gather(
+    handle.get_comms(), size, int{0}, handle.get_stream());
+  std::vector<size_t> rx_displs(is_root ? static_cast<size_t>(handle.get_comms().get_size())
+                                        : size_t{0});
+  if (is_root) { std::partial_sum(rx_sizes.begin(), rx_sizes.end() - 1, rx_displs.begin() + 1); }
+
+  rmm::device_uvector<T> gathered_v(
+    is_root ? std::reduce(rx_sizes.begin(), rx_sizes.end()) : size_t{0}, handle.get_stream());
+
+  cugraph::experimental::device_gatherv(handle.get_comms(),
+                                        d_input,
+                                        gathered_v.data(),
+                                        size,
+                                        rx_sizes,
+                                        rx_displs,
+                                        int{0},
+                                        handle.get_stream());
+
+  return gathered_v;
+}
+
+// explicit instantiation
+
+template rmm::device_uvector<int32_t> device_gatherv(raft::handle_t const &handle,
+                                                     int32_t const *d_input,
+                                                     size_t size);
+
+template rmm::device_uvector<int64_t> device_gatherv(raft::handle_t const &handle,
+                                                     int64_t const *d_input,
+                                                     size_t size);
+
+}  // namespace test
+}  // namespace cugraph

--- a/cpp/tests/utilities/device_comm_wrapper.cu
+++ b/cpp/tests/utilities/device_comm_wrapper.cu
@@ -60,5 +60,13 @@ template rmm::device_uvector<int64_t> device_gatherv(raft::handle_t const &handl
                                                      int64_t const *d_input,
                                                      size_t size);
 
+template rmm::device_uvector<float> device_gatherv(raft::handle_t const &handle,
+                                                     float const *d_input,
+                                                     size_t size);
+
+template rmm::device_uvector<double> device_gatherv(raft::handle_t const &handle,
+                                                     double const *d_input,
+                                                     size_t size);
+
 }  // namespace test
 }  // namespace cugraph

--- a/cpp/tests/utilities/device_comm_wrapper.cu
+++ b/cpp/tests/utilities/device_comm_wrapper.cu
@@ -61,12 +61,12 @@ template rmm::device_uvector<int64_t> device_gatherv(raft::handle_t const &handl
                                                      size_t size);
 
 template rmm::device_uvector<float> device_gatherv(raft::handle_t const &handle,
-                                                     float const *d_input,
-                                                     size_t size);
+                                                   float const *d_input,
+                                                   size_t size);
 
 template rmm::device_uvector<double> device_gatherv(raft::handle_t const &handle,
-                                                     double const *d_input,
-                                                     size_t size);
+                                                    double const *d_input,
+                                                    size_t size);
 
 }  // namespace test
 }  // namespace cugraph

--- a/cpp/tests/utilities/device_comm_wrapper.hpp
+++ b/cpp/tests/utilities/device_comm_wrapper.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/handle.hpp>
+#include <rmm/device_uvector.hpp>
+
+namespace cugraph {
+namespace test {
+
+template <typename T>
+rmm::device_uvector<T> device_gatherv(raft::handle_t const &handle, T const *d_input, size_t size);
+
+}  // namespace test
+}  // namespace cugraph

--- a/cpp/tests/utilities/thrust_wrapper.cu
+++ b/cpp/tests/utilities/thrust_wrapper.cu
@@ -26,10 +26,8 @@ namespace cugraph {
 namespace test {
 
 template <typename vertex_t, typename value_t>
-rmm::device_uvector<value_t> sort_by_key(raft::handle_t const& handle,
-                                         vertex_t const* keys,
-                                         value_t const* values,
-                                         size_t num_pairs)
+std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<value_t>> sort_by_key(
+  raft::handle_t const& handle, vertex_t const* keys, value_t const* values, size_t num_pairs)
 {
   rmm::device_uvector<vertex_t> sorted_keys(num_pairs, handle.get_stream_view());
   rmm::device_uvector<value_t> sorted_values(num_pairs, handle.get_stream_view());
@@ -44,38 +42,44 @@ rmm::device_uvector<value_t> sort_by_key(raft::handle_t const& handle,
                       sorted_keys.end(),
                       sorted_values.begin());
 
-  return sorted_values;
+  return std::make_tuple(std::move(sorted_keys), std::move(sorted_values));
 }
 
-template rmm::device_uvector<float> sort_by_key<int32_t, float>(raft::handle_t const& handle,
-                                                                int32_t const* keys,
-                                                                float const* values,
-                                                                size_t num_pairs);
+template std::tuple<rmm::device_uvector<int32_t>, rmm::device_uvector<float>>
+sort_by_key<int32_t, float>(raft::handle_t const& handle,
+                            int32_t const* keys,
+                            float const* values,
+                            size_t num_pairs);
 
-template rmm::device_uvector<double> sort_by_key<int32_t, double>(raft::handle_t const& handle,
-                                                                  int32_t const* keys,
-                                                                  double const* values,
-                                                                  size_t num_pairs);
+template std::tuple<rmm::device_uvector<int32_t>, rmm::device_uvector<double>>
+sort_by_key<int32_t, double>(raft::handle_t const& handle,
+                             int32_t const* keys,
+                             double const* values,
+                             size_t num_pairs);
 
-template rmm::device_uvector<int32_t> sort_by_key<int32_t, int32_t>(raft::handle_t const& handle,
-                                                                    int32_t const* keys,
-                                                                    int32_t const* values,
-                                                                    size_t num_pairs);
+template std::tuple<rmm::device_uvector<int32_t>, rmm::device_uvector<int32_t>>
+sort_by_key<int32_t, int32_t>(raft::handle_t const& handle,
+                              int32_t const* keys,
+                              int32_t const* values,
+                              size_t num_pairs);
 
-template rmm::device_uvector<float> sort_by_key<int64_t, float>(raft::handle_t const& handle,
-                                                                int64_t const* keys,
-                                                                float const* values,
-                                                                size_t num_pairs);
+template std::tuple<rmm::device_uvector<int64_t>, rmm::device_uvector<float>>
+sort_by_key<int64_t, float>(raft::handle_t const& handle,
+                            int64_t const* keys,
+                            float const* values,
+                            size_t num_pairs);
 
-template rmm::device_uvector<double> sort_by_key<int64_t, double>(raft::handle_t const& handle,
-                                                                  int64_t const* keys,
-                                                                  double const* values,
-                                                                  size_t num_pairs);
+template std::tuple<rmm::device_uvector<int64_t>, rmm::device_uvector<double>>
+sort_by_key<int64_t, double>(raft::handle_t const& handle,
+                             int64_t const* keys,
+                             double const* values,
+                             size_t num_pairs);
 
-template rmm::device_uvector<int64_t> sort_by_key<int64_t, int64_t>(raft::handle_t const& handle,
-                                                                    int64_t const* keys,
-                                                                    int64_t const* values,
-                                                                    size_t num_pairs);
+template std::tuple<rmm::device_uvector<int64_t>, rmm::device_uvector<int64_t>>
+sort_by_key<int64_t, int64_t>(raft::handle_t const& handle,
+                              int64_t const* keys,
+                              int64_t const* values,
+                              size_t num_pairs);
 
 }  // namespace test
 }  // namespace cugraph

--- a/cpp/tests/utilities/thrust_wrapper.hpp
+++ b/cpp/tests/utilities/thrust_wrapper.hpp
@@ -17,14 +17,14 @@
 #include <raft/handle.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <tuple>
+
 namespace cugraph {
 namespace test {
 
 template <typename vertex_t, typename value_t>
-rmm::device_uvector<value_t> sort_by_key(raft::handle_t const& handle,
-                                         vertex_t const* keys,
-                                         value_t const* values,
-                                         size_t num_pairs);
+std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<value_t>> sort_by_key(
+  raft::handle_t const& handle, vertex_t const* keys, value_t const* values, size_t num_pairs);
 
 }  // namespace test
 }  // namespace cugraph


### PR DESCRIPTION
- Move the utility function to gather distributed vectors from tests/community/mg_louvain_helper.cu to tests/utilities/device_comm_wrapper.cu and rename the function to device_gatherv
- Update MG tests to gather the MG results in root and compare with the SG result in root.
- Few more minor updates (sort_by_key thrust wrapper return value, adding missing const in input parameter, add missing include statement, add barrier in MG performance measurement)

This update is necessary to simplify MG WCC testing.