### PR TITLE
[skip-ci] Pinning cuco to a specific commit hash for release

### DIFF
--- a/cpp/cmake/thirdparty/get_cuco.cmake
+++ b/cpp/cmake/thirdparty/get_cuco.cmake
@@ -20,7 +20,7 @@ function(find_and_configure_cuco VERSION)
       GLOBAL_TARGETS cuco cuco::cuco
       CPM_ARGS
         GIT_REPOSITORY https://github.com/NVIDIA/cuCollections.git
-        GIT_TAG        dev
+        GIT_TAG        b1fea0cbe4c384160740af00f7c8760846539abb
         OPTIONS        "BUILD_TESTS OFF"
                        "BUILD_BENCHMARKS OFF"
                        "BUILD_EXAMPLES OFF"

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -30,7 +30,7 @@ function(find_and_configure_raft)
             OPTIONS "BUILD_TESTS OFF"
     )
 
-    message(VERBOSE "CUML: Using RAFT located in ${raft_SOURCE_DIR}")
+    message(VERBOSE "CUGRAPH: Using RAFT located in ${raft_SOURCE_DIR}")
 
 endfunction()
 
@@ -45,4 +45,3 @@ find_and_configure_raft(VERSION    ${CUGRAPH_MIN_VERSION_raft}
                         FORK       rapidsai
                         PINNED_TAG branch-${CUGRAPH_BRANCH_VERSION_raft}
                         )
-


### PR DESCRIPTION
Using the latest `cuco` commit hash as the `GIT_TAG` for release purposes.  See also RAFT PR https://github.com/rapidsai/raft/pull/304 .
Also updated a debug message.

NOTE: using `skip-ci` until https://github.com/rapidsai/raft/pull/304 is merged.
NOTE: The commit hash will likely be reverted to `dev` in 21.10 during development, then a new hash will be used for 21.10 release, and so on.
