### PR TITLE
Pass rmm memory allocator to cuco::static_map

### DIFF
--- a/cpp/src/experimental/renumber_edgelist.cu
+++ b/cpp/src/experimental/renumber_edgelist.cu
@@ -28,6 +28,8 @@
 #include <rmm/thrust_rmm_allocator.h>
 #include <raft/handle.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/device/polymorphic_allocator.hpp>
 
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
@@ -647,13 +649,17 @@ renumber_edgelist(raft::handle_t const& handle,
     CUDA_TRY(cudaStreamSynchronize(
       handle.get_stream()));  // cuco::static_map currently does not take stream
 
-    cuco::static_map<vertex_t, vertex_t> renumber_map{
-      // cuco::static_map requires at least one empty slot
-      std::max(static_cast<size_t>(
-                 static_cast<double>(partition.get_matrix_partition_major_size(i)) / load_factor),
-               static_cast<size_t>(partition.get_matrix_partition_major_size(i)) + 1),
-      invalid_vertex_id<vertex_t>::value,
-      invalid_vertex_id<vertex_t>::value};
+    auto poly_alloc = rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());
+    auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(poly_alloc, cudaStream_t{nullptr});
+    cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>
+      renumber_map{
+        // cuco::static_map requires at least one empty slot
+        std::max(static_cast<size_t>(
+                   static_cast<double>(partition.get_matrix_partition_major_size(i)) / load_factor),
+                 static_cast<size_t>(partition.get_matrix_partition_major_size(i)) + 1),
+        invalid_vertex_id<vertex_t>::value,
+        invalid_vertex_id<vertex_t>::value,
+        stream_adapter};
     auto pair_first = thrust::make_transform_iterator(
       thrust::make_zip_iterator(thrust::make_tuple(
         col_comm_rank == static_cast<int>(i) ? renumber_map_labels.begin()

--- a/cpp/src/experimental/renumber_edgelist.cu
+++ b/cpp/src/experimental/renumber_edgelist.cu
@@ -703,13 +703,16 @@ renumber_edgelist(raft::handle_t const& handle,
     CUDA_TRY(cudaStreamSynchronize(
       handle.get_stream()));  // cuco::static_map currently does not take stream
 
-    cuco::static_map<vertex_t, vertex_t> renumber_map{
-      // cuco::static_map requires at least one empty slot
-      std::max(
-        static_cast<size_t>(static_cast<double>(renumber_map_minor_labels.size()) / load_factor),
-        renumber_map_minor_labels.size() + 1),
-      invalid_vertex_id<vertex_t>::value,
-      invalid_vertex_id<vertex_t>::value};
+    auto poly_alloc = rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());
+    auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(poly_alloc, cudaStream_t{nullptr});
+    cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>
+      renumber_map{// cuco::static_map requires at least one empty slot
+                   std::max(static_cast<size_t>(
+                              static_cast<double>(renumber_map_minor_labels.size()) / load_factor),
+                            renumber_map_minor_labels.size() + 1),
+                   invalid_vertex_id<vertex_t>::value,
+                   invalid_vertex_id<vertex_t>::value,
+                   stream_adapter};
     auto pair_first = thrust::make_transform_iterator(
       thrust::make_zip_iterator(thrust::make_tuple(
         renumber_map_minor_labels.begin(),
@@ -781,12 +784,16 @@ std::enable_if_t<!multi_gpu, rmm::device_uvector<vertex_t>> renumber_edgelist(
   // FIXME: compare this hash based approach with a binary search based approach in both memory
   // footprint and execution time
 
-  cuco::static_map<vertex_t, vertex_t> renumber_map{
-    // cuco::static_map requires at least one empty slot
-    std::max(static_cast<size_t>(static_cast<double>(renumber_map_labels.size()) / load_factor),
-             renumber_map_labels.size() + 1),
-    invalid_vertex_id<vertex_t>::value,
-    invalid_vertex_id<vertex_t>::value};
+  auto poly_alloc = rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());
+  auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(poly_alloc, cudaStream_t{nullptr});
+  cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>
+    renumber_map{
+      // cuco::static_map requires at least one empty slot
+      std::max(static_cast<size_t>(static_cast<double>(renumber_map_labels.size()) / load_factor),
+               renumber_map_labels.size() + 1),
+      invalid_vertex_id<vertex_t>::value,
+      invalid_vertex_id<vertex_t>::value,
+      stream_adapter};
   auto pair_first = thrust::make_transform_iterator(
     thrust::make_zip_iterator(
       thrust::make_tuple(renumber_map_labels.begin(), thrust::make_counting_iterator(vertex_t{0}))),

--- a/cpp/src/experimental/renumber_utils.cu
+++ b/cpp/src/experimental/renumber_utils.cu
@@ -22,6 +22,9 @@
 #include <cugraph/utilities/collect_comm.cuh>
 #include <cugraph/utilities/error.hpp>
 
+#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/device/polymorphic_allocator.hpp>
+
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/count.h>
@@ -66,8 +69,14 @@ void renumber_ext_vertices(raft::handle_t const& handle,
                     "Invalid input arguments: renumber_map_labels have duplicate elements.");
   }
 
-  auto renumber_map_ptr = std::make_unique<cuco::static_map<vertex_t, vertex_t>>(
-    size_t{0}, invalid_vertex_id<vertex_t>::value, invalid_vertex_id<vertex_t>::value);
+  auto poly_alloc = rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());
+  auto stream_adapter   = rmm::mr::make_stream_allocator_adaptor(poly_alloc, cudaStream_t{nullptr});
+  auto renumber_map_ptr = std::make_unique<
+    cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>>(
+    size_t{0},
+    invalid_vertex_id<vertex_t>::value,
+    invalid_vertex_id<vertex_t>::value,
+    stream_adapter);
   if (multi_gpu) {
     auto& comm           = handle.get_comms();
     auto const comm_size = comm.get_size();
@@ -107,13 +116,15 @@ void renumber_ext_vertices(raft::handle_t const& handle,
 
     renumber_map_ptr.reset();
 
-    renumber_map_ptr = std::make_unique<cuco::static_map<vertex_t, vertex_t>>(
+    renumber_map_ptr = std::make_unique<
+      cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>>(
       // cuco::static_map requires at least one empty slot
       std::max(
         static_cast<size_t>(static_cast<double>(sorted_unique_ext_vertices.size()) / load_factor),
         sorted_unique_ext_vertices.size() + 1),
       invalid_vertex_id<vertex_t>::value,
-      invalid_vertex_id<vertex_t>::value);
+      invalid_vertex_id<vertex_t>::value,
+      stream_adapter);
 
     auto kv_pair_first = thrust::make_transform_iterator(
       thrust::make_zip_iterator(thrust::make_tuple(
@@ -127,13 +138,15 @@ void renumber_ext_vertices(raft::handle_t const& handle,
 
     renumber_map_ptr.reset();
 
-    renumber_map_ptr = std::make_unique<cuco::static_map<vertex_t, vertex_t>>(
+    renumber_map_ptr = std::make_unique<
+      cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>>(
       // cuco::static_map requires at least one empty slot
       std::max(static_cast<size_t>(
                  static_cast<double>(local_int_vertex_last - local_int_vertex_first) / load_factor),
                static_cast<size_t>(local_int_vertex_last - local_int_vertex_first) + 1),
       invalid_vertex_id<vertex_t>::value,
-      invalid_vertex_id<vertex_t>::value);
+      invalid_vertex_id<vertex_t>::value,
+      stream_adapter);
 
     auto pair_first = thrust::make_transform_iterator(
       thrust::make_zip_iterator(
@@ -306,13 +319,17 @@ void unrenumber_int_vertices(raft::handle_t const& handle,
 
     handle.get_stream_view().synchronize();  // cuco::static_map currently does not take stream
 
-    cuco::static_map<vertex_t, vertex_t> unrenumber_map(
-      // cuco::static_map requires at least one empty slot
-      std::max(
-        static_cast<size_t>(static_cast<double>(sorted_unique_int_vertices.size()) / load_factor),
-        sorted_unique_int_vertices.size() + 1),
-      invalid_vertex_id<vertex_t>::value,
-      invalid_vertex_id<vertex_t>::value);
+    auto poly_alloc = rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());
+    auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(poly_alloc, cudaStream_t{nullptr});
+    cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>
+      unrenumber_map{
+        // cuco::static_map requires at least one empty slot
+        std::max(
+          static_cast<size_t>(static_cast<double>(sorted_unique_int_vertices.size()) / load_factor),
+          sorted_unique_int_vertices.size() + 1),
+        invalid_vertex_id<vertex_t>::value,
+        invalid_vertex_id<vertex_t>::value,
+        stream_adapter};
 
     auto pair_first = thrust::make_transform_iterator(
       thrust::make_zip_iterator(


### PR DESCRIPTION
Currently cuco::static_map instances in cuGraph are initialized with the cuco::static_map default allocator (which uses CUDA memory allocator).

Update to provide the RMM memory allocator instead.