### PR TITLE
Undo disabling MG C++ testing outputs for non-root processes

### DIFF
--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -160,11 +160,6 @@ inline auto parse_test_options(int argc, char **argv)
     auto const cmd_opts = parse_test_options(argc, argv);                             \
     auto const rmm_mode = cmd_opts["rmm_mode"].as<std::string>();                     \
     auto resource       = cugraph::test::create_memory_resource(rmm_mode);            \
-                                                                                      \
-    if (comm_rank != 0) {                                                             \
-      auto &listeners = ::testing::UnitTest::GetInstance()->listeners();              \
-      delete listeners.Release(listeners.default_result_printer());                   \
-    }                                                                                 \
     rmm::mr::set_current_device_resource(resource.get());                             \
     auto ret = RUN_ALL_TESTS();                                                       \
     MPI_TRY(MPI_Finalize());                                                          \


### PR DESCRIPTION
Disabling MG C++ testing outputs for non-root processes has an undesirable side effect of disabling error messages (e.g. exception outputs) as well. This makes failure diagnosis difficult in large-scale runs.

Delete the code disabling MG C++ testing outputs for non-root processes in this PR. In long run, we need a more elegant mechanism to disable only redundant test progress messages while still allowing error messages to be displayed.