### PR TITLE
Upgraded recipe and dev envs to NCCL 2.9.9

### DIFF
--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -14,7 +14,7 @@ dependencies:
 - distributed>=2.12.0
 - dask-cuda=21.06*
 - dask-cudf=21.06*
-- nccl>=2.8.4
+- nccl>=2.9.9
 - ucx-py=21.06*
 - ucx-proc=*=gpu
 - scipy

--- a/conda/environments/cugraph_dev_cuda11.1.yml
+++ b/conda/environments/cugraph_dev_cuda11.1.yml
@@ -14,7 +14,7 @@ dependencies:
 - distributed>=2.12.0
 - dask-cuda=21.06*
 - dask-cudf=21.06*
-- nccl>=2.8.4
+- nccl>=2.9.9
 - ucx-py=21.06*
 - ucx-proc=*=gpu
 - scipy

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -14,7 +14,7 @@ dependencies:
 - distributed>=2.12.0
 - dask-cuda=21.06*
 - dask-cudf=21.06*
-- nccl>=2.8.4
+- nccl>=2.9.9
 - ucx-py=21.06*
 - ucx-proc=*=gpu
 - scipy

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -37,7 +37,6 @@ requirements:
     - dask-cuda {{ minor_version }}
     - dask>=2.12.0
     - distributed>=2.12.0
-    - nccl>=2.8.4
     - ucx-py {{ minor_version }}
     - ucx-proc=*=gpu
 

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - cudatoolkit {{ cuda_version }}.*
     - librmm {{ minor_version }}.*
     - boost-cpp>=1.66
-    - nccl>=2.8.4
+    - nccl>=2.9.9
     - ucx-proc=*=gpu
     - gtest
     - gmock
@@ -43,7 +43,7 @@ requirements:
     - conda-forge::libfaiss=1.7.0
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
-    - nccl>=2.8.4
+    - nccl>=2.9.9
     - ucx-proc=*=gpu
     - faiss-proc=*=cuda
     - conda-forge::libfaiss=1.7.0


### PR DESCRIPTION
Upgraded recipe and dev envs to NCCL 2.9.9.

The `cugraph` python conda recipe previously included NCCL, but (I think) it's a transient dependency since `libcugraph` actually needs it, so it was removed from the `cugraph` recipe.

cc @dantegd for consistency with cuML.

Note: the NCCL 2.9.9 upgrade was tested during benchmark runs, but the conda recipe changes have not been tested.