### PR TITLE
Fix update-version.sh [skip-ci]

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -20,7 +20,7 @@
 NEXT_FULL_TAG=$1
 
 # Get current version
-CURRENT_TAG=$(git tag | grep -xE 'v[0-9\.]+' | sort --version-sort | tail -n 1 | tr -d 'v')
+CURRENT_TAG=$(git tag --merged HEAD | grep -xE '^v.*' | sort --version-sort | tail -n 1 | tr -d 'v')
 CURRENT_MAJOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}')
 CURRENT_MINOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}')
 CURRENT_PATCH=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}')


### PR DESCRIPTION
This PR fixes the update-version.sh script to properly find the current tag after the CalVer transition.
