### PR TITLE
Update `conda` environment name for CI

### DIFF
--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -18,7 +18,8 @@ ERRORCODE=0
 PATH=/conda/bin:$PATH
 
 # Activate common conda env
-source activate gdf
+. /opt/conda/etc/profile.d/conda.sh
+conda activate rapids
 
 # Run flake8 and get results/return code
 FLAKE=`flake8 --config=python/.flake8 python`


### PR DESCRIPTION
The `gdf` conda environment has been replaced with the `rapids` environment. A symlink was put in place for `gdf` to continue to work, but the symlink will be removed in the near future. This PR updates all scripts to use the `rapids` environment name.
