### PR TITLE
Migrate old graph to legacy directory/namespace

### DIFF
--- a/cpp/include/cugraph/algorithms.hpp
+++ b/cpp/include/cugraph/algorithms.hpp
@@ -19,7 +19,7 @@
 #include <cugraph/experimental/graph.hpp>
 #include <cugraph/experimental/graph_view.hpp>
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/internals.hpp>
 
 #include <raft/handle.hpp>
@@ -45,7 +45,7 @@ namespace cugraph {
  * caller
  */
 template <typename VT, typename ET, typename WT>
-void jaccard(GraphCSRView<VT, ET, WT> const &graph, WT const *weights, WT *result);
+void jaccard(legacy::GraphCSRView<VT, ET, WT> const &graph, WT const *weights, WT *result);
 
 /**
  * @brief     Compute jaccard similarity coefficient for selected vertex pairs
@@ -69,7 +69,7 @@ void jaccard(GraphCSRView<VT, ET, WT> const &graph, WT const *weights, WT *resul
  * caller
  */
 template <typename VT, typename ET, typename WT>
-void jaccard_list(GraphCSRView<VT, ET, WT> const &graph,
+void jaccard_list(legacy::GraphCSRView<VT, ET, WT> const &graph,
                   WT const *weights,
                   ET num_pairs,
                   VT const *first,
@@ -95,7 +95,7 @@ void jaccard_list(GraphCSRView<VT, ET, WT> const &graph,
  * caller
  */
 template <typename VT, typename ET, typename WT>
-void overlap(GraphCSRView<VT, ET, WT> const &graph, WT const *weights, WT *result);
+void overlap(legacy::GraphCSRView<VT, ET, WT> const &graph, WT const *weights, WT *result);
 
 /**
  * @brief     Compute overlap coefficient for select pairs of vertices
@@ -119,7 +119,7 @@ void overlap(GraphCSRView<VT, ET, WT> const &graph, WT const *weights, WT *resul
  * caller
  */
 template <typename VT, typename ET, typename WT>
-void overlap_list(GraphCSRView<VT, ET, WT> const &graph,
+void overlap_list(legacy::GraphCSRView<VT, ET, WT> const &graph,
                   WT const *weights,
                   ET num_pairs,
                   VT const *first,
@@ -181,7 +181,7 @@ void overlap_list(GraphCSRView<VT, ET, WT> const &graph,
  */
 template <typename vertex_t, typename edge_t, typename weight_t>
 void force_atlas2(raft::handle_t const &handle,
-                  GraphCOOView<vertex_t, edge_t, weight_t> &graph,
+                  legacy::GraphCOOView<vertex_t, edge_t, weight_t> &graph,
                   float *pos,
                   const int max_iter                            = 500,
                   float *x_start                                = nullptr,
@@ -276,7 +276,7 @@ float traveling_salesperson(raft::handle_t const &handle,
  */
 template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
 void betweenness_centrality(const raft::handle_t &handle,
-                            GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+                            legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                             result_t *result,
                             bool normalized          = true,
                             bool endpoints           = false,
@@ -320,7 +320,7 @@ void betweenness_centrality(const raft::handle_t &handle,
  */
 template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
 void edge_betweenness_centrality(const raft::handle_t &handle,
-                                 GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+                                 legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                                  result_t *result,
                                  bool normalized          = true,
                                  weight_t const *weight   = nullptr,
@@ -363,7 +363,7 @@ enum class cugraph_cc_t {
  * associated with vertex id i.
  */
 template <typename VT, typename ET, typename WT>
-void connected_components(GraphCSRView<VT, ET, WT> const &graph,
+void connected_components(legacy::GraphCSRView<VT, ET, WT> const &graph,
                           cugraph_cc_t connectivity_type,
                           VT *labels);
 
@@ -392,8 +392,8 @@ void connected_components(GraphCSRView<VT, ET, WT> const &graph,
  *
  */
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<GraphCOO<VT, ET, WT>> k_truss_subgraph(
-  GraphCOOView<VT, ET, WT> const &graph,
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> k_truss_subgraph(
+  legacy::GraphCOOView<VT, ET, WT> const &graph,
   int k,
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
@@ -430,7 +430,7 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> k_truss_subgraph(
  * @param[in] normalized             If True normalize the resulting katz centrality values
  */
 template <typename VT, typename ET, typename WT, typename result_t>
-void katz_centrality(GraphCSRView<VT, ET, WT> const &graph,
+void katz_centrality(legacy::GraphCSRView<VT, ET, WT> const &graph,
                      result_t *result,
                      double alpha,
                      int max_iter,
@@ -448,7 +448,7 @@ void katz_centrality(GraphCSRView<VT, ET, WT> const &graph,
  */
 /* ----------------------------------------------------------------------------*/
 template <typename VT, typename ET, typename WT>
-void core_number(GraphCSRView<VT, ET, WT> const &graph, VT *core_number);
+void core_number(legacy::GraphCSRView<VT, ET, WT> const &graph, VT *core_number);
 
 /**
  * @brief   Compute K Core of the graph G
@@ -472,8 +472,8 @@ void core_number(GraphCSRView<VT, ET, WT> const &graph, VT *core_number);
  * @param[out] out_graph             Unique pointer to K Core subgraph in COO format
  */
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<GraphCOO<VT, ET, WT>> k_core(
-  GraphCOOView<VT, ET, WT> const &graph,
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> k_core(
+  legacy::GraphCOOView<VT, ET, WT> const &graph,
   int k,
   VT const *vertex_id,
   VT const *core_number,
@@ -498,7 +498,7 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> k_core(
  * @return                  Graph in COO format
  */
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<GraphCOO<VT, ET, WT>> get_two_hop_neighbors(GraphCSRView<VT, ET, WT> const &graph);
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> get_two_hop_neighbors(legacy::GraphCSRView<VT, ET, WT> const &graph);
 
 /**
  * @Synopsis   Performs a single source shortest path traversal of a graph starting from a vertex.
@@ -525,13 +525,13 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> get_two_hop_neighbors(GraphCSRView<VT, ET,
  *
  */
 template <typename VT, typename ET, typename WT>
-void sssp(GraphCSRView<VT, ET, WT> const &graph,
+void sssp(legacy::GraphCSRView<VT, ET, WT> const &graph,
           WT *distances,
           VT *predecessors,
           const VT source_vertex);
 
 // FIXME: Internally distances is of int (signed 32-bit) data type, but current
-// template uses data from VT, ET, WT from he GraphCSR View even if weights
+// template uses data from VT, ET, WT from the legacy::GraphCSR View even if weights
 // are not considered
 /**
  * @Synopsis   Performs a breadth first search traversal of a graph starting from a vertex.
@@ -567,7 +567,7 @@ void sssp(GraphCSRView<VT, ET, WT> const &graph,
  */
 template <typename VT, typename ET, typename WT>
 void bfs(raft::handle_t const &handle,
-         GraphCSRView<VT, ET, WT> const &graph,
+         legacy::GraphCSRView<VT, ET, WT> const &graph,
          VT *distances,
          VT *predecessors,
          double *sp_counters,
@@ -601,7 +601,7 @@ void bfs(raft::handle_t const &handle,
  */
 template <typename vertex_t, typename edge_t, typename weight_t>
 weight_t hungarian(raft::handle_t const &handle,
-                   GraphCOOView<vertex_t, edge_t, weight_t> const &graph,
+                   legacy::GraphCOOView<vertex_t, edge_t, weight_t> const &graph,
                    vertex_t num_workers,
                    vertex_t const *workers,
                    vertex_t *assignment);
@@ -634,7 +634,7 @@ weight_t hungarian(raft::handle_t const &handle,
  */
 template <typename vertex_t, typename edge_t, typename weight_t>
 weight_t hungarian(raft::handle_t const &handle,
-                   GraphCOOView<vertex_t, edge_t, weight_t> const &graph,
+                   legacy::GraphCOOView<vertex_t, edge_t, weight_t> const &graph,
                    vertex_t num_workers,
                    vertex_t const *workers,
                    vertex_t *assignment,
@@ -775,7 +775,7 @@ void flatten_dendrogram(raft::handle_t const &handle,
  */
 template <typename vertex_t, typename edge_t, typename weight_t>
 std::pair<size_t, weight_t> leiden(raft::handle_t const &handle,
-                                   GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+                                   legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                                    vertex_t *clustering,
                                    size_t max_iter     = 100,
                                    weight_t resolution = weight_t{1});
@@ -807,7 +807,7 @@ std::pair<size_t, weight_t> leiden(raft::handle_t const &handle,
  */
 template <typename vertex_t, typename edge_t, typename weight_t>
 void ecg(raft::handle_t const &handle,
-         GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+         legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
          weight_t min_weight,
          vertex_t ensemble_size,
          vertex_t *clustering);
@@ -833,9 +833,9 @@ void ecg(raft::handle_t const &handle,
  * @return out_graph             Unique pointer to MSF subgraph in COO format
  */
 template <typename vertex_t, typename edge_t, typename weight_t>
-std::unique_ptr<GraphCOO<vertex_t, edge_t, weight_t>> minimum_spanning_tree(
+std::unique_ptr<legacy::GraphCOO<vertex_t, edge_t, weight_t>> minimum_spanning_tree(
   raft::handle_t const &handle,
-  GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+  legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
 namespace triangle {
@@ -855,7 +855,7 @@ namespace triangle {
  * @return                           The number of triangles
  */
 template <typename VT, typename ET, typename WT>
-uint64_t triangle_count(GraphCSRView<VT, ET, WT> const &graph);
+uint64_t triangle_count(legacy::GraphCSRView<VT, ET, WT> const &graph);
 }  // namespace triangle
 
 namespace subgraph {
@@ -880,7 +880,7 @@ namespace subgraph {
  * @param[out] result                a graph in COO format containing the edges in the subgraph
  */
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<GraphCOO<VT, ET, WT>> extract_subgraph_vertex(GraphCOOView<VT, ET, WT> const &graph,
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> extract_subgraph_vertex(legacy::GraphCOOView<VT, ET, WT> const &graph,
                                                               VT const *vertices,
                                                               VT num_vertices);
 }  // namespace subgraph
@@ -909,7 +909,7 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> extract_subgraph_vertex(GraphCOOView<VT, E
 
 namespace ext_raft {
 template <typename VT, typename ET, typename WT>
-void balancedCutClustering(GraphCSRView<VT, ET, WT> const &graph,
+void balancedCutClustering(legacy::GraphCSRView<VT, ET, WT> const &graph,
                            VT num_clusters,
                            VT num_eigen_vects,
                            WT evs_tolerance,
@@ -940,7 +940,7 @@ void balancedCutClustering(GraphCSRView<VT, ET, WT> const &graph,
  * be stored
  */
 template <typename VT, typename ET, typename WT>
-void spectralModularityMaximization(GraphCSRView<VT, ET, WT> const &graph,
+void spectralModularityMaximization(legacy::GraphCSRView<VT, ET, WT> const &graph,
                                     VT n_clusters,
                                     VT n_eig_vects,
                                     WT evs_tolerance,
@@ -966,7 +966,7 @@ void spectralModularityMaximization(GraphCSRView<VT, ET, WT> const &graph,
  * @param[out] score                 Pointer to a float in which the result will be written
  */
 template <typename VT, typename ET, typename WT>
-void analyzeClustering_modularity(GraphCSRView<VT, ET, WT> const &graph,
+void analyzeClustering_modularity(legacy::GraphCSRView<VT, ET, WT> const &graph,
                                   int n_clusters,
                                   VT const *clustering,
                                   WT *score);
@@ -988,7 +988,7 @@ void analyzeClustering_modularity(GraphCSRView<VT, ET, WT> const &graph,
  * @param[out] score                 Pointer to a float in which the result will be written
  */
 template <typename VT, typename ET, typename WT>
-void analyzeClustering_edge_cut(GraphCSRView<VT, ET, WT> const &graph,
+void analyzeClustering_edge_cut(legacy::GraphCSRView<VT, ET, WT> const &graph,
                                 int n_clusters,
                                 VT const *clustering,
                                 WT *score);
@@ -1010,7 +1010,7 @@ void analyzeClustering_edge_cut(GraphCSRView<VT, ET, WT> const &graph,
  * @param[out] score                 Pointer to a float in which the result will be written
  */
 template <typename VT, typename ET, typename WT>
-void analyzeClustering_ratio_cut(GraphCSRView<VT, ET, WT> const &graph,
+void analyzeClustering_ratio_cut(legacy::GraphCSRView<VT, ET, WT> const &graph,
                                  int n_clusters,
                                  VT const *clustering,
                                  WT *score);
@@ -1046,7 +1046,7 @@ namespace gunrock {
  *
  */
 template <typename VT, typename ET, typename WT>
-void hits(GraphCSRView<VT, ET, WT> const &graph,
+void hits(legacy::GraphCSRView<VT, ET, WT> const &graph,
           int max_iter,
           WT tolerance,
           WT const *starting_value,

--- a/cpp/include/cugraph/algorithms.hpp
+++ b/cpp/include/cugraph/algorithms.hpp
@@ -19,8 +19,8 @@
 #include <cugraph/experimental/graph.hpp>
 #include <cugraph/experimental/graph_view.hpp>
 
-#include <cugraph/legacy/graph.hpp>
 #include <cugraph/internals.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <raft/handle.hpp>
 
@@ -498,7 +498,8 @@ std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> k_core(
  * @return                  Graph in COO format
  */
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> get_two_hop_neighbors(legacy::GraphCSRView<VT, ET, WT> const &graph);
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> get_two_hop_neighbors(
+  legacy::GraphCSRView<VT, ET, WT> const &graph);
 
 /**
  * @Synopsis   Performs a single source shortest path traversal of a graph starting from a vertex.
@@ -880,9 +881,8 @@ namespace subgraph {
  * @param[out] result                a graph in COO format containing the edges in the subgraph
  */
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> extract_subgraph_vertex(legacy::GraphCOOView<VT, ET, WT> const &graph,
-                                                              VT const *vertices,
-                                                              VT num_vertices);
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> extract_subgraph_vertex(
+  legacy::GraphCOOView<VT, ET, WT> const &graph, VT const *vertices, VT num_vertices);
 }  // namespace subgraph
 
 /**

--- a/cpp/include/cugraph/functions.hpp
+++ b/cpp/include/cugraph/functions.hpp
@@ -18,7 +18,7 @@
 #include <raft/handle.hpp>
 #include <rmm/device_buffer.hpp>
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 namespace cugraph {
 
@@ -40,8 +40,8 @@ namespace cugraph {
  *
  */
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<GraphCSR<VT, ET, WT>> coo_to_csr(
-  GraphCOOView<VT, ET, WT> const &graph,
+std::unique_ptr<legacy::GraphCSR<VT, ET, WT>> coo_to_csr(
+  legacy::GraphCOOView<VT, ET, WT> const &graph,
   rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
 /**

--- a/cpp/include/cugraph/legacy/eidecl_graph.hpp
+++ b/cpp/include/cugraph/legacy/eidecl_graph.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 namespace cugraph {
+namespace legacy {
 extern template class GraphViewBase<int32_t, int32_t, float>;
 extern template class GraphViewBase<int32_t, int32_t, double>;
 extern template class GraphViewBase<int32_t, int64_t, float>;
@@ -88,4 +89,5 @@ extern template class GraphCSC<int64_t, int32_t, float>;
 extern template class GraphCSC<int64_t, int32_t, double>;
 extern template class GraphCSC<int64_t, int64_t, float>;
 extern template class GraphCSC<int64_t, int64_t, double>;
+}  // namespace legacy
 }  // namespace cugraph

--- a/cpp/include/cugraph/legacy/eidir_graph.hpp
+++ b/cpp/include/cugraph/legacy/eidir_graph.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 namespace cugraph {
+namespace legacy {
 template class GraphViewBase<int32_t, int32_t, float>;
 template class GraphViewBase<int32_t, int32_t, double>;
 template class GraphViewBase<int32_t, int64_t, float>;
@@ -70,4 +71,5 @@ template class GraphCSC<int32_t, int64_t, float>;
 template class GraphCSC<int32_t, int64_t, double>;
 template class GraphCSC<int64_t, int64_t, float>;
 template class GraphCSC<int64_t, int64_t, double>;
+}  // namespace legacy
 }  // namespace cugraph

--- a/cpp/include/cugraph/legacy/graph.hpp
+++ b/cpp/include/cugraph/legacy/graph.hpp
@@ -23,6 +23,7 @@
 #include <rmm/device_buffer.hpp>
 
 namespace cugraph {
+namespace legacy {
 
 enum class PropType { PROP_UNDEF, PROP_FALSE, PROP_TRUE };
 
@@ -672,6 +673,8 @@ struct invalid_vertex_id : invalid_idx<vertex_t> {
 template <typename edge_t>
 struct invalid_edge_id : invalid_idx<edge_t> {
 };
+
+}  // namespace legacy
 }  // namespace cugraph
 
 #include "eidecl_graph.hpp"

--- a/cpp/include/cugraph/utilities/cython.hpp
+++ b/cpp/include/cugraph/utilities/cython.hpp
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <cugraph/experimental/graph.hpp>
-#include <cugraph/legacy/graph.hpp>
 #include <cugraph/graph_generators.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/graph_traits.hpp>
 
 #include <raft/handle.hpp>

--- a/cpp/include/cugraph/utilities/cython.hpp
+++ b/cpp/include/cugraph/utilities/cython.hpp
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <cugraph/experimental/graph.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/graph_generators.hpp>
 #include <cugraph/utilities/graph_traits.hpp>
 
@@ -67,12 +67,12 @@ struct graph_container_t {
     ~graphPtrUnion() {}
 
     void* null;
-    std::unique_ptr<GraphCSRView<int32_t, int32_t, float>> GraphCSRViewFloatPtr;
-    std::unique_ptr<GraphCSRView<int32_t, int32_t, double>> GraphCSRViewDoublePtr;
-    std::unique_ptr<GraphCSCView<int32_t, int32_t, float>> GraphCSCViewFloatPtr;
-    std::unique_ptr<GraphCSCView<int32_t, int32_t, double>> GraphCSCViewDoublePtr;
-    std::unique_ptr<GraphCOOView<int32_t, int32_t, float>> GraphCOOViewFloatPtr;
-    std::unique_ptr<GraphCOOView<int32_t, int32_t, double>> GraphCOOViewDoublePtr;
+    std::unique_ptr<legacy::GraphCSRView<int32_t, int32_t, float>> GraphCSRViewFloatPtr;
+    std::unique_ptr<legacy::GraphCSRView<int32_t, int32_t, double>> GraphCSRViewDoublePtr;
+    std::unique_ptr<legacy::GraphCSCView<int32_t, int32_t, float>> GraphCSCViewFloatPtr;
+    std::unique_ptr<legacy::GraphCSCView<int32_t, int32_t, double>> GraphCSCViewDoublePtr;
+    std::unique_ptr<legacy::GraphCOOView<int32_t, int32_t, float>> GraphCOOViewFloatPtr;
+    std::unique_ptr<legacy::GraphCOOView<int32_t, int32_t, double>> GraphCOOViewDoublePtr;
   };
 
   graph_container_t() : graph_ptr_union{nullptr}, graph_type{graphTypeEnum::null} {}

--- a/cpp/src/centrality/betweenness_centrality.cu
+++ b/cpp/src/centrality/betweenness_centrality.cu
@@ -21,7 +21,7 @@
 #include <raft/cudart_utils.h>
 
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 
 #include <rmm/device_scalar.hpp>
@@ -36,7 +36,7 @@ namespace detail {
 namespace {
 template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
 void betweenness_centrality_impl(raft::handle_t const &handle,
-                                 GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+                                 legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                                  result_t *result,
                                  bool normalize,
                                  bool endpoints,
@@ -60,7 +60,7 @@ void betweenness_centrality_impl(raft::handle_t const &handle,
 
 template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
 void edge_betweenness_centrality_impl(raft::handle_t const &handle,
-                                      GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+                                      legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                                       result_t *result,
                                       bool normalize,
                                       weight_t const *weight,
@@ -449,7 +449,7 @@ void BC<vertex_t, edge_t, weight_t, result_t>::rescale_by_total_sources_used(
 
 template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
 void betweenness_centrality(raft::handle_t const &handle,
-                            GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+                            legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                             result_t *result,
                             bool normalize,
                             bool endpoints,
@@ -489,7 +489,7 @@ void betweenness_centrality(raft::handle_t const &handle,
 }
 
 template void betweenness_centrality<int, int, float, float>(const raft::handle_t &,
-                                                             GraphCSRView<int, int, float> const &,
+                                                             legacy::GraphCSRView<int, int, float> const &,
                                                              float *,
                                                              bool,
                                                              bool,
@@ -498,7 +498,7 @@ template void betweenness_centrality<int, int, float, float>(const raft::handle_
                                                              int const *);
 template void betweenness_centrality<int, int, double, double>(
   const raft::handle_t &,
-  GraphCSRView<int, int, double> const &,
+  legacy::GraphCSRView<int, int, double> const &,
   double *,
   bool,
   bool,
@@ -508,7 +508,7 @@ template void betweenness_centrality<int, int, double, double>(
 
 template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
 void edge_betweenness_centrality(raft::handle_t const &handle,
-                                 GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+                                 legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                                  result_t *result,
                                  bool normalize,
                                  weight_t const *weight,
@@ -540,7 +540,7 @@ void edge_betweenness_centrality(raft::handle_t const &handle,
 
 template void edge_betweenness_centrality<int, int, float, float>(
   const raft::handle_t &,
-  GraphCSRView<int, int, float> const &,
+  legacy::GraphCSRView<int, int, float> const &,
   float *,
   bool,
   float const *,
@@ -549,7 +549,7 @@ template void edge_betweenness_centrality<int, int, float, float>(
 
 template void edge_betweenness_centrality<int, int, double, double>(
   raft::handle_t const &handle,
-  GraphCSRView<int, int, double> const &,
+  legacy::GraphCSRView<int, int, double> const &,
   double *,
   bool,
   double const *,

--- a/cpp/src/centrality/betweenness_centrality.cu
+++ b/cpp/src/centrality/betweenness_centrality.cu
@@ -488,14 +488,15 @@ void betweenness_centrality(raft::handle_t const &handle,
   }
 }
 
-template void betweenness_centrality<int, int, float, float>(const raft::handle_t &,
-                                                             legacy::GraphCSRView<int, int, float> const &,
-                                                             float *,
-                                                             bool,
-                                                             bool,
-                                                             float const *,
-                                                             int,
-                                                             int const *);
+template void betweenness_centrality<int, int, float, float>(
+  const raft::handle_t &,
+  legacy::GraphCSRView<int, int, float> const &,
+  float *,
+  bool,
+  bool,
+  float const *,
+  int,
+  int const *);
 template void betweenness_centrality<int, int, double, double>(
   const raft::handle_t &,
   legacy::GraphCSRView<int, int, double> const &,

--- a/cpp/src/centrality/betweenness_centrality.cuh
+++ b/cpp/src/centrality/betweenness_centrality.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/centrality/betweenness_centrality.cuh
+++ b/cpp/src/centrality/betweenness_centrality.cuh
@@ -23,7 +23,7 @@ namespace cugraph {
 namespace detail {
 template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
 void betweenness_centrality(raft::handle_t const &handle,
-                            GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+                            legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                             result_t *result,
                             bool normalize,
                             bool endpoints,
@@ -32,7 +32,7 @@ void betweenness_centrality(raft::handle_t const &handle,
                             vertex_t const *sources);
 
 template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
-void edge_betweenness_centrality(GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+void edge_betweenness_centrality(legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                                  result_t *result,
                                  bool normalize,
                                  weight_t const *weight,
@@ -53,7 +53,7 @@ class BC {
  public:
   virtual ~BC(void) {}
   BC(raft::handle_t const &handle,
-     GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+     legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
      cudaStream_t stream = 0)
     : handle_(handle), graph_(graph)
   {
@@ -79,7 +79,7 @@ class BC {
   // --- RAFT handle ---
   raft::handle_t const &handle_;
   // --- Information concerning the graph ---
-  const GraphCSRView<vertex_t, edge_t, weight_t> &graph_;
+  const legacy::GraphCSRView<vertex_t, edge_t, weight_t> &graph_;
   // --- These information are extracted on setup ---
   vertex_t number_of_vertices_;  // Number of vertices in the graph
   vertex_t number_of_edges_;     // Number of edges in the graph

--- a/cpp/src/centrality/katz_centrality.cu
+++ b/cpp/src/centrality/katz_centrality.cu
@@ -23,13 +23,13 @@
 
 #include <Hornet.hpp>
 #include <Static/KatzCentrality/Katz.cuh>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 
 namespace cugraph {
 
 template <typename VT, typename ET, typename WT, typename result_t>
-void katz_centrality(GraphCSRView<VT, ET, WT> const &graph,
+void katz_centrality(legacy::GraphCSRView<VT, ET, WT> const &graph,
                      result_t *result,
                      double alpha,
                      int max_iter,
@@ -52,6 +52,6 @@ void katz_centrality(GraphCSRView<VT, ET, WT> const &graph,
 }
 
 template void katz_centrality<int, int, float, double>(
-  GraphCSRView<int, int, float> const &, double *, double, int, double, bool, bool);
+  legacy::GraphCSRView<int, int, float> const &, double *, double, int, double, bool, bool);
 
 }  // namespace cugraph

--- a/cpp/src/community/ecg.cu
+++ b/cpp/src/community/ecg.cu
@@ -201,14 +201,16 @@ void ecg(raft::handle_t const &handle,
 }
 
 // Explicit template instantiations.
-template void ecg<int32_t, int32_t, float>(raft::handle_t const &,
-                                           legacy::GraphCSRView<int32_t, int32_t, float> const &graph,
-                                           float min_weight,
-                                           int32_t ensemble_size,
-                                           int32_t *clustering);
-template void ecg<int32_t, int32_t, double>(raft::handle_t const &,
-                                            legacy::GraphCSRView<int32_t, int32_t, double> const &graph,
-                                            double min_weight,
-                                            int32_t ensemble_size,
-                                            int32_t *clustering);
+template void ecg<int32_t, int32_t, float>(
+  raft::handle_t const &,
+  legacy::GraphCSRView<int32_t, int32_t, float> const &graph,
+  float min_weight,
+  int32_t ensemble_size,
+  int32_t *clustering);
+template void ecg<int32_t, int32_t, double>(
+  raft::handle_t const &,
+  legacy::GraphCSRView<int32_t, int32_t, double> const &graph,
+  double min_weight,
+  int32_t ensemble_size,
+  int32_t *clustering);
 }  // namespace cugraph

--- a/cpp/src/community/ecg.cu
+++ b/cpp/src/community/ecg.cu
@@ -134,12 +134,12 @@ namespace cugraph {
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 void ecg(raft::handle_t const &handle,
-         GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+         legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
          weight_t min_weight,
          vertex_t ensemble_size,
          vertex_t *clustering)
 {
-  using graph_type = GraphCSRView<vertex_t, edge_t, weight_t>;
+  using graph_type = legacy::GraphCSRView<vertex_t, edge_t, weight_t>;
 
   CUGRAPH_EXPECTS(graph.edge_data != nullptr,
                   "Invalid input argument: ecg expects a weighted graph");
@@ -190,7 +190,7 @@ void ecg(raft::handle_t const &handle,
 
   // Run Louvain on the original graph using the computed weights
   // (pass max_level = 100 for a "full run")
-  GraphCSRView<vertex_t, edge_t, weight_t> louvain_graph;
+  legacy::GraphCSRView<vertex_t, edge_t, weight_t> louvain_graph;
   louvain_graph.indices            = graph.indices;
   louvain_graph.offsets            = graph.offsets;
   louvain_graph.edge_data          = ecg_weights_v.data();
@@ -202,12 +202,12 @@ void ecg(raft::handle_t const &handle,
 
 // Explicit template instantiations.
 template void ecg<int32_t, int32_t, float>(raft::handle_t const &,
-                                           GraphCSRView<int32_t, int32_t, float> const &graph,
+                                           legacy::GraphCSRView<int32_t, int32_t, float> const &graph,
                                            float min_weight,
                                            int32_t ensemble_size,
                                            int32_t *clustering);
 template void ecg<int32_t, int32_t, double>(raft::handle_t const &,
-                                            GraphCSRView<int32_t, int32_t, double> const &graph,
+                                            legacy::GraphCSRView<int32_t, int32_t, double> const &graph,
                                             double min_weight,
                                             int32_t ensemble_size,
                                             int32_t *clustering);

--- a/cpp/src/community/egonet.cu
+++ b/cpp/src/community/egonet.cu
@@ -28,7 +28,7 @@
 #include <thrust/transform.h>
 #include <ctime>
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <cugraph/experimental/graph.hpp>
 #include <cugraph/utilities/error.hpp>

--- a/cpp/src/community/extract_subgraph_by_vertex.cu
+++ b/cpp/src/community/extract_subgraph_by_vertex.cu
@@ -15,7 +15,7 @@
  */
 
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 
 #include <rmm/thrust_rmm_allocator.h>
@@ -24,8 +24,8 @@
 namespace {
 
 template <typename vertex_t, typename edge_t, typename weight_t, bool has_weight>
-std::unique_ptr<cugraph::GraphCOO<vertex_t, edge_t, weight_t>> extract_subgraph_by_vertices(
-  cugraph::GraphCOOView<vertex_t, edge_t, weight_t> const &graph,
+std::unique_ptr<cugraph::legacy::GraphCOO<vertex_t, edge_t, weight_t>> extract_subgraph_by_vertices(
+  cugraph::legacy::GraphCOOView<vertex_t, edge_t, weight_t> const &graph,
   vertex_t const *vertices,
   vertex_t num_vertices,
   cudaStream_t stream)
@@ -70,7 +70,7 @@ std::unique_ptr<cugraph::GraphCOO<vertex_t, edge_t, weight_t>> extract_subgraph_
     });
 
   if (count > 0) {
-    auto result = std::make_unique<cugraph::GraphCOO<vertex_t, edge_t, weight_t>>(
+    auto result = std::make_unique<cugraph::legacy::GraphCOO<vertex_t, edge_t, weight_t>>(
       num_vertices, count, has_weight);
 
     vertex_t *d_new_src    = result->src_indices();
@@ -106,7 +106,7 @@ std::unique_ptr<cugraph::GraphCOO<vertex_t, edge_t, weight_t>> extract_subgraph_
 
     return result;
   } else {
-    return std::make_unique<cugraph::GraphCOO<vertex_t, edge_t, weight_t>>(0, 0, has_weight);
+    return std::make_unique<cugraph::legacy::GraphCOO<vertex_t, edge_t, weight_t>>(0, 0, has_weight);
   }
 }
 }  // namespace
@@ -115,7 +115,7 @@ namespace cugraph {
 namespace subgraph {
 
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<GraphCOO<VT, ET, WT>> extract_subgraph_vertex(GraphCOOView<VT, ET, WT> const &graph,
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> extract_subgraph_vertex(legacy::GraphCOOView<VT, ET, WT> const &graph,
                                                               VT const *vertices,
                                                               VT num_vertices)
 {
@@ -130,12 +130,12 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> extract_subgraph_vertex(GraphCOOView<VT, E
   }
 }
 
-template std::unique_ptr<GraphCOO<int32_t, int32_t, float>>
-extract_subgraph_vertex<int32_t, int32_t, float>(GraphCOOView<int32_t, int32_t, float> const &,
+template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, float>>
+extract_subgraph_vertex<int32_t, int32_t, float>(legacy::GraphCOOView<int32_t, int32_t, float> const &,
                                                  int32_t const *,
                                                  int32_t);
-template std::unique_ptr<GraphCOO<int32_t, int32_t, double>>
-extract_subgraph_vertex<int32_t, int32_t, double>(GraphCOOView<int32_t, int32_t, double> const &,
+template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, double>>
+extract_subgraph_vertex<int32_t, int32_t, double>(legacy::GraphCOOView<int32_t, int32_t, double> const &,
                                                   int32_t const *,
                                                   int32_t);
 

--- a/cpp/src/community/extract_subgraph_by_vertex.cu
+++ b/cpp/src/community/extract_subgraph_by_vertex.cu
@@ -106,7 +106,8 @@ std::unique_ptr<cugraph::legacy::GraphCOO<vertex_t, edge_t, weight_t>> extract_s
 
     return result;
   } else {
-    return std::make_unique<cugraph::legacy::GraphCOO<vertex_t, edge_t, weight_t>>(0, 0, has_weight);
+    return std::make_unique<cugraph::legacy::GraphCOO<vertex_t, edge_t, weight_t>>(
+      0, 0, has_weight);
   }
 }
 }  // namespace
@@ -115,9 +116,8 @@ namespace cugraph {
 namespace subgraph {
 
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> extract_subgraph_vertex(legacy::GraphCOOView<VT, ET, WT> const &graph,
-                                                              VT const *vertices,
-                                                              VT num_vertices)
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> extract_subgraph_vertex(
+  legacy::GraphCOOView<VT, ET, WT> const &graph, VT const *vertices, VT num_vertices)
 {
   CUGRAPH_EXPECTS(vertices != nullptr, "Invalid input argument: vertices must be non null");
 
@@ -131,13 +131,11 @@ std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> extract_subgraph_vertex(legacy::Gr
 }
 
 template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, float>>
-extract_subgraph_vertex<int32_t, int32_t, float>(legacy::GraphCOOView<int32_t, int32_t, float> const &,
-                                                 int32_t const *,
-                                                 int32_t);
+extract_subgraph_vertex<int32_t, int32_t, float>(
+  legacy::GraphCOOView<int32_t, int32_t, float> const &, int32_t const *, int32_t);
 template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, double>>
-extract_subgraph_vertex<int32_t, int32_t, double>(legacy::GraphCOOView<int32_t, int32_t, double> const &,
-                                                  int32_t const *,
-                                                  int32_t);
+extract_subgraph_vertex<int32_t, int32_t, double>(
+  legacy::GraphCOOView<int32_t, int32_t, double> const &, int32_t const *, int32_t);
 
 }  // namespace subgraph
 }  // namespace cugraph

--- a/cpp/src/community/ktruss.cu
+++ b/cpp/src/community/ktruss.cu
@@ -35,7 +35,7 @@ namespace cugraph {
 namespace detail {
 
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<GraphCOO<VT, ET, WT>> ktruss_subgraph_impl(GraphCOOView<VT, ET, WT> const &graph,
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> ktruss_subgraph_impl(legacy::GraphCOOView<VT, ET, WT> const &graph,
                                                            int k,
                                                            rmm::mr::device_memory_resource *mr)
 {
@@ -68,7 +68,7 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> ktruss_subgraph_impl(GraphCOOView<VT, ET, 
   kt.runForK(k);
   CUGRAPH_EXPECTS(cudaPeekAtLastError() == cudaSuccess, "KTruss : Failed to run");
 
-  auto out_graph = std::make_unique<GraphCOO<VT, ET, WT>>(
+  auto out_graph = std::make_unique<legacy::GraphCOO<VT, ET, WT>>(
     graph.number_of_vertices, kt.getGraphEdgeCount(), graph.has_data(), stream, mr);
 
   kt.copyGraph(out_graph->src_indices(), out_graph->dst_indices());
@@ -79,8 +79,8 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> ktruss_subgraph_impl(GraphCOOView<VT, ET, 
   return out_graph;
 }
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<GraphCOO<VT, ET, WT>> weighted_ktruss_subgraph_impl(
-  GraphCOOView<VT, ET, WT> const &graph, int k, rmm::mr::device_memory_resource *mr)
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> weighted_ktruss_subgraph_impl(
+  legacy::GraphCOOView<VT, ET, WT> const &graph, int k, rmm::mr::device_memory_resource *mr)
 {
   using HornetGraph = hornet::gpu::Hornet<VT, hornet::EMPTY, hornet::TypeList<WT>>;
   using UpdatePtr   = hornet::BatchUpdatePtr<VT, hornet::TypeList<WT>, hornet::DeviceType::DEVICE>;
@@ -111,7 +111,7 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> weighted_ktruss_subgraph_impl(
   kt.runForK(k);
   CUGRAPH_EXPECTS(cudaPeekAtLastError() == cudaSuccess, "KTruss : Failed to run");
 
-  auto out_graph = std::make_unique<GraphCOO<VT, ET, WT>>(
+  auto out_graph = std::make_unique<legacy::GraphCOO<VT, ET, WT>>(
     graph.number_of_vertices, kt.getGraphEdgeCount(), graph.has_data(), stream, mr);
 
   kt.copyGraph(out_graph->src_indices(), out_graph->dst_indices(), out_graph->edge_data());
@@ -125,7 +125,7 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> weighted_ktruss_subgraph_impl(
 }  // namespace detail
 
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<GraphCOO<VT, ET, WT>> k_truss_subgraph(GraphCOOView<VT, ET, WT> const &graph,
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> k_truss_subgraph(legacy::GraphCOOView<VT, ET, WT> const &graph,
                                                        int k,
                                                        rmm::mr::device_memory_resource *mr)
 {
@@ -139,10 +139,10 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> k_truss_subgraph(GraphCOOView<VT, ET, WT> 
   }
 }
 
-template std::unique_ptr<GraphCOO<int32_t, int32_t, float>> k_truss_subgraph<int, int, float>(
-  GraphCOOView<int, int, float> const &, int, rmm::mr::device_memory_resource *);
+template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, float>> k_truss_subgraph<int, int, float>(
+  legacy::GraphCOOView<int, int, float> const &, int, rmm::mr::device_memory_resource *);
 
-template std::unique_ptr<GraphCOO<int32_t, int32_t, double>> k_truss_subgraph<int, int, double>(
-  GraphCOOView<int, int, double> const &, int, rmm::mr::device_memory_resource *);
+template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, double>> k_truss_subgraph<int, int, double>(
+  legacy::GraphCOOView<int, int, double> const &, int, rmm::mr::device_memory_resource *);
 
 }  // namespace cugraph

--- a/cpp/src/community/ktruss.cu
+++ b/cpp/src/community/ktruss.cu
@@ -35,9 +35,8 @@ namespace cugraph {
 namespace detail {
 
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> ktruss_subgraph_impl(legacy::GraphCOOView<VT, ET, WT> const &graph,
-                                                           int k,
-                                                           rmm::mr::device_memory_resource *mr)
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> ktruss_subgraph_impl(
+  legacy::GraphCOOView<VT, ET, WT> const &graph, int k, rmm::mr::device_memory_resource *mr)
 {
   using HornetGraph = hornet::gpu::Hornet<VT>;
   using UpdatePtr   = hornet::BatchUpdatePtr<VT, hornet::EMPTY, hornet::DeviceType::DEVICE>;
@@ -125,9 +124,8 @@ std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> weighted_ktruss_subgraph_impl(
 }  // namespace detail
 
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> k_truss_subgraph(legacy::GraphCOOView<VT, ET, WT> const &graph,
-                                                       int k,
-                                                       rmm::mr::device_memory_resource *mr)
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> k_truss_subgraph(
+  legacy::GraphCOOView<VT, ET, WT> const &graph, int k, rmm::mr::device_memory_resource *mr)
 {
   CUGRAPH_EXPECTS(graph.src_indices != nullptr, "Graph source indices cannot be a nullptr");
   CUGRAPH_EXPECTS(graph.dst_indices != nullptr, "Graph destination indices cannot be a nullptr");
@@ -139,10 +137,14 @@ std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> k_truss_subgraph(legacy::GraphCOOV
   }
 }
 
-template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, float>> k_truss_subgraph<int, int, float>(
-  legacy::GraphCOOView<int, int, float> const &, int, rmm::mr::device_memory_resource *);
+template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, float>>
+k_truss_subgraph<int, int, float>(legacy::GraphCOOView<int, int, float> const &,
+                                  int,
+                                  rmm::mr::device_memory_resource *);
 
-template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, double>> k_truss_subgraph<int, int, double>(
-  legacy::GraphCOOView<int, int, double> const &, int, rmm::mr::device_memory_resource *);
+template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, double>>
+k_truss_subgraph<int, int, double>(legacy::GraphCOOView<int, int, double> const &,
+                                   int,
+                                   rmm::mr::device_memory_resource *);
 
 }  // namespace cugraph

--- a/cpp/src/community/leiden.cu
+++ b/cpp/src/community/leiden.cu
@@ -23,7 +23,7 @@ namespace cugraph {
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 std::pair<size_t, weight_t> leiden(raft::handle_t const &handle,
-                                   GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+                                   legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                                    vertex_t *clustering,
                                    size_t max_level,
                                    weight_t resolution)
@@ -34,7 +34,7 @@ std::pair<size_t, weight_t> leiden(raft::handle_t const &handle,
                   "Invalid input argument: clustering is null, should be a device pointer to "
                   "memory for storing the result");
 
-  Leiden<GraphCSRView<vertex_t, edge_t, weight_t>> runner(handle, graph);
+  Leiden<legacy::GraphCSRView<vertex_t, edge_t, weight_t>> runner(handle, graph);
   weight_t wt = runner(max_level, resolution);
 
   rmm::device_uvector<vertex_t> vertex_ids_v(graph.number_of_vertices, handle.get_stream());
@@ -57,10 +57,10 @@ std::pair<size_t, weight_t> leiden(raft::handle_t const &handle,
 
 // Explicit template instantations
 template std::pair<size_t, float> leiden(
-  raft::handle_t const &, GraphCSRView<int32_t, int32_t, float> const &, int32_t *, size_t, float);
+  raft::handle_t const &, legacy::GraphCSRView<int32_t, int32_t, float> const &, int32_t *, size_t, float);
 
 template std::pair<size_t, double> leiden(raft::handle_t const &,
-                                          GraphCSRView<int32_t, int32_t, double> const &,
+                                          legacy::GraphCSRView<int32_t, int32_t, double> const &,
                                           int32_t *,
                                           size_t,
                                           double);

--- a/cpp/src/community/leiden.cu
+++ b/cpp/src/community/leiden.cu
@@ -56,8 +56,11 @@ std::pair<size_t, weight_t> leiden(raft::handle_t const &handle,
 }
 
 // Explicit template instantations
-template std::pair<size_t, float> leiden(
-  raft::handle_t const &, legacy::GraphCSRView<int32_t, int32_t, float> const &, int32_t *, size_t, float);
+template std::pair<size_t, float> leiden(raft::handle_t const &,
+                                         legacy::GraphCSRView<int32_t, int32_t, float> const &,
+                                         int32_t *,
+                                         size_t,
+                                         float);
 
 template std::pair<size_t, double> leiden(raft::handle_t const &,
                                           legacy::GraphCSRView<int32_t, int32_t, double> const &,

--- a/cpp/src/community/leiden.cuh
+++ b/cpp/src/community/leiden.cuh
@@ -122,7 +122,7 @@ class Leiden : public Louvain<graph_type> {
     //  Our copy of the graph.  Each iteration of the outer loop will
     //  shrink this copy of the graph.
     //
-    GraphCSRView<vertex_t, edge_t, weight_t> current_graph(this->offsets_v_.data(),
+    legacy::GraphCSRView<vertex_t, edge_t, weight_t> current_graph(this->offsets_v_.data(),
                                                            this->indices_v_.data(),
                                                            this->weights_v_.data(),
                                                            this->number_of_vertices_,

--- a/cpp/src/community/leiden.cuh
+++ b/cpp/src/community/leiden.cuh
@@ -123,10 +123,10 @@ class Leiden : public Louvain<graph_type> {
     //  shrink this copy of the graph.
     //
     legacy::GraphCSRView<vertex_t, edge_t, weight_t> current_graph(this->offsets_v_.data(),
-                                                           this->indices_v_.data(),
-                                                           this->weights_v_.data(),
-                                                           this->number_of_vertices_,
-                                                           this->number_of_edges_);
+                                                                   this->indices_v_.data(),
+                                                                   this->weights_v_.data(),
+                                                                   this->number_of_vertices_,
+                                                                   this->number_of_edges_);
 
     current_graph.get_source_indices(this->src_indices_v_.data());
 

--- a/cpp/src/community/louvain.cu
+++ b/cpp/src/community/louvain.cu
@@ -31,14 +31,14 @@ namespace detail {
 template <typename vertex_t, typename edge_t, typename weight_t>
 std::pair<std::unique_ptr<Dendrogram<vertex_t>>, weight_t> louvain(
   raft::handle_t const &handle,
-  GraphCSRView<vertex_t, edge_t, weight_t> const &graph_view,
+  legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph_view,
   size_t max_level,
   weight_t resolution)
 {
   CUGRAPH_EXPECTS(graph_view.edge_data != nullptr,
                   "Invalid input argument: louvain expects a weighted graph");
 
-  Louvain<GraphCSRView<vertex_t, edge_t, weight_t>> runner(handle, graph_view);
+  Louvain<legacy::GraphCSRView<vertex_t, edge_t, weight_t>> runner(handle, graph_view);
   weight_t wt = runner(max_level, resolution);
 
   return std::make_pair(runner.move_dendrogram(), wt);
@@ -61,7 +61,7 @@ std::pair<std::unique_ptr<Dendrogram<vertex_t>>, weight_t> louvain(
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 void flatten_dendrogram(raft::handle_t const &handle,
-                        GraphCSRView<vertex_t, edge_t, weight_t> const &graph_view,
+                        legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph_view,
                         Dendrogram<vertex_t> const &dendrogram,
                         vertex_t *clustering)
 {
@@ -203,9 +203,9 @@ template std::pair<std::unique_ptr<Dendrogram<int64_t>>, double> louvain(
   double);
 
 template std::pair<size_t, float> louvain(
-  raft::handle_t const &, GraphCSRView<int32_t, int32_t, float> const &, int32_t *, size_t, float);
+  raft::handle_t const &, legacy::GraphCSRView<int32_t, int32_t, float> const &, int32_t *, size_t, float);
 template std::pair<size_t, double> louvain(raft::handle_t const &,
-                                           GraphCSRView<int32_t, int32_t, double> const &,
+                                           legacy::GraphCSRView<int32_t, int32_t, double> const &,
                                            int32_t *,
                                            size_t,
                                            double);
@@ -287,4 +287,4 @@ template std::pair<size_t, double> louvain(
 
 }  // namespace cugraph
 
-#include <cugraph/eidir_graph.hpp>
+#include <cugraph/legacy/eidir_graph.hpp>

--- a/cpp/src/community/louvain.cu
+++ b/cpp/src/community/louvain.cu
@@ -202,8 +202,11 @@ template std::pair<std::unique_ptr<Dendrogram<int64_t>>, double> louvain(
   size_t,
   double);
 
-template std::pair<size_t, float> louvain(
-  raft::handle_t const &, legacy::GraphCSRView<int32_t, int32_t, float> const &, int32_t *, size_t, float);
+template std::pair<size_t, float> louvain(raft::handle_t const &,
+                                          legacy::GraphCSRView<int32_t, int32_t, float> const &,
+                                          int32_t *,
+                                          size_t,
+                                          float);
 template std::pair<size_t, double> louvain(raft::handle_t const &,
                                            legacy::GraphCSRView<int32_t, int32_t, double> const &,
                                            int32_t *,

--- a/cpp/src/community/louvain.cuh
+++ b/cpp/src/community/louvain.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <converters/COOtoCSR.cuh>
 #include <utilities/graph_utils.cuh>
@@ -157,7 +157,7 @@ class Louvain {
     //  Our copy of the graph.  Each iteration of the outer loop will
     //  shrink this copy of the graph.
     //
-    GraphCSRView<vertex_t, edge_t, weight_t> current_graph(offsets_v_.data(),
+    legacy::GraphCSRView<vertex_t, edge_t, weight_t> current_graph(offsets_v_.data(),
                                                            indices_v_.data(),
                                                            weights_v_.data(),
                                                            number_of_vertices_,

--- a/cpp/src/community/louvain.cuh
+++ b/cpp/src/community/louvain.cuh
@@ -158,10 +158,10 @@ class Louvain {
     //  shrink this copy of the graph.
     //
     legacy::GraphCSRView<vertex_t, edge_t, weight_t> current_graph(offsets_v_.data(),
-                                                           indices_v_.data(),
-                                                           weights_v_.data(),
-                                                           number_of_vertices_,
-                                                           number_of_edges_);
+                                                                   indices_v_.data(),
+                                                                   weights_v_.data(),
+                                                                   number_of_vertices_,
+                                                                   number_of_edges_);
 
     current_graph.get_source_indices(src_indices_v_.data());
 

--- a/cpp/src/community/spectral_clustering.cu
+++ b/cpp/src/community/spectral_clustering.cu
@@ -109,16 +109,17 @@ void balancedCutClustering_impl(legacy::GraphCSRView<vertex_t, edge_t, weight_t>
 }
 
 template <typename vertex_t, typename edge_t, typename weight_t>
-void spectralModularityMaximization_impl(legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
-                                         vertex_t n_clusters,
-                                         vertex_t n_eig_vects,
-                                         weight_t evs_tolerance,
-                                         int evs_max_iter,
-                                         weight_t kmean_tolerance,
-                                         int kmean_max_iter,
-                                         vertex_t *clustering,
-                                         weight_t *eig_vals,
-                                         weight_t *eig_vects)
+void spectralModularityMaximization_impl(
+  legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+  vertex_t n_clusters,
+  vertex_t n_eig_vects,
+  weight_t evs_tolerance,
+  int evs_max_iter,
+  weight_t kmean_tolerance,
+  int kmean_max_iter,
+  vertex_t *clustering,
+  weight_t *eig_vals,
+  weight_t *eig_vects)
 {
   RAFT_EXPECTS(graph.edge_data != nullptr, "API error, graph must have weights");
   RAFT_EXPECTS(evs_tolerance >= weight_t{0.0},
@@ -326,30 +327,18 @@ template void spectralModularityMaximization<int, int, float>(
   legacy::GraphCSRView<int, int, float> const &, int, int, float, int, float, int, int *);
 template void spectralModularityMaximization<int, int, double>(
   legacy::GraphCSRView<int, int, double> const &, int, int, double, int, double, int, int *);
-template void analyzeClustering_modularity<int, int, float>(legacy::GraphCSRView<int, int, float> const &,
-                                                            int,
-                                                            int const *,
-                                                            float *);
-template void analyzeClustering_modularity<int, int, double>(legacy::GraphCSRView<int, int, double> const &,
-                                                             int,
-                                                             int const *,
-                                                             double *);
-template void analyzeClustering_edge_cut<int, int, float>(legacy::GraphCSRView<int, int, float> const &,
-                                                          int,
-                                                          int const *,
-                                                          float *);
-template void analyzeClustering_edge_cut<int, int, double>(legacy::GraphCSRView<int, int, double> const &,
-                                                           int,
-                                                           int const *,
-                                                           double *);
-template void analyzeClustering_ratio_cut<int, int, float>(legacy::GraphCSRView<int, int, float> const &,
-                                                           int,
-                                                           int const *,
-                                                           float *);
-template void analyzeClustering_ratio_cut<int, int, double>(legacy::GraphCSRView<int, int, double> const &,
-                                                            int,
-                                                            int const *,
-                                                            double *);
+template void analyzeClustering_modularity<int, int, float>(
+  legacy::GraphCSRView<int, int, float> const &, int, int const *, float *);
+template void analyzeClustering_modularity<int, int, double>(
+  legacy::GraphCSRView<int, int, double> const &, int, int const *, double *);
+template void analyzeClustering_edge_cut<int, int, float>(
+  legacy::GraphCSRView<int, int, float> const &, int, int const *, float *);
+template void analyzeClustering_edge_cut<int, int, double>(
+  legacy::GraphCSRView<int, int, double> const &, int, int const *, double *);
+template void analyzeClustering_ratio_cut<int, int, float>(
+  legacy::GraphCSRView<int, int, float> const &, int, int const *, float *);
+template void analyzeClustering_ratio_cut<int, int, double>(
+  legacy::GraphCSRView<int, int, double> const &, int, int const *, double *);
 
 }  // namespace ext_raft
 }  // namespace cugraph

--- a/cpp/src/community/spectral_clustering.cu
+++ b/cpp/src/community/spectral_clustering.cu
@@ -26,7 +26,7 @@
 #include <thrust/transform.h>
 #include <ctime>
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 
 #include <raft/spectral/modularity_maximization.hpp>
@@ -39,7 +39,7 @@ namespace ext_raft {
 namespace detail {
 
 template <typename vertex_t, typename edge_t, typename weight_t>
-void balancedCutClustering_impl(GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+void balancedCutClustering_impl(legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                                 vertex_t n_clusters,
                                 vertex_t n_eig_vects,
                                 weight_t evs_tolerance,
@@ -109,7 +109,7 @@ void balancedCutClustering_impl(GraphCSRView<vertex_t, edge_t, weight_t> const &
 }
 
 template <typename vertex_t, typename edge_t, typename weight_t>
-void spectralModularityMaximization_impl(GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+void spectralModularityMaximization_impl(legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                                          vertex_t n_clusters,
                                          vertex_t n_eig_vects,
                                          weight_t evs_tolerance,
@@ -186,7 +186,7 @@ void spectralModularityMaximization_impl(GraphCSRView<vertex_t, edge_t, weight_t
 }
 
 template <typename vertex_t, typename edge_t, typename weight_t>
-void analyzeModularityClustering_impl(GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+void analyzeModularityClustering_impl(legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                                       int n_clusters,
                                       vertex_t const *clustering,
                                       weight_t *modularity)
@@ -207,7 +207,7 @@ void analyzeModularityClustering_impl(GraphCSRView<vertex_t, edge_t, weight_t> c
 }
 
 template <typename vertex_t, typename edge_t, typename weight_t>
-void analyzeBalancedCut_impl(GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+void analyzeBalancedCut_impl(legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                              vertex_t n_clusters,
                              vertex_t const *clustering,
                              weight_t *edgeCut,
@@ -240,7 +240,7 @@ void analyzeBalancedCut_impl(GraphCSRView<vertex_t, edge_t, weight_t> const &gra
 }  // namespace detail
 
 template <typename VT, typename ET, typename WT>
-void balancedCutClustering(GraphCSRView<VT, ET, WT> const &graph,
+void balancedCutClustering(legacy::GraphCSRView<VT, ET, WT> const &graph,
                            VT num_clusters,
                            VT num_eigen_vects,
                            WT evs_tolerance,
@@ -265,7 +265,7 @@ void balancedCutClustering(GraphCSRView<VT, ET, WT> const &graph,
 }
 
 template <typename VT, typename ET, typename WT>
-void spectralModularityMaximization(GraphCSRView<VT, ET, WT> const &graph,
+void spectralModularityMaximization(legacy::GraphCSRView<VT, ET, WT> const &graph,
                                     VT n_clusters,
                                     VT n_eigen_vects,
                                     WT evs_tolerance,
@@ -290,7 +290,7 @@ void spectralModularityMaximization(GraphCSRView<VT, ET, WT> const &graph,
 }
 
 template <typename VT, typename ET, typename WT>
-void analyzeClustering_modularity(GraphCSRView<VT, ET, WT> const &graph,
+void analyzeClustering_modularity(legacy::GraphCSRView<VT, ET, WT> const &graph,
                                   int n_clusters,
                                   VT const *clustering,
                                   WT *score)
@@ -299,7 +299,7 @@ void analyzeClustering_modularity(GraphCSRView<VT, ET, WT> const &graph,
 }
 
 template <typename VT, typename ET, typename WT>
-void analyzeClustering_edge_cut(GraphCSRView<VT, ET, WT> const &graph,
+void analyzeClustering_edge_cut(legacy::GraphCSRView<VT, ET, WT> const &graph,
                                 int n_clusters,
                                 VT const *clustering,
                                 WT *score)
@@ -309,7 +309,7 @@ void analyzeClustering_edge_cut(GraphCSRView<VT, ET, WT> const &graph,
 }
 
 template <typename VT, typename ET, typename WT>
-void analyzeClustering_ratio_cut(GraphCSRView<VT, ET, WT> const &graph,
+void analyzeClustering_ratio_cut(legacy::GraphCSRView<VT, ET, WT> const &graph,
                                  int n_clusters,
                                  VT const *clustering,
                                  WT *score)
@@ -319,34 +319,34 @@ void analyzeClustering_ratio_cut(GraphCSRView<VT, ET, WT> const &graph,
 }
 
 template void balancedCutClustering<int, int, float>(
-  GraphCSRView<int, int, float> const &, int, int, float, int, float, int, int *);
+  legacy::GraphCSRView<int, int, float> const &, int, int, float, int, float, int, int *);
 template void balancedCutClustering<int, int, double>(
-  GraphCSRView<int, int, double> const &, int, int, double, int, double, int, int *);
+  legacy::GraphCSRView<int, int, double> const &, int, int, double, int, double, int, int *);
 template void spectralModularityMaximization<int, int, float>(
-  GraphCSRView<int, int, float> const &, int, int, float, int, float, int, int *);
+  legacy::GraphCSRView<int, int, float> const &, int, int, float, int, float, int, int *);
 template void spectralModularityMaximization<int, int, double>(
-  GraphCSRView<int, int, double> const &, int, int, double, int, double, int, int *);
-template void analyzeClustering_modularity<int, int, float>(GraphCSRView<int, int, float> const &,
+  legacy::GraphCSRView<int, int, double> const &, int, int, double, int, double, int, int *);
+template void analyzeClustering_modularity<int, int, float>(legacy::GraphCSRView<int, int, float> const &,
                                                             int,
                                                             int const *,
                                                             float *);
-template void analyzeClustering_modularity<int, int, double>(GraphCSRView<int, int, double> const &,
+template void analyzeClustering_modularity<int, int, double>(legacy::GraphCSRView<int, int, double> const &,
                                                              int,
                                                              int const *,
                                                              double *);
-template void analyzeClustering_edge_cut<int, int, float>(GraphCSRView<int, int, float> const &,
+template void analyzeClustering_edge_cut<int, int, float>(legacy::GraphCSRView<int, int, float> const &,
                                                           int,
                                                           int const *,
                                                           float *);
-template void analyzeClustering_edge_cut<int, int, double>(GraphCSRView<int, int, double> const &,
+template void analyzeClustering_edge_cut<int, int, double>(legacy::GraphCSRView<int, int, double> const &,
                                                            int,
                                                            int const *,
                                                            double *);
-template void analyzeClustering_ratio_cut<int, int, float>(GraphCSRView<int, int, float> const &,
+template void analyzeClustering_ratio_cut<int, int, float>(legacy::GraphCSRView<int, int, float> const &,
                                                            int,
                                                            int const *,
                                                            float *);
-template void analyzeClustering_ratio_cut<int, int, double>(GraphCSRView<int, int, double> const &,
+template void analyzeClustering_ratio_cut<int, int, double>(legacy::GraphCSRView<int, int, double> const &,
                                                             int,
                                                             int const *,
                                                             double *);

--- a/cpp/src/community/triangles_counting.cu
+++ b/cpp/src/community/triangles_counting.cu
@@ -18,7 +18,7 @@
 
 #include <raft/cudart_utils.h>
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <cugraph/utilities/error.hpp>
 
@@ -841,7 +841,7 @@ void TrianglesCount<IndexType>::count()
 }  // namespace
 
 template <typename VT, typename ET, typename WT>
-uint64_t triangle_count(GraphCSRView<VT, ET, WT> const &graph)
+uint64_t triangle_count(legacy::GraphCSRView<VT, ET, WT> const &graph)
 {
   TrianglesCount<VT> counter(
     graph.number_of_vertices, graph.number_of_edges, graph.offsets, graph.indices);
@@ -851,7 +851,7 @@ uint64_t triangle_count(GraphCSRView<VT, ET, WT> const &graph)
 }
 
 template uint64_t triangle_count<int32_t, int32_t, float>(
-  GraphCSRView<int32_t, int32_t, float> const &);
+  legacy::GraphCSRView<int32_t, int32_t, float> const &);
 
 }  // namespace triangle
 }  // namespace cugraph

--- a/cpp/src/components/connectivity.cu
+++ b/cpp/src/components/connectivity.cu
@@ -21,7 +21,7 @@
 
 #include <cstdint>
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <iostream>
 #include <type_traits>
@@ -57,7 +57,7 @@ namespace detail {
  */
 template <typename VT, typename ET, typename WT, int TPB_X = 32>
 std::enable_if_t<std::is_signed<VT>::value> connected_components_impl(
-  GraphCSRView<VT, ET, WT> const &graph,
+  legacy::GraphCSRView<VT, ET, WT> const &graph,
   cugraph_cc_t connectivity_type,
   VT *labels,
   cudaStream_t stream)
@@ -84,7 +84,7 @@ std::enable_if_t<std::is_signed<VT>::value> connected_components_impl(
 }  // namespace detail
 
 template <typename VT, typename ET, typename WT>
-void connected_components(GraphCSRView<VT, ET, WT> const &graph,
+void connected_components(legacy::GraphCSRView<VT, ET, WT> const &graph,
                           cugraph_cc_t connectivity_type,
                           VT *labels)
 {
@@ -96,8 +96,8 @@ void connected_components(GraphCSRView<VT, ET, WT> const &graph,
 }
 
 template void connected_components<int32_t, int32_t, float>(
-  GraphCSRView<int32_t, int32_t, float> const &, cugraph_cc_t, int32_t *);
+  legacy::GraphCSRView<int32_t, int32_t, float> const &, cugraph_cc_t, int32_t *);
 template void connected_components<int64_t, int64_t, float>(
-  GraphCSRView<int64_t, int64_t, float> const &, cugraph_cc_t, int64_t *);
+  legacy::GraphCSRView<int64_t, int64_t, float> const &, cugraph_cc_t, int64_t *);
 
 }  // namespace cugraph

--- a/cpp/src/converters/COOtoCSR.cu
+++ b/cpp/src/converters/COOtoCSR.cu
@@ -20,55 +20,55 @@
 namespace cugraph {
 
 // Explicit instantiation for uint32_t + float
-template std::unique_ptr<GraphCSR<uint32_t, uint32_t, float>> coo_to_csr<uint32_t, uint32_t, float>(
-  GraphCOOView<uint32_t, uint32_t, float> const &graph, rmm::mr::device_memory_resource *);
+template std::unique_ptr<legacy::GraphCSR<uint32_t, uint32_t, float>> coo_to_csr<uint32_t, uint32_t, float>(
+  legacy::GraphCOOView<uint32_t, uint32_t, float> const &graph, rmm::mr::device_memory_resource *);
 
 // Explicit instantiation for uint32_t + double
-template std::unique_ptr<GraphCSR<uint32_t, uint32_t, double>>
-coo_to_csr<uint32_t, uint32_t, double>(GraphCOOView<uint32_t, uint32_t, double> const &graph,
+template std::unique_ptr<legacy::GraphCSR<uint32_t, uint32_t, double>>
+coo_to_csr<uint32_t, uint32_t, double>(legacy::GraphCOOView<uint32_t, uint32_t, double> const &graph,
                                        rmm::mr::device_memory_resource *);
 
 // Explicit instantiation for int + float
-template std::unique_ptr<GraphCSR<int32_t, int32_t, float>> coo_to_csr<int32_t, int32_t, float>(
-  GraphCOOView<int32_t, int32_t, float> const &graph, rmm::mr::device_memory_resource *);
+template std::unique_ptr<legacy::GraphCSR<int32_t, int32_t, float>> coo_to_csr<int32_t, int32_t, float>(
+  legacy::GraphCOOView<int32_t, int32_t, float> const &graph, rmm::mr::device_memory_resource *);
 
 // Explicit instantiation for int + double
-template std::unique_ptr<GraphCSR<int32_t, int32_t, double>> coo_to_csr<int32_t, int32_t, double>(
-  GraphCOOView<int32_t, int32_t, double> const &graph, rmm::mr::device_memory_resource *);
+template std::unique_ptr<legacy::GraphCSR<int32_t, int32_t, double>> coo_to_csr<int32_t, int32_t, double>(
+  legacy::GraphCOOView<int32_t, int32_t, double> const &graph, rmm::mr::device_memory_resource *);
 
 // Explicit instantiation for int64_t + float
-template std::unique_ptr<GraphCSR<int64_t, int64_t, float>> coo_to_csr<int64_t, int64_t, float>(
-  GraphCOOView<int64_t, int64_t, float> const &graph, rmm::mr::device_memory_resource *);
+template std::unique_ptr<legacy::GraphCSR<int64_t, int64_t, float>> coo_to_csr<int64_t, int64_t, float>(
+  legacy::GraphCOOView<int64_t, int64_t, float> const &graph, rmm::mr::device_memory_resource *);
 
 // Explicit instantiation for int64_t + double
-template std::unique_ptr<GraphCSR<int64_t, int64_t, double>> coo_to_csr<int64_t, int64_t, double>(
-  GraphCOOView<int64_t, int64_t, double> const &graph, rmm::mr::device_memory_resource *);
+template std::unique_ptr<legacy::GraphCSR<int64_t, int64_t, double>> coo_to_csr<int64_t, int64_t, double>(
+  legacy::GraphCOOView<int64_t, int64_t, double> const &graph, rmm::mr::device_memory_resource *);
 
 // in-place versions:
 //
 // Explicit instantiation for uint32_t + float
 template void coo_to_csr_inplace<uint32_t, uint32_t, float>(
-  GraphCOOView<uint32_t, uint32_t, float> &graph, GraphCSRView<uint32_t, uint32_t, float> &result);
+  legacy::GraphCOOView<uint32_t, uint32_t, float> &graph, legacy::GraphCSRView<uint32_t, uint32_t, float> &result);
 
 // Explicit instantiation for uint32_t + double
 template void coo_to_csr_inplace<uint32_t, uint32_t, double>(
-  GraphCOOView<uint32_t, uint32_t, double> &graph,
-  GraphCSRView<uint32_t, uint32_t, double> &result);
+  legacy::GraphCOOView<uint32_t, uint32_t, double> &graph,
+  legacy::GraphCSRView<uint32_t, uint32_t, double> &result);
 
 // Explicit instantiation for int + float
 template void coo_to_csr_inplace<int32_t, int32_t, float>(
-  GraphCOOView<int32_t, int32_t, float> &graph, GraphCSRView<int32_t, int32_t, float> &result);
+  legacy::GraphCOOView<int32_t, int32_t, float> &graph, legacy::GraphCSRView<int32_t, int32_t, float> &result);
 
 // Explicit instantiation for int + double
 template void coo_to_csr_inplace<int32_t, int32_t, double>(
-  GraphCOOView<int32_t, int32_t, double> &graph, GraphCSRView<int32_t, int32_t, double> &result);
+  legacy::GraphCOOView<int32_t, int32_t, double> &graph, legacy::GraphCSRView<int32_t, int32_t, double> &result);
 
 // Explicit instantiation for int64_t + float
 template void coo_to_csr_inplace<int64_t, int64_t, float>(
-  GraphCOOView<int64_t, int64_t, float> &graph, GraphCSRView<int64_t, int64_t, float> &result);
+  legacy::GraphCOOView<int64_t, int64_t, float> &graph, legacy::GraphCSRView<int64_t, int64_t, float> &result);
 
 // Explicit instantiation for int64_t + double
 template void coo_to_csr_inplace<int64_t, int64_t, double>(
-  GraphCOOView<int64_t, int64_t, double> &graph, GraphCSRView<int64_t, int64_t, double> &result);
+  legacy::GraphCOOView<int64_t, int64_t, double> &graph, legacy::GraphCSRView<int64_t, int64_t, double> &result);
 
 }  // namespace cugraph

--- a/cpp/src/converters/COOtoCSR.cu
+++ b/cpp/src/converters/COOtoCSR.cu
@@ -20,35 +20,41 @@
 namespace cugraph {
 
 // Explicit instantiation for uint32_t + float
-template std::unique_ptr<legacy::GraphCSR<uint32_t, uint32_t, float>> coo_to_csr<uint32_t, uint32_t, float>(
-  legacy::GraphCOOView<uint32_t, uint32_t, float> const &graph, rmm::mr::device_memory_resource *);
+template std::unique_ptr<legacy::GraphCSR<uint32_t, uint32_t, float>>
+coo_to_csr<uint32_t, uint32_t, float>(legacy::GraphCOOView<uint32_t, uint32_t, float> const &graph,
+                                      rmm::mr::device_memory_resource *);
 
 // Explicit instantiation for uint32_t + double
 template std::unique_ptr<legacy::GraphCSR<uint32_t, uint32_t, double>>
-coo_to_csr<uint32_t, uint32_t, double>(legacy::GraphCOOView<uint32_t, uint32_t, double> const &graph,
-                                       rmm::mr::device_memory_resource *);
+coo_to_csr<uint32_t, uint32_t, double>(
+  legacy::GraphCOOView<uint32_t, uint32_t, double> const &graph, rmm::mr::device_memory_resource *);
 
 // Explicit instantiation for int + float
-template std::unique_ptr<legacy::GraphCSR<int32_t, int32_t, float>> coo_to_csr<int32_t, int32_t, float>(
-  legacy::GraphCOOView<int32_t, int32_t, float> const &graph, rmm::mr::device_memory_resource *);
+template std::unique_ptr<legacy::GraphCSR<int32_t, int32_t, float>>
+coo_to_csr<int32_t, int32_t, float>(legacy::GraphCOOView<int32_t, int32_t, float> const &graph,
+                                    rmm::mr::device_memory_resource *);
 
 // Explicit instantiation for int + double
-template std::unique_ptr<legacy::GraphCSR<int32_t, int32_t, double>> coo_to_csr<int32_t, int32_t, double>(
-  legacy::GraphCOOView<int32_t, int32_t, double> const &graph, rmm::mr::device_memory_resource *);
+template std::unique_ptr<legacy::GraphCSR<int32_t, int32_t, double>>
+coo_to_csr<int32_t, int32_t, double>(legacy::GraphCOOView<int32_t, int32_t, double> const &graph,
+                                     rmm::mr::device_memory_resource *);
 
 // Explicit instantiation for int64_t + float
-template std::unique_ptr<legacy::GraphCSR<int64_t, int64_t, float>> coo_to_csr<int64_t, int64_t, float>(
-  legacy::GraphCOOView<int64_t, int64_t, float> const &graph, rmm::mr::device_memory_resource *);
+template std::unique_ptr<legacy::GraphCSR<int64_t, int64_t, float>>
+coo_to_csr<int64_t, int64_t, float>(legacy::GraphCOOView<int64_t, int64_t, float> const &graph,
+                                    rmm::mr::device_memory_resource *);
 
 // Explicit instantiation for int64_t + double
-template std::unique_ptr<legacy::GraphCSR<int64_t, int64_t, double>> coo_to_csr<int64_t, int64_t, double>(
-  legacy::GraphCOOView<int64_t, int64_t, double> const &graph, rmm::mr::device_memory_resource *);
+template std::unique_ptr<legacy::GraphCSR<int64_t, int64_t, double>>
+coo_to_csr<int64_t, int64_t, double>(legacy::GraphCOOView<int64_t, int64_t, double> const &graph,
+                                     rmm::mr::device_memory_resource *);
 
 // in-place versions:
 //
 // Explicit instantiation for uint32_t + float
 template void coo_to_csr_inplace<uint32_t, uint32_t, float>(
-  legacy::GraphCOOView<uint32_t, uint32_t, float> &graph, legacy::GraphCSRView<uint32_t, uint32_t, float> &result);
+  legacy::GraphCOOView<uint32_t, uint32_t, float> &graph,
+  legacy::GraphCSRView<uint32_t, uint32_t, float> &result);
 
 // Explicit instantiation for uint32_t + double
 template void coo_to_csr_inplace<uint32_t, uint32_t, double>(
@@ -57,18 +63,22 @@ template void coo_to_csr_inplace<uint32_t, uint32_t, double>(
 
 // Explicit instantiation for int + float
 template void coo_to_csr_inplace<int32_t, int32_t, float>(
-  legacy::GraphCOOView<int32_t, int32_t, float> &graph, legacy::GraphCSRView<int32_t, int32_t, float> &result);
+  legacy::GraphCOOView<int32_t, int32_t, float> &graph,
+  legacy::GraphCSRView<int32_t, int32_t, float> &result);
 
 // Explicit instantiation for int + double
 template void coo_to_csr_inplace<int32_t, int32_t, double>(
-  legacy::GraphCOOView<int32_t, int32_t, double> &graph, legacy::GraphCSRView<int32_t, int32_t, double> &result);
+  legacy::GraphCOOView<int32_t, int32_t, double> &graph,
+  legacy::GraphCSRView<int32_t, int32_t, double> &result);
 
 // Explicit instantiation for int64_t + float
 template void coo_to_csr_inplace<int64_t, int64_t, float>(
-  legacy::GraphCOOView<int64_t, int64_t, float> &graph, legacy::GraphCSRView<int64_t, int64_t, float> &result);
+  legacy::GraphCOOView<int64_t, int64_t, float> &graph,
+  legacy::GraphCSRView<int64_t, int64_t, float> &result);
 
 // Explicit instantiation for int64_t + double
 template void coo_to_csr_inplace<int64_t, int64_t, double>(
-  legacy::GraphCOOView<int64_t, int64_t, double> &graph, legacy::GraphCSRView<int64_t, int64_t, double> &result);
+  legacy::GraphCOOView<int64_t, int64_t, double> &graph,
+  legacy::GraphCSRView<int64_t, int64_t, double> &result);
 
 }  // namespace cugraph

--- a/cpp/src/converters/COOtoCSR.cuh
+++ b/cpp/src/converters/COOtoCSR.cuh
@@ -38,7 +38,7 @@
 
 #include <cugraph/functions.hpp>
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 namespace cugraph {
 namespace detail {
@@ -60,7 +60,7 @@ namespace detail {
  * @param[out] result      Total number of vertices
  */
 template <typename VT, typename ET, typename WT>
-VT sort(GraphCOOView<VT, ET, WT> &graph, rmm::cuda_stream_view stream_view)
+VT sort(legacy::GraphCOOView<VT, ET, WT> &graph, rmm::cuda_stream_view stream_view)
 {
   VT max_src_id;
   VT max_dst_id;
@@ -144,29 +144,29 @@ rmm::device_buffer create_offset(VT *source,
 }  // namespace detail
 
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<GraphCSR<VT, ET, WT>> coo_to_csr(GraphCOOView<VT, ET, WT> const &graph,
+std::unique_ptr<legacy::GraphCSR<VT, ET, WT>> coo_to_csr(legacy::GraphCOOView<VT, ET, WT> const &graph,
                                                  rmm::mr::device_memory_resource *mr)
 {
   rmm::cuda_stream_view stream_view;
 
-  GraphCOO<VT, ET, WT> temp_graph(graph, stream_view.value(), mr);
-  GraphCOOView<VT, ET, WT> temp_graph_view = temp_graph.view();
+  legacy::GraphCOO<VT, ET, WT> temp_graph(graph, stream_view.value(), mr);
+  legacy::GraphCOOView<VT, ET, WT> temp_graph_view = temp_graph.view();
   VT total_vertex_count                    = detail::sort(temp_graph_view, stream_view);
   rmm::device_buffer offsets               = detail::create_offset(
     temp_graph.src_indices(), total_vertex_count, temp_graph.number_of_edges(), stream_view, mr);
   auto coo_contents = temp_graph.release();
-  GraphSparseContents<VT, ET, WT> csr_contents{
+  legacy::GraphSparseContents<VT, ET, WT> csr_contents{
     total_vertex_count,
     coo_contents.number_of_edges,
     std::make_unique<rmm::device_buffer>(std::move(offsets)),
     std::move(coo_contents.dst_indices),
     std::move(coo_contents.edge_data)};
 
-  return std::make_unique<GraphCSR<VT, ET, WT>>(std::move(csr_contents));
+  return std::make_unique<legacy::GraphCSR<VT, ET, WT>>(std::move(csr_contents));
 }
 
 template <typename VT, typename ET, typename WT>
-void coo_to_csr_inplace(GraphCOOView<VT, ET, WT> &graph, GraphCSRView<VT, ET, WT> &result)
+void coo_to_csr_inplace(legacy::GraphCOOView<VT, ET, WT> &graph, legacy::GraphCSRView<VT, ET, WT> &result)
 {
   rmm::cuda_stream_view stream_view;
 
@@ -188,60 +188,60 @@ void coo_to_csr_inplace(GraphCOOView<VT, ET, WT> &graph, GraphCSRView<VT, ET, WT
 // to attempt decrease in compile time:
 //
 // EIDecl for uint32_t + float
-extern template std::unique_ptr<GraphCSR<uint32_t, uint32_t, float>>
-coo_to_csr<uint32_t, uint32_t, float>(GraphCOOView<uint32_t, uint32_t, float> const &graph,
+extern template std::unique_ptr<legacy::GraphCSR<uint32_t, uint32_t, float>>
+coo_to_csr<uint32_t, uint32_t, float>(legacy::GraphCOOView<uint32_t, uint32_t, float> const &graph,
                                       rmm::mr::device_memory_resource *);
 
 // EIDecl for uint32_t + double
-extern template std::unique_ptr<GraphCSR<uint32_t, uint32_t, double>>
-coo_to_csr<uint32_t, uint32_t, double>(GraphCOOView<uint32_t, uint32_t, double> const &graph,
+extern template std::unique_ptr<legacy::GraphCSR<uint32_t, uint32_t, double>>
+coo_to_csr<uint32_t, uint32_t, double>(legacy::GraphCOOView<uint32_t, uint32_t, double> const &graph,
                                        rmm::mr::device_memory_resource *);
 
 // EIDecl for int + float
-extern template std::unique_ptr<GraphCSR<int32_t, int32_t, float>>
-coo_to_csr<int32_t, int32_t, float>(GraphCOOView<int32_t, int32_t, float> const &graph,
+extern template std::unique_ptr<legacy::GraphCSR<int32_t, int32_t, float>>
+coo_to_csr<int32_t, int32_t, float>(legacy::GraphCOOView<int32_t, int32_t, float> const &graph,
                                     rmm::mr::device_memory_resource *);
 
 // EIDecl for int + double
-extern template std::unique_ptr<GraphCSR<int32_t, int32_t, double>>
-coo_to_csr<int32_t, int32_t, double>(GraphCOOView<int32_t, int32_t, double> const &graph,
+extern template std::unique_ptr<legacy::GraphCSR<int32_t, int32_t, double>>
+coo_to_csr<int32_t, int32_t, double>(legacy::GraphCOOView<int32_t, int32_t, double> const &graph,
                                      rmm::mr::device_memory_resource *);
 
 // EIDecl for int64_t + float
-extern template std::unique_ptr<GraphCSR<int64_t, int64_t, float>>
-coo_to_csr<int64_t, int64_t, float>(GraphCOOView<int64_t, int64_t, float> const &graph,
+extern template std::unique_ptr<legacy::GraphCSR<int64_t, int64_t, float>>
+coo_to_csr<int64_t, int64_t, float>(legacy::GraphCOOView<int64_t, int64_t, float> const &graph,
                                     rmm::mr::device_memory_resource *);
 
 // EIDecl for int64_t + double
-extern template std::unique_ptr<GraphCSR<int64_t, int64_t, double>>
-coo_to_csr<int64_t, int64_t, double>(GraphCOOView<int64_t, int64_t, double> const &graph,
+extern template std::unique_ptr<legacy::GraphCSR<int64_t, int64_t, double>>
+coo_to_csr<int64_t, int64_t, double>(legacy::GraphCOOView<int64_t, int64_t, double> const &graph,
                                      rmm::mr::device_memory_resource *);
 
 // in-place versions:
 //
 // EIDecl for uint32_t + float
 extern template void coo_to_csr_inplace<uint32_t, uint32_t, float>(
-  GraphCOOView<uint32_t, uint32_t, float> &graph, GraphCSRView<uint32_t, uint32_t, float> &result);
+  legacy::GraphCOOView<uint32_t, uint32_t, float> &graph, legacy::GraphCSRView<uint32_t, uint32_t, float> &result);
 
 // EIDecl for uint32_t + double
 extern template void coo_to_csr_inplace<uint32_t, uint32_t, double>(
-  GraphCOOView<uint32_t, uint32_t, double> &graph,
-  GraphCSRView<uint32_t, uint32_t, double> &result);
+  legacy::GraphCOOView<uint32_t, uint32_t, double> &graph,
+  legacy::GraphCSRView<uint32_t, uint32_t, double> &result);
 
 // EIDecl for int + float
 extern template void coo_to_csr_inplace<int32_t, int32_t, float>(
-  GraphCOOView<int32_t, int32_t, float> &graph, GraphCSRView<int32_t, int32_t, float> &result);
+  legacy::GraphCOOView<int32_t, int32_t, float> &graph, legacy::GraphCSRView<int32_t, int32_t, float> &result);
 
 // EIDecl for int + double
 extern template void coo_to_csr_inplace<int32_t, int32_t, double>(
-  GraphCOOView<int32_t, int32_t, double> &graph, GraphCSRView<int32_t, int32_t, double> &result);
+  legacy::GraphCOOView<int32_t, int32_t, double> &graph, legacy::GraphCSRView<int32_t, int32_t, double> &result);
 
 // EIDecl for int64_t + float
 extern template void coo_to_csr_inplace<int64_t, int64_t, float>(
-  GraphCOOView<int64_t, int64_t, float> &graph, GraphCSRView<int64_t, int64_t, float> &result);
+  legacy::GraphCOOView<int64_t, int64_t, float> &graph, legacy::GraphCSRView<int64_t, int64_t, float> &result);
 
 // EIDecl for int64_t + double
 extern template void coo_to_csr_inplace<int64_t, int64_t, double>(
-  GraphCOOView<int64_t, int64_t, double> &graph, GraphCSRView<int64_t, int64_t, double> &result);
+  legacy::GraphCOOView<int64_t, int64_t, double> &graph, legacy::GraphCSRView<int64_t, int64_t, double> &result);
 
 }  // namespace cugraph

--- a/cpp/src/converters/COOtoCSR.cuh
+++ b/cpp/src/converters/COOtoCSR.cuh
@@ -144,15 +144,15 @@ rmm::device_buffer create_offset(VT *source,
 }  // namespace detail
 
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<legacy::GraphCSR<VT, ET, WT>> coo_to_csr(legacy::GraphCOOView<VT, ET, WT> const &graph,
-                                                 rmm::mr::device_memory_resource *mr)
+std::unique_ptr<legacy::GraphCSR<VT, ET, WT>> coo_to_csr(
+  legacy::GraphCOOView<VT, ET, WT> const &graph, rmm::mr::device_memory_resource *mr)
 {
   rmm::cuda_stream_view stream_view;
 
   legacy::GraphCOO<VT, ET, WT> temp_graph(graph, stream_view.value(), mr);
   legacy::GraphCOOView<VT, ET, WT> temp_graph_view = temp_graph.view();
-  VT total_vertex_count                    = detail::sort(temp_graph_view, stream_view);
-  rmm::device_buffer offsets               = detail::create_offset(
+  VT total_vertex_count                            = detail::sort(temp_graph_view, stream_view);
+  rmm::device_buffer offsets                       = detail::create_offset(
     temp_graph.src_indices(), total_vertex_count, temp_graph.number_of_edges(), stream_view, mr);
   auto coo_contents = temp_graph.release();
   legacy::GraphSparseContents<VT, ET, WT> csr_contents{
@@ -166,7 +166,8 @@ std::unique_ptr<legacy::GraphCSR<VT, ET, WT>> coo_to_csr(legacy::GraphCOOView<VT
 }
 
 template <typename VT, typename ET, typename WT>
-void coo_to_csr_inplace(legacy::GraphCOOView<VT, ET, WT> &graph, legacy::GraphCSRView<VT, ET, WT> &result)
+void coo_to_csr_inplace(legacy::GraphCOOView<VT, ET, WT> &graph,
+                        legacy::GraphCSRView<VT, ET, WT> &result)
 {
   rmm::cuda_stream_view stream_view;
 
@@ -194,8 +195,8 @@ coo_to_csr<uint32_t, uint32_t, float>(legacy::GraphCOOView<uint32_t, uint32_t, f
 
 // EIDecl for uint32_t + double
 extern template std::unique_ptr<legacy::GraphCSR<uint32_t, uint32_t, double>>
-coo_to_csr<uint32_t, uint32_t, double>(legacy::GraphCOOView<uint32_t, uint32_t, double> const &graph,
-                                       rmm::mr::device_memory_resource *);
+coo_to_csr<uint32_t, uint32_t, double>(
+  legacy::GraphCOOView<uint32_t, uint32_t, double> const &graph, rmm::mr::device_memory_resource *);
 
 // EIDecl for int + float
 extern template std::unique_ptr<legacy::GraphCSR<int32_t, int32_t, float>>
@@ -221,7 +222,8 @@ coo_to_csr<int64_t, int64_t, double>(legacy::GraphCOOView<int64_t, int64_t, doub
 //
 // EIDecl for uint32_t + float
 extern template void coo_to_csr_inplace<uint32_t, uint32_t, float>(
-  legacy::GraphCOOView<uint32_t, uint32_t, float> &graph, legacy::GraphCSRView<uint32_t, uint32_t, float> &result);
+  legacy::GraphCOOView<uint32_t, uint32_t, float> &graph,
+  legacy::GraphCSRView<uint32_t, uint32_t, float> &result);
 
 // EIDecl for uint32_t + double
 extern template void coo_to_csr_inplace<uint32_t, uint32_t, double>(
@@ -230,18 +232,22 @@ extern template void coo_to_csr_inplace<uint32_t, uint32_t, double>(
 
 // EIDecl for int + float
 extern template void coo_to_csr_inplace<int32_t, int32_t, float>(
-  legacy::GraphCOOView<int32_t, int32_t, float> &graph, legacy::GraphCSRView<int32_t, int32_t, float> &result);
+  legacy::GraphCOOView<int32_t, int32_t, float> &graph,
+  legacy::GraphCSRView<int32_t, int32_t, float> &result);
 
 // EIDecl for int + double
 extern template void coo_to_csr_inplace<int32_t, int32_t, double>(
-  legacy::GraphCOOView<int32_t, int32_t, double> &graph, legacy::GraphCSRView<int32_t, int32_t, double> &result);
+  legacy::GraphCOOView<int32_t, int32_t, double> &graph,
+  legacy::GraphCSRView<int32_t, int32_t, double> &result);
 
 // EIDecl for int64_t + float
 extern template void coo_to_csr_inplace<int64_t, int64_t, float>(
-  legacy::GraphCOOView<int64_t, int64_t, float> &graph, legacy::GraphCSRView<int64_t, int64_t, float> &result);
+  legacy::GraphCOOView<int64_t, int64_t, float> &graph,
+  legacy::GraphCSRView<int64_t, int64_t, float> &result);
 
 // EIDecl for int64_t + double
 extern template void coo_to_csr_inplace<int64_t, int64_t, double>(
-  legacy::GraphCOOView<int64_t, int64_t, double> &graph, legacy::GraphCSRView<int64_t, int64_t, double> &result);
+  legacy::GraphCOOView<int64_t, int64_t, double> &graph,
+  legacy::GraphCSRView<int64_t, int64_t, double> &result);
 
 }  // namespace cugraph

--- a/cpp/src/converters/permute_graph.cuh
+++ b/cpp/src/converters/permute_graph.cuh
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include <rmm/thrust_rmm_allocator.h>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <utilities/graph_utils.cuh>
 #include "converters/COOtoCSR.cuh"
@@ -42,9 +42,9 @@ struct permutation_functor {
  * @return The permuted graph.
  */
 template <typename vertex_t, typename edge_t, typename weight_t>
-void permute_graph(GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+void permute_graph(legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                    vertex_t const *permutation,
-                   GraphCSRView<vertex_t, edge_t, weight_t> result,
+                   legacy::GraphCSRView<vertex_t, edge_t, weight_t> result,
                    cudaStream_t stream = 0)
 {
   //  Create a COO out of the CSR
@@ -76,7 +76,7 @@ void permute_graph(GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                     d_dst,
                     pf);
 
-  GraphCOOView<vertex_t, edge_t, weight_t> graph_coo;
+  legacy::GraphCOOView<vertex_t, edge_t, weight_t> graph_coo;
 
   graph_coo.number_of_vertices = graph.number_of_vertices;
   graph_coo.number_of_edges    = graph.number_of_edges;

--- a/cpp/src/cores/core_number.cu
+++ b/cpp/src/cores/core_number.cu
@@ -17,7 +17,7 @@
 #include <rmm/thrust_rmm_allocator.h>
 #include <Hornet.hpp>
 #include <Static/CoreNumber/CoreNumber.cuh>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 //#include <nvgraph_gdf.h>
 
@@ -25,7 +25,7 @@ namespace cugraph {
 namespace detail {
 
 template <typename VT, typename ET, typename WT>
-void core_number(GraphCSRView<VT, ET, WT> const &graph, int *core_number)
+void core_number(legacy::GraphCSRView<VT, ET, WT> const &graph, int *core_number)
 {
   using HornetGraph = hornet::gpu::HornetStatic<int>;
   using HornetInit  = hornet::HornetInit<VT>;
@@ -52,8 +52,8 @@ struct FilterEdges {
 };
 
 template <typename VT, typename ET, typename WT>
-void extract_edges(GraphCOOView<VT, ET, WT> const &i_graph,
-                   GraphCOOView<VT, ET, WT> &o_graph,
+void extract_edges(legacy::GraphCOOView<VT, ET, WT> const &i_graph,
+                   legacy::GraphCOOView<VT, ET, WT> &o_graph,
                    VT *d_core,
                    int k)
 {
@@ -96,8 +96,8 @@ void extract_edges(GraphCOOView<VT, ET, WT> const &i_graph,
 // i.e. All edges (s,d,w) in in_graph are copied over to out_graph
 // if core_num[s] and core_num[d] are greater than or equal to k.
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<GraphCOO<VT, ET, WT>> extract_subgraph(
-  GraphCOOView<VT, ET, WT> const &in_graph,
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> extract_subgraph(
+  legacy::GraphCOOView<VT, ET, WT> const &in_graph,
   int const *vid,
   int const *core_num,
   int k,
@@ -119,7 +119,7 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> extract_subgraph(
   auto edge =
     thrust::make_zip_iterator(thrust::make_tuple(in_graph.src_indices, in_graph.dst_indices));
 
-  auto out_graph = std::make_unique<GraphCOO<VT, ET, WT>>(
+  auto out_graph = std::make_unique<legacy::GraphCOO<VT, ET, WT>>(
     in_graph.number_of_vertices,
     thrust::count_if(rmm::exec_policy(stream)->on(stream),
                      edge,
@@ -129,7 +129,7 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> extract_subgraph(
     stream,
     mr);
 
-  GraphCOOView<VT, ET, WT> out_graph_view = out_graph->view();
+  legacy::GraphCOOView<VT, ET, WT> out_graph_view = out_graph->view();
   extract_edges(in_graph, out_graph_view, d_sorted_core_num, k);
 
   return out_graph;
@@ -138,13 +138,13 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> extract_subgraph(
 }  // namespace detail
 
 template <typename VT, typename ET, typename WT>
-void core_number(GraphCSRView<VT, ET, WT> const &graph, VT *core_number)
+void core_number(legacy::GraphCSRView<VT, ET, WT> const &graph, VT *core_number)
 {
   return detail::core_number(graph, core_number);
 }
 
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<GraphCOO<VT, ET, WT>> k_core(GraphCOOView<VT, ET, WT> const &in_graph,
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> k_core(legacy::GraphCOOView<VT, ET, WT> const &in_graph,
                                              int k,
                                              VT const *vertex_id,
                                              VT const *core_number,
@@ -158,17 +158,17 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> k_core(GraphCOOView<VT, ET, WT> const &in_
   return detail::extract_subgraph(in_graph, vertex_id, core_number, k, num_vertex_ids, mr);
 }
 
-template void core_number<int32_t, int32_t, float>(GraphCSRView<int32_t, int32_t, float> const &,
+template void core_number<int32_t, int32_t, float>(legacy::GraphCSRView<int32_t, int32_t, float> const &,
                                                    int32_t *core_number);
-template std::unique_ptr<GraphCOO<int32_t, int32_t, float>> k_core<int32_t, int32_t, float>(
-  GraphCOOView<int32_t, int32_t, float> const &,
+template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, float>> k_core<int32_t, int32_t, float>(
+  legacy::GraphCOOView<int32_t, int32_t, float> const &,
   int,
   int32_t const *,
   int32_t const *,
   int32_t,
   rmm::mr::device_memory_resource *);
-template std::unique_ptr<GraphCOO<int32_t, int32_t, double>> k_core<int32_t, int32_t, double>(
-  GraphCOOView<int32_t, int32_t, double> const &,
+template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, double>> k_core<int32_t, int32_t, double>(
+  legacy::GraphCOOView<int32_t, int32_t, double> const &,
   int,
   int32_t const *,
   int32_t const *,

--- a/cpp/src/cores/core_number.cu
+++ b/cpp/src/cores/core_number.cu
@@ -144,12 +144,13 @@ void core_number(legacy::GraphCSRView<VT, ET, WT> const &graph, VT *core_number)
 }
 
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> k_core(legacy::GraphCOOView<VT, ET, WT> const &in_graph,
-                                             int k,
-                                             VT const *vertex_id,
-                                             VT const *core_number,
-                                             VT num_vertex_ids,
-                                             rmm::mr::device_memory_resource *mr)
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> k_core(
+  legacy::GraphCOOView<VT, ET, WT> const &in_graph,
+  int k,
+  VT const *vertex_id,
+  VT const *core_number,
+  VT num_vertex_ids,
+  rmm::mr::device_memory_resource *mr)
 {
   CUGRAPH_EXPECTS(vertex_id != nullptr, "Invalid input argument: vertex_id is NULL");
   CUGRAPH_EXPECTS(core_number != nullptr, "Invalid input argument: core_number is NULL");
@@ -158,8 +159,8 @@ std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> k_core(legacy::GraphCOOView<VT, ET
   return detail::extract_subgraph(in_graph, vertex_id, core_number, k, num_vertex_ids, mr);
 }
 
-template void core_number<int32_t, int32_t, float>(legacy::GraphCSRView<int32_t, int32_t, float> const &,
-                                                   int32_t *core_number);
+template void core_number<int32_t, int32_t, float>(
+  legacy::GraphCSRView<int32_t, int32_t, float> const &, int32_t *core_number);
 template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, float>> k_core<int32_t, int32_t, float>(
   legacy::GraphCOOView<int32_t, int32_t, float> const &,
   int,
@@ -167,12 +168,12 @@ template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, float>> k_core<int32
   int32_t const *,
   int32_t,
   rmm::mr::device_memory_resource *);
-template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, double>> k_core<int32_t, int32_t, double>(
-  legacy::GraphCOOView<int32_t, int32_t, double> const &,
-  int,
-  int32_t const *,
-  int32_t const *,
-  int32_t,
-  rmm::mr::device_memory_resource *);
+template std::unique_ptr<legacy::GraphCOO<int32_t, int32_t, double>>
+k_core<int32_t, int32_t, double>(legacy::GraphCOOView<int32_t, int32_t, double> const &,
+                                 int,
+                                 int32_t const *,
+                                 int32_t const *,
+                                 int32_t,
+                                 rmm::mr::device_memory_resource *);
 
 }  // namespace cugraph

--- a/cpp/src/layout/barnes_hut.hpp
+++ b/cpp/src/layout/barnes_hut.hpp
@@ -23,8 +23,8 @@
 #include <converters/COOtoCSR.cuh>
 #include <utilities/graph_utils.cuh>
 
-#include <cugraph/legacy/graph.hpp>
 #include <cugraph/internals.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 
 #include <raft/random/rng.cuh>

--- a/cpp/src/layout/barnes_hut.hpp
+++ b/cpp/src/layout/barnes_hut.hpp
@@ -23,7 +23,7 @@
 #include <converters/COOtoCSR.cuh>
 #include <utilities/graph_utils.cuh>
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/internals.hpp>
 #include <cugraph/utilities/error.hpp>
 
@@ -37,7 +37,7 @@ namespace detail {
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 void barnes_hut(raft::handle_t const &handle,
-                GraphCOOView<vertex_t, edge_t, weight_t> &graph,
+                legacy::GraphCOOView<vertex_t, edge_t, weight_t> &graph,
                 float *pos,
                 const int max_iter                            = 500,
                 float *x_start                                = nullptr,
@@ -160,7 +160,7 @@ void barnes_hut(raft::handle_t const &handle,
   sort(graph, stream_view.value());
   CHECK_CUDA(stream_view.value());
 
-  graph.degree(massl, cugraph::DegreeDirection::OUT);
+  graph.degree(massl, cugraph::legacy::DegreeDirection::OUT);
   CHECK_CUDA(stream_view.value());
 
   const vertex_t *row = graph.src_indices;

--- a/cpp/src/layout/exact_fa2.hpp
+++ b/cpp/src/layout/exact_fa2.hpp
@@ -21,7 +21,7 @@
 
 #include <converters/COOtoCSR.cuh>
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/internals.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <raft/random/rng.cuh>
@@ -35,7 +35,7 @@ namespace detail {
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 void exact_fa2(raft::handle_t const &handle,
-               GraphCOOView<vertex_t, edge_t, weight_t> &graph,
+               legacy::GraphCOOView<vertex_t, edge_t, weight_t> &graph,
                float *pos,
                const int max_iter                            = 500,
                float *x_start                                = nullptr,
@@ -92,7 +92,7 @@ void exact_fa2(raft::handle_t const &handle,
   sort(graph, stream_view.value());
   CHECK_CUDA(stream_view.value());
 
-  graph.degree(d_mass, cugraph::DegreeDirection::OUT);
+  graph.degree(d_mass, cugraph::legacy::DegreeDirection::OUT);
   CHECK_CUDA(stream_view.value());
 
   const vertex_t *row = graph.src_indices;

--- a/cpp/src/layout/exact_fa2.hpp
+++ b/cpp/src/layout/exact_fa2.hpp
@@ -21,8 +21,8 @@
 
 #include <converters/COOtoCSR.cuh>
 
-#include <cugraph/legacy/graph.hpp>
 #include <cugraph/internals.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <raft/random/rng.cuh>
 

--- a/cpp/src/layout/force_atlas2.cu
+++ b/cpp/src/layout/force_atlas2.cu
@@ -21,7 +21,7 @@ namespace cugraph {
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 void force_atlas2(raft::handle_t const &handle,
-                  GraphCOOView<vertex_t, edge_t, weight_t> &graph,
+                  legacy::GraphCOOView<vertex_t, edge_t, weight_t> &graph,
                   float *pos,
                   const int max_iter,
                   float *x_start,
@@ -81,7 +81,7 @@ void force_atlas2(raft::handle_t const &handle,
 }
 
 template void force_atlas2<int, int, float>(raft::handle_t const &handle,
-                                            GraphCOOView<int, int, float> &graph,
+                                            legacy::GraphCOOView<int, int, float> &graph,
                                             float *pos,
                                             const int max_iter,
                                             float *x_start,
@@ -100,7 +100,7 @@ template void force_atlas2<int, int, float>(raft::handle_t const &handle,
                                             internals::GraphBasedDimRedCallback *callback);
 
 template void force_atlas2<int, int, double>(raft::handle_t const &handle,
-                                             GraphCOOView<int, int, double> &graph,
+                                             legacy::GraphCOOView<int, int, double> &graph,
                                              float *pos,
                                              const int max_iter,
                                              float *x_start,

--- a/cpp/src/linear_assignment/hungarian.cu
+++ b/cpp/src/linear_assignment/hungarian.cu
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 
 #include <raft/lap/lap.cuh>
@@ -117,7 +117,7 @@ weight_t hungarian(raft::handle_t const &handle,
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 weight_t hungarian_sparse(raft::handle_t const &handle,
-                          GraphCOOView<vertex_t, edge_t, weight_t> const &graph,
+                          legacy::GraphCOOView<vertex_t, edge_t, weight_t> const &graph,
                           vertex_t num_workers,
                           vertex_t const *workers,
                           vertex_t *assignment,
@@ -266,7 +266,7 @@ weight_t hungarian_sparse(raft::handle_t const &handle,
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 weight_t hungarian(raft::handle_t const &handle,
-                   GraphCOOView<vertex_t, edge_t, weight_t> const &graph,
+                   legacy::GraphCOOView<vertex_t, edge_t, weight_t> const &graph,
                    vertex_t num_workers,
                    vertex_t const *workers,
                    vertex_t *assignment)
@@ -277,7 +277,7 @@ weight_t hungarian(raft::handle_t const &handle,
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 weight_t hungarian(raft::handle_t const &handle,
-                   GraphCOOView<vertex_t, edge_t, weight_t> const &graph,
+                   legacy::GraphCOOView<vertex_t, edge_t, weight_t> const &graph,
                    vertex_t num_workers,
                    vertex_t const *workers,
                    vertex_t *assignment,
@@ -288,20 +288,20 @@ weight_t hungarian(raft::handle_t const &handle,
 
 template int32_t hungarian<int32_t, int32_t, int32_t>(
   raft::handle_t const &,
-  GraphCOOView<int32_t, int32_t, int32_t> const &,
+  legacy::GraphCOOView<int32_t, int32_t, int32_t> const &,
   int32_t,
   int32_t const *,
   int32_t *,
   int32_t);
 
 template float hungarian<int32_t, int32_t, float>(raft::handle_t const &,
-                                                  GraphCOOView<int32_t, int32_t, float> const &,
+                                                  legacy::GraphCOOView<int32_t, int32_t, float> const &,
                                                   int32_t,
                                                   int32_t const *,
                                                   int32_t *,
                                                   float);
 template double hungarian<int32_t, int32_t, double>(raft::handle_t const &,
-                                                    GraphCOOView<int32_t, int32_t, double> const &,
+                                                    legacy::GraphCOOView<int32_t, int32_t, double> const &,
                                                     int32_t,
                                                     int32_t const *,
                                                     int32_t *,
@@ -309,18 +309,18 @@ template double hungarian<int32_t, int32_t, double>(raft::handle_t const &,
 
 template int32_t hungarian<int32_t, int32_t, int32_t>(
   raft::handle_t const &,
-  GraphCOOView<int32_t, int32_t, int32_t> const &,
+  legacy::GraphCOOView<int32_t, int32_t, int32_t> const &,
   int32_t,
   int32_t const *,
   int32_t *);
 
 template float hungarian<int32_t, int32_t, float>(raft::handle_t const &,
-                                                  GraphCOOView<int32_t, int32_t, float> const &,
+                                                  legacy::GraphCOOView<int32_t, int32_t, float> const &,
                                                   int32_t,
                                                   int32_t const *,
                                                   int32_t *);
 template double hungarian<int32_t, int32_t, double>(raft::handle_t const &,
-                                                    GraphCOOView<int32_t, int32_t, double> const &,
+                                                    legacy::GraphCOOView<int32_t, int32_t, double> const &,
                                                     int32_t,
                                                     int32_t const *,
                                                     int32_t *);

--- a/cpp/src/linear_assignment/hungarian.cu
+++ b/cpp/src/linear_assignment/hungarian.cu
@@ -294,18 +294,20 @@ template int32_t hungarian<int32_t, int32_t, int32_t>(
   int32_t *,
   int32_t);
 
-template float hungarian<int32_t, int32_t, float>(raft::handle_t const &,
-                                                  legacy::GraphCOOView<int32_t, int32_t, float> const &,
-                                                  int32_t,
-                                                  int32_t const *,
-                                                  int32_t *,
-                                                  float);
-template double hungarian<int32_t, int32_t, double>(raft::handle_t const &,
-                                                    legacy::GraphCOOView<int32_t, int32_t, double> const &,
-                                                    int32_t,
-                                                    int32_t const *,
-                                                    int32_t *,
-                                                    double);
+template float hungarian<int32_t, int32_t, float>(
+  raft::handle_t const &,
+  legacy::GraphCOOView<int32_t, int32_t, float> const &,
+  int32_t,
+  int32_t const *,
+  int32_t *,
+  float);
+template double hungarian<int32_t, int32_t, double>(
+  raft::handle_t const &,
+  legacy::GraphCOOView<int32_t, int32_t, double> const &,
+  int32_t,
+  int32_t const *,
+  int32_t *,
+  double);
 
 template int32_t hungarian<int32_t, int32_t, int32_t>(
   raft::handle_t const &,
@@ -314,16 +316,18 @@ template int32_t hungarian<int32_t, int32_t, int32_t>(
   int32_t const *,
   int32_t *);
 
-template float hungarian<int32_t, int32_t, float>(raft::handle_t const &,
-                                                  legacy::GraphCOOView<int32_t, int32_t, float> const &,
-                                                  int32_t,
-                                                  int32_t const *,
-                                                  int32_t *);
-template double hungarian<int32_t, int32_t, double>(raft::handle_t const &,
-                                                    legacy::GraphCOOView<int32_t, int32_t, double> const &,
-                                                    int32_t,
-                                                    int32_t const *,
-                                                    int32_t *);
+template float hungarian<int32_t, int32_t, float>(
+  raft::handle_t const &,
+  legacy::GraphCOOView<int32_t, int32_t, float> const &,
+  int32_t,
+  int32_t const *,
+  int32_t *);
+template double hungarian<int32_t, int32_t, double>(
+  raft::handle_t const &,
+  legacy::GraphCOOView<int32_t, int32_t, double> const &,
+  int32_t,
+  int32_t const *,
+  int32_t *);
 
 namespace dense {
 

--- a/cpp/src/link_analysis/gunrock_hits.cpp
+++ b/cpp/src/link_analysis/gunrock_hits.cpp
@@ -20,7 +20,7 @@
  * --------------------------------------------------------------------------*/
 
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <cugraph/utilities/error.hpp>
 
@@ -34,7 +34,7 @@ const int HOST{1};    // gunrock should expose the device constant at the API le
 const int DEVICE{2};  // gunrock should expose the device constant at the API level.
 
 template <typename vertex_t, typename edge_t, typename weight_t>
-void hits(cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+void hits(cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
           int max_iter,
           weight_t tolerance,
           weight_t const *starting_value,
@@ -61,7 +61,7 @@ void hits(cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
          DEVICE);
 }
 
-template void hits(cugraph::GraphCSRView<int32_t, int32_t, float> const &,
+template void hits(cugraph::legacy::GraphCSRView<int32_t, int32_t, float> const &,
                    int,
                    float,
                    float const *,

--- a/cpp/src/link_prediction/jaccard.cu
+++ b/cpp/src/link_prediction/jaccard.cu
@@ -19,7 +19,7 @@
  * @file jaccard.cu
  * ---------------------------------------------------------------------------**/
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <utilities/graph_utils.cuh>
 
@@ -316,7 +316,7 @@ int jaccard_pairs(vertex_t n,
 }  // namespace detail
 
 template <typename VT, typename ET, typename WT>
-void jaccard(GraphCSRView<VT, ET, WT> const &graph, WT const *weights, WT *result)
+void jaccard(legacy::GraphCSRView<VT, ET, WT> const &graph, WT const *weights, WT *result)
 {
   CUGRAPH_EXPECTS(result != nullptr, "Invalid input argument: result pointer is NULL");
 
@@ -348,7 +348,7 @@ void jaccard(GraphCSRView<VT, ET, WT> const &graph, WT const *weights, WT *resul
 }
 
 template <typename VT, typename ET, typename WT>
-void jaccard_list(GraphCSRView<VT, ET, WT> const &graph,
+void jaccard_list(legacy::GraphCSRView<VT, ET, WT> const &graph,
                   WT const *weights,
                   ET num_pairs,
                   VT const *first,
@@ -390,37 +390,37 @@ void jaccard_list(GraphCSRView<VT, ET, WT> const &graph,
   }
 }
 
-template void jaccard<int32_t, int32_t, float>(GraphCSRView<int32_t, int32_t, float> const &,
+template void jaccard<int32_t, int32_t, float>(legacy::GraphCSRView<int32_t, int32_t, float> const &,
                                                float const *,
                                                float *);
-template void jaccard<int32_t, int32_t, double>(GraphCSRView<int32_t, int32_t, double> const &,
+template void jaccard<int32_t, int32_t, double>(legacy::GraphCSRView<int32_t, int32_t, double> const &,
                                                 double const *,
                                                 double *);
-template void jaccard<int64_t, int64_t, float>(GraphCSRView<int64_t, int64_t, float> const &,
+template void jaccard<int64_t, int64_t, float>(legacy::GraphCSRView<int64_t, int64_t, float> const &,
                                                float const *,
                                                float *);
-template void jaccard<int64_t, int64_t, double>(GraphCSRView<int64_t, int64_t, double> const &,
+template void jaccard<int64_t, int64_t, double>(legacy::GraphCSRView<int64_t, int64_t, double> const &,
                                                 double const *,
                                                 double *);
-template void jaccard_list<int32_t, int32_t, float>(GraphCSRView<int32_t, int32_t, float> const &,
+template void jaccard_list<int32_t, int32_t, float>(legacy::GraphCSRView<int32_t, int32_t, float> const &,
                                                     float const *,
                                                     int32_t,
                                                     int32_t const *,
                                                     int32_t const *,
                                                     float *);
-template void jaccard_list<int32_t, int32_t, double>(GraphCSRView<int32_t, int32_t, double> const &,
+template void jaccard_list<int32_t, int32_t, double>(legacy::GraphCSRView<int32_t, int32_t, double> const &,
                                                      double const *,
                                                      int32_t,
                                                      int32_t const *,
                                                      int32_t const *,
                                                      double *);
-template void jaccard_list<int64_t, int64_t, float>(GraphCSRView<int64_t, int64_t, float> const &,
+template void jaccard_list<int64_t, int64_t, float>(legacy::GraphCSRView<int64_t, int64_t, float> const &,
                                                     float const *,
                                                     int64_t,
                                                     int64_t const *,
                                                     int64_t const *,
                                                     float *);
-template void jaccard_list<int64_t, int64_t, double>(GraphCSRView<int64_t, int64_t, double> const &,
+template void jaccard_list<int64_t, int64_t, double>(legacy::GraphCSRView<int64_t, int64_t, double> const &,
                                                      double const *,
                                                      int64_t,
                                                      int64_t const *,

--- a/cpp/src/link_prediction/jaccard.cu
+++ b/cpp/src/link_prediction/jaccard.cu
@@ -390,41 +390,41 @@ void jaccard_list(legacy::GraphCSRView<VT, ET, WT> const &graph,
   }
 }
 
-template void jaccard<int32_t, int32_t, float>(legacy::GraphCSRView<int32_t, int32_t, float> const &,
-                                               float const *,
-                                               float *);
-template void jaccard<int32_t, int32_t, double>(legacy::GraphCSRView<int32_t, int32_t, double> const &,
-                                                double const *,
-                                                double *);
-template void jaccard<int64_t, int64_t, float>(legacy::GraphCSRView<int64_t, int64_t, float> const &,
-                                               float const *,
-                                               float *);
-template void jaccard<int64_t, int64_t, double>(legacy::GraphCSRView<int64_t, int64_t, double> const &,
-                                                double const *,
-                                                double *);
-template void jaccard_list<int32_t, int32_t, float>(legacy::GraphCSRView<int32_t, int32_t, float> const &,
-                                                    float const *,
-                                                    int32_t,
-                                                    int32_t const *,
-                                                    int32_t const *,
-                                                    float *);
-template void jaccard_list<int32_t, int32_t, double>(legacy::GraphCSRView<int32_t, int32_t, double> const &,
-                                                     double const *,
-                                                     int32_t,
-                                                     int32_t const *,
-                                                     int32_t const *,
-                                                     double *);
-template void jaccard_list<int64_t, int64_t, float>(legacy::GraphCSRView<int64_t, int64_t, float> const &,
-                                                    float const *,
-                                                    int64_t,
-                                                    int64_t const *,
-                                                    int64_t const *,
-                                                    float *);
-template void jaccard_list<int64_t, int64_t, double>(legacy::GraphCSRView<int64_t, int64_t, double> const &,
-                                                     double const *,
-                                                     int64_t,
-                                                     int64_t const *,
-                                                     int64_t const *,
-                                                     double *);
+template void jaccard<int32_t, int32_t, float>(
+  legacy::GraphCSRView<int32_t, int32_t, float> const &, float const *, float *);
+template void jaccard<int32_t, int32_t, double>(
+  legacy::GraphCSRView<int32_t, int32_t, double> const &, double const *, double *);
+template void jaccard<int64_t, int64_t, float>(
+  legacy::GraphCSRView<int64_t, int64_t, float> const &, float const *, float *);
+template void jaccard<int64_t, int64_t, double>(
+  legacy::GraphCSRView<int64_t, int64_t, double> const &, double const *, double *);
+template void jaccard_list<int32_t, int32_t, float>(
+  legacy::GraphCSRView<int32_t, int32_t, float> const &,
+  float const *,
+  int32_t,
+  int32_t const *,
+  int32_t const *,
+  float *);
+template void jaccard_list<int32_t, int32_t, double>(
+  legacy::GraphCSRView<int32_t, int32_t, double> const &,
+  double const *,
+  int32_t,
+  int32_t const *,
+  int32_t const *,
+  double *);
+template void jaccard_list<int64_t, int64_t, float>(
+  legacy::GraphCSRView<int64_t, int64_t, float> const &,
+  float const *,
+  int64_t,
+  int64_t const *,
+  int64_t const *,
+  float *);
+template void jaccard_list<int64_t, int64_t, double>(
+  legacy::GraphCSRView<int64_t, int64_t, double> const &,
+  double const *,
+  int64_t,
+  int64_t const *,
+  int64_t const *,
+  double *);
 
 }  // namespace cugraph

--- a/cpp/src/link_prediction/overlap.cu
+++ b/cpp/src/link_prediction/overlap.cu
@@ -20,7 +20,7 @@
  * ---------------------------------------------------------------------------**/
 
 #include <rmm/thrust_rmm_allocator.h>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <utilities/graph_utils.cuh>
 
@@ -314,7 +314,7 @@ int overlap_pairs(vertex_t n,
 }  // namespace detail
 
 template <typename VT, typename ET, typename WT>
-void overlap(GraphCSRView<VT, ET, WT> const &graph, WT const *weights, WT *result)
+void overlap(legacy::GraphCSRView<VT, ET, WT> const &graph, WT const *weights, WT *result)
 {
   CUGRAPH_EXPECTS(result != nullptr, "Invalid input argument: result pointer is NULL");
 
@@ -346,7 +346,7 @@ void overlap(GraphCSRView<VT, ET, WT> const &graph, WT const *weights, WT *resul
 }
 
 template <typename VT, typename ET, typename WT>
-void overlap_list(GraphCSRView<VT, ET, WT> const &graph,
+void overlap_list(legacy::GraphCSRView<VT, ET, WT> const &graph,
                   WT const *weights,
                   ET num_pairs,
                   VT const *first,
@@ -388,37 +388,37 @@ void overlap_list(GraphCSRView<VT, ET, WT> const &graph,
   }
 }
 
-template void overlap<int32_t, int32_t, float>(GraphCSRView<int32_t, int32_t, float> const &,
+template void overlap<int32_t, int32_t, float>(legacy::GraphCSRView<int32_t, int32_t, float> const &,
                                                float const *,
                                                float *);
-template void overlap<int32_t, int32_t, double>(GraphCSRView<int32_t, int32_t, double> const &,
+template void overlap<int32_t, int32_t, double>(legacy::GraphCSRView<int32_t, int32_t, double> const &,
                                                 double const *,
                                                 double *);
-template void overlap<int64_t, int64_t, float>(GraphCSRView<int64_t, int64_t, float> const &,
+template void overlap<int64_t, int64_t, float>(legacy::GraphCSRView<int64_t, int64_t, float> const &,
                                                float const *,
                                                float *);
-template void overlap<int64_t, int64_t, double>(GraphCSRView<int64_t, int64_t, double> const &,
+template void overlap<int64_t, int64_t, double>(legacy::GraphCSRView<int64_t, int64_t, double> const &,
                                                 double const *,
                                                 double *);
-template void overlap_list<int32_t, int32_t, float>(GraphCSRView<int32_t, int32_t, float> const &,
+template void overlap_list<int32_t, int32_t, float>(legacy::GraphCSRView<int32_t, int32_t, float> const &,
                                                     float const *,
                                                     int32_t,
                                                     int32_t const *,
                                                     int32_t const *,
                                                     float *);
-template void overlap_list<int32_t, int32_t, double>(GraphCSRView<int32_t, int32_t, double> const &,
+template void overlap_list<int32_t, int32_t, double>(legacy::GraphCSRView<int32_t, int32_t, double> const &,
                                                      double const *,
                                                      int32_t,
                                                      int32_t const *,
                                                      int32_t const *,
                                                      double *);
-template void overlap_list<int64_t, int64_t, float>(GraphCSRView<int64_t, int64_t, float> const &,
+template void overlap_list<int64_t, int64_t, float>(legacy::GraphCSRView<int64_t, int64_t, float> const &,
                                                     float const *,
                                                     int64_t,
                                                     int64_t const *,
                                                     int64_t const *,
                                                     float *);
-template void overlap_list<int64_t, int64_t, double>(GraphCSRView<int64_t, int64_t, double> const &,
+template void overlap_list<int64_t, int64_t, double>(legacy::GraphCSRView<int64_t, int64_t, double> const &,
                                                      double const *,
                                                      int64_t,
                                                      int64_t const *,

--- a/cpp/src/link_prediction/overlap.cu
+++ b/cpp/src/link_prediction/overlap.cu
@@ -388,41 +388,41 @@ void overlap_list(legacy::GraphCSRView<VT, ET, WT> const &graph,
   }
 }
 
-template void overlap<int32_t, int32_t, float>(legacy::GraphCSRView<int32_t, int32_t, float> const &,
-                                               float const *,
-                                               float *);
-template void overlap<int32_t, int32_t, double>(legacy::GraphCSRView<int32_t, int32_t, double> const &,
-                                                double const *,
-                                                double *);
-template void overlap<int64_t, int64_t, float>(legacy::GraphCSRView<int64_t, int64_t, float> const &,
-                                               float const *,
-                                               float *);
-template void overlap<int64_t, int64_t, double>(legacy::GraphCSRView<int64_t, int64_t, double> const &,
-                                                double const *,
-                                                double *);
-template void overlap_list<int32_t, int32_t, float>(legacy::GraphCSRView<int32_t, int32_t, float> const &,
-                                                    float const *,
-                                                    int32_t,
-                                                    int32_t const *,
-                                                    int32_t const *,
-                                                    float *);
-template void overlap_list<int32_t, int32_t, double>(legacy::GraphCSRView<int32_t, int32_t, double> const &,
-                                                     double const *,
-                                                     int32_t,
-                                                     int32_t const *,
-                                                     int32_t const *,
-                                                     double *);
-template void overlap_list<int64_t, int64_t, float>(legacy::GraphCSRView<int64_t, int64_t, float> const &,
-                                                    float const *,
-                                                    int64_t,
-                                                    int64_t const *,
-                                                    int64_t const *,
-                                                    float *);
-template void overlap_list<int64_t, int64_t, double>(legacy::GraphCSRView<int64_t, int64_t, double> const &,
-                                                     double const *,
-                                                     int64_t,
-                                                     int64_t const *,
-                                                     int64_t const *,
-                                                     double *);
+template void overlap<int32_t, int32_t, float>(
+  legacy::GraphCSRView<int32_t, int32_t, float> const &, float const *, float *);
+template void overlap<int32_t, int32_t, double>(
+  legacy::GraphCSRView<int32_t, int32_t, double> const &, double const *, double *);
+template void overlap<int64_t, int64_t, float>(
+  legacy::GraphCSRView<int64_t, int64_t, float> const &, float const *, float *);
+template void overlap<int64_t, int64_t, double>(
+  legacy::GraphCSRView<int64_t, int64_t, double> const &, double const *, double *);
+template void overlap_list<int32_t, int32_t, float>(
+  legacy::GraphCSRView<int32_t, int32_t, float> const &,
+  float const *,
+  int32_t,
+  int32_t const *,
+  int32_t const *,
+  float *);
+template void overlap_list<int32_t, int32_t, double>(
+  legacy::GraphCSRView<int32_t, int32_t, double> const &,
+  double const *,
+  int32_t,
+  int32_t const *,
+  int32_t const *,
+  double *);
+template void overlap_list<int64_t, int64_t, float>(
+  legacy::GraphCSRView<int64_t, int64_t, float> const &,
+  float const *,
+  int64_t,
+  int64_t const *,
+  int64_t const *,
+  float *);
+template void overlap_list<int64_t, int64_t, double>(
+  legacy::GraphCSRView<int64_t, int64_t, double> const &,
+  double const *,
+  int64_t,
+  int64_t const *,
+  int64_t const *,
+  double *);
 
 }  // namespace cugraph

--- a/cpp/src/structure/graph.cu
+++ b/cpp/src/structure/graph.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <utilities/graph_utils.cuh>
 
@@ -58,6 +58,7 @@ void degree_from_vertex_ids(const raft::handle_t *handle,
 }  // namespace
 
 namespace cugraph {
+namespace legacy {
 
 template <typename VT, typename ET, typename WT>
 void GraphViewBase<VT, ET, WT>::get_vertex_identifiers(VT *identifiers) const
@@ -149,6 +150,7 @@ template class GraphCOOView<int32_t, int32_t, float>;
 template class GraphCOOView<int32_t, int32_t, double>;
 template class GraphCompressedSparseBaseView<int32_t, int32_t, float>;
 template class GraphCompressedSparseBaseView<int32_t, int32_t, double>;
+}  // namespace legacy
 }  // namespace cugraph
 
 #include <utilities/eidir_graph_utils.hpp>

--- a/cpp/src/traversal/bfs.cu
+++ b/cpp/src/traversal/bfs.cu
@@ -511,63 +511,69 @@ void bfs(raft::handle_t const &handle,
 }
 
 // Explicit Instantiation
-template void bfs<uint32_t, uint32_t, float>(raft::handle_t const &handle,
-                                             legacy::GraphCSRView<uint32_t, uint32_t, float> const &graph,
-                                             uint32_t *distances,
-                                             uint32_t *predecessors,
-                                             double *sp_counters,
-                                             const uint32_t source_vertex,
-                                             bool directed,
-                                             bool mg_batch);
+template void bfs<uint32_t, uint32_t, float>(
+  raft::handle_t const &handle,
+  legacy::GraphCSRView<uint32_t, uint32_t, float> const &graph,
+  uint32_t *distances,
+  uint32_t *predecessors,
+  double *sp_counters,
+  const uint32_t source_vertex,
+  bool directed,
+  bool mg_batch);
 
 // Explicit Instantiation
-template void bfs<uint32_t, uint32_t, double>(raft::handle_t const &handle,
-                                              legacy::GraphCSRView<uint32_t, uint32_t, double> const &graph,
-                                              uint32_t *distances,
-                                              uint32_t *predecessors,
-                                              double *sp_counters,
-                                              const uint32_t source_vertex,
-                                              bool directed,
-                                              bool mg_batch);
+template void bfs<uint32_t, uint32_t, double>(
+  raft::handle_t const &handle,
+  legacy::GraphCSRView<uint32_t, uint32_t, double> const &graph,
+  uint32_t *distances,
+  uint32_t *predecessors,
+  double *sp_counters,
+  const uint32_t source_vertex,
+  bool directed,
+  bool mg_batch);
 
 // Explicit Instantiation
-template void bfs<int32_t, int32_t, float>(raft::handle_t const &handle,
-                                           legacy::GraphCSRView<int32_t, int32_t, float> const &graph,
-                                           int32_t *distances,
-                                           int32_t *predecessors,
-                                           double *sp_counters,
-                                           const int32_t source_vertex,
-                                           bool directed,
-                                           bool mg_batch);
+template void bfs<int32_t, int32_t, float>(
+  raft::handle_t const &handle,
+  legacy::GraphCSRView<int32_t, int32_t, float> const &graph,
+  int32_t *distances,
+  int32_t *predecessors,
+  double *sp_counters,
+  const int32_t source_vertex,
+  bool directed,
+  bool mg_batch);
 
 // Explicit Instantiation
-template void bfs<int32_t, int32_t, double>(raft::handle_t const &handle,
-                                            legacy::GraphCSRView<int32_t, int32_t, double> const &graph,
-                                            int32_t *distances,
-                                            int32_t *predecessors,
-                                            double *sp_counters,
-                                            const int32_t source_vertex,
-                                            bool directed,
-                                            bool mg_batch);
+template void bfs<int32_t, int32_t, double>(
+  raft::handle_t const &handle,
+  legacy::GraphCSRView<int32_t, int32_t, double> const &graph,
+  int32_t *distances,
+  int32_t *predecessors,
+  double *sp_counters,
+  const int32_t source_vertex,
+  bool directed,
+  bool mg_batch);
 
 // Explicit Instantiation
-template void bfs<int64_t, int64_t, float>(raft::handle_t const &handle,
-                                           legacy::GraphCSRView<int64_t, int64_t, float> const &graph,
-                                           int64_t *distances,
-                                           int64_t *predecessors,
-                                           double *sp_counters,
-                                           const int64_t source_vertex,
-                                           bool directed,
-                                           bool mg_batch);
+template void bfs<int64_t, int64_t, float>(
+  raft::handle_t const &handle,
+  legacy::GraphCSRView<int64_t, int64_t, float> const &graph,
+  int64_t *distances,
+  int64_t *predecessors,
+  double *sp_counters,
+  const int64_t source_vertex,
+  bool directed,
+  bool mg_batch);
 
 // Explicit Instantiation
-template void bfs<int64_t, int64_t, double>(raft::handle_t const &handle,
-                                            legacy::GraphCSRView<int64_t, int64_t, double> const &graph,
-                                            int64_t *distances,
-                                            int64_t *predecessors,
-                                            double *sp_counters,
-                                            const int64_t source_vertex,
-                                            bool directed,
-                                            bool mg_batch);
+template void bfs<int64_t, int64_t, double>(
+  raft::handle_t const &handle,
+  legacy::GraphCSRView<int64_t, int64_t, double> const &graph,
+  int64_t *distances,
+  int64_t *predecessors,
+  double *sp_counters,
+  const int64_t source_vertex,
+  bool directed,
+  bool mg_batch);
 
 }  // namespace cugraph

--- a/cpp/src/traversal/bfs.cu
+++ b/cpp/src/traversal/bfs.cu
@@ -14,7 +14,7 @@
 #include <limits>
 #include "bfs.cuh"
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <cugraph/utilities/error.hpp>
 #include <utilities/graph_utils.cuh>
@@ -474,7 +474,7 @@ template class BFS<int64_t>;
 //       It can easily reach 1e40~1e70 on GAP-road.mtx
 template <typename VT, typename ET, typename WT>
 void bfs(raft::handle_t const &handle,
-         GraphCSRView<VT, ET, WT> const &graph,
+         legacy::GraphCSRView<VT, ET, WT> const &graph,
          VT *distances,
          VT *predecessors,
          double *sp_counters,
@@ -512,7 +512,7 @@ void bfs(raft::handle_t const &handle,
 
 // Explicit Instantiation
 template void bfs<uint32_t, uint32_t, float>(raft::handle_t const &handle,
-                                             GraphCSRView<uint32_t, uint32_t, float> const &graph,
+                                             legacy::GraphCSRView<uint32_t, uint32_t, float> const &graph,
                                              uint32_t *distances,
                                              uint32_t *predecessors,
                                              double *sp_counters,
@@ -522,7 +522,7 @@ template void bfs<uint32_t, uint32_t, float>(raft::handle_t const &handle,
 
 // Explicit Instantiation
 template void bfs<uint32_t, uint32_t, double>(raft::handle_t const &handle,
-                                              GraphCSRView<uint32_t, uint32_t, double> const &graph,
+                                              legacy::GraphCSRView<uint32_t, uint32_t, double> const &graph,
                                               uint32_t *distances,
                                               uint32_t *predecessors,
                                               double *sp_counters,
@@ -532,7 +532,7 @@ template void bfs<uint32_t, uint32_t, double>(raft::handle_t const &handle,
 
 // Explicit Instantiation
 template void bfs<int32_t, int32_t, float>(raft::handle_t const &handle,
-                                           GraphCSRView<int32_t, int32_t, float> const &graph,
+                                           legacy::GraphCSRView<int32_t, int32_t, float> const &graph,
                                            int32_t *distances,
                                            int32_t *predecessors,
                                            double *sp_counters,
@@ -542,7 +542,7 @@ template void bfs<int32_t, int32_t, float>(raft::handle_t const &handle,
 
 // Explicit Instantiation
 template void bfs<int32_t, int32_t, double>(raft::handle_t const &handle,
-                                            GraphCSRView<int32_t, int32_t, double> const &graph,
+                                            legacy::GraphCSRView<int32_t, int32_t, double> const &graph,
                                             int32_t *distances,
                                             int32_t *predecessors,
                                             double *sp_counters,
@@ -552,7 +552,7 @@ template void bfs<int32_t, int32_t, double>(raft::handle_t const &handle,
 
 // Explicit Instantiation
 template void bfs<int64_t, int64_t, float>(raft::handle_t const &handle,
-                                           GraphCSRView<int64_t, int64_t, float> const &graph,
+                                           legacy::GraphCSRView<int64_t, int64_t, float> const &graph,
                                            int64_t *distances,
                                            int64_t *predecessors,
                                            double *sp_counters,
@@ -562,7 +562,7 @@ template void bfs<int64_t, int64_t, float>(raft::handle_t const &handle,
 
 // Explicit Instantiation
 template void bfs<int64_t, int64_t, double>(raft::handle_t const &handle,
-                                            GraphCSRView<int64_t, int64_t, double> const &graph,
+                                            legacy::GraphCSRView<int64_t, int64_t, double> const &graph,
                                             int64_t *distances,
                                             int64_t *predecessors,
                                             double *sp_counters,

--- a/cpp/src/traversal/bfs_kernels.cuh
+++ b/cpp/src/traversal/bfs_kernels.cuh
@@ -18,7 +18,7 @@
 #include <raft/cudart_utils.h>
 #include <cub/cub.cuh>
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include "traversal_common.cuh"
 
 namespace cugraph {
@@ -292,7 +292,7 @@ __global__ void main_bottomup_kernel(const IndexType *unvisited,
   // When this kernel is converted to support different VT and ET, this
   // will likely split into invalid_vid and invalid_eid
   // This is equivalent to ~IndexType(0) (i.e., all bits set to 1)
-  constexpr IndexType invalid_idx = cugraph::invalid_idx<IndexType>::value;
+  constexpr IndexType invalid_idx = cugraph::legacy::invalid_idx<IndexType>::value;
 
   // we will call __syncthreads inside the loop
   // we need to keep complete block active
@@ -550,7 +550,7 @@ __global__ void bottom_up_large_degree_kernel(IndexType *left_unvisited,
   // When this kernel is converted to support different VT and ET, this
   // will likely split into invalid_vid and invalid_eid
   // This is equivalent to ~IndexType(0) (i.e., all bits set to 1)
-  constexpr IndexType invalid_idx = cugraph::invalid_idx<IndexType>::value;
+  constexpr IndexType invalid_idx = cugraph::legacy::invalid_idx<IndexType>::value;
 
   // Inactive threads are not a pb for __ballot (known behaviour)
   for (IndexType idx = logical_warps_per_block * blockIdx.x + logical_warp_id;
@@ -728,7 +728,7 @@ __global__ void topdown_expand_kernel(
   // When this kernel is converted to support different VT and ET, this
   // will likely split into invalid_vid and invalid_eid
   // This is equivalent to ~IndexType(0) (i.e., all bits set to 1)
-  constexpr IndexType invalid_idx = cugraph::invalid_idx<IndexType>::value;
+  constexpr IndexType invalid_idx = cugraph::legacy::invalid_idx<IndexType>::value;
 
   IndexType n_items_per_thread_left =
     (totaldegree > block_offset)

--- a/cpp/src/traversal/mg/bfs.cuh
+++ b/cpp/src/traversal/mg/bfs.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/traversal/mg/bfs.cuh
+++ b/cpp/src/traversal/mg/bfs.cuh
@@ -29,7 +29,7 @@ namespace detail {
 
 template <typename vertex_t, typename edge_t, typename weight_t, typename operator_t>
 void bfs_traverse(raft::handle_t const &handle,
-                  cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+                  cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                   const vertex_t start_vertex,
                   rmm::device_vector<uint32_t> &visited_bmap,
                   rmm::device_vector<uint32_t> &output_frontier_bmap,
@@ -111,7 +111,7 @@ void bfs_traverse(raft::handle_t const &handle,
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 void bfs(raft::handle_t const &handle,
-         cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+         cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
          vertex_t *distances,
          vertex_t *predecessors,
          const vertex_t start_vertex)
@@ -132,7 +132,7 @@ void bfs(raft::handle_t const &handle,
   thrust::fill(rmm::exec_policy(stream)->on(stream),
                predecessors,
                predecessors + global_number_of_vertices,
-               cugraph::invalid_idx<vertex_t>::value);
+               cugraph::legacy::invalid_idx<vertex_t>::value);
 
   if (distances == nullptr) {
     detail::BFSStepNoDist<vertex_t, edge_t> bfs_op(

--- a/cpp/src/traversal/mg/common_utils.cuh
+++ b/cpp/src/traversal/mg/common_utils.cuh
@@ -138,7 +138,7 @@ struct BFSStep {
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 vertex_t populate_isolated_vertices(raft::handle_t const &handle,
-                                    cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+                                    cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                                     rmm::device_vector<vertex_t> &isolated_vertex_ids)
 {
   bool is_mg          = (handle.comms_initialized() && (graph.local_vertices != nullptr) &&
@@ -218,7 +218,7 @@ void add_to_bitmap(raft::handle_t const &handle,
 // ith bit of isolated_bmap to 1
 template <typename vertex_t, typename edge_t, typename weight_t>
 void create_isolated_bitmap(raft::handle_t const &handle,
-                            cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+                            cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                             rmm::device_vector<vertex_t> &local_isolated_ids,
                             rmm::device_vector<vertex_t> &global_isolated_ids,
                             rmm::device_vector<size_t> &temp_buffer_len,
@@ -384,7 +384,7 @@ return_t remove_duplicates(raft::handle_t const &handle,
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 vertex_t preprocess_input_frontier(raft::handle_t const &handle,
-                                   cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+                                   cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                                    rmm::device_vector<uint32_t> &bmap,
                                    rmm::device_vector<uint32_t> &isolated_bmap,
                                    rmm::device_vector<vertex_t> &input_frontier,
@@ -416,7 +416,7 @@ vertex_t preprocess_input_frontier(raft::handle_t const &handle,
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 vertex_t preprocess_input_frontier(raft::handle_t const &handle,
-                                   cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+                                   cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                                    rmm::device_vector<uint32_t> &bmap,
                                    rmm::device_vector<vertex_t> &input_frontier,
                                    vertex_t input_frontier_len,
@@ -458,7 +458,7 @@ __global__ void fill_kernel(vertex_t *distances, vertex_t count, vertex_t start_
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 void fill_max_dist(raft::handle_t const &handle,
-                   cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+                   cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                    vertex_t start_vertex,
                    vertex_t global_number_of_vertices,
                    vertex_t *distances)
@@ -472,7 +472,7 @@ void fill_max_dist(raft::handle_t const &handle,
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 vertex_t get_global_vertex_count(raft::handle_t const &handle,
-                                 cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph)
+                                 cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph)
 {
   rmm::device_vector<vertex_t> id(1);
   id[0] = *thrust::max_element(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),

--- a/cpp/src/traversal/mg/common_utils.cuh
+++ b/cpp/src/traversal/mg/common_utils.cuh
@@ -137,9 +137,10 @@ struct BFSStep {
 };
 
 template <typename vertex_t, typename edge_t, typename weight_t>
-vertex_t populate_isolated_vertices(raft::handle_t const &handle,
-                                    cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
-                                    rmm::device_vector<vertex_t> &isolated_vertex_ids)
+vertex_t populate_isolated_vertices(
+  raft::handle_t const &handle,
+  cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+  rmm::device_vector<vertex_t> &isolated_vertex_ids)
 {
   bool is_mg          = (handle.comms_initialized() && (graph.local_vertices != nullptr) &&
                 (graph.local_offsets != nullptr));
@@ -383,13 +384,14 @@ return_t remove_duplicates(raft::handle_t const &handle,
 }
 
 template <typename vertex_t, typename edge_t, typename weight_t>
-vertex_t preprocess_input_frontier(raft::handle_t const &handle,
-                                   cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
-                                   rmm::device_vector<uint32_t> &bmap,
-                                   rmm::device_vector<uint32_t> &isolated_bmap,
-                                   rmm::device_vector<vertex_t> &input_frontier,
-                                   vertex_t input_frontier_len,
-                                   rmm::device_vector<vertex_t> &output_frontier)
+vertex_t preprocess_input_frontier(
+  raft::handle_t const &handle,
+  cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+  rmm::device_vector<uint32_t> &bmap,
+  rmm::device_vector<uint32_t> &isolated_bmap,
+  rmm::device_vector<vertex_t> &input_frontier,
+  vertex_t input_frontier_len,
+  rmm::device_vector<vertex_t> &output_frontier)
 {
   cudaStream_t stream = handle.get_stream();
 
@@ -415,12 +417,13 @@ vertex_t preprocess_input_frontier(raft::handle_t const &handle,
 }
 
 template <typename vertex_t, typename edge_t, typename weight_t>
-vertex_t preprocess_input_frontier(raft::handle_t const &handle,
-                                   cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
-                                   rmm::device_vector<uint32_t> &bmap,
-                                   rmm::device_vector<vertex_t> &input_frontier,
-                                   vertex_t input_frontier_len,
-                                   rmm::device_vector<vertex_t> &output_frontier)
+vertex_t preprocess_input_frontier(
+  raft::handle_t const &handle,
+  cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+  rmm::device_vector<uint32_t> &bmap,
+  rmm::device_vector<vertex_t> &input_frontier,
+  vertex_t input_frontier_len,
+  rmm::device_vector<vertex_t> &output_frontier)
 {
   cudaStream_t stream = handle.get_stream();
 
@@ -471,8 +474,9 @@ void fill_max_dist(raft::handle_t const &handle,
 }
 
 template <typename vertex_t, typename edge_t, typename weight_t>
-vertex_t get_global_vertex_count(raft::handle_t const &handle,
-                                 cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph)
+vertex_t get_global_vertex_count(
+  raft::handle_t const &handle,
+  cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph)
 {
   rmm::device_vector<vertex_t> id(1);
   id[0] = *thrust::max_element(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),

--- a/cpp/src/traversal/mg/frontier_expand.cuh
+++ b/cpp/src/traversal/mg/frontier_expand.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include "frontier_expand_kernels.cuh"
 #include "vertex_binning.cuh"
 
@@ -29,7 +29,7 @@ namespace detail {
 template <typename vertex_t, typename edge_t, typename weight_t>
 class FrontierExpand {
   raft::handle_t const &handle_;
-  cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph_;
+  cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph_;
   VertexBinner<vertex_t, edge_t> dist_;
   rmm::device_vector<vertex_t> reorganized_vertices_;
   edge_t vertex_begin_;
@@ -38,7 +38,7 @@ class FrontierExpand {
 
  public:
   FrontierExpand(raft::handle_t const &handle,
-                 cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph)
+                 cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph)
     : handle_(handle), graph_(graph)
   {
     bool is_mg = (handle.comms_initialized() && (graph.local_vertices != nullptr) &&

--- a/cpp/src/traversal/mg/frontier_expand_kernels.cuh
+++ b/cpp/src/traversal/mg/frontier_expand_kernels.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include "vertex_binning.cuh"
 
 namespace cugraph {
@@ -171,7 +171,7 @@ __global__ void kernel_per_vertex(edge_t const *offsets,
 }
 
 template <typename vertex_t, typename edge_t, typename weight_t, typename operator_t>
-void large_vertex_lb(cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+void large_vertex_lb(cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                      DegreeBucket<vertex_t, edge_t> &bucket,
                      operator_t op,
                      vertex_t vertex_begin,
@@ -196,7 +196,7 @@ void large_vertex_lb(cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &gr
 }
 
 template <typename vertex_t, typename edge_t, typename weight_t, typename operator_t>
-void medium_vertex_lb(cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+void medium_vertex_lb(cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                       DegreeBucket<vertex_t, edge_t> &bucket,
                       operator_t op,
                       vertex_t vertex_begin,
@@ -223,7 +223,7 @@ void medium_vertex_lb(cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &g
 }
 
 template <typename vertex_t, typename edge_t, typename weight_t, typename operator_t>
-void small_vertex_lb(cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+void small_vertex_lb(cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
                      DegreeBucket<vertex_t, edge_t> &bucket,
                      operator_t op,
                      vertex_t vertex_begin,

--- a/cpp/src/traversal/sssp.cu
+++ b/cpp/src/traversal/sssp.cu
@@ -19,7 +19,7 @@
 #include <algorithm>
 #include <cugraph/utilities/error.hpp>
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include "sssp.cuh"
 #include "sssp_kernels.cuh"
@@ -242,7 +242,7 @@ void SSSP<IndexType, DistType>::clean()
  * @file sssp.cu
  * --------------------------------------------------------------------------*/
 template <typename VT, typename ET, typename WT>
-void sssp(GraphCSRView<VT, ET, WT> const &graph,
+void sssp(legacy::GraphCSRView<VT, ET, WT> const &graph,
           WT *distances,
           VT *predecessors,
           const VT source_vertex)
@@ -281,7 +281,7 @@ void sssp(GraphCSRView<VT, ET, WT> const &graph,
   } else {
     // SSSP is not defined for graphs with negative weight cycles
     // Warn user about any negative edges
-    if (graph.prop.has_negative_edges == PropType::PROP_TRUE)
+    if (graph.prop.has_negative_edges == legacy::PropType::PROP_TRUE)
       std::cerr << "WARN: The graph has negative weight edges. SSSP will not "
                    "converge if the graph has negative weight cycles\n";
     edge_weights_ptr = graph.edge_data;
@@ -293,11 +293,11 @@ void sssp(GraphCSRView<VT, ET, WT> const &graph,
 }
 
 // explicit instantiation
-template void sssp<int, int, float>(GraphCSRView<int, int, float> const &graph,
+template void sssp<int, int, float>(legacy::GraphCSRView<int, int, float> const &graph,
                                     float *distances,
                                     int *predecessors,
                                     const int source_vertex);
-template void sssp<int, int, double>(GraphCSRView<int, int, double> const &graph,
+template void sssp<int, int, double>(legacy::GraphCSRView<int, int, double> const &graph,
                                      double *distances,
                                      int *predecessors,
                                      const int source_vertex);

--- a/cpp/src/traversal/two_hop_neighbors.cu
+++ b/cpp/src/traversal/two_hop_neighbors.cu
@@ -32,7 +32,8 @@
 namespace cugraph {
 
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> get_two_hop_neighbors(legacy::GraphCSRView<VT, ET, WT> const &graph)
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> get_two_hop_neighbors(
+  legacy::GraphCSRView<VT, ET, WT> const &graph)
 {
   cudaStream_t stream{nullptr};
 
@@ -108,7 +109,8 @@ std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> get_two_hop_neighbors(legacy::Grap
   // Get things ready to return
   ET outputSize = tuple_end - tuple_start;
 
-  auto result = std::make_unique<legacy::GraphCOO<VT, ET, WT>>(graph.number_of_vertices, outputSize, false);
+  auto result =
+    std::make_unique<legacy::GraphCOO<VT, ET, WT>>(graph.number_of_vertices, outputSize, false);
 
   cudaMemcpy(result->src_indices(), d_first_pair, sizeof(VT) * outputSize, cudaMemcpyDefault);
   cudaMemcpy(result->dst_indices(), d_second_pair, sizeof(VT) * outputSize, cudaMemcpyDefault);

--- a/cpp/src/traversal/two_hop_neighbors.cu
+++ b/cpp/src/traversal/two_hop_neighbors.cu
@@ -21,7 +21,7 @@
 
 #include <rmm/thrust_rmm_allocator.h>
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 #include "two_hop_neighbors.cuh"
 
@@ -32,7 +32,7 @@
 namespace cugraph {
 
 template <typename VT, typename ET, typename WT>
-std::unique_ptr<GraphCOO<VT, ET, WT>> get_two_hop_neighbors(GraphCSRView<VT, ET, WT> const &graph)
+std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> get_two_hop_neighbors(legacy::GraphCSRView<VT, ET, WT> const &graph)
 {
   cudaStream_t stream{nullptr};
 
@@ -108,7 +108,7 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> get_two_hop_neighbors(GraphCSRView<VT, ET,
   // Get things ready to return
   ET outputSize = tuple_end - tuple_start;
 
-  auto result = std::make_unique<GraphCOO<VT, ET, WT>>(graph.number_of_vertices, outputSize, false);
+  auto result = std::make_unique<legacy::GraphCOO<VT, ET, WT>>(graph.number_of_vertices, outputSize, false);
 
   cudaMemcpy(result->src_indices(), d_first_pair, sizeof(VT) * outputSize, cudaMemcpyDefault);
   cudaMemcpy(result->dst_indices(), d_second_pair, sizeof(VT) * outputSize, cudaMemcpyDefault);
@@ -116,10 +116,10 @@ std::unique_ptr<GraphCOO<VT, ET, WT>> get_two_hop_neighbors(GraphCSRView<VT, ET,
   return result;
 }
 
-template std::unique_ptr<GraphCOO<int, int, float>> get_two_hop_neighbors(
-  GraphCSRView<int, int, float> const &);
+template std::unique_ptr<legacy::GraphCOO<int, int, float>> get_two_hop_neighbors(
+  legacy::GraphCSRView<int, int, float> const &);
 
-template std::unique_ptr<GraphCOO<int, int, double>> get_two_hop_neighbors(
-  GraphCSRView<int, int, double> const &);
+template std::unique_ptr<legacy::GraphCOO<int, int, double>> get_two_hop_neighbors(
+  legacy::GraphCSRView<int, int, double> const &);
 
 }  // namespace cugraph

--- a/cpp/src/tree/mst.cu
+++ b/cpp/src/tree/mst.cu
@@ -80,8 +80,8 @@ template std::unique_ptr<legacy::GraphCOO<int, int, float>> minimum_spanning_tre
   raft::handle_t const &handle,
   legacy::GraphCSRView<int, int, float> const &graph,
   rmm::mr::device_memory_resource *mr);
-template std::unique_ptr<legacy::GraphCOO<int, int, double>> minimum_spanning_tree<int, int, double>(
-  raft::handle_t const &handle,
-  legacy::GraphCSRView<int, int, double> const &graph,
-  rmm::mr::device_memory_resource *mr);
+template std::unique_ptr<legacy::GraphCOO<int, int, double>>
+minimum_spanning_tree<int, int, double>(raft::handle_t const &handle,
+                                        legacy::GraphCSRView<int, int, double> const &graph,
+                                        rmm::mr::device_memory_resource *mr);
 }  // namespace cugraph

--- a/cpp/src/tree/mst.cu
+++ b/cpp/src/tree/mst.cu
@@ -28,7 +28,7 @@
 #include <thrust/transform.h>
 #include <ctime>
 
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 
 #include <raft/sparse/mst/mst.cuh>
@@ -38,9 +38,9 @@ namespace cugraph {
 namespace detail {
 
 template <typename vertex_t, typename edge_t, typename weight_t>
-std::unique_ptr<GraphCOO<vertex_t, edge_t, weight_t>> mst_impl(
+std::unique_ptr<legacy::GraphCOO<vertex_t, edge_t, weight_t>> mst_impl(
   raft::handle_t const &handle,
-  GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+  legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
   rmm::mr::device_memory_resource *mr)
 
 {
@@ -55,33 +55,33 @@ std::unique_ptr<GraphCOO<vertex_t, edge_t, weight_t>> mst_impl(
                                                               colors.data(),
                                                               stream);
 
-  GraphCOOContents<vertex_t, edge_t, weight_t> coo_contents{
+  legacy::GraphCOOContents<vertex_t, edge_t, weight_t> coo_contents{
     graph.number_of_vertices,
     mst_edges.n_edges,
     std::make_unique<rmm::device_buffer>(mst_edges.src.release()),
     std::make_unique<rmm::device_buffer>(mst_edges.dst.release()),
     std::make_unique<rmm::device_buffer>(mst_edges.weights.release())};
 
-  return std::make_unique<GraphCOO<vertex_t, edge_t, weight_t>>(std::move(coo_contents));
+  return std::make_unique<legacy::GraphCOO<vertex_t, edge_t, weight_t>>(std::move(coo_contents));
 }
 
 }  // namespace detail
 
 template <typename vertex_t, typename edge_t, typename weight_t>
-std::unique_ptr<GraphCOO<vertex_t, edge_t, weight_t>> minimum_spanning_tree(
+std::unique_ptr<legacy::GraphCOO<vertex_t, edge_t, weight_t>> minimum_spanning_tree(
   raft::handle_t const &handle,
-  GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+  legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
   rmm::mr::device_memory_resource *mr)
 {
   return detail::mst_impl(handle, graph, mr);
 }
 
-template std::unique_ptr<GraphCOO<int, int, float>> minimum_spanning_tree<int, int, float>(
+template std::unique_ptr<legacy::GraphCOO<int, int, float>> minimum_spanning_tree<int, int, float>(
   raft::handle_t const &handle,
-  GraphCSRView<int, int, float> const &graph,
+  legacy::GraphCSRView<int, int, float> const &graph,
   rmm::mr::device_memory_resource *mr);
-template std::unique_ptr<GraphCOO<int, int, double>> minimum_spanning_tree<int, int, double>(
+template std::unique_ptr<legacy::GraphCOO<int, int, double>> minimum_spanning_tree<int, int, double>(
   raft::handle_t const &handle,
-  GraphCSRView<int, int, double> const &graph,
+  legacy::GraphCSRView<int, int, double> const &graph,
   rmm::mr::device_memory_resource *mr);
 }  // namespace cugraph

--- a/cpp/src/utilities/cython.cu
+++ b/cpp/src/utilities/cython.cu
@@ -18,7 +18,7 @@
 #include <cugraph/experimental/detail/graph_utils.cuh>
 #include <cugraph/experimental/graph_functions.hpp>
 #include <cugraph/experimental/graph_view.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/graph_generators.hpp>
 #include <cugraph/partition_manager.hpp>
 #include <cugraph/utilities/cython.hpp>
@@ -281,7 +281,7 @@ void populate_graph_container_legacy(graph_container_t& graph_container,
     switch (legacyType) {
       case graphTypeEnum::LegacyCSR: {
         graph_container.graph_ptr_union.GraphCSRViewFloatPtr =
-          std::make_unique<GraphCSRView<int, int, float>>(reinterpret_cast<int*>(offsets),
+          std::make_unique<legacy::GraphCSRView<int, int, float>>(reinterpret_cast<int*>(offsets),
                                                           reinterpret_cast<int*>(indices),
                                                           reinterpret_cast<float*>(weights),
                                                           num_global_vertices,
@@ -294,7 +294,7 @@ void populate_graph_container_legacy(graph_container_t& graph_container,
       } break;
       case graphTypeEnum::LegacyCSC: {
         graph_container.graph_ptr_union.GraphCSCViewFloatPtr =
-          std::make_unique<GraphCSCView<int, int, float>>(reinterpret_cast<int*>(offsets),
+          std::make_unique<legacy::GraphCSCView<int, int, float>>(reinterpret_cast<int*>(offsets),
                                                           reinterpret_cast<int*>(indices),
                                                           reinterpret_cast<float*>(weights),
                                                           num_global_vertices,
@@ -307,7 +307,7 @@ void populate_graph_container_legacy(graph_container_t& graph_container,
       } break;
       case graphTypeEnum::LegacyCOO: {
         graph_container.graph_ptr_union.GraphCOOViewFloatPtr =
-          std::make_unique<GraphCOOView<int, int, float>>(reinterpret_cast<int*>(offsets),
+          std::make_unique<legacy::GraphCOOView<int, int, float>>(reinterpret_cast<int*>(offsets),
                                                           reinterpret_cast<int*>(indices),
                                                           reinterpret_cast<float*>(weights),
                                                           num_global_vertices,
@@ -325,7 +325,7 @@ void populate_graph_container_legacy(graph_container_t& graph_container,
     switch (legacyType) {
       case graphTypeEnum::LegacyCSR: {
         graph_container.graph_ptr_union.GraphCSRViewDoublePtr =
-          std::make_unique<GraphCSRView<int, int, double>>(reinterpret_cast<int*>(offsets),
+          std::make_unique<legacy::GraphCSRView<int, int, double>>(reinterpret_cast<int*>(offsets),
                                                            reinterpret_cast<int*>(indices),
                                                            reinterpret_cast<double*>(weights),
                                                            num_global_vertices,
@@ -338,7 +338,7 @@ void populate_graph_container_legacy(graph_container_t& graph_container,
       } break;
       case graphTypeEnum::LegacyCSC: {
         graph_container.graph_ptr_union.GraphCSCViewDoublePtr =
-          std::make_unique<GraphCSCView<int, int, double>>(reinterpret_cast<int*>(offsets),
+          std::make_unique<legacy::GraphCSCView<int, int, double>>(reinterpret_cast<int*>(offsets),
                                                            reinterpret_cast<int*>(indices),
                                                            reinterpret_cast<double*>(weights),
                                                            num_global_vertices,
@@ -351,7 +351,7 @@ void populate_graph_container_legacy(graph_container_t& graph_container,
       } break;
       case graphTypeEnum::LegacyCOO: {
         graph_container.graph_ptr_union.GraphCOOViewDoublePtr =
-          std::make_unique<GraphCOOView<int, int, double>>(reinterpret_cast<int*>(offsets),
+          std::make_unique<legacy::GraphCOOView<int, int, double>>(reinterpret_cast<int*>(offsets),
                                                            reinterpret_cast<int*>(indices),
                                                            reinterpret_cast<double*>(weights),
                                                            num_global_vertices,

--- a/cpp/src/utilities/cython.cu
+++ b/cpp/src/utilities/cython.cu
@@ -18,8 +18,8 @@
 #include <cugraph/experimental/detail/graph_utils.cuh>
 #include <cugraph/experimental/graph_functions.hpp>
 #include <cugraph/experimental/graph_view.hpp>
-#include <cugraph/legacy/graph.hpp>
 #include <cugraph/graph_generators.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <cugraph/partition_manager.hpp>
 #include <cugraph/utilities/cython.hpp>
 #include <cugraph/utilities/error.hpp>
@@ -282,10 +282,10 @@ void populate_graph_container_legacy(graph_container_t& graph_container,
       case graphTypeEnum::LegacyCSR: {
         graph_container.graph_ptr_union.GraphCSRViewFloatPtr =
           std::make_unique<legacy::GraphCSRView<int, int, float>>(reinterpret_cast<int*>(offsets),
-                                                          reinterpret_cast<int*>(indices),
-                                                          reinterpret_cast<float*>(weights),
-                                                          num_global_vertices,
-                                                          num_global_edges);
+                                                                  reinterpret_cast<int*>(indices),
+                                                                  reinterpret_cast<float*>(weights),
+                                                                  num_global_vertices,
+                                                                  num_global_edges);
         graph_container.graph_type = graphTypeEnum::GraphCSRViewFloat;
         (graph_container.graph_ptr_union.GraphCSRViewFloatPtr)
           ->set_local_data(local_vertices, local_edges, local_offsets);
@@ -295,10 +295,10 @@ void populate_graph_container_legacy(graph_container_t& graph_container,
       case graphTypeEnum::LegacyCSC: {
         graph_container.graph_ptr_union.GraphCSCViewFloatPtr =
           std::make_unique<legacy::GraphCSCView<int, int, float>>(reinterpret_cast<int*>(offsets),
-                                                          reinterpret_cast<int*>(indices),
-                                                          reinterpret_cast<float*>(weights),
-                                                          num_global_vertices,
-                                                          num_global_edges);
+                                                                  reinterpret_cast<int*>(indices),
+                                                                  reinterpret_cast<float*>(weights),
+                                                                  num_global_vertices,
+                                                                  num_global_edges);
         graph_container.graph_type = graphTypeEnum::GraphCSCViewFloat;
         (graph_container.graph_ptr_union.GraphCSCViewFloatPtr)
           ->set_local_data(local_vertices, local_edges, local_offsets);
@@ -308,10 +308,10 @@ void populate_graph_container_legacy(graph_container_t& graph_container,
       case graphTypeEnum::LegacyCOO: {
         graph_container.graph_ptr_union.GraphCOOViewFloatPtr =
           std::make_unique<legacy::GraphCOOView<int, int, float>>(reinterpret_cast<int*>(offsets),
-                                                          reinterpret_cast<int*>(indices),
-                                                          reinterpret_cast<float*>(weights),
-                                                          num_global_vertices,
-                                                          num_global_edges);
+                                                                  reinterpret_cast<int*>(indices),
+                                                                  reinterpret_cast<float*>(weights),
+                                                                  num_global_vertices,
+                                                                  num_global_edges);
         graph_container.graph_type = graphTypeEnum::GraphCOOViewFloat;
         (graph_container.graph_ptr_union.GraphCOOViewFloatPtr)
           ->set_local_data(local_vertices, local_edges, local_offsets);
@@ -325,11 +325,12 @@ void populate_graph_container_legacy(graph_container_t& graph_container,
     switch (legacyType) {
       case graphTypeEnum::LegacyCSR: {
         graph_container.graph_ptr_union.GraphCSRViewDoublePtr =
-          std::make_unique<legacy::GraphCSRView<int, int, double>>(reinterpret_cast<int*>(offsets),
-                                                           reinterpret_cast<int*>(indices),
-                                                           reinterpret_cast<double*>(weights),
-                                                           num_global_vertices,
-                                                           num_global_edges);
+          std::make_unique<legacy::GraphCSRView<int, int, double>>(
+            reinterpret_cast<int*>(offsets),
+            reinterpret_cast<int*>(indices),
+            reinterpret_cast<double*>(weights),
+            num_global_vertices,
+            num_global_edges);
         graph_container.graph_type = graphTypeEnum::GraphCSRViewDouble;
         (graph_container.graph_ptr_union.GraphCSRViewDoublePtr)
           ->set_local_data(local_vertices, local_edges, local_offsets);
@@ -338,11 +339,12 @@ void populate_graph_container_legacy(graph_container_t& graph_container,
       } break;
       case graphTypeEnum::LegacyCSC: {
         graph_container.graph_ptr_union.GraphCSCViewDoublePtr =
-          std::make_unique<legacy::GraphCSCView<int, int, double>>(reinterpret_cast<int*>(offsets),
-                                                           reinterpret_cast<int*>(indices),
-                                                           reinterpret_cast<double*>(weights),
-                                                           num_global_vertices,
-                                                           num_global_edges);
+          std::make_unique<legacy::GraphCSCView<int, int, double>>(
+            reinterpret_cast<int*>(offsets),
+            reinterpret_cast<int*>(indices),
+            reinterpret_cast<double*>(weights),
+            num_global_vertices,
+            num_global_edges);
         graph_container.graph_type = graphTypeEnum::GraphCSCViewDouble;
         (graph_container.graph_ptr_union.GraphCSCViewDoublePtr)
           ->set_local_data(local_vertices, local_edges, local_offsets);
@@ -351,11 +353,12 @@ void populate_graph_container_legacy(graph_container_t& graph_container,
       } break;
       case graphTypeEnum::LegacyCOO: {
         graph_container.graph_ptr_union.GraphCOOViewDoublePtr =
-          std::make_unique<legacy::GraphCOOView<int, int, double>>(reinterpret_cast<int*>(offsets),
-                                                           reinterpret_cast<int*>(indices),
-                                                           reinterpret_cast<double*>(weights),
-                                                           num_global_vertices,
-                                                           num_global_edges);
+          std::make_unique<legacy::GraphCOOView<int, int, double>>(
+            reinterpret_cast<int*>(offsets),
+            reinterpret_cast<int*>(indices),
+            reinterpret_cast<double*>(weights),
+            num_global_vertices,
+            num_global_edges);
         graph_container.graph_type = graphTypeEnum::GraphCOOViewDouble;
         (graph_container.graph_ptr_union.GraphCOOViewDoublePtr)
           ->set_local_data(local_vertices, local_edges, local_offsets);

--- a/cpp/tests/centrality/betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/betweenness_centrality_test.cu
@@ -19,7 +19,7 @@
 #include <utilities/test_utilities.hpp>
 
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <raft/error.hpp>
 #include <raft/handle.hpp>
@@ -195,7 +195,7 @@ void reference_rescale(result_t *result,
 
 template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
 void reference_betweenness_centrality(
-  cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+  cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
   result_t *result,
   bool normalize,
   bool endpoints,  // This is not yet implemented
@@ -228,14 +228,14 @@ void reference_betweenness_centrality(
 // Explicit instantiation
 /*    FIXME!!!
 template void reference_betweenness_centrality<int, int, float, float>(
-  cugraph::GraphCSRView<int, int, float> const &,
+  cugraph::legacy::GraphCSRView<int, int, float> const &,
   float *,
   bool,
   bool,
   const int,
   int const *);
 template void reference_betweenness_centrality<int, int, double, double>(
-  cugraph::GraphCSRView<int, int, double> const &,
+  cugraph::legacy::GraphCSRView<int, int, double> const &,
   double *,
   bool,
   bool,
@@ -308,7 +308,7 @@ class Tests_BC : public ::testing::TestWithParam<BC_Usecase> {
     auto csr         = cugraph::test::generate_graph_csr_from_mm<vertex_t, edge_t, weight_t>(
       is_directed, configuration.file_path_);
     cudaDeviceSynchronize();
-    cugraph::GraphCSRView<vertex_t, edge_t, weight_t> G = csr->view();
+    cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> G = csr->view();
     G.prop.directed                                     = is_directed;
     CUDA_TRY(cudaGetLastError());
     std::vector<result_t> result(G.number_of_vertices, 0);

--- a/cpp/tests/centrality/betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/betweenness_centrality_test.cu
@@ -309,7 +309,7 @@ class Tests_BC : public ::testing::TestWithParam<BC_Usecase> {
       is_directed, configuration.file_path_);
     cudaDeviceSynchronize();
     cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> G = csr->view();
-    G.prop.directed                                     = is_directed;
+    G.prop.directed                                             = is_directed;
     CUDA_TRY(cudaGetLastError());
     std::vector<result_t> result(G.number_of_vertices, 0);
     std::vector<result_t> expected(G.number_of_vertices, 0);

--- a/cpp/tests/centrality/edge_betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/edge_betweenness_centrality_test.cu
@@ -27,7 +27,7 @@
 #include <gmock/gmock.h>
 
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <fstream>
 #include <queue>
@@ -155,7 +155,7 @@ void reference_rescale(result_t *result,
 
 template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
 void reference_edge_betweenness_centrality(
-  cugraph::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
+  cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> const &graph,
   result_t *result,
   bool normalize,
   vertex_t const number_of_sources,
@@ -244,7 +244,7 @@ class Tests_EdgeBC : public ::testing::TestWithParam<EdgeBC_Usecase> {
     auto csr         = cugraph::test::generate_graph_csr_from_mm<vertex_t, edge_t, weight_t>(
       is_directed, configuration.file_path_);
     cudaDeviceSynchronize();
-    cugraph::GraphCSRView<vertex_t, edge_t, weight_t> G = csr->view();
+    cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> G = csr->view();
     G.prop.directed                                     = is_directed;
     CUDA_TRY(cudaGetLastError());
     std::vector<result_t> result(G.number_of_edges, 0);

--- a/cpp/tests/centrality/edge_betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/edge_betweenness_centrality_test.cu
@@ -245,7 +245,7 @@ class Tests_EdgeBC : public ::testing::TestWithParam<EdgeBC_Usecase> {
       is_directed, configuration.file_path_);
     cudaDeviceSynchronize();
     cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> G = csr->view();
-    G.prop.directed                                     = is_directed;
+    G.prop.directed                                             = is_directed;
     CUDA_TRY(cudaGetLastError());
     std::vector<result_t> result(G.number_of_edges, 0);
     std::vector<result_t> expected(G.number_of_edges, 0);

--- a/cpp/tests/centrality/katz_centrality_test.cu
+++ b/cpp/tests/centrality/katz_centrality_test.cu
@@ -21,7 +21,7 @@
 #include <converters/COOtoCSR.cuh>
 
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <gmock/gmock-generated-matchers.h>
 #include <gmock/gmock.h>
@@ -56,13 +56,13 @@ std::vector<int> getTopKIds(double* p_katz, int count, int k = 10)
 }
 
 template <typename VT, typename ET, typename WT>
-int getMaxDegree(cugraph::GraphCSRView<VT, ET, WT> const& g)
+int getMaxDegree(cugraph::legacy::GraphCSRView<VT, ET, WT> const& g)
 {
   cudaStream_t stream{nullptr};
 
   rmm::device_vector<ET> degree_vector(g.number_of_vertices);
   ET* p_degree = degree_vector.data().get();
-  g.degree(p_degree, cugraph::DegreeDirection::OUT);
+  g.degree(p_degree, cugraph::legacy::DegreeDirection::OUT);
   ET max_out_degree = thrust::reduce(rmm::exec_policy(stream)->on(stream),
                                      p_degree,
                                      p_degree + g.number_of_vertices,
@@ -137,9 +137,9 @@ class Tests_Katz : public ::testing::TestWithParam<Katz_Usecase> {
       << "\n";
     ASSERT_EQ(fclose(fpin), 0);
 
-    cugraph::GraphCOOView<int, int, float> cooview(&cooColInd[0], &cooRowInd[0], nullptr, m, nnz);
+    cugraph::legacy::GraphCOOView<int, int, float> cooview(&cooColInd[0], &cooRowInd[0], nullptr, m, nnz);
     auto csr                                 = cugraph::coo_to_csr(cooview);
-    cugraph::GraphCSRView<int, int, float> G = csr->view();
+    cugraph::legacy::GraphCSRView<int, int, float> G = csr->view();
 
     rmm::device_vector<double> katz_vector(m);
     double* d_katz = thrust::raw_pointer_cast(katz_vector.data());

--- a/cpp/tests/centrality/katz_centrality_test.cu
+++ b/cpp/tests/centrality/katz_centrality_test.cu
@@ -137,8 +137,9 @@ class Tests_Katz : public ::testing::TestWithParam<Katz_Usecase> {
       << "\n";
     ASSERT_EQ(fclose(fpin), 0);
 
-    cugraph::legacy::GraphCOOView<int, int, float> cooview(&cooColInd[0], &cooRowInd[0], nullptr, m, nnz);
-    auto csr                                 = cugraph::coo_to_csr(cooview);
+    cugraph::legacy::GraphCOOView<int, int, float> cooview(
+      &cooColInd[0], &cooRowInd[0], nullptr, m, nnz);
+    auto csr                                         = cugraph::coo_to_csr(cooview);
     cugraph::legacy::GraphCSRView<int, int, float> G = csr->view();
 
     rmm::device_vector<double> katz_vector(m);

--- a/cpp/tests/community/balanced_edge_test.cpp
+++ b/cpp/tests/community/balanced_edge_test.cpp
@@ -48,7 +48,7 @@ TEST(balanced_edge, success)
   rmm::device_vector<float> weights_v(w_h);
   rmm::device_vector<int> result_v(cluster_id);
 
-  cugraph::GraphCSRView<int, int, float> G(
+  cugraph::legacy::GraphCSRView<int, int, float> G(
     offsets_v.data().get(), indices_v.data().get(), weights_v.data().get(), num_verts, num_edges);
 
   int num_clusters{8};

--- a/cpp/tests/community/ecg_test.cpp
+++ b/cpp/tests/community/ecg_test.cpp
@@ -11,7 +11,7 @@
 #include <utilities/base_fixture.hpp>
 
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <rmm/thrust_rmm_allocator.h>
 
@@ -47,7 +47,7 @@ TEST(ecg, success)
   rmm::device_vector<float> weights_v(w_h);
   rmm::device_vector<int> result_v(cluster_id);
 
-  cugraph::GraphCSRView<int, int, float> graph_csr(
+  cugraph::legacy::GraphCSRView<int, int, float> graph_csr(
     offsets_v.data().get(), indices_v.data().get(), weights_v.data().get(), num_verts, num_edges);
 
   raft::handle_t handle;
@@ -118,7 +118,7 @@ TEST(ecg, dolphin)
   raft::update_device(indices_v.data(), ind_h.data(), ind_h.size(), stream);
   raft::update_device(weights_v.data(), w_h.data(), w_h.size(), stream);
 
-  cugraph::GraphCSRView<int, int, float> graph_csr(
+  cugraph::legacy::GraphCSRView<int, int, float> graph_csr(
     offsets_v.data(), indices_v.data(), weights_v.data(), num_verts, num_edges);
 
   // "FIXME": remove this check once we drop support for Pascal

--- a/cpp/tests/community/leiden_test.cpp
+++ b/cpp/tests/community/leiden_test.cpp
@@ -11,7 +11,7 @@
 #include <gtest/gtest.h>
 
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <thrust/extrema.h>
 
@@ -59,7 +59,7 @@ TEST(leiden_karate, success)
   raft::update_device(indices_v.data(), ind_h.data(), ind_h.size(), stream);
   raft::update_device(weights_v.data(), w_h.data(), w_h.size(), stream);
 
-  cugraph::GraphCSRView<int, int, float> G(
+  cugraph::legacy::GraphCSRView<int, int, float> G(
     offsets_v.data(), indices_v.data(), weights_v.data(), num_verts, num_edges);
 
   float modularity{0.0};

--- a/cpp/tests/community/louvain_test.cpp
+++ b/cpp/tests/community/louvain_test.cpp
@@ -204,7 +204,7 @@ TEST(louvain_legacy, success)
   raft::update_device(indices_v.data(), ind_h.data(), ind_h.size(), stream);
   raft::update_device(weights_v.data(), w_h.data(), w_h.size(), stream);
 
-  cugraph::GraphCSRView<int, int, float> G(
+  cugraph::legacy::GraphCSRView<int, int, float> G(
     offsets_v.data(), indices_v.data(), weights_v.data(), num_verts, num_edges);
 
   float modularity{0.0};
@@ -275,7 +275,7 @@ TEST(louvain_legacy_renumbered, success)
   raft::update_device(indices_v.data(), ind_h.data(), ind_h.size(), stream);
   raft::update_device(weights_v.data(), w_h.data(), w_h.size(), stream);
 
-  cugraph::GraphCSRView<int, int, float> G(
+  cugraph::legacy::GraphCSRView<int, int, float> G(
     offsets_v.data(), indices_v.data(), weights_v.data(), num_verts, num_edges);
 
   float modularity{0.0};

--- a/cpp/tests/community/triangle_test.cu
+++ b/cpp/tests/community/triangle_test.cu
@@ -11,7 +11,7 @@
 #include <utilities/base_fixture.hpp>
 
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <rmm/thrust_rmm_allocator.h>
 
@@ -49,7 +49,7 @@ TEST(triangle, dolphin)
   rmm::device_vector<int> indices_v(ind_h);
   rmm::device_vector<float> weights_v(w_h);
 
-  cugraph::GraphCSRView<int, int, float> graph_csr(
+  cugraph::legacy::GraphCSRView<int, int, float> graph_csr(
     offsets_v.data().get(), indices_v.data().get(), weights_v.data().get(), num_verts, num_edges);
 
   uint64_t count{0};
@@ -92,7 +92,7 @@ TEST(triangle, karate)
   rmm::device_vector<vertex_t> indices_v(ind_h);
   rmm::device_vector<weight_t> weights_v(w_h);
 
-  cugraph::GraphCSRView<vertex_t, vertex_t, weight_t> graph_csr(
+  cugraph::legacy::GraphCSRView<vertex_t, vertex_t, weight_t> graph_csr(
     offsets_v.data().get(), indices_v.data().get(), weights_v.data().get(), num_verts, num_edges);
 
   uint64_t count{0};

--- a/cpp/tests/components/con_comp_test.cu
+++ b/cpp/tests/components/con_comp_test.cu
@@ -113,8 +113,9 @@ struct Tests_Weakly_CC : ::testing::TestWithParam<Usecase> {
       << "\n";
     ASSERT_EQ(fclose(fpin), 0);
 
-    cugraph::legacy::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, m, nnz);
-    auto G_unique                            = cugraph::coo_to_csr(G_coo);
+    cugraph::legacy::GraphCOOView<int, int, float> G_coo(
+      &cooRowInd[0], &cooColInd[0], nullptr, m, nnz);
+    auto G_unique                                    = cugraph::coo_to_csr(G_coo);
     cugraph::legacy::GraphCSRView<int, int, float> G = G_unique->view();
 
     rmm::device_vector<int> d_labels(m);

--- a/cpp/tests/components/con_comp_test.cu
+++ b/cpp/tests/components/con_comp_test.cu
@@ -20,7 +20,7 @@
 
 #include <converters/COOtoCSR.cuh>
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <algorithm>
 #include <iterator>
@@ -113,9 +113,9 @@ struct Tests_Weakly_CC : ::testing::TestWithParam<Usecase> {
       << "\n";
     ASSERT_EQ(fclose(fpin), 0);
 
-    cugraph::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, m, nnz);
+    cugraph::legacy::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, m, nnz);
     auto G_unique                            = cugraph::coo_to_csr(G_coo);
-    cugraph::GraphCSRView<int, int, float> G = G_unique->view();
+    cugraph::legacy::GraphCSRView<int, int, float> G = G_unique->view();
 
     rmm::device_vector<int> d_labels(m);
 

--- a/cpp/tests/components/scc_test.cu
+++ b/cpp/tests/components/scc_test.cu
@@ -19,7 +19,7 @@
 #include <components/scc_matrix.cuh>
 #include <converters/COOtoCSR.cuh>
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 #include <topology/topology.cuh>
 
 #include <cuda_profiler_api.h>
@@ -176,9 +176,9 @@ struct Tests_Strongly_CC : ::testing::TestWithParam<Usecase> {
       << "\n";
     ASSERT_EQ(fclose(fpin), 0);
 
-    cugraph::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
+    cugraph::legacy::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
     auto G_unique                            = cugraph::coo_to_csr(G_coo);
-    cugraph::GraphCSRView<int, int, float> G = G_unique->view();
+    cugraph::legacy::GraphCSRView<int, int, float> G = G_unique->view();
 
     rmm::device_vector<int> d_labels(nrows);
 
@@ -246,9 +246,9 @@ TEST_F(SCCSmallTest, CustomGraphSimpleLoops)
 
   EXPECT_EQ(nnz, cooColInd.size());
 
-  cugraph::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
+  cugraph::legacy::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
   auto G_unique                            = cugraph::coo_to_csr(G_coo);
-  cugraph::GraphCSRView<int, int, float> G = G_unique->view();
+  cugraph::legacy::GraphCSRView<int, int, float> G = G_unique->view();
 
   rmm::device_vector<IndexT> d_labels(nrows);
 
@@ -296,9 +296,9 @@ TEST_F(SCCSmallTest, /*DISABLED_*/ CustomGraphWithSelfLoops)
 
   EXPECT_EQ(nnz, cooColInd.size());
 
-  cugraph::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
+  cugraph::legacy::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
   auto G_unique                            = cugraph::coo_to_csr(G_coo);
-  cugraph::GraphCSRView<int, int, float> G = G_unique->view();
+  cugraph::legacy::GraphCSRView<int, int, float> G = G_unique->view();
 
   rmm::device_vector<IndexT> d_labels(nrows);
 
@@ -341,9 +341,9 @@ TEST_F(SCCSmallTest, SmallGraphWithSelfLoops1)
 
   EXPECT_EQ(nnz, cooColInd.size());
 
-  cugraph::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
+  cugraph::legacy::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
   auto G_unique                            = cugraph::coo_to_csr(G_coo);
-  cugraph::GraphCSRView<int, int, float> G = G_unique->view();
+  cugraph::legacy::GraphCSRView<int, int, float> G = G_unique->view();
 
   rmm::device_vector<IndexT> d_labels(nrows);
 
@@ -381,10 +381,10 @@ TEST_F(SCCSmallTest, SmallGraphWithIsolated)
   // Note: there seems to be a BUG in coo_to_csr() or view()
   // COO format doesn't account for isolated vertices;
   //
-  // cugraph::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, nrows,
+  // cugraph::legacy::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, nrows,
   // nnz);
   // auto G_unique                            = cugraph::coo_to_csr(G_coo);
-  // cugraph::GraphCSRView<int, int, float> G = G_unique->view();
+  // cugraph::legacy::GraphCSRView<int, int, float> G = G_unique->view();
   //
   //
   // size_t num_vertices = G.number_of_vertices;
@@ -401,7 +401,7 @@ TEST_F(SCCSmallTest, SmallGraphWithIsolated)
   thrust::device_vector<IndexT> d_ro(ro);
   thrust::device_vector<IndexT> d_ci(ci);
 
-  cugraph::GraphCSRView<int, int, float> G{
+  cugraph::legacy::GraphCSRView<int, int, float> G{
     d_ro.data().get(), d_ci.data().get(), nullptr, static_cast<int>(nrows), static_cast<int>(nnz)};
 
   size_t num_vertices = G.number_of_vertices;

--- a/cpp/tests/components/scc_test.cu
+++ b/cpp/tests/components/scc_test.cu
@@ -176,8 +176,9 @@ struct Tests_Strongly_CC : ::testing::TestWithParam<Usecase> {
       << "\n";
     ASSERT_EQ(fclose(fpin), 0);
 
-    cugraph::legacy::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
-    auto G_unique                            = cugraph::coo_to_csr(G_coo);
+    cugraph::legacy::GraphCOOView<int, int, float> G_coo(
+      &cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
+    auto G_unique                                    = cugraph::coo_to_csr(G_coo);
     cugraph::legacy::GraphCSRView<int, int, float> G = G_unique->view();
 
     rmm::device_vector<int> d_labels(nrows);
@@ -246,8 +247,9 @@ TEST_F(SCCSmallTest, CustomGraphSimpleLoops)
 
   EXPECT_EQ(nnz, cooColInd.size());
 
-  cugraph::legacy::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
-  auto G_unique                            = cugraph::coo_to_csr(G_coo);
+  cugraph::legacy::GraphCOOView<int, int, float> G_coo(
+    &cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
+  auto G_unique                                    = cugraph::coo_to_csr(G_coo);
   cugraph::legacy::GraphCSRView<int, int, float> G = G_unique->view();
 
   rmm::device_vector<IndexT> d_labels(nrows);
@@ -296,8 +298,9 @@ TEST_F(SCCSmallTest, /*DISABLED_*/ CustomGraphWithSelfLoops)
 
   EXPECT_EQ(nnz, cooColInd.size());
 
-  cugraph::legacy::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
-  auto G_unique                            = cugraph::coo_to_csr(G_coo);
+  cugraph::legacy::GraphCOOView<int, int, float> G_coo(
+    &cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
+  auto G_unique                                    = cugraph::coo_to_csr(G_coo);
   cugraph::legacy::GraphCSRView<int, int, float> G = G_unique->view();
 
   rmm::device_vector<IndexT> d_labels(nrows);
@@ -341,8 +344,9 @@ TEST_F(SCCSmallTest, SmallGraphWithSelfLoops1)
 
   EXPECT_EQ(nnz, cooColInd.size());
 
-  cugraph::legacy::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
-  auto G_unique                            = cugraph::coo_to_csr(G_coo);
+  cugraph::legacy::GraphCOOView<int, int, float> G_coo(
+    &cooRowInd[0], &cooColInd[0], nullptr, nrows, nnz);
+  auto G_unique                                    = cugraph::coo_to_csr(G_coo);
   cugraph::legacy::GraphCSRView<int, int, float> G = G_unique->view();
 
   rmm::device_vector<IndexT> d_labels(nrows);
@@ -381,9 +385,8 @@ TEST_F(SCCSmallTest, SmallGraphWithIsolated)
   // Note: there seems to be a BUG in coo_to_csr() or view()
   // COO format doesn't account for isolated vertices;
   //
-  // cugraph::legacy::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr, nrows,
-  // nnz);
-  // auto G_unique                            = cugraph::coo_to_csr(G_coo);
+  // cugraph::legacy::GraphCOOView<int, int, float> G_coo(&cooRowInd[0], &cooColInd[0], nullptr,
+  // nrows, nnz); auto G_unique                            = cugraph::coo_to_csr(G_coo);
   // cugraph::legacy::GraphCSRView<int, int, float> G = G_unique->view();
   //
   //

--- a/cpp/tests/experimental/bfs_test.cpp
+++ b/cpp/tests/experimental/bfs_test.cpp
@@ -54,7 +54,9 @@ void bfs_reference(edge_t const* offsets,
   vertex_t depth{0};
 
   std::fill(distances, distances + num_vertices, std::numeric_limits<vertex_t>::max());
-  std::fill(predecessors, predecessors + num_vertices, cugraph::experimental::invalid_vertex_id<vertex_t>::value);
+  std::fill(predecessors,
+            predecessors + num_vertices,
+            cugraph::experimental::invalid_vertex_id<vertex_t>::value);
 
   *(distances + source) = depth;
   std::vector<vertex_t> cur_frontier_rows{source};

--- a/cpp/tests/experimental/bfs_test.cpp
+++ b/cpp/tests/experimental/bfs_test.cpp
@@ -54,7 +54,7 @@ void bfs_reference(edge_t const* offsets,
   vertex_t depth{0};
 
   std::fill(distances, distances + num_vertices, std::numeric_limits<vertex_t>::max());
-  std::fill(predecessors, predecessors + num_vertices, cugraph::invalid_vertex_id<vertex_t>::value);
+  std::fill(predecessors, predecessors + num_vertices, cugraph::experimental::invalid_vertex_id<vertex_t>::value);
 
   *(distances + source) = depth;
   std::vector<vertex_t> cur_frontier_rows{source};
@@ -249,7 +249,7 @@ class Tests_BFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, input_
 
       for (auto it = h_cugraph_predecessors.begin(); it != h_cugraph_predecessors.end(); ++it) {
         auto i = std::distance(h_cugraph_predecessors.begin(), it);
-        if (*it == cugraph::invalid_vertex_id<vertex_t>::value) {
+        if (*it == cugraph::experimental::invalid_vertex_id<vertex_t>::value) {
           ASSERT_TRUE(h_reference_predecessors[i] == *it)
             << "vertex reachability does not match with the reference.";
         } else {

--- a/cpp/tests/experimental/ms_bfs_test.cpp
+++ b/cpp/tests/experimental/ms_bfs_test.cpp
@@ -21,7 +21,6 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/experimental/graph.hpp>
 #include <cugraph/experimental/graph_view.hpp>
-#include <cugraph/graph.hpp>
 
 #include <raft/cudart_utils.h>
 #include <raft/handle.hpp>

--- a/cpp/tests/experimental/sssp_test.cpp
+++ b/cpp/tests/experimental/sssp_test.cpp
@@ -58,7 +58,7 @@ void sssp_reference(edge_t const* offsets,
   using queue_item_t = std::tuple<weight_t, vertex_t>;
 
   std::fill(distances, distances + num_vertices, std::numeric_limits<weight_t>::max());
-  std::fill(predecessors, predecessors + num_vertices, cugraph::invalid_vertex_id<vertex_t>::value);
+  std::fill(predecessors, predecessors + num_vertices, cugraph::experimental::invalid_vertex_id<vertex_t>::value);
 
   *(distances + source) = weight_t{0.0};
   std::priority_queue<queue_item_t, std::vector<queue_item_t>, std::greater<queue_item_t>> queue{};
@@ -264,7 +264,7 @@ class Tests_SSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, inpu
 
       for (auto it = h_cugraph_predecessors.begin(); it != h_cugraph_predecessors.end(); ++it) {
         auto i = std::distance(h_cugraph_predecessors.begin(), it);
-        if (*it == cugraph::invalid_vertex_id<vertex_t>::value) {
+        if (*it == cugraph::experimental::invalid_vertex_id<vertex_t>::value) {
           ASSERT_TRUE(h_reference_predecessors[i] == *it)
             << "vertex reachability do not match with the reference.";
         } else {

--- a/cpp/tests/experimental/sssp_test.cpp
+++ b/cpp/tests/experimental/sssp_test.cpp
@@ -58,7 +58,9 @@ void sssp_reference(edge_t const* offsets,
   using queue_item_t = std::tuple<weight_t, vertex_t>;
 
   std::fill(distances, distances + num_vertices, std::numeric_limits<weight_t>::max());
-  std::fill(predecessors, predecessors + num_vertices, cugraph::experimental::invalid_vertex_id<vertex_t>::value);
+  std::fill(predecessors,
+            predecessors + num_vertices,
+            cugraph::experimental::invalid_vertex_id<vertex_t>::value);
 
   *(distances + source) = weight_t{0.0};
   std::priority_queue<queue_item_t, std::vector<queue_item_t>, std::greater<queue_item_t>> queue{};

--- a/cpp/tests/layout/force_atlas2_test.cu
+++ b/cpp/tests/layout/force_atlas2_test.cu
@@ -18,7 +18,7 @@
 
 #include <layout/trust_worthiness.h>
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <rmm/thrust_rmm_allocator.h>
 #include <raft/error.hpp>
@@ -144,7 +144,7 @@ class Tests_Force_Atlas2 : public ::testing::TestWithParam<Force_Atlas2_Usecase>
     CUDA_TRY(cudaMemcpy(srcs, &cooRowInd[0], sizeof(int) * nnz, cudaMemcpyDefault));
     CUDA_TRY(cudaMemcpy(dests, &cooColInd[0], sizeof(int) * nnz, cudaMemcpyDefault));
     CUDA_TRY(cudaMemcpy(weights, &cooVal[0], sizeof(T) * nnz, cudaMemcpyDefault));
-    cugraph::GraphCOOView<int, int, T> G(srcs, dests, weights, m, nnz);
+    cugraph::legacy::GraphCOOView<int, int, T> G(srcs, dests, weights, m, nnz);
 
     const int max_iter                    = 500;
     float* x_start                        = nullptr;

--- a/cpp/tests/linear_assignment/hungarian_test.cu
+++ b/cpp/tests/linear_assignment/hungarian_test.cu
@@ -12,7 +12,7 @@
 #include <utilities/high_res_timer.hpp>
 
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <raft/handle.hpp>
 
@@ -86,7 +86,7 @@ TEST_F(HungarianTest, Bipartite4x4)
   raft::update_device(cost_v.begin(), cost, length, handle.get_stream());
   raft::update_device(workers_v.begin(), workers, length_workers, handle.get_stream());
 
-  cugraph::GraphCOOView<int32_t, int32_t, float> g(
+  cugraph::legacy::GraphCOOView<int32_t, int32_t, float> g(
     src_v.data(), dst_v.data(), cost_v.data(), num_vertices, length);
 
   float r = cugraph::hungarian(handle, g, length_workers, workers_v.data(), assignment_v.data());
@@ -128,7 +128,7 @@ TEST_F(HungarianTest, Bipartite5x5)
   raft::update_device(cost_v.begin(), cost, length, handle.get_stream());
   raft::update_device(workers_v.begin(), workers, length_workers, handle.get_stream());
 
-  cugraph::GraphCOOView<int32_t, int32_t, float> g(
+  cugraph::legacy::GraphCOOView<int32_t, int32_t, float> g(
     src_v.data(), dst_v.data(), cost_v.data(), num_vertices, length);
 
   float r = cugraph::hungarian(handle, g, length_workers, workers_v.data(), assignment_v.data());
@@ -174,7 +174,7 @@ TEST_F(HungarianTest, Bipartite4x4_multiple_answers)
   raft::update_device(cost_v.begin(), cost, length, handle.get_stream());
   raft::update_device(workers_v.begin(), workers, length_workers, handle.get_stream());
 
-  cugraph::GraphCOOView<int32_t, int32_t, float> g(
+  cugraph::legacy::GraphCOOView<int32_t, int32_t, float> g(
     src_v.data(), dst_v.data(), cost_v.data(), num_vertices, length);
 
   float r = cugraph::hungarian(handle, g, length_workers, workers_v.data(), assignment_v.data());

--- a/cpp/tests/sampling/random_walks_profiling.cu
+++ b/cpp/tests/sampling/random_walks_profiling.cu
@@ -19,7 +19,6 @@
 #include <utilities/test_utilities.hpp>
 
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
 #include <sampling/random_walks.cuh>
 
 #include <raft/handle.hpp>

--- a/cpp/tests/sampling/random_walks_test.cu
+++ b/cpp/tests/sampling/random_walks_test.cu
@@ -24,7 +24,6 @@
 #include <thrust/random.h>
 
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
 #include <sampling/random_walks.cuh>
 
 #include <raft/handle.hpp>

--- a/cpp/tests/sampling/random_walks_utils.cuh
+++ b/cpp/tests/sampling/random_walks_utils.cuh
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <rmm/thrust_rmm_allocator.h>
-#include <cugraph/graph.hpp>
 #include <sampling/random_walks.cuh>
 
 #include <raft/handle.hpp>

--- a/cpp/tests/sampling/rw_low_level_test.cu
+++ b/cpp/tests/sampling/rw_low_level_test.cu
@@ -24,7 +24,6 @@
 #include <thrust/random.h>
 
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
 #include <sampling/random_walks.cuh>
 
 #include <raft/handle.hpp>

--- a/cpp/tests/traversal/bfs_test.cu
+++ b/cpp/tests/traversal/bfs_test.cu
@@ -95,7 +95,7 @@ class Tests_BFS : public ::testing::TestWithParam<BFS_Usecase> {
     auto csr =
       cugraph::test::generate_graph_csr_from_mm<VT, ET, WT>(directed, configuration.file_path_);
     cudaDeviceSynchronize();
-    cugraph::GraphCSRView<VT, ET, WT> G = csr->view();
+    cugraph::legacy::GraphCSRView<VT, ET, WT> G = csr->view();
     G.prop.directed                     = directed;
 
     ASSERT_TRUE(configuration.source_ >= 0 && (VT)configuration.source_ < G.number_of_vertices)
@@ -174,7 +174,7 @@ class Tests_BFS : public ::testing::TestWithParam<BFS_Usecase> {
       // that the predecessor obtained with the GPU implementation is one of the
       // predecessors obtained during the C++ BFS traversal
       VT pred = cugraph_pred[i];  // It could be equal to -1 if the node is never reached
-      constexpr VT invalid_vid = cugraph::invalid_vertex_id<VT>::value;
+      constexpr VT invalid_vid = cugraph::legacy::invalid_vertex_id<VT>::value;
       if (pred == invalid_vid) {
         EXPECT_TRUE(ref_bfs_pred[i].empty())
           << "[MISMATCH][PREDECESSOR] vaid = " << i << " cugraph had not predecessor,"

--- a/cpp/tests/traversal/bfs_test.cu
+++ b/cpp/tests/traversal/bfs_test.cu
@@ -96,7 +96,7 @@ class Tests_BFS : public ::testing::TestWithParam<BFS_Usecase> {
       cugraph::test::generate_graph_csr_from_mm<VT, ET, WT>(directed, configuration.file_path_);
     cudaDeviceSynchronize();
     cugraph::legacy::GraphCSRView<VT, ET, WT> G = csr->view();
-    G.prop.directed                     = directed;
+    G.prop.directed                             = directed;
 
     ASSERT_TRUE(configuration.source_ >= 0 && (VT)configuration.source_ < G.number_of_vertices)
       << "Starting sources should be >= 0 and"

--- a/cpp/tests/traversal/sssp_test.cu
+++ b/cpp/tests/traversal/sssp_test.cu
@@ -261,7 +261,7 @@ class Tests_SSSP : public ::testing::TestWithParam<SSSP_Usecase> {
       (DoRandomWeights ? &cooVal[0] : nullptr),
       num_vertices,
       num_edges);
-    auto G_unique                                         = cugraph::coo_to_csr(G_coo);
+    auto G_unique                                                 = cugraph::coo_to_csr(G_coo);
     cugraph::legacy::GraphCSRView<MaxVType, MaxEType, DistType> G = G_unique->view();
     cudaDeviceSynchronize();
 

--- a/cpp/tests/traversal/sssp_test.cu
+++ b/cpp/tests/traversal/sssp_test.cu
@@ -15,7 +15,7 @@
 
 #include <converters/COOtoCSR.cuh>
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <thrust/fill.h>
 
@@ -255,14 +255,14 @@ class Tests_SSSP : public ::testing::TestWithParam<SSSP_Usecase> {
       ASSERT_TRUE(0);
     }
 
-    cugraph::GraphCOOView<MaxVType, MaxEType, DistType> G_coo(
+    cugraph::legacy::GraphCOOView<MaxVType, MaxEType, DistType> G_coo(
       &cooRowInd[0],
       &cooColInd[0],
       (DoRandomWeights ? &cooVal[0] : nullptr),
       num_vertices,
       num_edges);
     auto G_unique                                         = cugraph::coo_to_csr(G_coo);
-    cugraph::GraphCSRView<MaxVType, MaxEType, DistType> G = G_unique->view();
+    cugraph::legacy::GraphCSRView<MaxVType, MaxEType, DistType> G = G_unique->view();
     cudaDeviceSynchronize();
 
     std::vector<DistType> dist_vec;

--- a/cpp/tests/traversal/tsp_test.cu
+++ b/cpp/tests/traversal/tsp_test.cu
@@ -31,7 +31,7 @@
 #include <utilities/test_utilities.hpp>
 
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <cuda_profiler_api.h>
 

--- a/cpp/tests/tree/mst_test.cu
+++ b/cpp/tests/tree/mst_test.cu
@@ -105,13 +105,14 @@ class Tests_Mst : public ::testing::TestWithParam<Mst_Usecase> {
     raft::handle_t handle;
 
     std::cout << std::endl;
-    cugraph::legacy::GraphCOOView<int, int, T> G_coo(&cooRowInd[0], &cooColInd[0], &cooVal[0], m, nnz);
+    cugraph::legacy::GraphCOOView<int, int, T> G_coo(
+      &cooRowInd[0], &cooColInd[0], &cooVal[0], m, nnz);
     auto G_unique = cugraph::coo_to_csr(G_coo);
     cugraph::legacy::GraphCSRView<int, int, T> G(G_unique->view().offsets,
-                                         G_unique->view().indices,
-                                         G_unique->view().edge_data,
-                                         G_unique->view().number_of_vertices,
-                                         G_unique->view().number_of_edges);
+                                                 G_unique->view().indices,
+                                                 G_unique->view().edge_data,
+                                                 G_unique->view().number_of_vertices,
+                                                 G_unique->view().number_of_edges);
 
     cudaDeviceSynchronize();
 

--- a/cpp/tests/tree/mst_test.cu
+++ b/cpp/tests/tree/mst_test.cu
@@ -22,7 +22,7 @@
 #include <utilities/test_utilities.hpp>
 
 #include <cugraph/algorithms.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <raft/error.hpp>
 #include <raft/handle.hpp>
@@ -105,9 +105,9 @@ class Tests_Mst : public ::testing::TestWithParam<Mst_Usecase> {
     raft::handle_t handle;
 
     std::cout << std::endl;
-    cugraph::GraphCOOView<int, int, T> G_coo(&cooRowInd[0], &cooColInd[0], &cooVal[0], m, nnz);
+    cugraph::legacy::GraphCOOView<int, int, T> G_coo(&cooRowInd[0], &cooColInd[0], &cooVal[0], m, nnz);
     auto G_unique = cugraph::coo_to_csr(G_coo);
-    cugraph::GraphCSRView<int, int, T> G(G_unique->view().offsets,
+    cugraph::legacy::GraphCSRView<int, int, T> G(G_unique->view().offsets,
                                          G_unique->view().indices,
                                          G_unique->view().edge_data,
                                          G_unique->view().number_of_vertices,

--- a/cpp/tests/utilities/matrix_market_file_utilities.cu
+++ b/cpp/tests/utilities/matrix_market_file_utilities.cu
@@ -448,17 +448,17 @@ template int32_t mm_to_coo(FILE* f,
                            float* cooRVal,
                            float* cooIVal);
 
-template std::unique_ptr<cugraph::legacy::GraphCSR<int32_t, int32_t, float>> generate_graph_csr_from_mm(
-  bool& directed, std::string mm_file);
+template std::unique_ptr<cugraph::legacy::GraphCSR<int32_t, int32_t, float>>
+generate_graph_csr_from_mm(bool& directed, std::string mm_file);
 
-template std::unique_ptr<cugraph::legacy::GraphCSR<uint32_t, uint32_t, float>> generate_graph_csr_from_mm(
-  bool& directed, std::string mm_file);
+template std::unique_ptr<cugraph::legacy::GraphCSR<uint32_t, uint32_t, float>>
+generate_graph_csr_from_mm(bool& directed, std::string mm_file);
 
-template std::unique_ptr<cugraph::legacy::GraphCSR<int32_t, int32_t, double>> generate_graph_csr_from_mm(
-  bool& directed, std::string mm_file);
+template std::unique_ptr<cugraph::legacy::GraphCSR<int32_t, int32_t, double>>
+generate_graph_csr_from_mm(bool& directed, std::string mm_file);
 
-template std::unique_ptr<cugraph::legacy::GraphCSR<int64_t, int64_t, float>> generate_graph_csr_from_mm(
-  bool& directed, std::string mm_file);
+template std::unique_ptr<cugraph::legacy::GraphCSR<int64_t, int64_t, float>>
+generate_graph_csr_from_mm(bool& directed, std::string mm_file);
 
 template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, float, false, false>,
                     rmm::device_uvector<int32_t>>

--- a/cpp/tests/utilities/matrix_market_file_utilities.cu
+++ b/cpp/tests/utilities/matrix_market_file_utilities.cu
@@ -219,7 +219,7 @@ int mm_to_coo(FILE* f,
  * @tparam
  */
 template <typename vertex_t, typename edge_t, typename weight_t>
-std::unique_ptr<cugraph::GraphCSR<vertex_t, edge_t, weight_t>> generate_graph_csr_from_mm(
+std::unique_ptr<cugraph::legacy::GraphCSR<vertex_t, edge_t, weight_t>> generate_graph_csr_from_mm(
   bool& directed, std::string mm_file)
 {
   vertex_t number_of_vertices;
@@ -253,7 +253,7 @@ std::unique_ptr<cugraph::GraphCSR<vertex_t, edge_t, weight_t>> generate_graph_cs
     "file read failure.");
   CUGRAPH_EXPECTS(fclose(fpin) == 0, "fclose failure.");
 
-  cugraph::GraphCOOView<vertex_t, edge_t, weight_t> cooview(
+  cugraph::legacy::GraphCOOView<vertex_t, edge_t, weight_t> cooview(
     &coo_row_ind[0], &coo_col_ind[0], &coo_val[0], number_of_vertices, number_of_edges);
 
   return cugraph::coo_to_csr(cooview);
@@ -448,16 +448,16 @@ template int32_t mm_to_coo(FILE* f,
                            float* cooRVal,
                            float* cooIVal);
 
-template std::unique_ptr<cugraph::GraphCSR<int32_t, int32_t, float>> generate_graph_csr_from_mm(
+template std::unique_ptr<cugraph::legacy::GraphCSR<int32_t, int32_t, float>> generate_graph_csr_from_mm(
   bool& directed, std::string mm_file);
 
-template std::unique_ptr<cugraph::GraphCSR<uint32_t, uint32_t, float>> generate_graph_csr_from_mm(
+template std::unique_ptr<cugraph::legacy::GraphCSR<uint32_t, uint32_t, float>> generate_graph_csr_from_mm(
   bool& directed, std::string mm_file);
 
-template std::unique_ptr<cugraph::GraphCSR<int32_t, int32_t, double>> generate_graph_csr_from_mm(
+template std::unique_ptr<cugraph::legacy::GraphCSR<int32_t, int32_t, double>> generate_graph_csr_from_mm(
   bool& directed, std::string mm_file);
 
-template std::unique_ptr<cugraph::GraphCSR<int64_t, int64_t, float>> generate_graph_csr_from_mm(
+template std::unique_ptr<cugraph::legacy::GraphCSR<int64_t, int64_t, float>> generate_graph_csr_from_mm(
   bool& directed, std::string mm_file);
 
 template std::tuple<cugraph::experimental::graph_t<int32_t, int32_t, float, false, false>,

--- a/cpp/tests/utilities/test_utilities.hpp
+++ b/cpp/tests/utilities/test_utilities.hpp
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <cugraph/experimental/graph.hpp>
-#include <cugraph/graph.hpp>
+#include <cugraph/legacy/graph.hpp>
 
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/tuple.h>
@@ -89,7 +89,7 @@ int mm_to_coo(FILE* f,
  * @tparam
  */
 template <typename vertex_t, typename edge_t, typename weight_t>
-std::unique_ptr<cugraph::GraphCSR<vertex_t, edge_t, weight_t>> generate_graph_csr_from_mm(
+std::unique_ptr<cugraph::legacy::GraphCSR<vertex_t, edge_t, weight_t>> generate_graph_csr_from_mm(
   bool& directed, std::string mm_file);
 
 // Define RAPIDS_DATASET_ROOT_DIR using a preprocessor variable to

--- a/python/cugraph/structure/graph_primtypes.pxd
+++ b/python/cugraph/structure/graph_primtypes.pxd
@@ -23,17 +23,17 @@ from libcpp.vector cimport vector
 from cugraph.raft.common.handle cimport *
 from rmm._lib.device_buffer cimport device_buffer
 
-cdef extern from "cugraph/graph.hpp" namespace "cugraph":
+cdef extern from "cugraph/legacy/graph.hpp" namespace "cugraph::legacy":
 
     ctypedef enum PropType:
-        PROP_UNDEF "cugraph::PROP_UNDEF"
-        PROP_FALSE "cugraph::PROP_FALSE"
-        PROP_TRUE "cugraph::PROP_TRUE"
+        PROP_UNDEF "cugraph::legacy::PROP_UNDEF"
+        PROP_FALSE "cugraph::legacy::PROP_FALSE"
+        PROP_TRUE "cugraph::legacy::PROP_TRUE"
 
     ctypedef enum DegreeDirection:
-        DIRECTION_IN_PLUS_OUT "cugraph::DegreeDirection::IN_PLUS_OUT"
-        DIRECTION_IN "cugraph::DegreeDirection::IN"
-        DIRECTION_OUT "cugraph::DegreeDirection::OUT"
+        DIRECTION_IN_PLUS_OUT "cugraph::legacy::DegreeDirection::IN_PLUS_OUT"
+        DIRECTION_IN "cugraph::legacy::DegreeDirection::IN"
+        DIRECTION_OUT "cugraph::legacy::DegreeDirection::OUT"
 
     struct GraphProperties:
         bool directed


### PR DESCRIPTION
Code cleanup.  We want to migrate the new graph object into the cugraph namespace.  Moving the legacy graph objects into a legacy namespace to clear the way.