### PR TITLE
Fea rmm device buffer change

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -275,7 +275,7 @@ message("set LIBCUDACXX_INCLUDE_DIR to: ${LIBCUDACXX_INCLUDE_DIR}")
 FetchContent_Declare(
     cuhornet
     GIT_REPOSITORY    https://github.com/rapidsai/cuhornet.git
-    GIT_TAG           6d2fc894cc56dd2ca8fc9d1523a18a6ec444b663
+    GIT_TAG           261399356e62bd76fa7628880f1a847aee713eed
     SOURCE_SUBDIR     hornet
 )
 

--- a/cpp/src/traversal/sssp.cu
+++ b/cpp/src/traversal/sssp.cu
@@ -47,7 +47,7 @@ void SSSP<IndexType, DistType>::setup()
 
   // Allocate buffer for data that need to be reset every iteration
   iter_buffer_size = sizeof(int) * (edges_bmap_size + vertices_bmap_size) + sizeof(IndexType);
-  iter_buffer.resize(iter_buffer_size);
+  iter_buffer.resize(iter_buffer_size, stream);
   // ith bit of relaxed_edges_bmap <=> ith edge was relaxed
   relaxed_edges_bmap = static_cast<int *>(iter_buffer.data());
   // ith bit of next_frontier_bmap <=> vertex is active in the next frontier


### PR DESCRIPTION
RMM is going to require specifying the stream in the device_buffer constructor.

This changes the one `cugraph` item and it updates to a version of `cuhornet` that makes the necessary changes.