### PR TITLE
[gpuCI] Forward-merge branch-21.08 to branch-21.10 [skip ci]

### DIFF
--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -10,8 +10,8 @@ dependencies:
 - libcudf=21.08.*
 - rmm=21.08.*
 - librmm=21.08.*
-- dask>=2021.6.0
-- distributed>=2021.6.0
+- dask>=2021.6.0,<=2021.07.1
+- distributed>=2021.6.0,<=2021.07.1
 - dask-cuda=21.08.*
 - dask-cudf=21.08.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -10,8 +10,8 @@ dependencies:
 - libcudf=21.08.*
 - rmm=21.08.*
 - librmm=21.08.*
-- dask>=2021.6.0
-- distributed>=2021.6.0
+- dask>=2021.6.0,<=2021.07.1
+- distributed>=2021.6.0,<=2021.07.1
 - dask-cuda=21.08.*
 - dask-cudf=21.08.*
 - nccl>=2.9.9

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -37,8 +37,8 @@ requirements:
     - cudf={{ minor_version }}
     - dask-cudf {{ minor_version }}
     - dask-cuda {{ minor_version }}
-    - dask>=2021.6.0
-    - distributed>=2021.6.0
+    - dask>=2021.6.0,<=2021.07.1
+    - distributed>=2021.6.0,<=2021.07.1
     - ucx-py 0.21
     - ucx-proc=*=gpu
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.08` that creates a PR to keep `branch-21.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.