### PR TITLE
C++ benchmarking for additional algorithms

### DIFF
--- a/cpp/tests/components/con_comp_test.cu
+++ b/cpp/tests/components/con_comp_test.cu
@@ -25,11 +25,6 @@
 #include <algorithm>
 #include <iterator>
 
-// do the perf measurements
-// enabled by command line parameter s'--perf'
-//
-static int PERF = 0;
-
 namespace {  // un-nammed
 struct Usecase {
   explicit Usecase(const std::string& a)
@@ -56,7 +51,7 @@ struct Tests_Weakly_CC : ::testing::TestWithParam<Usecase> {
   static void SetupTestCase() {}
   static void TearDownTestCase()
   {
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       for (unsigned int i = 0; i < weakly_cc_time.size(); ++i) {
         std::cout << weakly_cc_time[i] << std::endl;
       }
@@ -120,7 +115,7 @@ struct Tests_Weakly_CC : ::testing::TestWithParam<Usecase> {
 
     rmm::device_vector<int> d_labels(m);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       hr_clock.start();
       cugraph::connected_components<int, int, float>(
         G, cugraph::cugraph_cc_t::CUGRAPH_WEAK, d_labels.data().get());

--- a/cpp/tests/components/mg_weakly_connected_components_test.cpp
+++ b/cpp/tests/components/mg_weakly_connected_components_test.cpp
@@ -241,10 +241,11 @@ INSTANTIATE_TEST_SUITE_P(rmat_small_test,
                                              10, 16, 0.57, 0.19, 0.19, 0, true, false, 0, true))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
-                          line arguments and do not include more than one Rmat_Usecase that differ
-                          only in scale or edge factor (to avoid running same benchmarks more than
-                          once) */
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with
+                          --gtest_filter to select only the rmat_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one Rmat_Usecase that differ only in scale or edge
+                          factor (to avoid running same benchmarks more than once) */
   Tests_MGWeaklyConnectedComponents_Rmat,
   ::testing::Values(
     // disable correctness checks

--- a/cpp/tests/components/mg_weakly_connected_components_test.cpp
+++ b/cpp/tests/components/mg_weakly_connected_components_test.cpp
@@ -230,12 +230,16 @@ INSTANTIATE_TEST_SUITE_P(rmat_small_test,
                                            cugraph::test::Rmat_Usecase(
                                              10, 16, 0.57, 0.19, 0.19, 0, true, false, 0, true))));
 
-INSTANTIATE_TEST_SUITE_P(rmat_large_test,
-                         Tests_MGWeaklyConnectedComponents_Rmat,
-                         ::testing::Values(
-                           // disable correctness checks
-                           std::make_tuple(WeaklyConnectedComponents_Usecase{false},
-                                           cugraph::test::Rmat_Usecase(
-                                             20, 16, 0.57, 0.19, 0.19, 0, true, false, 0, true))));
+INSTANTIATE_TEST_SUITE_P(
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
+                          line arguments and do not include more than one Rmat_Usecase that differ
+                          only in scale or edge factor (to avoid running same benchmarks more than
+                          once) */
+  Tests_MGWeaklyConnectedComponents_Rmat,
+  ::testing::Values(
+    // disable correctness checks
+    std::make_tuple(
+      WeaklyConnectedComponents_Usecase{false},
+      cugraph::test::Rmat_Usecase(20, 16, 0.57, 0.19, 0.19, 0, true, false, 0, true))));
 
 CUGRAPH_MG_TEST_PROGRAM_MAIN()

--- a/cpp/tests/components/mg_weakly_connected_components_test.cpp
+++ b/cpp/tests/components/mg_weakly_connected_components_test.cpp
@@ -204,7 +204,22 @@ TEST_P(Tests_MGWeaklyConnectedComponents_File, CheckInt32Int32)
 TEST_P(Tests_MGWeaklyConnectedComponents_Rmat, CheckInt32Int32)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_MGWeaklyConnectedComponents_Rmat, CheckInt32Int64)
+{
+  auto param = GetParam();
+  run_current_test<int32_t, int64_t>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_MGWeaklyConnectedComponents_Rmat, CheckInt64Int64)
+{
+  auto param = GetParam();
+  run_current_test<int64_t, int64_t>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/components/mg_weakly_connected_components_test.cpp
+++ b/cpp/tests/components/mg_weakly_connected_components_test.cpp
@@ -34,11 +34,6 @@
 
 #include <gtest/gtest.h>
 
-// do the perf measurements
-// enabled by command line parameter s'--perf'
-//
-static int PERF = 0;
-
 struct WeaklyConnectedComponents_Usecase {
   bool check_correctness{true};
 };
@@ -83,7 +78,7 @@ class Tests_MGWeaklyConnectedComponents
 
     // 2. create MG graph
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
@@ -93,7 +88,7 @@ class Tests_MGWeaklyConnectedComponents
       input_usecase.template construct_graph<vertex_t, edge_t, weight_t, false, true>(
         handle, false, true);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
@@ -108,7 +103,7 @@ class Tests_MGWeaklyConnectedComponents
     rmm::device_uvector<vertex_t> d_mg_components(mg_graph_view.get_number_of_local_vertices(),
                                                   handle.get_stream());
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
@@ -116,7 +111,7 @@ class Tests_MGWeaklyConnectedComponents
 
     cugraph::weakly_connected_components(handle, mg_graph_view, d_mg_components.data());
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};

--- a/cpp/tests/components/scc_test.cu
+++ b/cpp/tests/components/scc_test.cu
@@ -33,11 +33,6 @@
 #include <algorithm>
 #include <iterator>
 
-// do the perf measurements
-// enabled by command line parameter s'--perf'
-//
-static int PERF = 0;
-
 template <typename T>
 using DVector = rmm::device_vector<T>;
 
@@ -109,7 +104,7 @@ struct Tests_Strongly_CC : ::testing::TestWithParam<Usecase> {
   static void SetupTestCase() {}
   static void TearDownTestCase()
   {
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       for (unsigned int i = 0; i < strongly_cc_time.size(); ++i) {
         std::cout << strongly_cc_time[i] << std::endl;
       }
@@ -186,7 +181,7 @@ struct Tests_Strongly_CC : ::testing::TestWithParam<Usecase> {
 
     size_t count = 0;
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       hr_clock.start();
       cugraph::connected_components(
         G, cugraph::cugraph_cc_t::CUGRAPH_STRONG, d_labels.data().get());

--- a/cpp/tests/components/weakly_connected_components_test.cpp
+++ b/cpp/tests/components/weakly_connected_components_test.cpp
@@ -36,11 +36,6 @@
 #include <limits>
 #include <vector>
 
-// do the perf measurements
-// enabled by command line parameter s'--perf'
-//
-static int PERF = 0;
-
 template <typename vertex_t, typename edge_t>
 void weakly_connected_components_reference(edge_t const* offsets,
                                            vertex_t const* indices,
@@ -111,7 +106,7 @@ class Tests_WeaklyConnectedComponent
     raft::handle_t handle{};
     HighResClock hr_clock{};
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
@@ -120,7 +115,7 @@ class Tests_WeaklyConnectedComponent
       input_usecase.template construct_graph<vertex_t, edge_t, weight_t, false, false>(
         handle, false, renumber);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -134,14 +129,14 @@ class Tests_WeaklyConnectedComponent
     rmm::device_uvector<vertex_t> d_components(graph_view.get_number_of_vertices(),
                                                handle.get_stream());
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
     cugraph::weakly_connected_components(handle, graph_view, d_components.data());
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/components/weakly_connected_components_test.cpp
+++ b/cpp/tests/components/weakly_connected_components_test.cpp
@@ -255,7 +255,10 @@ INSTANTIATE_TEST_SUITE_P(
                     cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, true, false))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_large_test,
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
+                          line arguments and do not include more than one Rmat_Usecase that differ
+                          only in scale or edge factor (to avoid running same benchmarks more than
+                          once) */
   Tests_WeaklyConnectedComponents_Rmat,
   ::testing::Values(
     // disable correctness checks

--- a/cpp/tests/components/weakly_connected_components_test.cpp
+++ b/cpp/tests/components/weakly_connected_components_test.cpp
@@ -226,7 +226,22 @@ TEST_P(Tests_WeaklyConnectedComponents_File, CheckInt32Int32)
 TEST_P(Tests_WeaklyConnectedComponents_Rmat, CheckInt32Int32)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_WeaklyConnectedComponents_Rmat, CheckInt32Int64)
+{
+  auto param = GetParam();
+  run_current_test<int32_t, int64_t>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_WeaklyConnectedComponents_Rmat, CheckInt64Int64)
+{
+  auto param = GetParam();
+  run_current_test<int64_t, int64_t>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/components/weakly_connected_components_test.cpp
+++ b/cpp/tests/components/weakly_connected_components_test.cpp
@@ -265,10 +265,11 @@ INSTANTIATE_TEST_SUITE_P(
                     cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, true, false))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
-                          line arguments and do not include more than one Rmat_Usecase that differ
-                          only in scale or edge factor (to avoid running same benchmarks more than
-                          once) */
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with
+                          --gtest_filter to select only the rmat_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one Rmat_Usecase that differ only in scale or edge
+                          factor (to avoid running same benchmarks more than once) */
   Tests_WeaklyConnectedComponents_Rmat,
   ::testing::Values(
     // disable correctness checks

--- a/cpp/tests/experimental/bfs_test.cpp
+++ b/cpp/tests/experimental/bfs_test.cpp
@@ -278,7 +278,22 @@ TEST_P(Tests_BFS_File, CheckInt32Int32)
 TEST_P(Tests_BFS_Rmat, CheckInt32Int32)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_BFS_Rmat, CheckInt32Int64)
+{
+  auto param = GetParam();
+  run_current_test<int32_t, int64_t>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_BFS_Rmat, CheckInt64Int64)
+{
+  auto param = GetParam();
+  run_current_test<int64_t, int64_t>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/experimental/bfs_test.cpp
+++ b/cpp/tests/experimental/bfs_test.cpp
@@ -308,7 +308,10 @@ INSTANTIATE_TEST_SUITE_P(
                     cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_large_test,
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
+                          line arguments and do not include more than one Rmat_Usecase that differ
+                          only in scale or edge factor (to avoid running same benchmarks more than
+                          once) */
   Tests_BFS_Rmat,
   ::testing::Values(
     // disable correctness checks for large graphs

--- a/cpp/tests/experimental/bfs_test.cpp
+++ b/cpp/tests/experimental/bfs_test.cpp
@@ -318,10 +318,11 @@ INSTANTIATE_TEST_SUITE_P(
                     cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
-                          line arguments and do not include more than one Rmat_Usecase that differ
-                          only in scale or edge factor (to avoid running same benchmarks more than
-                          once) */
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with
+                          --gtest_filter to select only the rmat_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one Rmat_Usecase that differ only in scale or edge
+                          factor (to avoid running same benchmarks more than once) */
   Tests_BFS_Rmat,
   ::testing::Values(
     // disable correctness checks for large graphs

--- a/cpp/tests/experimental/bfs_test.cpp
+++ b/cpp/tests/experimental/bfs_test.cpp
@@ -37,11 +37,6 @@
 #include <limits>
 #include <vector>
 
-// do the perf measurements
-// enabled by command line parameter s'--perf'
-//
-static int PERF = 0;
-
 template <typename vertex_t, typename edge_t>
 void bfs_reference(edge_t const* offsets,
                    vertex_t const* indices,
@@ -107,7 +102,7 @@ class Tests_BFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, input_
     raft::handle_t handle{};
     HighResClock hr_clock{};
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
@@ -116,7 +111,7 @@ class Tests_BFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, input_
       input_usecase.template construct_graph<vertex_t, edge_t, weight_t, false, false>(
         handle, true, renumber);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -133,7 +128,7 @@ class Tests_BFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, input_
     rmm::device_uvector<vertex_t> d_predecessors(graph_view.get_number_of_vertices(),
                                                  handle.get_stream());
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
@@ -146,7 +141,7 @@ class Tests_BFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, input_
                  false,
                  std::numeric_limits<vertex_t>::max());
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/experimental/katz_centrality_test.cpp
+++ b/cpp/tests/experimental/katz_centrality_test.cpp
@@ -38,11 +38,6 @@
 #include <numeric>
 #include <vector>
 
-// do the perf measurements
-// enabled by command line parameter s'--perf'
-//
-static int PERF = 0;
-
 template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
 void katz_centrality_reference(edge_t const* offsets,
                                vertex_t const* indices,
@@ -122,7 +117,7 @@ class Tests_KatzCentrality
     raft::handle_t handle{};
     HighResClock hr_clock{};
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
@@ -131,7 +126,7 @@ class Tests_KatzCentrality
       input_usecase.template construct_graph<vertex_t, edge_t, weight_t, true, false>(
         handle, katz_usecase.test_weighted, renumber);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -153,7 +148,7 @@ class Tests_KatzCentrality
     rmm::device_uvector<result_t> d_katz_centralities(graph_view.get_number_of_vertices(),
                                                       handle.get_stream());
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
@@ -169,7 +164,7 @@ class Tests_KatzCentrality
                              false,
                              true);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/experimental/katz_centrality_test.cpp
+++ b/cpp/tests/experimental/katz_centrality_test.cpp
@@ -300,12 +300,15 @@ INSTANTIATE_TEST_SUITE_P(rmat_small_test,
                                             ::testing::Values(cugraph::test::Rmat_Usecase(
                                               10, 16, 0.57, 0.19, 0.19, 0, false, false))));
 
-INSTANTIATE_TEST_SUITE_P(rmat_large_test,
-                         Tests_KatzCentrality_Rmat,
-                         // disable correctness checks for large graphs
-                         ::testing::Combine(::testing::Values(KatzCentrality_Usecase{false, false},
-                                                              KatzCentrality_Usecase{true, false}),
-                                            ::testing::Values(cugraph::test::Rmat_Usecase(
-                                              20, 32, 0.57, 0.19, 0.19, 0, false, false))));
+INSTANTIATE_TEST_SUITE_P(
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
+                          line arguments and do not include more than one Rmat_Usecase that differ
+                          only in scale or edge factor (to avoid running same benchmarks more than
+                          once) */
+  Tests_KatzCentrality_Rmat,
+  // disable correctness checks for large graphs
+  ::testing::Combine(
+    ::testing::Values(KatzCentrality_Usecase{false, false}, KatzCentrality_Usecase{true, false}),
+    ::testing::Values(cugraph::test::Rmat_Usecase(20, 32, 0.57, 0.19, 0.19, 0, false, false))));
 
 CUGRAPH_TEST_PROGRAM_MAIN()

--- a/cpp/tests/experimental/katz_centrality_test.cpp
+++ b/cpp/tests/experimental/katz_centrality_test.cpp
@@ -311,10 +311,11 @@ INSTANTIATE_TEST_SUITE_P(rmat_small_test,
                                               10, 16, 0.57, 0.19, 0.19, 0, false, false))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
-                          line arguments and do not include more than one Rmat_Usecase that differ
-                          only in scale or edge factor (to avoid running same benchmarks more than
-                          once) */
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with
+                          --gtest_filter to select only the rmat_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one Rmat_Usecase that differ only in scale or edge
+                          factor (to avoid running same benchmarks more than once) */
   Tests_KatzCentrality_Rmat,
   // disable correctness checks for large graphs
   ::testing::Combine(

--- a/cpp/tests/experimental/katz_centrality_test.cpp
+++ b/cpp/tests/experimental/katz_centrality_test.cpp
@@ -273,7 +273,22 @@ TEST_P(Tests_KatzCentrality_File, CheckInt32Int32FloatFloat)
 TEST_P(Tests_KatzCentrality_Rmat, CheckInt32Int32FloatFloat)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, float>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, float>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_KatzCentrality_Rmat, CheckInt32Int64FloatFloat)
+{
+  auto param = GetParam();
+  run_current_test<int32_t, int64_t, float, float>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_KatzCentrality_Rmat, CheckInt64Int64FloatFloat)
+{
+  auto param = GetParam();
+  run_current_test<int64_t, int64_t, float, float>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/experimental/mg_bfs_test.cpp
+++ b/cpp/tests/experimental/mg_bfs_test.cpp
@@ -300,12 +300,16 @@ INSTANTIATE_TEST_SUITE_P(rmat_small_test,
                                            cugraph::test::Rmat_Usecase(
                                              10, 16, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
 
-INSTANTIATE_TEST_SUITE_P(rmat_large_test,
-                         Tests_MGBFS_Rmat,
-                         ::testing::Values(
-                           // disable correctness checks for large graphs
-                           std::make_tuple(BFS_Usecase{0, false},
-                                           cugraph::test::Rmat_Usecase(
-                                             20, 32, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
+INSTANTIATE_TEST_SUITE_P(
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
+                          line arguments and do not include more than one Rmat_Usecase that differ
+                          only in scale or edge factor (to avoid running same benchmarks more than
+                          once) */
+  Tests_MGBFS_Rmat,
+  ::testing::Values(
+    // disable correctness checks for large graphs
+    std::make_tuple(
+      BFS_Usecase{0, false},
+      cugraph::test::Rmat_Usecase(20, 32, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
 
 CUGRAPH_MG_TEST_PROGRAM_MAIN()

--- a/cpp/tests/experimental/mg_bfs_test.cpp
+++ b/cpp/tests/experimental/mg_bfs_test.cpp
@@ -311,10 +311,11 @@ INSTANTIATE_TEST_SUITE_P(rmat_small_test,
                                              10, 16, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
-                          line arguments and do not include more than one Rmat_Usecase that differ
-                          only in scale or edge factor (to avoid running same benchmarks more than
-                          once) */
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with
+                          --gtest_filter to select only the rmat_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one Rmat_Usecase that differ only in scale or edge
+                          factor (to avoid running same benchmarks more than once) */
   Tests_MGBFS_Rmat,
   ::testing::Values(
     // disable correctness checks for large graphs

--- a/cpp/tests/experimental/mg_bfs_test.cpp
+++ b/cpp/tests/experimental/mg_bfs_test.cpp
@@ -37,11 +37,6 @@
 
 #include <random>
 
-// do the perf measurements
-// enabled by command line parameter s'--perf'
-//
-static int PERF = 0;
-
 struct BFS_Usecase {
   size_t source{0};
   bool check_correctness{true};
@@ -82,7 +77,7 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
 
     // 2. create MG graph
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
@@ -92,7 +87,7 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
       input_usecase.template construct_graph<vertex_t, edge_t, weight_t, false, true>(
         handle, false, true);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
@@ -113,7 +108,7 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
     rmm::device_uvector<vertex_t> d_mg_predecessors(mg_graph_view.get_number_of_local_vertices(),
                                                     handle.get_stream());
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
@@ -127,7 +122,7 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
                  false,
                  std::numeric_limits<vertex_t>::max());
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};

--- a/cpp/tests/experimental/mg_bfs_test.cpp
+++ b/cpp/tests/experimental/mg_bfs_test.cpp
@@ -273,7 +273,22 @@ TEST_P(Tests_MGBFS_File, CheckInt32Int32)
 TEST_P(Tests_MGBFS_Rmat, CheckInt32Int32)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_MGBFS_Rmat, CheckInt32Int64)
+{
+  auto param = GetParam();
+  run_current_test<int32_t, int64_t>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_MGBFS_Rmat, CheckInt64Int64)
+{
+  auto param = GetParam();
+  run_current_test<int64_t, int64_t>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/experimental/mg_katz_centrality_test.cpp
+++ b/cpp/tests/experimental/mg_katz_centrality_test.cpp
@@ -225,19 +225,22 @@ TEST_P(Tests_MGKatzCentrality_File, CheckInt32Int32FloatFloat)
 TEST_P(Tests_MGKatzCentrality_Rmat, CheckInt32Int32FloatFloat)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, float>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, float>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
 TEST_P(Tests_MGKatzCentrality_Rmat, CheckInt32Int64FloatFloat)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int64_t, float, float>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int64_t, float, float>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
 TEST_P(Tests_MGKatzCentrality_Rmat, CheckInt64Int64FloatFloat)
 {
   auto param = GetParam();
-  run_current_test<int64_t, int64_t, float, float>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int64_t, int64_t, float, float>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/experimental/mg_katz_centrality_test.cpp
+++ b/cpp/tests/experimental/mg_katz_centrality_test.cpp
@@ -34,11 +34,6 @@
 
 #include <random>
 
-// do the perf measurements
-// enabled by command line parameter s'--perf'
-//
-static int PERF = 0;
-
 struct KatzCentrality_Usecase {
   bool test_weighted{false};
   bool check_correctness{true};
@@ -79,7 +74,7 @@ class Tests_MGKatzCentrality
 
     // 2. create MG graph
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
@@ -89,7 +84,7 @@ class Tests_MGKatzCentrality
       input_usecase.template construct_graph<vertex_t, edge_t, weight_t, true, true>(
         handle, katz_usecase.test_weighted, true);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
@@ -112,7 +107,7 @@ class Tests_MGKatzCentrality
     rmm::device_uvector<result_t> d_mg_katz_centralities(
       mg_graph_view.get_number_of_local_vertices(), handle.get_stream());
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
@@ -128,7 +123,7 @@ class Tests_MGKatzCentrality
                              std::numeric_limits<size_t>::max(),
                              false);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};

--- a/cpp/tests/experimental/mg_katz_centrality_test.cpp
+++ b/cpp/tests/experimental/mg_katz_centrality_test.cpp
@@ -253,13 +253,16 @@ INSTANTIATE_TEST_SUITE_P(rmat_small_test,
                            ::testing::Values(cugraph::test::Rmat_Usecase(
                              10, 16, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
 
-INSTANTIATE_TEST_SUITE_P(rmat_large_test,
-                         Tests_MGKatzCentrality_Rmat,
-                         ::testing::Combine(
-                           // disable correctness checks for large graphs
-                           ::testing::Values(KatzCentrality_Usecase{false, false},
-                                             KatzCentrality_Usecase{true, false}),
-                           ::testing::Values(cugraph::test::Rmat_Usecase(
-                             20, 32, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
+INSTANTIATE_TEST_SUITE_P(
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
+                          line arguments and do not include more than one Rmat_Usecase that differ
+                          only in scale or edge factor (to avoid running same benchmarks more than
+                          once) */
+  Tests_MGKatzCentrality_Rmat,
+  ::testing::Combine(
+    // disable correctness checks for large graphs
+    ::testing::Values(KatzCentrality_Usecase{false, false}, KatzCentrality_Usecase{true, false}),
+    ::testing::Values(
+      cugraph::test::Rmat_Usecase(20, 32, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
 
 CUGRAPH_MG_TEST_PROGRAM_MAIN()

--- a/cpp/tests/experimental/mg_katz_centrality_test.cpp
+++ b/cpp/tests/experimental/mg_katz_centrality_test.cpp
@@ -228,6 +228,18 @@ TEST_P(Tests_MGKatzCentrality_Rmat, CheckInt32Int32FloatFloat)
   run_current_test<int32_t, int32_t, float, float>(std::get<0>(param), std::get<1>(param));
 }
 
+TEST_P(Tests_MGKatzCentrality_Rmat, CheckInt32Int64FloatFloat)
+{
+  auto param = GetParam();
+  run_current_test<int32_t, int64_t, float, float>(std::get<0>(param), std::get<1>(param));
+}
+
+TEST_P(Tests_MGKatzCentrality_Rmat, CheckInt64Int64FloatFloat)
+{
+  auto param = GetParam();
+  run_current_test<int64_t, int64_t, float, float>(std::get<0>(param), std::get<1>(param));
+}
+
 INSTANTIATE_TEST_SUITE_P(
   file_test,
   Tests_MGKatzCentrality_File,

--- a/cpp/tests/experimental/mg_katz_centrality_test.cpp
+++ b/cpp/tests/experimental/mg_katz_centrality_test.cpp
@@ -261,10 +261,11 @@ INSTANTIATE_TEST_SUITE_P(rmat_small_test,
                              10, 16, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
-                          line arguments and do not include more than one Rmat_Usecase that differ
-                          only in scale or edge factor (to avoid running same benchmarks more than
-                          once) */
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with
+                          --gtest_filter to select only the rmat_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one Rmat_Usecase that differ only in scale or edge
+                          factor (to avoid running same benchmarks more than once) */
   Tests_MGKatzCentrality_Rmat,
   ::testing::Combine(
     // disable correctness checks for large graphs

--- a/cpp/tests/experimental/mg_sssp_test.cpp
+++ b/cpp/tests/experimental/mg_sssp_test.cpp
@@ -308,12 +308,16 @@ INSTANTIATE_TEST_SUITE_P(rmat_small_test,
                                            cugraph::test::Rmat_Usecase(
                                              10, 16, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
 
-INSTANTIATE_TEST_SUITE_P(rmat_large_test,
-                         Tests_MGSSSP_Rmat,
-                         ::testing::Values(
-                           // disable correctness checks for large graphs
-                           std::make_tuple(SSSP_Usecase{0, false},
-                                           cugraph::test::Rmat_Usecase(
-                                             20, 32, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
+INSTANTIATE_TEST_SUITE_P(
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
+                          line arguments and do not include more than one Rmat_Usecase that differ
+                          only in scale or edge factor (to avoid running same benchmarks more than
+                          once) */
+  Tests_MGSSSP_Rmat,
+  ::testing::Values(
+    // disable correctness checks for large graphs
+    std::make_tuple(
+      SSSP_Usecase{0, false},
+      cugraph::test::Rmat_Usecase(20, 32, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
 
 CUGRAPH_MG_TEST_PROGRAM_MAIN()

--- a/cpp/tests/experimental/mg_sssp_test.cpp
+++ b/cpp/tests/experimental/mg_sssp_test.cpp
@@ -37,11 +37,6 @@
 
 #include <random>
 
-// do the perf measurements
-// enabled by command line parameter s'--perf'
-//
-static int PERF = 0;
-
 struct SSSP_Usecase {
   size_t source{0};
   bool check_correctness{true};
@@ -79,7 +74,7 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
 
     // 2. create MG graph
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
@@ -89,7 +84,7 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
       input_usecase.template construct_graph<vertex_t, edge_t, weight_t, false, true>(
         handle, true, true);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
@@ -110,7 +105,7 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
     rmm::device_uvector<vertex_t> d_mg_predecessors(mg_graph_view.get_number_of_local_vertices(),
                                                     handle.get_stream());
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
@@ -123,7 +118,7 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
                   static_cast<vertex_t>(sssp_usecase.source),
                   std::numeric_limits<weight_t>::max());
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};

--- a/cpp/tests/experimental/mg_sssp_test.cpp
+++ b/cpp/tests/experimental/mg_sssp_test.cpp
@@ -319,10 +319,11 @@ INSTANTIATE_TEST_SUITE_P(rmat_small_test,
                                              10, 16, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
-                          line arguments and do not include more than one Rmat_Usecase that differ
-                          only in scale or edge factor (to avoid running same benchmarks more than
-                          once) */
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with
+                          --gtest_filter to select only the rmat_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one Rmat_Usecase that differ only in scale or edge
+                          factor (to avoid running same benchmarks more than once) */
   Tests_MGSSSP_Rmat,
   ::testing::Values(
     // disable correctness checks for large graphs

--- a/cpp/tests/experimental/mg_sssp_test.cpp
+++ b/cpp/tests/experimental/mg_sssp_test.cpp
@@ -282,7 +282,22 @@ TEST_P(Tests_MGSSSP_File, CheckInt32Int32Float)
 TEST_P(Tests_MGSSSP_Rmat, CheckInt32Int32Float)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t, float>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_MGSSSP_Rmat, CheckInt32Int64Float)
+{
+  auto param = GetParam();
+  run_current_test<int32_t, int64_t, float>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_MGSSSP_Rmat, CheckInt64Int64Float)
+{
+  auto param = GetParam();
+  run_current_test<int64_t, int64_t, float>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/experimental/pagerank_test.cpp
+++ b/cpp/tests/experimental/pagerank_test.cpp
@@ -39,11 +39,6 @@
 #include <random>
 #include <vector>
 
-// do the perf measurements
-// enabled by command line parameter s'--perf'
-//
-static int PERF = 0;
-
 template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
 void pagerank_reference(edge_t const* offsets,
                         vertex_t const* indices,
@@ -160,7 +155,7 @@ class Tests_PageRank
     raft::handle_t handle{};
     HighResClock hr_clock{};
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
@@ -169,7 +164,7 @@ class Tests_PageRank
       input_usecase.template construct_graph<vertex_t, edge_t, weight_t, true, false>(
         handle, pagerank_usecase.test_weighted, renumber);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -234,7 +229,7 @@ class Tests_PageRank
     rmm::device_uvector<result_t> d_pageranks(graph_view.get_number_of_vertices(),
                                               handle.get_stream());
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
@@ -257,7 +252,7 @@ class Tests_PageRank
       false,
       false);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/experimental/pagerank_test.cpp
+++ b/cpp/tests/experimental/pagerank_test.cpp
@@ -462,10 +462,11 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
-                          line arguments and do not include more than one Rmat_Usecase that differ
-                          only in scale or edge factor (to avoid running same benchmarks more than
-                          once) */
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with
+                          --gtest_filter to select only the rmat_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one Rmat_Usecase that differ only in scale or edge
+                          factor (to avoid running same benchmarks more than once) */
   Tests_PageRank_Rmat,
   ::testing::Combine(
     // disable correctness checks for large graphs

--- a/cpp/tests/experimental/pagerank_test.cpp
+++ b/cpp/tests/experimental/pagerank_test.cpp
@@ -415,11 +415,25 @@ TEST_P(Tests_PageRank_File, CheckInt32Int32FloatFloat)
   run_current_test<int32_t, int32_t, float, float>(std::get<0>(param), std::get<1>(param));
 }
 
-// FIXME: add tests for type combinations
 TEST_P(Tests_PageRank_Rmat, CheckInt32Int32FloatFloat)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, float>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, float>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_PageRank_Rmat, CheckInt32Int64FloatFloat)
+{
+  auto param = GetParam();
+  run_current_test<int32_t, int64_t, float, float>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_PageRank_Rmat, CheckInt64Int64FloatFloat)
+{
+  auto param = GetParam();
+  run_current_test<int64_t, int64_t, float, float>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/experimental/pagerank_test.cpp
+++ b/cpp/tests/experimental/pagerank_test.cpp
@@ -442,7 +442,7 @@ INSTANTIATE_TEST_SUITE_P(
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_small_tests,
+  rmat_small_test,
   Tests_PageRank_Rmat,
   ::testing::Combine(
     // enable correctness checks
@@ -453,7 +453,10 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_large_tests,
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
+                          line arguments and do not include more than one Rmat_Usecase that differ
+                          only in scale or edge factor (to avoid running same benchmarks more than
+                          once) */
   Tests_PageRank_Rmat,
   ::testing::Combine(
     // disable correctness checks for large graphs

--- a/cpp/tests/experimental/sssp_test.cpp
+++ b/cpp/tests/experimental/sssp_test.cpp
@@ -321,7 +321,10 @@ INSTANTIATE_TEST_SUITE_P(
     SSSP_Usecase{0}, cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_large_test,
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
+                          line arguments and do not include more than one Rmat_Usecase that differ
+                          only in scale or edge factor (to avoid running same benchmarks more than
+                          once) */
   Tests_SSSP_Rmat,
   // disable correctness checks for large graphs
   ::testing::Values(

--- a/cpp/tests/experimental/sssp_test.cpp
+++ b/cpp/tests/experimental/sssp_test.cpp
@@ -292,10 +292,26 @@ TEST_P(Tests_SSSP_File, CheckInt32Int32Float)
   auto param = GetParam();
   run_current_test<int32_t, int32_t, float>(std::get<0>(param), std::get<1>(param));
 }
+
 TEST_P(Tests_SSSP_Rmat, CheckInt32Int32Float)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t, float>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_SSSP_Rmat, CheckInt32Int64Float)
+{
+  auto param = GetParam();
+  run_current_test<int32_t, int64_t, float>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_SSSP_Rmat, CheckInt64Int64Float)
+{
+  auto param = GetParam();
+  run_current_test<int64_t, int64_t, float>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/experimental/sssp_test.cpp
+++ b/cpp/tests/experimental/sssp_test.cpp
@@ -39,11 +39,6 @@
 #include <tuple>
 #include <vector>
 
-// do the perf measurements
-// enabled by command line parameter s'--perf'
-//
-static int PERF = 0;
-
 // Dijkstra's algorithm
 template <typename vertex_t, typename edge_t, typename weight_t>
 void sssp_reference(edge_t const* offsets,
@@ -110,7 +105,7 @@ class Tests_SSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, inpu
     raft::handle_t handle{};
     HighResClock hr_clock{};
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
@@ -119,7 +114,7 @@ class Tests_SSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, inpu
       input_usecase.template construct_graph<vertex_t, edge_t, weight_t, false, false>(
         handle, true, renumber);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -136,7 +131,7 @@ class Tests_SSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, inpu
     rmm::device_uvector<vertex_t> d_predecessors(graph_view.get_number_of_vertices(),
                                                  handle.get_stream());
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
@@ -149,7 +144,7 @@ class Tests_SSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, inpu
                   std::numeric_limits<weight_t>::max(),
                   false);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/experimental/sssp_test.cpp
+++ b/cpp/tests/experimental/sssp_test.cpp
@@ -332,10 +332,11 @@ INSTANTIATE_TEST_SUITE_P(
     SSSP_Usecase{0}, cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
-                          line arguments and do not include more than one Rmat_Usecase that differ
-                          only in scale or edge factor (to avoid running same benchmarks more than
-                          once) */
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with
+                          --gtest_filter to select only the rmat_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one Rmat_Usecase that differ only in scale or edge
+                          factor (to avoid running same benchmarks more than once) */
   Tests_SSSP_Rmat,
   // disable correctness checks for large graphs
   ::testing::Values(

--- a/cpp/tests/layout/force_atlas2_test.cu
+++ b/cpp/tests/layout/force_atlas2_test.cu
@@ -29,7 +29,6 @@
 #include <iostream>
 
 // iterations for perf tests
-// enabled by command line parameter '--perf-iters"
 static int PERF_MULTIPLIER = 5;
 
 typedef struct Force_Atlas2_Usecase_t {

--- a/cpp/tests/layout/force_atlas2_test.cu
+++ b/cpp/tests/layout/force_atlas2_test.cu
@@ -28,10 +28,6 @@
 #include <fstream>
 #include <iostream>
 
-// do the perf measurements
-// enabled by command line parameter s'--perf'
-static int PERF = 0;
-
 // iterations for perf tests
 // enabled by command line parameter '--perf-iters"
 static int PERF_MULTIPLIER = 5;
@@ -64,7 +60,7 @@ class Tests_Force_Atlas2 : public ::testing::TestWithParam<Force_Atlas2_Usecase>
   static void SetupTestCase() {}
   static void TearDownTestCase()
   {
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       for (unsigned int i = 0; i < force_atlas2_time.size(); ++i) {
         std::cout << force_atlas2_time[i] / PERF_MULTIPLIER << std::endl;
       }
@@ -161,7 +157,7 @@ class Tests_Force_Atlas2 : public ::testing::TestWithParam<Force_Atlas2_Usecase>
     const float gravity                   = 1.0;
     bool verbose                          = false;
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       hr_clock.start();
       for (int i = 0; i < PERF_MULTIPLIER; ++i) {
         cugraph::force_atlas2<int, int, T>(handle,

--- a/cpp/tests/pagerank/mg_pagerank_test.cpp
+++ b/cpp/tests/pagerank/mg_pagerank_test.cpp
@@ -354,7 +354,10 @@ INSTANTIATE_TEST_SUITE_P(
                        10, 16, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_large_tests,
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
+                          line arguments and do not include more than one Rmat_Usecase that differ
+                          only in scale or edge factor (to avoid running same benchmarks more than
+                          once) */
   Tests_MGPageRank_Rmat,
   ::testing::Combine(::testing::Values(PageRank_Usecase{0.0, false, false},
                                        PageRank_Usecase{0.5, false, false},

--- a/cpp/tests/pagerank/mg_pagerank_test.cpp
+++ b/cpp/tests/pagerank/mg_pagerank_test.cpp
@@ -354,10 +354,11 @@ INSTANTIATE_TEST_SUITE_P(
                        10, 16, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
-                          line arguments and do not include more than one Rmat_Usecase that differ
-                          only in scale or edge factor (to avoid running same benchmarks more than
-                          once) */
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with
+                          --gtest_filter to select only the rmat_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one Rmat_Usecase that differ only in scale or edge
+                          factor (to avoid running same benchmarks more than once) */
   Tests_MGPageRank_Rmat,
   ::testing::Combine(::testing::Values(PageRank_Usecase{0.0, false, false},
                                        PageRank_Usecase{0.5, false, false},

--- a/cpp/tests/prims/mg_count_if_v.cu
+++ b/cpp/tests/prims/mg_count_if_v.cu
@@ -39,11 +39,6 @@
 
 #include <random>
 
-// do the perf measurements
-// enabled by command line parameter s'--perf'
-//
-static int PERF = 0;
-
 template <typename vertex_t>
 struct test_predicate {
   int mod{};
@@ -93,7 +88,7 @@ class Tests_MG_CountIfV
 
     // 2. create MG graph
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
@@ -102,7 +97,7 @@ class Tests_MG_CountIfV
       input_usecase.template construct_graph<vertex_t, edge_t, weight_t, store_transposed, true>(
         handle, true, true);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
@@ -116,7 +111,7 @@ class Tests_MG_CountIfV
 
     // 3. run MG count if
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
@@ -126,7 +121,7 @@ class Tests_MG_CountIfV
     auto vertex_count =
       count_if_v(handle, mg_graph_view, data, test_predicate<vertex_t>(hash_bin_count));
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};

--- a/cpp/tests/prims/mg_count_if_v.cu
+++ b/cpp/tests/prims/mg_count_if_v.cu
@@ -222,10 +222,11 @@ INSTANTIATE_TEST_SUITE_P(
                        10, 16, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
-                          line arguments and do not include more than one Rmat_Usecase that differ
-                          only in scale or edge factor (to avoid running same benchmarks more than
-                          once) */
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with
+                          --gtest_filter to select only the rmat_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one Rmat_Usecase that differ only in scale or edge
+                          factor (to avoid running same benchmarks more than once) */
   Tests_MG_CountIfV_Rmat,
   ::testing::Combine(::testing::Values(Prims_Usecase{false}),
                      ::testing::Values(cugraph::test::Rmat_Usecase(

--- a/cpp/tests/prims/mg_count_if_v.cu
+++ b/cpp/tests/prims/mg_count_if_v.cu
@@ -197,7 +197,10 @@ INSTANTIATE_TEST_SUITE_P(
                        10, 16, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_large_test,
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
+                          line arguments and do not include more than one Rmat_Usecase that differ
+                          only in scale or edge factor (to avoid running same benchmarks more than
+                          once) */
   Tests_MG_CountIfV_Rmat,
   ::testing::Combine(::testing::Values(Prims_Usecase{false}),
                      ::testing::Values(cugraph::test::Rmat_Usecase(

--- a/cpp/tests/prims/mg_count_if_v.cu
+++ b/cpp/tests/prims/mg_count_if_v.cu
@@ -159,7 +159,22 @@ TEST_P(Tests_MG_CountIfV_File, CheckInt32Int32FloatTransposeFalse)
 TEST_P(Tests_MG_CountIfV_Rmat, CheckInt32Int32FloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, false>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, false>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_MG_CountIfV_Rmat, CheckInt32Int64FloatTransposeFalse)
+{
+  auto param = GetParam();
+  run_current_test<int32_t, int64_t, float, false>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_MG_CountIfV_Rmat, CheckInt64Int64FloatTransposeFalse)
+{
+  auto param = GetParam();
+  run_current_test<int64_t, int64_t, float, false>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
 TEST_P(Tests_MG_CountIfV_File, CheckInt32Int32FloatTransposeTrue)
@@ -171,7 +186,22 @@ TEST_P(Tests_MG_CountIfV_File, CheckInt32Int32FloatTransposeTrue)
 TEST_P(Tests_MG_CountIfV_Rmat, CheckInt32Int32FloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, true>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, true>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_MG_CountIfV_Rmat, CheckInt32Int64FloatTransposeTrue)
+{
+  auto param = GetParam();
+  run_current_test<int32_t, int64_t, float, true>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_MG_CountIfV_Rmat, CheckInt64Int64FloatTransposeTrue)
+{
+  auto param = GetParam();
+  run_current_test<int64_t, int64_t, float, true>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/prims/mg_reduce_v.cu
+++ b/cpp/tests/prims/mg_reduce_v.cu
@@ -39,11 +39,6 @@
 
 #include <random>
 
-// do the perf measurements
-// enabled by command line parameter s'--perf'
-//
-static int PERF = 0;
-
 template <typename vertex_t, typename... T>
 struct property_transform : public thrust::unary_function<vertex_t, thrust::tuple<T...>> {
   int mod{};
@@ -204,7 +199,7 @@ class Tests_MG_ReduceIfV
 
     // 2. create MG graph
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
@@ -213,7 +208,7 @@ class Tests_MG_ReduceIfV
       input_usecase.template construct_graph<vertex_t, edge_t, weight_t, store_transposed, true>(
         handle, true, true);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
@@ -233,7 +228,7 @@ class Tests_MG_ReduceIfV
       generate<result_t>::property((*d_mg_renumber_map_labels), hash_bin_count, handle);
     auto property_iter = get_property_iterator(property_data);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
@@ -245,7 +240,7 @@ class Tests_MG_ReduceIfV
                            property_iter + (*d_mg_renumber_map_labels).size(),
                            property_initial_value);
 
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};

--- a/cpp/tests/prims/mg_reduce_v.cu
+++ b/cpp/tests/prims/mg_reduce_v.cu
@@ -317,7 +317,22 @@ TEST_P(Tests_MG_ReduceIfV_File, CheckInt32Int32FloatTransposeFalse)
 TEST_P(Tests_MG_ReduceIfV_Rmat, CheckInt32Int32FloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, int, false>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, int, false>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_MG_ReduceIfV_Rmat, CheckInt32Int64FloatTransposeFalse)
+{
+  auto param = GetParam();
+  run_current_test<int32_t, int64_t, float, int, false>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_MG_ReduceIfV_Rmat, CheckInt64Int64FloatTransposeFalse)
+{
+  auto param = GetParam();
+  run_current_test<int64_t, int64_t, float, int, false>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
 TEST_P(Tests_MG_ReduceIfV_File, CheckInt32Int32FloatTransposeTrue)
@@ -329,7 +344,22 @@ TEST_P(Tests_MG_ReduceIfV_File, CheckInt32Int32FloatTransposeTrue)
 TEST_P(Tests_MG_ReduceIfV_Rmat, CheckInt32Int32FloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, int, true>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, int, true>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_MG_ReduceIfV_Rmat, CheckInt32Int64FloatTransposeTrue)
+{
+  auto param = GetParam();
+  run_current_test<int32_t, int64_t, float, int, true>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+}
+
+TEST_P(Tests_MG_ReduceIfV_Rmat, CheckInt64Int64FloatTransposeTrue)
+{
+  auto param = GetParam();
+  run_current_test<int64_t, int64_t, float, int, true>(
+    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/prims/mg_reduce_v.cu
+++ b/cpp/tests/prims/mg_reduce_v.cu
@@ -355,7 +355,10 @@ INSTANTIATE_TEST_SUITE_P(
                        10, 16, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_large_test,
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
+                          line arguments and do not include more than one Rmat_Usecase that differ
+                          only in scale or edge factor (to avoid running same benchmarks more than
+                          once) */
   Tests_MG_ReduceIfV_Rmat,
   ::testing::Combine(::testing::Values(Prims_Usecase{false}),
                      ::testing::Values(cugraph::test::Rmat_Usecase(

--- a/cpp/tests/prims/mg_reduce_v.cu
+++ b/cpp/tests/prims/mg_reduce_v.cu
@@ -380,10 +380,11 @@ INSTANTIATE_TEST_SUITE_P(
                        10, 16, 0.57, 0.19, 0.19, 0, false, false, 0, true))));
 
 INSTANTIATE_TEST_SUITE_P(
-  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking by command
-                          line arguments and do not include more than one Rmat_Usecase that differ
-                          only in scale or edge factor (to avoid running same benchmarks more than
-                          once) */
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with
+                          --gtest_filter to select only the rmat_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one Rmat_Usecase that differ only in scale or edge
+                          factor (to avoid running same benchmarks more than once) */
   Tests_MG_ReduceIfV_Rmat,
   ::testing::Combine(::testing::Values(Prims_Usecase{false}),
                      ::testing::Values(cugraph::test::Rmat_Usecase(

--- a/cpp/tests/prims/mg_reduce_v.cu
+++ b/cpp/tests/prims/mg_reduce_v.cu
@@ -28,7 +28,7 @@
 #include <cugraph/graph_view.hpp>
 #include <cugraph/prims/reduce_v.cuh>
 
-#include <thrust/count.h>
+#include <thrust/reduce.h>
 #include <raft/comms/comms.hpp>
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/handle.hpp>
@@ -218,7 +218,7 @@ class Tests_MG_ReduceIfV
 
     auto mg_graph_view = mg_graph.view();
 
-    // 3. run MG count if
+    // 3. run MG reduce
 
     const int hash_bin_count = 5;
     const int initial_value  = 10;
@@ -245,7 +245,7 @@ class Tests_MG_ReduceIfV
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
-      std::cout << "MG count if took " << elapsed_time * 1e-6 << " s.\n";
+      std::cout << "MG reduce took " << elapsed_time * 1e-6 << " s.\n";
     }
 
     //// 4. compare SG & MG results

--- a/cpp/tests/traversal/legacy/sssp_test.cu
+++ b/cpp/tests/traversal/legacy/sssp_test.cu
@@ -109,8 +109,6 @@ void ref_sssp(const std::vector<MaxEType>& rowPtr,
 }
 
 // iterations for perf tests
-
-// enabled by command line parameter '--perf-iters"
 static int PERF_MULTIPLIER = 5;
 
 typedef struct SSSP_Usecase_t {

--- a/cpp/tests/traversal/legacy/sssp_test.cu
+++ b/cpp/tests/traversal/legacy/sssp_test.cu
@@ -108,11 +108,8 @@ void ref_sssp(const std::vector<MaxEType>& rowPtr,
   }
 }
 
-// do the perf measurements
-// enabled by command line parameter s'--perf'
-static int PERF = 0;
-
 // iterations for perf tests
+
 // enabled by command line parameter '--perf-iters"
 static int PERF_MULTIPLIER = 5;
 
@@ -143,7 +140,7 @@ class Tests_SSSP : public ::testing::TestWithParam<SSSP_Usecase> {
   static void SetupTestCase() {}
   static void TearDownTestCase()
   {
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       for (size_t i = 0; i < SSSP_time.size(); ++i) {
         std::cout << SSSP_time[i] / PERF_MULTIPLIER << std::endl;
       }
@@ -288,7 +285,7 @@ class Tests_SSSP : public ::testing::TestWithParam<SSSP_Usecase> {
     double time_tmp;
 
     cudaDeviceSynchronize();
-    if (PERF) {
+    if (cugraph::test::g_perf) {
       hr_clock.start();
       for (auto i = 0; i < PERF_MULTIPLIER; ++i) {
         cugraph::sssp(G, distances, preds, src);

--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -134,7 +134,7 @@ inline Rmat_Usecase override_Rmat_Usecase_with_cmd_line_arguments(Rmat_Usecase u
  *
  * Example:
  * ```
- * ./tests/PAGERANK_TEST --gtest_filter=rmat_large_tests/Tests_PageRank_Rmat.CheckInt32Int32*
+ * ./tests/PAGERANK_TEST --gtest_filter=rmat_benchmark_test/Tests_PageRank_Rmat.CheckInt32Int32*
  * --rmm_mode=pool --perf --rmat_scale=25 --rmat_edge_factor=16
  * ```
  *


### PR DESCRIPTION
Apply the updates in PR #1755 (for MG PageRank) to

MG: Katz Centrality, BFS, SSSP, WCC, and primitive tests
SG: PageRank, Katz Centrality, BFS, SSSP, and WCC tests

@ChuckHastings I will defer Louvain test updates to you :-) once Louvain tests get updated to take R-mat graphs.