### PR TITLE
address 'ValueError: Series contains NULL values' from from_cudf_edge…

### DIFF
--- a/notebooks/demo/batch_betweenness.ipynb
+++ b/notebooks/demo/batch_betweenness.ipynb
@@ -138,7 +138,7 @@
    "outputs": [],
    "source": [
     "t_start_read_sg = time.perf_counter()\n",
-    "e_list = cudf.read_csv(input_data_path, delimiter='\\t', names=['src', 'dst'], dtype=['int32', 'int32'])\n",
+    "e_list = cudf.read_csv(input_data_path, delimiter='\\t', names=['src', 'dst'], dtype=['int32', 'int32'], comment='#')\n",
     "t_stop_read_sg = time.perf_counter()"
    ]
   },


### PR DESCRIPTION
`G.from_cudf_edgelist` after the `cudf.read_csv` fails with the following error -
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-7-d38ba590f728> in <module>
      1 t_start_build_sg = time.perf_counter()
      2 G = cugraph.DiGraph()
----> 3 G.from_cudf_edgelist(e_list, source='src', destination='dst')
      4 t_stop_build_sg = time.perf_counter()

/opt/conda/envs/rapids/lib/python3.7/site-packages/cugraph/structure/graph_classes.py in from_cudf_edgelist(self, input_df, source, destination, edge_attr, renumber)
    127                                                    destination=destination,
    128                                                    edge_attr=edge_attr,
--> 129                                                    renumber=renumber)
    130 
    131     def from_cudf_adjlist(self, offset_col, index_col, value_col=None):

/opt/conda/envs/rapids/lib/python3.7/site-packages/cugraph/structure/graph_implementation/simpleGraph.py in __from_edgelist(self, input_df, source, destination, edge_attr, renumber)
    171             source_col, dest_col = symmetrize(
    172                 source_col, dest_col, multi=self.properties.multi_edge,
--> 173                 symmetrize=not self.properties.directed)
    174 
    175         self.edgelist = simpleGraphImpl.EdgeList(source_col, dest_col,

/opt/conda/envs/rapids/lib/python3.7/site-packages/cugraph/structure/symmetrize.py in symmetrize(source_col, dest_col, value_col, multi, symmetrize)
    200         )
    201         csg.null_check(source_col)
--> 202         csg.null_check(dest_col)
    203     if value_col is not None:
    204         if isinstance(value_col, cudf.Series):

/opt/conda/envs/rapids/lib/python3.7/site-packages/cugraph/structure/graph_classes.py in null_check(col)
     23 def null_check(col):
     24     if col.null_count != 0:
---> 25         raise ValueError("Series contains NULL values")
     26 
     27 

ValueError: Series contains NULL values
```

the header from the input is turning into NULLs -
```
$ head soc-LiveJournal1.txt
# Directed graph (each unordered pair of nodes is saved once): soc-LiveJournal1.txt 
# Directed LiveJournal friednship social network
# Nodes: 4847571 Edges: 68993773
# FromNodeId    ToNodeId
0       1
0       2
0       3
```
`e_list`
||src|dst
|---|---|---
|0|0|NA
|1|0|NA
|2|0|NA
|3|0|0
|4|0|1
...

this issue has existed since at least 0.16 and may warrant further test coverage for cudf's read_csv.