### PR TITLE
Use the 21.08 branch of rapids-cmake as rmm requires it

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -19,7 +19,7 @@ include(FetchContent)
 FetchContent_Declare(
   rapids-cmake
   GIT_REPOSITORY https://github.com/rapidsai/rapids-cmake.git
-  GIT_TAG        origin/branch-21.06
+  GIT_TAG        origin/branch-21.08
   )
 FetchContent_MakeAvailable(rapids-cmake)
 


### PR DESCRIPTION
Now that rmm uses rapids-cmake we need to update to the 21.08 branch to get the new `rapids_cmake_write_version_file` function