### PR TITLE
Delete CUDA_ARCHITECTURES=OFF

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -71,17 +71,6 @@ target_include_directories(cugraphmgtestutil
 
 target_link_libraries(cugraphmgtestutil cugraph)
 
-# CUDA_ARCHITECTURES=OFF implies cmake will not pass arch flags to the
-# compiler. CUDA_ARCHITECTURES must be set to a non-empty value to prevent
-# cmake warnings about policy CMP0104. With this setting, arch flags must be
-# manually set! ("evaluate_gpu_archs(GPU_ARCHS)" is the current mechanism
-# used in cpp/CMakeLists.txt for setting arch options).
-# Run "cmake --help-policy CMP0104" for policy details.
-# NOTE: the CUDA_ARCHITECTURES=OFF setting may be removed after migrating to
-# the findcudatoolkit features in cmake 3.17+
-set_target_properties(cugraphmgtestutil PROPERTIES
-        CUDA_ARCHITECTURES OFF)
-
 ###################################################################################################
 # - compiler function -----------------------------------------------------------------------------
 


### PR DESCRIPTION
`set_target_properties(cugraphmgtestutil PROPERTIES CUDA_ARCHITECTURES OFF)` was set and this caused cudaFuncGetAttribute to intermittently return an invalid PTX version. This PR deletes this.