### PR TITLE
[FIX] Initialize force_atlas2 `old_forces` device_uvector, use new `rmm::exec_policy`

### DIFF
--- a/cpp/src/layout/barnes_hut.hpp
+++ b/cpp/src/layout/barnes_hut.hpp
@@ -89,7 +89,7 @@ void barnes_hut(raft::handle_t const &handle,
   rmm::device_uvector<int> d_childl((nnodes + 1) * 4, stream);
   // FA2 requires degree + 1
   rmm::device_uvector<int> d_massl(nnodes + 1, stream);
-  thrust::fill(rmm::exec_policy(stream), d_massl.begin(), d_massl.end(), 1.f);
+  thrust::fill(rmm::exec_policy(stream), d_massl.begin(), d_massl.end(), 1);
 
   rmm::device_uvector<float> d_maxxl(blocks * FACTOR1, stream);
   rmm::device_uvector<float> d_maxyl(blocks * FACTOR1, stream);

--- a/cpp/src/layout/barnes_hut.hpp
+++ b/cpp/src/layout/barnes_hut.hpp
@@ -151,6 +151,8 @@ void barnes_hut(raft::handle_t const &handle,
   swinging   = d_swinging.data();
   traction   = d_traction.data();
 
+  thrust::fill(rmm::exec_policy(stream)->on(stream), d_old_forces.begin(), d_old_forces.end(), 0.f);
+
   // Sort COO for coalesced memory access.
   sort(graph, stream);
   CHECK_CUDA(stream);

--- a/cpp/src/layout/barnes_hut.hpp
+++ b/cpp/src/layout/barnes_hut.hpp
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <converters/COOtoCSR.cuh>
 #include <utilities/graph_utils.cuh>
@@ -52,9 +52,9 @@ void barnes_hut(raft::handle_t const &handle,
                 bool verbose                                  = false,
                 internals::GraphBasedDimRedCallback *callback = nullptr)
 {
-  cudaStream_t stream = handle.get_stream();
-  const edge_t e      = graph.number_of_edges;
-  const vertex_t n    = graph.number_of_vertices;
+  rmm::cuda_stream_view stream(handle.get_stream());
+  const edge_t e   = graph.number_of_edges;
+  const vertex_t n = graph.number_of_vertices;
 
   const int blocks = getMultiProcessorCount();
   // A tiny jitter to promote numerical stability/
@@ -77,8 +77,8 @@ void barnes_hut(raft::handle_t const &handle,
   int *bottomd      = d_bottomd.data();
   float *radiusd    = d_radiusd.data();
 
-  InitializationKernel<<<1, 1, 0, stream>>>(limiter, maxdepthd, radiusd);
-  CHECK_CUDA(stream);
+  InitializationKernel<<<1, 1, 0, stream.value()>>>(limiter, maxdepthd, radiusd);
+  CHECK_CUDA(stream.value());
 
   const int FOUR_NNODES     = 4 * nnodes;
   const int FOUR_N          = 4 * n;
@@ -89,7 +89,7 @@ void barnes_hut(raft::handle_t const &handle,
   rmm::device_uvector<int> d_childl((nnodes + 1) * 4, stream);
   // FA2 requires degree + 1
   rmm::device_uvector<int> d_massl(nnodes + 1, stream);
-  thrust::fill(rmm::exec_policy(stream)->on(stream), d_massl.begin(), d_massl.end(), 1.f);
+  thrust::fill(rmm::exec_policy(stream), d_massl.begin(), d_massl.end(), 1.f);
 
   rmm::device_uvector<float> d_maxxl(blocks * FACTOR1, stream);
   rmm::device_uvector<float> d_maxyl(blocks * FACTOR1, stream);
@@ -129,10 +129,10 @@ void barnes_hut(raft::handle_t const &handle,
 
   // Copy start x and y positions.
   if (x_start && y_start) {
-    raft::copy(nodes_pos, x_start, n, stream);
-    raft::copy(nodes_pos + nnodes + 1, y_start, n, stream);
+    raft::copy(nodes_pos, x_start, n, stream.value());
+    raft::copy(nodes_pos + nnodes + 1, y_start, n, stream.value());
   } else {
-    random_vector(nodes_pos, (nnodes + 1) * 2, random_state, stream);
+    random_vector(nodes_pos, (nnodes + 1) * 2, random_state, stream.value());
   }
 
   // Allocate arrays for force computation
@@ -151,14 +151,14 @@ void barnes_hut(raft::handle_t const &handle,
   swinging   = d_swinging.data();
   traction   = d_traction.data();
 
-  thrust::fill(rmm::exec_policy(stream)->on(stream), d_old_forces.begin(), d_old_forces.end(), 0.f);
+  thrust::fill(rmm::exec_policy(stream), d_old_forces.begin(), d_old_forces.end(), 0.f);
 
   // Sort COO for coalesced memory access.
-  sort(graph, stream);
-  CHECK_CUDA(stream);
+  sort(graph, stream.value());
+  CHECK_CUDA(stream.value());
 
   graph.degree(massl, cugraph::DegreeDirection::OUT);
-  CHECK_CUDA(stream);
+  CHECK_CUDA(stream.value());
 
   const vertex_t *row = graph.src_indices;
   const vertex_t *col = graph.dst_indices;
@@ -172,8 +172,7 @@ void barnes_hut(raft::handle_t const &handle,
 
   // If outboundAttractionDistribution active, compensate.
   if (outbound_attraction_distribution) {
-    int sum =
-      thrust::reduce(rmm::exec_policy(stream)->on(stream), d_massl.begin(), d_massl.begin() + n);
+    int sum = thrust::reduce(rmm::exec_policy(stream), d_massl.begin(), d_massl.begin() + n);
     outbound_att_compensation = sum / (float)n;
   }
 
@@ -196,71 +195,70 @@ void barnes_hut(raft::handle_t const &handle,
 
   for (int iter = 0; iter < max_iter; ++iter) {
     // Reset force values
-    thrust::fill(
-      rmm::exec_policy(stream)->on(stream), d_rep_forces.begin(), d_rep_forces.end(), 0.f);
-    thrust::fill(rmm::exec_policy(stream)->on(stream), d_attract.begin(), d_attract.end(), 0.f);
-    thrust::fill(rmm::exec_policy(stream)->on(stream), d_swinging.begin(), d_swinging.end(), 0.f);
-    thrust::fill(rmm::exec_policy(stream)->on(stream), d_traction.begin(), d_traction.end(), 0.f);
+    thrust::fill(rmm::exec_policy(stream), d_rep_forces.begin(), d_rep_forces.end(), 0.f);
+    thrust::fill(rmm::exec_policy(stream), d_attract.begin(), d_attract.end(), 0.f);
+    thrust::fill(rmm::exec_policy(stream), d_swinging.begin(), d_swinging.end(), 0.f);
+    thrust::fill(rmm::exec_policy(stream), d_traction.begin(), d_traction.end(), 0.f);
 
-    ResetKernel<<<1, 1, 0, stream>>>(radiusd_squared, bottomd, NNODES, radiusd);
-    CHECK_CUDA(stream);
+    ResetKernel<<<1, 1, 0, stream.value()>>>(radiusd_squared, bottomd, NNODES, radiusd);
+    CHECK_CUDA(stream.value());
 
     // Compute bounding box arround all bodies
-    BoundingBoxKernel<<<blocks * FACTOR1, THREADS1, 0, stream>>>(startl,
-                                                                 childl,
-                                                                 massl,
-                                                                 nodes_pos,
-                                                                 nodes_pos + nnodes + 1,
-                                                                 maxxl,
-                                                                 maxyl,
-                                                                 minxl,
-                                                                 minyl,
-                                                                 FOUR_NNODES,
-                                                                 NNODES,
-                                                                 n,
-                                                                 limiter,
-                                                                 radiusd);
-    CHECK_CUDA(stream);
+    BoundingBoxKernel<<<blocks * FACTOR1, THREADS1, 0, stream.value()>>>(startl,
+                                                                         childl,
+                                                                         massl,
+                                                                         nodes_pos,
+                                                                         nodes_pos + nnodes + 1,
+                                                                         maxxl,
+                                                                         maxyl,
+                                                                         minxl,
+                                                                         minyl,
+                                                                         FOUR_NNODES,
+                                                                         NNODES,
+                                                                         n,
+                                                                         limiter,
+                                                                         radiusd);
+    CHECK_CUDA(stream.value());
 
-    ClearKernel1<<<blocks, 1024, 0, stream>>>(childl, FOUR_NNODES, FOUR_N);
-    CHECK_CUDA(stream);
+    ClearKernel1<<<blocks, 1024, 0, stream.value()>>>(childl, FOUR_NNODES, FOUR_N);
+    CHECK_CUDA(stream.value());
 
     // Build quadtree
-    TreeBuildingKernel<<<blocks * FACTOR2, THREADS2, 0, stream>>>(
+    TreeBuildingKernel<<<blocks * FACTOR2, THREADS2, 0, stream.value()>>>(
       childl, nodes_pos, nodes_pos + nnodes + 1, NNODES, n, maxdepthd, bottomd, radiusd);
-    CHECK_CUDA(stream);
+    CHECK_CUDA(stream.value());
 
-    ClearKernel2<<<blocks, 1024, 0, stream>>>(startl, massl, NNODES, bottomd);
-    CHECK_CUDA(stream);
+    ClearKernel2<<<blocks, 1024, 0, stream.value()>>>(startl, massl, NNODES, bottomd);
+    CHECK_CUDA(stream.value());
 
     // Summarizes mass and position for each cell, bottom up approach
-    SummarizationKernel<<<blocks * FACTOR3, THREADS3, 0, stream>>>(
+    SummarizationKernel<<<blocks * FACTOR3, THREADS3, 0, stream.value()>>>(
       countl, childl, massl, nodes_pos, nodes_pos + nnodes + 1, NNODES, n, bottomd);
-    CHECK_CUDA(stream);
+    CHECK_CUDA(stream.value());
 
     // Group closed bodies together, used to speed up Repulsion kernel
-    SortKernel<<<blocks * FACTOR4, THREADS4, 0, stream>>>(
+    SortKernel<<<blocks * FACTOR4, THREADS4, 0, stream.value()>>>(
       sortl, countl, startl, childl, NNODES, n, bottomd);
-    CHECK_CUDA(stream);
+    CHECK_CUDA(stream.value());
 
     // Force computation O(n . log(n))
-    RepulsionKernel<<<blocks * FACTOR5, THREADS5, 0, stream>>>(scaling_ratio,
-                                                               theta,
-                                                               epssq,
-                                                               sortl,
-                                                               childl,
-                                                               massl,
-                                                               nodes_pos,
-                                                               nodes_pos + nnodes + 1,
-                                                               rep_forces,
-                                                               rep_forces + nnodes + 1,
-                                                               theta_squared,
-                                                               NNODES,
-                                                               FOUR_NNODES,
-                                                               n,
-                                                               radiusd_squared,
-                                                               maxdepthd);
-    CHECK_CUDA(stream);
+    RepulsionKernel<<<blocks * FACTOR5, THREADS5, 0, stream.value()>>>(scaling_ratio,
+                                                                       theta,
+                                                                       epssq,
+                                                                       sortl,
+                                                                       childl,
+                                                                       massl,
+                                                                       nodes_pos,
+                                                                       nodes_pos + nnodes + 1,
+                                                                       rep_forces,
+                                                                       rep_forces + nnodes + 1,
+                                                                       theta_squared,
+                                                                       NNODES,
+                                                                       FOUR_NNODES,
+                                                                       n,
+                                                                       radiusd_squared,
+                                                                       maxdepthd);
+    CHECK_CUDA(stream.value());
 
     apply_gravity<vertex_t>(nodes_pos,
                             nodes_pos + nnodes + 1,
@@ -271,7 +269,7 @@ void barnes_hut(raft::handle_t const &handle,
                             strong_gravity_mode,
                             scaling_ratio,
                             n,
-                            stream);
+                            stream.value());
 
     apply_attraction<vertex_t, edge_t, weight_t>(row,
                                                  col,
@@ -286,7 +284,7 @@ void barnes_hut(raft::handle_t const &handle,
                                                  lin_log_mode,
                                                  edge_weight_influence,
                                                  outbound_att_compensation,
-                                                 stream);
+                                                 stream.value());
 
     compute_local_speed(rep_forces,
                         rep_forces + nnodes + 1,
@@ -298,30 +296,28 @@ void barnes_hut(raft::handle_t const &handle,
                         swinging,
                         traction,
                         n,
-                        stream);
+                        stream.value());
 
     // Compute global swinging and traction values
-    const float s =
-      thrust::reduce(rmm::exec_policy(stream)->on(stream), d_swinging.begin(), d_swinging.end());
+    const float s = thrust::reduce(rmm::exec_policy(stream), d_swinging.begin(), d_swinging.end());
 
-    const float t =
-      thrust::reduce(rmm::exec_policy(stream)->on(stream), d_traction.begin(), d_traction.end());
+    const float t = thrust::reduce(rmm::exec_policy(stream), d_traction.begin(), d_traction.end());
 
     // Compute global speed based on gloab and local swinging and traction.
     adapt_speed<vertex_t>(jitter_tolerance, &jt, &speed, &speed_efficiency, s, t, n);
 
     // Update positions
-    apply_forces_bh<<<blocks * FACTOR6, THREADS6, 0, stream>>>(nodes_pos,
-                                                               nodes_pos + nnodes + 1,
-                                                               attract,
-                                                               attract + n,
-                                                               rep_forces,
-                                                               rep_forces + nnodes + 1,
-                                                               old_forces,
-                                                               old_forces + n,
-                                                               swinging,
-                                                               speed,
-                                                               n);
+    apply_forces_bh<<<blocks * FACTOR6, THREADS6, 0, stream.value()>>>(nodes_pos,
+                                                                       nodes_pos + nnodes + 1,
+                                                                       attract,
+                                                                       attract + n,
+                                                                       rep_forces,
+                                                                       rep_forces + nnodes + 1,
+                                                                       old_forces,
+                                                                       old_forces + n,
+                                                                       swinging,
+                                                                       speed,
+                                                                       n);
 
     if (callback) callback->on_epoch_end(nodes_pos);
 
@@ -333,8 +329,8 @@ void barnes_hut(raft::handle_t const &handle,
   }
 
   // Copy nodes positions into final output pos
-  raft::copy(pos, nodes_pos, n, stream);
-  raft::copy(pos + n, nodes_pos + nnodes + 1, n, stream);
+  raft::copy(pos, nodes_pos, n, stream.value());
+  raft::copy(pos + n, nodes_pos + nnodes + 1, n, stream.value());
 
   if (callback) callback->on_train_end(nodes_pos);
 }

--- a/cpp/src/layout/exact_fa2.hpp
+++ b/cpp/src/layout/exact_fa2.hpp
@@ -67,7 +67,7 @@ void exact_fa2(raft::handle_t const &handle,
   thrust::fill(rmm::exec_policy(stream), old_forces.begin(), old_forces.end(), 0.f);
   // FA2 requires degree + 1.
   rmm::device_uvector<int> mass(n, stream);
-  thrust::fill(rmm::exec_policy(stream), mass.begin(), mass.end(), 1.f);
+  thrust::fill(rmm::exec_policy(stream), mass.begin(), mass.end(), 1);
   rmm::device_uvector<float> swinging(n, stream);
   rmm::device_uvector<float> traction(n, stream);
 

--- a/cpp/src/layout/exact_fa2.hpp
+++ b/cpp/src/layout/exact_fa2.hpp
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <converters/COOtoCSR.cuh>
 
@@ -50,9 +50,9 @@ void exact_fa2(raft::handle_t const &handle,
                bool verbose                                  = false,
                internals::GraphBasedDimRedCallback *callback = nullptr)
 {
-  cudaStream_t stream = handle.get_stream();
-  const edge_t e      = graph.number_of_edges;
-  const vertex_t n    = graph.number_of_vertices;
+  rmm::cuda_stream_view stream(handle.get_stream());
+  const edge_t e   = graph.number_of_edges;
+  const vertex_t n = graph.number_of_vertices;
 
   float *d_repel{nullptr};
   float *d_attract{nullptr};
@@ -64,9 +64,10 @@ void exact_fa2(raft::handle_t const &handle,
   rmm::device_uvector<float> repel(n * 2, stream);
   rmm::device_uvector<float> attract(n * 2, stream);
   rmm::device_uvector<float> old_forces(n * 2, stream);
+  thrust::fill(rmm::exec_policy(stream), old_forces.begin(), old_forces.end(), 0.f);
   // FA2 requires degree + 1.
   rmm::device_uvector<int> mass(n, stream);
-  thrust::fill(rmm::exec_policy(stream)->on(stream), mass.begin(), mass.end(), 1.f);
+  thrust::fill(rmm::exec_policy(stream), mass.begin(), mass.end(), 1.f);
   rmm::device_uvector<float> swinging(n, stream);
   rmm::device_uvector<float> traction(n, stream);
 
@@ -78,19 +79,19 @@ void exact_fa2(raft::handle_t const &handle,
   d_traction   = traction.data();
 
   int random_state = 0;
-  random_vector(pos, n * 2, random_state, stream);
+  random_vector(pos, n * 2, random_state, stream.value());
 
   if (x_start && y_start) {
-    raft::copy(pos, x_start, n, stream);
-    raft::copy(pos + n, y_start, n, stream);
+    raft::copy(pos, x_start, n, stream.value());
+    raft::copy(pos + n, y_start, n, stream.value());
   }
 
   // Sort COO for coalesced memory access.
-  sort(graph, stream);
-  CHECK_CUDA(stream);
+  sort(graph, stream.value());
+  CHECK_CUDA(stream.value());
 
   graph.degree(d_mass, cugraph::DegreeDirection::OUT);
-  CHECK_CUDA(stream);
+  CHECK_CUDA(stream.value());
 
   const vertex_t *row = graph.src_indices;
   const vertex_t *col = graph.dst_indices;
@@ -102,7 +103,7 @@ void exact_fa2(raft::handle_t const &handle,
   float jt                        = 0.f;
 
   if (outbound_attraction_distribution) {
-    int sum = thrust::reduce(rmm::exec_policy(stream)->on(stream), mass.begin(), mass.end());
+    int sum                   = thrust::reduce(rmm::exec_policy(stream), mass.begin(), mass.end());
     outbound_att_compensation = sum / (float)n;
   }
 
@@ -113,13 +114,14 @@ void exact_fa2(raft::handle_t const &handle,
 
   for (int iter = 0; iter < max_iter; ++iter) {
     // Reset force arrays
-    thrust::fill(rmm::exec_policy(stream)->on(stream), repel.begin(), repel.end(), 0.f);
-    thrust::fill(rmm::exec_policy(stream)->on(stream), attract.begin(), attract.end(), 0.f);
-    thrust::fill(rmm::exec_policy(stream)->on(stream), swinging.begin(), swinging.end(), 0.f);
-    thrust::fill(rmm::exec_policy(stream)->on(stream), traction.begin(), traction.end(), 0.f);
+    thrust::fill(rmm::exec_policy(stream), repel.begin(), repel.end(), 0.f);
+    thrust::fill(rmm::exec_policy(stream), attract.begin(), attract.end(), 0.f);
+    thrust::fill(rmm::exec_policy(stream), swinging.begin(), swinging.end(), 0.f);
+    thrust::fill(rmm::exec_policy(stream), traction.begin(), traction.end(), 0.f);
 
     // Exact repulsion
-    apply_repulsion<vertex_t>(pos, pos + n, d_repel, d_repel + n, d_mass, scaling_ratio, n, stream);
+    apply_repulsion<vertex_t>(
+      pos, pos + n, d_repel, d_repel + n, d_mass, scaling_ratio, n, stream.value());
 
     apply_gravity<vertex_t>(pos,
                             pos + n,
@@ -130,7 +132,7 @@ void exact_fa2(raft::handle_t const &handle,
                             strong_gravity_mode,
                             scaling_ratio,
                             n,
-                            stream);
+                            stream.value());
 
     apply_attraction<vertex_t, edge_t, weight_t>(row,
                                                  col,
@@ -145,7 +147,7 @@ void exact_fa2(raft::handle_t const &handle,
                                                  lin_log_mode,
                                                  edge_weight_influence,
                                                  outbound_att_compensation,
-                                                 stream);
+                                                 stream.value());
 
     compute_local_speed(d_repel,
                         d_repel + n,
@@ -157,13 +159,11 @@ void exact_fa2(raft::handle_t const &handle,
                         d_swinging,
                         d_traction,
                         n,
-                        stream);
+                        stream.value());
 
     // Compute global swinging and traction values.
-    const float s =
-      thrust::reduce(rmm::exec_policy(stream)->on(stream), swinging.begin(), swinging.end());
-    const float t =
-      thrust::reduce(rmm::exec_policy(stream)->on(stream), traction.begin(), traction.end());
+    const float s = thrust::reduce(rmm::exec_policy(stream), swinging.begin(), swinging.end());
+    const float t = thrust::reduce(rmm::exec_policy(stream), traction.begin(), traction.end());
 
     adapt_speed<vertex_t>(jitter_tolerance, &jt, &speed, &speed_efficiency, s, t, n);
 
@@ -178,7 +178,7 @@ void exact_fa2(raft::handle_t const &handle,
                            d_swinging,
                            speed,
                            n,
-                           stream);
+                           stream.value());
 
     if (callback) callback->on_epoch_end(pos);
 


### PR DESCRIPTION
Fixes an issue where the layout for all points converge to `(0,0)` when running multiple layout ticks after https://github.com/rapidsai/cugraph/pull/1607.

* Initializes the `d_old_forces` vector to fix layout issue.
* Updates to `barnes_hut.hpp` to use non-deprecated `rmm::exec_policy`.