### PR TITLE
Updated for CUDA-specific py packages

### DIFF
--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -4,6 +4,7 @@
 #   conda build -c nvidia -c rapidsai -c conda-forge  .
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
+{% set cuda_version='.'.join(environ.get('CUDA', 'unknown').split('.')[:2]) %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
 package:
   name: cugraph
@@ -14,7 +15,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: cuda{{ cuda_version }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - CC
     - CXX
@@ -29,6 +30,7 @@ requirements:
     - cudf={{ minor_version }}
     - ucx-py 0.21
     - ucx-proc=*=gpu
+    - cudatoolkit {{ cuda_version }}.*
   run:
     - python x.x
     - libcugraph={{ version }}
@@ -39,14 +41,10 @@ requirements:
     - distributed>=2021.6.0
     - ucx-py 0.21
     - ucx-proc=*=gpu
-
-#test:
-#  commands:
-#    - test -f $PREFIX/include/cugraph.h
-
+    - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 
 about:
   home: http://rapids.ai/
   license: Apache-2.0
   license_file: ../../../LICENSE
-  summary: libcugraph library
+  summary: cuGraph library


### PR DESCRIPTION
Updated cugraph recipe to include CUDA version in build string and depend on a specific cudatoolkit based on CUDA version. This pattern was copied from cuML's recipe.

closes #1708 