### PR TITLE
Correct install path for include folder to avoid double nesting

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -333,7 +333,7 @@ install(TARGETS cugraph
         EXPORT cugraph-exports)
 
 install(DIRECTORY include/
-        DESTINATION include/cugraph)
+        DESTINATION include)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/cugraph/version_config.hpp
         DESTINATION include/cugraph)


### PR DESCRIPTION
Similar to https://github.com/rapidsai/cuml/pull/3901. 

After #1491 and #rapids-cmake and #1585, now at install time, the cugraph headers are being nested into `path/to/env/include/cugraph/cugraph` instead of just `path/to/env/include/cugraph/`. This, as far as I'm aware, is unintentional and unlike the rest of RAPIDS projects (cuDF, RMM and cuML). 

cc @trxcllnt @robertmaynard 