### PR TITLE
ENH Replace gpuci_conda_retry with gpuci_mamba_retry

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -54,7 +54,7 @@ gpuci_logger "Activate conda env"
 conda activate rapids
 
 gpuci_logger "Install dependencies"
-gpuci_conda_retry install -y \
+gpuci_mamba_retry install -y \
       "libcudf=${MINOR_VERSION}" \
       "cudf=${MINOR_VERSION}" \
       "librmm=${MINOR_VERSION}" \
@@ -69,8 +69,8 @@ gpuci_conda_retry install -y \
       rapids-pytest-benchmark
 
 # https://docs.rapids.ai/maintainers/depmgmt/
-# gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env
-# gpuci_conda_retry install -y "your-pkg=1.0.0"
+# gpuci_mamba_retry remove --force rapids-build-env rapids-notebook-env
+# gpuci_mamba_retry install -y "your-pkg=1.0.0"
 
 gpuci_logger "Check versions"
 python --version


### PR DESCRIPTION
`mamba` was recently added to gpuCI build environment, testing usage and solvability with this PR which should speed up build times.