### PR TITLE
transform_reduce_e bug fixes

### DIFF
--- a/cpp/include/cugraph/patterns/transform_reduce_e.cuh
+++ b/cpp/include/cugraph/patterns/transform_reduce_e.cuh
@@ -76,7 +76,7 @@ __global__ void for_all_major_for_all_nbr_low_degree(
        &adj_matrix_row_value_input_first,
        &adj_matrix_col_value_input_first,
        &e_op,
-       idx,
+       major_offset,
        indices,
        weights] __device__(auto i) {
         auto minor        = indices[i];
@@ -84,14 +84,14 @@ __global__ void for_all_major_for_all_nbr_low_degree(
         auto minor_offset = matrix_partition.get_minor_offset_from_minor_nocheck(minor);
         auto row          = GraphViewType::is_adj_matrix_transposed
                      ? minor
-                     : matrix_partition.get_major_from_major_offset_nocheck(idx);
+                     : matrix_partition.get_major_from_major_offset_nocheck(major_offset);
         auto col = GraphViewType::is_adj_matrix_transposed
-                     ? matrix_partition.get_major_from_major_offset_nocheck(idx)
+                     ? matrix_partition.get_major_from_major_offset_nocheck(major_offset)
                      : minor;
         auto row_offset =
-          GraphViewType::is_adj_matrix_transposed ? minor_offset : static_cast<vertex_t>(idx);
+          GraphViewType::is_adj_matrix_transposed ? minor_offset : static_cast<vertex_t>(major_offset);
         auto col_offset =
-          GraphViewType::is_adj_matrix_transposed ? static_cast<vertex_t>(idx) : minor_offset;
+          GraphViewType::is_adj_matrix_transposed ? static_cast<vertex_t>(major_offset) : minor_offset;
         return evaluate_edge_op<GraphViewType,
                                 vertex_t,
                                 AdjMatrixRowValueInputIterator,
@@ -155,14 +155,14 @@ __global__ void for_all_major_for_all_nbr_mid_degree(
       auto minor_offset = matrix_partition.get_minor_offset_from_minor_nocheck(minor);
       auto row          = GraphViewType::is_adj_matrix_transposed
                    ? minor
-                   : matrix_partition.get_major_from_major_offset_nocheck(idx);
+                   : matrix_partition.get_major_from_major_offset_nocheck(major_offset);
       auto col = GraphViewType::is_adj_matrix_transposed
-                   ? matrix_partition.get_major_from_major_offset_nocheck(idx)
+                   ? matrix_partition.get_major_from_major_offset_nocheck(major_offset)
                    : minor;
       auto row_offset =
-        GraphViewType::is_adj_matrix_transposed ? minor_offset : static_cast<vertex_t>(idx);
+        GraphViewType::is_adj_matrix_transposed ? minor_offset : static_cast<vertex_t>(major_offset);
       auto col_offset =
-        GraphViewType::is_adj_matrix_transposed ? static_cast<vertex_t>(idx) : minor_offset;
+        GraphViewType::is_adj_matrix_transposed ? static_cast<vertex_t>(major_offset) : minor_offset;
       auto e_op_result = evaluate_edge_op<GraphViewType,
                                           vertex_t,
                                           AdjMatrixRowValueInputIterator,
@@ -220,14 +220,14 @@ __global__ void for_all_major_for_all_nbr_high_degree(
       auto minor_offset = matrix_partition.get_minor_offset_from_minor_nocheck(minor);
       auto row          = GraphViewType::is_adj_matrix_transposed
                    ? minor
-                   : matrix_partition.get_major_from_major_offset_nocheck(idx);
+                   : matrix_partition.get_major_from_major_offset_nocheck(major_offset);
       auto col = GraphViewType::is_adj_matrix_transposed
-                   ? matrix_partition.get_major_from_major_offset_nocheck(idx)
+                   ? matrix_partition.get_major_from_major_offset_nocheck(major_offset)
                    : minor;
       auto row_offset =
-        GraphViewType::is_adj_matrix_transposed ? minor_offset : static_cast<vertex_t>(idx);
+        GraphViewType::is_adj_matrix_transposed ? minor_offset : static_cast<vertex_t>(major_offset);
       auto col_offset =
-        GraphViewType::is_adj_matrix_transposed ? static_cast<vertex_t>(idx) : minor_offset;
+        GraphViewType::is_adj_matrix_transposed ? static_cast<vertex_t>(major_offset) : minor_offset;
       auto e_op_result = evaluate_edge_op<GraphViewType,
                                           vertex_t,
                                           AdjMatrixRowValueInputIterator,

--- a/cpp/include/cugraph/patterns/transform_reduce_e.cuh
+++ b/cpp/include/cugraph/patterns/transform_reduce_e.cuh
@@ -88,10 +88,12 @@ __global__ void for_all_major_for_all_nbr_low_degree(
         auto col = GraphViewType::is_adj_matrix_transposed
                      ? matrix_partition.get_major_from_major_offset_nocheck(major_offset)
                      : minor;
-        auto row_offset =
-          GraphViewType::is_adj_matrix_transposed ? minor_offset : static_cast<vertex_t>(major_offset);
-        auto col_offset =
-          GraphViewType::is_adj_matrix_transposed ? static_cast<vertex_t>(major_offset) : minor_offset;
+        auto row_offset = GraphViewType::is_adj_matrix_transposed
+                            ? minor_offset
+                            : static_cast<vertex_t>(major_offset);
+        auto col_offset = GraphViewType::is_adj_matrix_transposed
+                            ? static_cast<vertex_t>(major_offset)
+                            : minor_offset;
         return evaluate_edge_op<GraphViewType,
                                 vertex_t,
                                 AdjMatrixRowValueInputIterator,
@@ -159,10 +161,12 @@ __global__ void for_all_major_for_all_nbr_mid_degree(
       auto col = GraphViewType::is_adj_matrix_transposed
                    ? matrix_partition.get_major_from_major_offset_nocheck(major_offset)
                    : minor;
-      auto row_offset =
-        GraphViewType::is_adj_matrix_transposed ? minor_offset : static_cast<vertex_t>(major_offset);
-      auto col_offset =
-        GraphViewType::is_adj_matrix_transposed ? static_cast<vertex_t>(major_offset) : minor_offset;
+      auto row_offset = GraphViewType::is_adj_matrix_transposed
+                          ? minor_offset
+                          : static_cast<vertex_t>(major_offset);
+      auto col_offset = GraphViewType::is_adj_matrix_transposed
+                          ? static_cast<vertex_t>(major_offset)
+                          : minor_offset;
       auto e_op_result = evaluate_edge_op<GraphViewType,
                                           vertex_t,
                                           AdjMatrixRowValueInputIterator,
@@ -224,10 +228,12 @@ __global__ void for_all_major_for_all_nbr_high_degree(
       auto col = GraphViewType::is_adj_matrix_transposed
                    ? matrix_partition.get_major_from_major_offset_nocheck(major_offset)
                    : minor;
-      auto row_offset =
-        GraphViewType::is_adj_matrix_transposed ? minor_offset : static_cast<vertex_t>(major_offset);
-      auto col_offset =
-        GraphViewType::is_adj_matrix_transposed ? static_cast<vertex_t>(major_offset) : minor_offset;
+      auto row_offset = GraphViewType::is_adj_matrix_transposed
+                          ? minor_offset
+                          : static_cast<vertex_t>(major_offset);
+      auto col_offset = GraphViewType::is_adj_matrix_transposed
+                          ? static_cast<vertex_t>(major_offset)
+                          : minor_offset;
       auto e_op_result = evaluate_edge_op<GraphViewType,
                                           vertex_t,
                                           AdjMatrixRowValueInputIterator,


### PR DESCRIPTION
Discovered this bug during louvain testing.  The variable `idx` is an index controlling iteration over a subset of the vertices, while `major_offset` identifies a particular vertex offset in the overall data structure.  Several places where using `idx` where they needed to be using `major_offset`.