### PR TITLE
Fix `conda` uploads

### DIFF
--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -18,12 +18,6 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     export BUILD_LIBCUGRAPH=1
 fi
 
-if [[ "$CUDA" == "11.0" ]]; then
-    export UPLOAD_CUGRAPH=1
-else
-    export UPLOAD_CUGRAPH=0
-fi
-
 if [[ "$PYTHON" == "3.7" ]]; then
     export UPLOAD_LIBCUGRAPH=1
 else

--- a/ci/cpu/upload.sh
+++ b/ci/cpu/upload.sh
@@ -46,7 +46,7 @@ if [[ "$BUILD_LIBCUGRAPH" == "1" && "$UPLOAD_LIBCUGRAPH" == "1" ]]; then
   gpuci_retry anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai} ${LABEL_OPTION} --skip-existing ${LIBCUGRAPH_FILE} --no-progress
 fi
 
-if [[ "$BUILD_CUGRAPH" == "1" && "$UPLOAD_CUGRAPH" == "1" ]]; then
+if [[ "$BUILD_CUGRAPH" == "1" ]]; then
   test -e ${CUGRAPH_FILE}
   echo "Upload cugraph"
   echo ${CUGRAPH_FILE}


### PR DESCRIPTION
This PR removes some conditional statements & variables that prevent all the variants of the `cugraph` package from being uploaded to Anaconda.org. This is a continuation of #1709.