### PR TITLE
Include `cpack` to generate source packages

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -337,6 +337,8 @@ endif(BUILD_TESTS)
 ###################################################################################################
 # - install targets -------------------------------------------------------------------------------
 
+include(CPack)
+
 install(TARGETS cugraph
         DESTINATION lib
         EXPORT cugraph-exports)


### PR DESCRIPTION
This PR adds `include(CPack)` to CMakeLists.txt to support generating source packages for `cugraph`.

cc: @trxcllnt