### PR TITLE
[REVIEW] revert cuco to latest dev branch, issues should be fixed

### DIFF
--- a/cpp/cmake/thirdparty/get_cuco.cmake
+++ b/cpp/cmake/thirdparty/get_cuco.cmake
@@ -20,7 +20,7 @@ function(find_and_configure_cuco VERSION)
       GLOBAL_TARGETS cuco cuco::cuco
       CPM_ARGS
         GIT_REPOSITORY https://github.com/NVIDIA/cuCollections.git
-        GIT_TAG        0b672bbde7c85a79df4d7ca5f82e15e5b4a57700
+        GIT_TAG        dev
         OPTIONS        "BUILD_TESTS OFF"
                        "BUILD_BENCHMARKS OFF"
                        "BUILD_EXAMPLES OFF"


### PR DESCRIPTION
We had an issue in CI that uncovered the fact that raft is referencing the `dev` branch of coco while `cugraph` has it pinned to a previous commit.  CI is using the newer `dev` branch version, which doesn't match what happens when we do local builds.

The original motivation for pinning was a temporary fix because of a bug introduced in `coco` which has since been resolved.  This PR reverts us back to using the `dev` branch.