### PR TITLE
Changed cuco cmake function to return early if cuco has already been added as a target

### DIFF
--- a/cpp/cmake/thirdparty/get_cuco.cmake
+++ b/cpp/cmake/thirdparty/get_cuco.cmake
@@ -16,6 +16,10 @@
 
 function(find_and_configure_cuco VERSION)
 
+    if(TARGET cuco::cuco)
+      return()
+    endif()
+
     rapids_cpm_find(cuco ${VERSION}
       GLOBAL_TARGETS cuco cuco::cuco
       CPM_ARGS
@@ -26,9 +30,7 @@ function(find_and_configure_cuco VERSION)
                        "BUILD_EXAMPLES OFF"
     )
 
-    if(NOT TARGET cuco::cuco)
-      add_library(cuco::cuco ALIAS cuco)
-    endif()
+    add_library(cuco::cuco ALIAS cuco)
 
 endfunction()
 


### PR DESCRIPTION
Changed cuco cmake function to return early if cuco has already been added as a target.  This matches the technique used by raft [here](https://github.com/rapidsai/raft/blob/a3af3895410c19f3e713caa608ea2024f6008350/cpp/cmake/thirdparty/get_cuco.cmake#L19).

Tested by doing a build and install of cuML, followed by a build of cuGraph and observing a CPM error about the alias target `cuco::cuco` already existing.  Made the change to return early if cuco is already a target and observed the cuGraph `libcugraph.so` build succeed.
