### PR TITLE
[gpuCI] Forward-merge branch-21.08 to branch-21.10 [skip ci]

### DIFF
--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -40,13 +40,13 @@ requirements:
     - gtest
     - gmock
     - faiss-proc=*=cuda
-    - conda-forge::libfaiss=1.7.0
+    - libfaiss 1.7.0 *_cuda
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
     - nccl>=2.9.9
     - ucx-proc=*=gpu
     - faiss-proc=*=cuda
-    - conda-forge::libfaiss=1.7.0
+    - libfaiss 1.7.0 *_cuda
 
 about:
   home: http://rapids.ai/


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.08` that creates a PR to keep `branch-21.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.