### PR TITLE
MNMG memory footprint improvement for low average vertex degree graphs (part 1)

### DIFF
--- a/cpp/include/cugraph/detail/shuffle_wrappers.hpp
+++ b/cpp/include/cugraph/detail/shuffle_wrappers.hpp
@@ -22,53 +22,43 @@ namespace cugraph {
 namespace detail {
 
 /**
- * @brief    Shuffle edgelist using the edge key function which returns the target GPU ID.
+ * @brief Shuffle edgelist using the edge key function which returns the target GPU ID.
  *
- * NOTE:  d_edgelist_rows, d_edgelist_cols and d_edgelist_weights
- *        are modified within this function (data is sorted)
- *        But the actual output is returned. The exact contents
- *        of d_edgelist_rows, d_edgelist_cols and d_edgelist_weights
- *        after the function is undefined.
+ * @tparam vertex_t Type of vertex identifiers. Needs to be an integral type.
+ * @tparam weight_t Type of edge weights. Needs to be a floating point type.
  *
- * @tparam         vertex_t             vertex type
- * @tparam         weight_t             weight type
+ * @param[in] handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator,
+ * and handles to various CUDA libraries) to run graph algorithms.
+ * @param[in] d_edgelist_majors Vertex IDs for rows (if the graph adjacency matrix is stored as is)
+ * or columns (if the graph adjacency matrix is stored transposed)
+ * @param[in] d_edgelist_minors Vertex IDs for columns (if the graph adjacency matrix is stored as
+ * is) or rows (if the graph adjacency matrix is stored transposed)
+ * @param[in] d_edgelist_weights Optional edge weights
  *
- * @param[in]      handle               raft handle
- * @param[in/out]  d_edgelist_majors    vertex IDs for rows (if the graph adjacency matrix is stored
- * as is) or columns (if the graph adjacency matrix is stored transposed)
- * @param[in/out]  d_edgelist_minors    vertex IDs for columns (if the graph adjacency matrix is
- * stored as is) or rows (if the graph adjacency matrix is stored transposed)
- * @param[in/out]  d_edgelist_weights   optional edge weights
- *
- * @return tuple of shuffled major vertices, minor vertices and optional weights
+ * @return Tuple of shuffled major vertices, minor vertices and optional weights
  */
 template <typename vertex_t, typename weight_t>
 std::tuple<rmm::device_uvector<vertex_t>,
            rmm::device_uvector<vertex_t>,
            std::optional<rmm::device_uvector<weight_t>>>
 shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
-                           rmm::device_uvector<vertex_t>& d_edgelist_majors,
-                           rmm::device_uvector<vertex_t>& d_edgelist_minors,
-                           std::optional<rmm::device_uvector<weight_t>>& d_edgelist_weights);
+                           rmm::device_uvector<vertex_t>&& d_edgelist_majors,
+                           rmm::device_uvector<vertex_t>&& d_edgelist_minors,
+                           std::optional<rmm::device_uvector<weight_t>>&& d_edgelist_weights);
 
 /**
- * @brief    Shuffle vertices using the vertex key function which returns the target GPU ID.
+ * @brief Shuffle vertices using the vertex key function which returns the target GPU ID.
  *
- * NOTE:  d_value is modified within this function
- *        (data is sorted).  But the actual output is returned.
- *        The exact contents of d_value after the function is
- *        undefined.
+ * @tparam vertex_t Type of vertex identifiers. Needs to be an integral type.
  *
- * @tparam         vertex_t      vertex type
- *
- * @param[in]      handle        raft handle
- * @param[in/out]  d_vertices    vertex ids to shuffle
+ * @param[in] handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator,
+ * @param[in] d_vertices Vertex IDs to shuffle
  *
  * @return device vector of shuffled vertices
  */
 template <typename vertex_t>
-rmm::device_uvector<vertex_t> shuffle_vertices_by_gpu_id(raft::handle_t const& handle,
-                                                         rmm::device_uvector<vertex_t>& d_vertices);
+rmm::device_uvector<vertex_t> shuffle_vertices_by_gpu_id(
+  raft::handle_t const& handle, rmm::device_uvector<vertex_t>&& d_vertices);
 
 /**
  * @brief Groupby and count edgelist using the key function which returns the target local partition
@@ -79,10 +69,10 @@ rmm::device_uvector<vertex_t> shuffle_vertices_by_gpu_id(raft::handle_t const& h
  *
  * @param[in] handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator,
  * and handles to various CUDA libraries) to run graph algorithms.
- * @param[in/out] d_edgelist_majors Vertex IDs for rows (if the graph adjacency matrix is stored as is)
- * or columns (if the graph adjacency matrix is stored transposed)
- * @param[in/out] d_edgelist_minors Vertex IDs for columns (if the graph adjacency matrix is stored as
- * is) or rows (if the graph adjacency matrix is stored transposed)
+ * @param[in/out] d_edgelist_majors Vertex IDs for rows (if the graph adjacency matrix is stored as
+ * is) or columns (if the graph adjacency matrix is stored transposed)
+ * @param[in/out] d_edgelist_minors Vertex IDs for columns (if the graph adjacency matrix is stored
+ * as is) or rows (if the graph adjacency matrix is stored transposed)
  * @param[in/out] d_edgelist_weights Optional edge weights
  * @param[in] groupby_and_count_local_partition If set to true, groupby and count edges based on
  * (local partition ID, GPU ID) pairs (where GPU IDs are computed by applying the

--- a/cpp/include/cugraph/detail/shuffle_wrappers.hpp
+++ b/cpp/include/cugraph/detail/shuffle_wrappers.hpp
@@ -22,7 +22,7 @@ namespace cugraph {
 namespace detail {
 
 /**
- * @brief    Shuffle edgelist using the edge key function
+ * @brief    Shuffle edgelist using the edge key function which returns the target GPU ID.
  *
  * NOTE:  d_edgelist_rows, d_edgelist_cols and d_edgelist_weights
  *        are modified within this function (data is sorted)
@@ -46,14 +46,14 @@ template <typename vertex_t, typename weight_t>
 std::tuple<rmm::device_uvector<vertex_t>,
            rmm::device_uvector<vertex_t>,
            std::optional<rmm::device_uvector<weight_t>>>
-shuffle_edgelist_by_edge(raft::handle_t const& handle,
+shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
                          rmm::device_uvector<vertex_t>& d_edgelist_rows,
                          rmm::device_uvector<vertex_t>& d_edgelist_cols,
                          std::optional<rmm::device_uvector<weight_t>>& d_edgelist_weights,
                          bool store_transposed);
 
 /**
- * @brief    Shuffle vertices using the vertex key function
+ * @brief    Shuffle vertices using the vertex key function which returns the target GPU ID.
  *
  * NOTE:  d_value is modified within this function
  *        (data is sorted).  But the actual output is returned.
@@ -68,11 +68,11 @@ shuffle_edgelist_by_edge(raft::handle_t const& handle,
  * @return device vector of shuffled vertices
  */
 template <typename vertex_t>
-rmm::device_uvector<vertex_t> shuffle_vertices(raft::handle_t const& handle,
+rmm::device_uvector<vertex_t> shuffle_vertices_by_gpu_id(raft::handle_t const& handle,
                                                rmm::device_uvector<vertex_t>& d_vertices);
 
 /**
- * @brief    Groupby and count edgelist using the edge key function
+ * @brief    Groupby and count edgelist using the edge key function which returns the target local partition ID.
  *
  * NOTE:  d_edgelist_rows, d_edgelist_cols and d_edgelist_weights
  *        are modified within this function (data is sorted)
@@ -91,7 +91,7 @@ rmm::device_uvector<vertex_t> shuffle_vertices(raft::handle_t const& handle,
  * @return tuple of shuffled rows, columns and optional weights
  */
 template <typename vertex_t, typename weight_t>
-rmm::device_uvector<size_t> groupby_and_count_by_edge(
+rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   raft::handle_t const& handle,
   rmm::device_uvector<vertex_t>& d_edgelist_rows,
   rmm::device_uvector<vertex_t>& d_edgelist_cols,

--- a/cpp/include/cugraph/detail/shuffle_wrappers.hpp
+++ b/cpp/include/cugraph/detail/shuffle_wrappers.hpp
@@ -34,23 +34,22 @@ namespace detail {
  * @tparam         weight_t             weight type
  *
  * @param[in]      handle               raft handle
- * @param[in/out]  d_edgelist_rows      vertex ids for row
- * @param[in/out]  d_edgelist_cols      vertex ids for column
+ * @param[in/out]  d_edgelist_majors    vertex IDs for rows (if the graph adjacency matrix is stored
+ * as is) or columns (if the graph adjacency matrix is stored transposed)
+ * @param[in/out]  d_edgelist_minors    vertex IDs for columns (if the graph adjacency matrix is
+ * stored as is) or rows (if the graph adjacency matrix is stored transposed)
  * @param[in/out]  d_edgelist_weights   optional edge weights
- * @param[in]      store_transposed     true if operating on
- *                                      transposed matrix
  *
- * @return tuple of shuffled rows, columns and optional weights
+ * @return tuple of shuffled major vertices, minor vertices and optional weights
  */
 template <typename vertex_t, typename weight_t>
 std::tuple<rmm::device_uvector<vertex_t>,
            rmm::device_uvector<vertex_t>,
            std::optional<rmm::device_uvector<weight_t>>>
 shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
-                         rmm::device_uvector<vertex_t>& d_edgelist_rows,
-                         rmm::device_uvector<vertex_t>& d_edgelist_cols,
-                         std::optional<rmm::device_uvector<weight_t>>& d_edgelist_weights,
-                         bool store_transposed);
+                           rmm::device_uvector<vertex_t>& d_edgelist_majors,
+                           rmm::device_uvector<vertex_t>& d_edgelist_minors,
+                           std::optional<rmm::device_uvector<weight_t>>& d_edgelist_weights);
 
 /**
  * @brief    Shuffle vertices using the vertex key function which returns the target GPU ID.
@@ -69,10 +68,11 @@ shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
  */
 template <typename vertex_t>
 rmm::device_uvector<vertex_t> shuffle_vertices_by_gpu_id(raft::handle_t const& handle,
-                                               rmm::device_uvector<vertex_t>& d_vertices);
+                                                         rmm::device_uvector<vertex_t>& d_vertices);
 
 /**
- * @brief    Groupby and count edgelist using the edge key function which returns the target local partition ID.
+ * @brief    Groupby and count edgelist using the edge key function which returns the target local
+ * partition ID.
  *
  * NOTE:  d_edgelist_rows, d_edgelist_cols and d_edgelist_weights
  *        are modified within this function (data is sorted)
@@ -84,8 +84,10 @@ rmm::device_uvector<vertex_t> shuffle_vertices_by_gpu_id(raft::handle_t const& h
  * @tparam         weight_t             weight type
  *
  * @param[in]      handle               raft handle
- * @param[in/out]  d_edgelist_rows      vertex ids for row
- * @param[in/out]  d_edgelist_cols      vertex ids for column
+ * @param[in/out]  d_edgelist_majors    vertex IDs for rows (if the graph adjacency matrix is stored
+ * as is) or columns (if the graph adjacency matrix is stored transposed)
+ * @param[in/out]  d_edgelist_minors    vertex IDs for columns (if the graph adjacency matrix is
+ * stored as is) or rows (if the graph adjacency matrix is stored transposed)
  * @param[in/out]  d_edgelist_weights   optional edge weights
  *
  * @return tuple of shuffled rows, columns and optional weights
@@ -93,8 +95,8 @@ rmm::device_uvector<vertex_t> shuffle_vertices_by_gpu_id(raft::handle_t const& h
 template <typename vertex_t, typename weight_t>
 rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   raft::handle_t const& handle,
-  rmm::device_uvector<vertex_t>& d_edgelist_rows,
-  rmm::device_uvector<vertex_t>& d_edgelist_cols,
+  rmm::device_uvector<vertex_t>& d_edgelist_majors,
+  rmm::device_uvector<vertex_t>& d_edgelist_minors,
   std::optional<rmm::device_uvector<weight_t>>& d_edgelist_weights,
   size_t number_of_local_adj_matrix_partitions);
 

--- a/cpp/src/detail/shuffle_wrappers.cu
+++ b/cpp/src/detail/shuffle_wrappers.cu
@@ -32,9 +32,9 @@ std::tuple<rmm::device_uvector<vertex_t>,
            rmm::device_uvector<vertex_t>,
            std::optional<rmm::device_uvector<weight_t>>>
 shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
-                           rmm::device_uvector<vertex_t>& d_edgelist_majors,
-                           rmm::device_uvector<vertex_t>& d_edgelist_minors,
-                           std::optional<rmm::device_uvector<weight_t>>& d_edgelist_weights)
+                           rmm::device_uvector<vertex_t>&& d_edgelist_majors,
+                           rmm::device_uvector<vertex_t>&& d_edgelist_minors,
+                           std::optional<rmm::device_uvector<weight_t>>&& d_edgelist_weights)
 {
   auto& comm               = handle.get_comms();
   auto const comm_size     = comm.get_size();
@@ -90,37 +90,37 @@ template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
                     std::optional<rmm::device_uvector<float>>>
 shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
-                           rmm::device_uvector<int32_t>& d_edgelist_majors,
-                           rmm::device_uvector<int32_t>& d_edgelist_minors,
-                           std::optional<rmm::device_uvector<float>>& d_edgelist_weights);
+                           rmm::device_uvector<int32_t>&& d_edgelist_majors,
+                           rmm::device_uvector<int32_t>&& d_edgelist_minors,
+                           std::optional<rmm::device_uvector<float>>&& d_edgelist_weights);
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
                     std::optional<rmm::device_uvector<double>>>
 shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
-                           rmm::device_uvector<int32_t>& d_edgelist_majors,
-                           rmm::device_uvector<int32_t>& d_edgelist_minors,
-                           std::optional<rmm::device_uvector<double>>& d_edgelist_weights);
+                           rmm::device_uvector<int32_t>&& d_edgelist_majors,
+                           rmm::device_uvector<int32_t>&& d_edgelist_minors,
+                           std::optional<rmm::device_uvector<double>>&& d_edgelist_weights);
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
                     std::optional<rmm::device_uvector<float>>>
 shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
-                           rmm::device_uvector<int64_t>& d_edgelist_majors,
-                           rmm::device_uvector<int64_t>& d_edgelist_minors,
-                           std::optional<rmm::device_uvector<float>>& d_edgelist_weights);
+                           rmm::device_uvector<int64_t>&& d_edgelist_majors,
+                           rmm::device_uvector<int64_t>&& d_edgelist_minors,
+                           std::optional<rmm::device_uvector<float>>&& d_edgelist_weights);
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
                     std::optional<rmm::device_uvector<double>>>
 shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
-                           rmm::device_uvector<int64_t>& d_edgelist_majors,
-                           rmm::device_uvector<int64_t>& d_edgelist_minors,
-                           std::optional<rmm::device_uvector<double>>& d_edgelist_weights);
+                           rmm::device_uvector<int64_t>&& d_edgelist_majors,
+                           rmm::device_uvector<int64_t>&& d_edgelist_minors,
+                           std::optional<rmm::device_uvector<double>>&& d_edgelist_weights);
 
 template <typename vertex_t>
 rmm::device_uvector<vertex_t> shuffle_vertices_by_gpu_id(raft::handle_t const& handle,
-                                                         rmm::device_uvector<vertex_t>& d_vertices)
+                                                         rmm::device_uvector<vertex_t>&& d_vertices)
 {
   auto& comm           = handle.get_comms();
   auto const comm_size = comm.get_size();
@@ -138,10 +138,10 @@ rmm::device_uvector<vertex_t> shuffle_vertices_by_gpu_id(raft::handle_t const& h
 }
 
 template rmm::device_uvector<int32_t> shuffle_vertices_by_gpu_id(
-  raft::handle_t const& handle, rmm::device_uvector<int32_t>& d_vertices);
+  raft::handle_t const& handle, rmm::device_uvector<int32_t>&& d_vertices);
 
 template rmm::device_uvector<int64_t> shuffle_vertices_by_gpu_id(
-  raft::handle_t const& handle, rmm::device_uvector<int64_t>& d_vertices);
+  raft::handle_t const& handle, rmm::device_uvector<int64_t>&& d_vertices);
 
 template <typename vertex_t, typename weight_t>
 rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(

--- a/cpp/src/detail/shuffle_wrappers.cu
+++ b/cpp/src/detail/shuffle_wrappers.cu
@@ -31,7 +31,7 @@ template <typename vertex_t, typename weight_t>
 std::tuple<rmm::device_uvector<vertex_t>,
            rmm::device_uvector<vertex_t>,
            std::optional<rmm::device_uvector<weight_t>>>
-shuffle_edgelist_by_edge(raft::handle_t const& handle,
+shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
                          rmm::device_uvector<vertex_t>& d_edgelist_rows,
                          rmm::device_uvector<vertex_t>& d_edgelist_cols,
                          std::optional<rmm::device_uvector<weight_t>>& d_edgelist_weights,
@@ -95,7 +95,7 @@ shuffle_edgelist_by_edge(raft::handle_t const& handle,
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
                     std::optional<rmm::device_uvector<float>>>
-shuffle_edgelist_by_edge(raft::handle_t const& handle,
+shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
                          rmm::device_uvector<int32_t>& d_edgelist_rows,
                          rmm::device_uvector<int32_t>& d_edgelist_cols,
                          std::optional<rmm::device_uvector<float>>& d_edgelist_weights,
@@ -104,7 +104,7 @@ shuffle_edgelist_by_edge(raft::handle_t const& handle,
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
                     std::optional<rmm::device_uvector<double>>>
-shuffle_edgelist_by_edge(raft::handle_t const& handle,
+shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
                          rmm::device_uvector<int32_t>& d_edgelist_rows,
                          rmm::device_uvector<int32_t>& d_edgelist_cols,
                          std::optional<rmm::device_uvector<double>>& d_edgelist_weights,
@@ -113,7 +113,7 @@ shuffle_edgelist_by_edge(raft::handle_t const& handle,
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
                     std::optional<rmm::device_uvector<float>>>
-shuffle_edgelist_by_edge(raft::handle_t const& handle,
+shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
                          rmm::device_uvector<int64_t>& d_edgelist_rows,
                          rmm::device_uvector<int64_t>& d_edgelist_cols,
                          std::optional<rmm::device_uvector<float>>& d_edgelist_weights,
@@ -122,14 +122,14 @@ shuffle_edgelist_by_edge(raft::handle_t const& handle,
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
                     std::optional<rmm::device_uvector<double>>>
-shuffle_edgelist_by_edge(raft::handle_t const& handle,
+shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
                          rmm::device_uvector<int64_t>& d_edgelist_rows,
                          rmm::device_uvector<int64_t>& d_edgelist_cols,
                          std::optional<rmm::device_uvector<double>>& d_edgelist_weights,
                          bool store_transposed);
 
 template <typename vertex_t>
-rmm::device_uvector<vertex_t> shuffle_vertices(raft::handle_t const& handle,
+rmm::device_uvector<vertex_t> shuffle_vertices_by_gpu_id(raft::handle_t const& handle,
                                                rmm::device_uvector<vertex_t>& d_vertices)
 {
   auto& comm           = handle.get_comms();
@@ -147,14 +147,14 @@ rmm::device_uvector<vertex_t> shuffle_vertices(raft::handle_t const& handle,
   return d_rx_vertices;
 }
 
-template rmm::device_uvector<int32_t> shuffle_vertices(raft::handle_t const& handle,
+template rmm::device_uvector<int32_t> shuffle_vertices_by_gpu_id(raft::handle_t const& handle,
                                                        rmm::device_uvector<int32_t>& d_vertices);
 
-template rmm::device_uvector<int64_t> shuffle_vertices(raft::handle_t const& handle,
+template rmm::device_uvector<int64_t> shuffle_vertices_by_gpu_id(raft::handle_t const& handle,
                                                        rmm::device_uvector<int64_t>& d_vertices);
 
 template <typename vertex_t, typename weight_t>
-rmm::device_uvector<size_t> groupby_and_count_by_edge(
+rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   raft::handle_t const& handle,
   rmm::device_uvector<vertex_t>& d_edgelist_rows,
   rmm::device_uvector<vertex_t>& d_edgelist_cols,
@@ -195,28 +195,28 @@ rmm::device_uvector<size_t> groupby_and_count_by_edge(
                                                          handle.get_stream());
 }
 
-template rmm::device_uvector<size_t> groupby_and_count_by_edge(
+template rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   raft::handle_t const& handle,
   rmm::device_uvector<int32_t>& d_edgelist_rows,
   rmm::device_uvector<int32_t>& d_edgelist_cols,
   std::optional<rmm::device_uvector<float>>& d_edgelist_weights,
   size_t number_of_local_adj_matrix_partitions);
 
-template rmm::device_uvector<size_t> groupby_and_count_by_edge(
+template rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   raft::handle_t const& handle,
   rmm::device_uvector<int32_t>& d_edgelist_rows,
   rmm::device_uvector<int32_t>& d_edgelist_cols,
   std::optional<rmm::device_uvector<double>>& d_edgelist_weights,
   size_t number_of_local_adj_matrix_partitions);
 
-template rmm::device_uvector<size_t> groupby_and_count_by_edge(
+template rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   raft::handle_t const& handle,
   rmm::device_uvector<int64_t>& d_edgelist_rows,
   rmm::device_uvector<int64_t>& d_edgelist_cols,
   std::optional<rmm::device_uvector<float>>& d_edgelist_weights,
   size_t number_of_local_adj_matrix_partitions);
 
-template rmm::device_uvector<size_t> groupby_and_count_by_edge(
+template rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   raft::handle_t const& handle,
   rmm::device_uvector<int64_t>& d_edgelist_rows,
   rmm::device_uvector<int64_t>& d_edgelist_cols,

--- a/cpp/src/detail/shuffle_wrappers.cu
+++ b/cpp/src/detail/shuffle_wrappers.cu
@@ -32,10 +32,9 @@ std::tuple<rmm::device_uvector<vertex_t>,
            rmm::device_uvector<vertex_t>,
            std::optional<rmm::device_uvector<weight_t>>>
 shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
-                         rmm::device_uvector<vertex_t>& d_edgelist_rows,
-                         rmm::device_uvector<vertex_t>& d_edgelist_cols,
-                         std::optional<rmm::device_uvector<weight_t>>& d_edgelist_weights,
-                         bool store_transposed)
+                           rmm::device_uvector<vertex_t>& d_edgelist_majors,
+                           rmm::device_uvector<vertex_t>& d_edgelist_minors,
+                           std::optional<rmm::device_uvector<weight_t>>& d_edgelist_weights)
 {
   auto& comm               = handle.get_comms();
   auto const comm_size     = comm.get_size();
@@ -44,24 +43,20 @@ shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
   auto& col_comm           = handle.get_subcomm(cugraph::partition_2d::key_naming_t().col_name());
   auto const col_comm_size = col_comm.get_size();
 
-  // TODO:  Make a shuffle_edges and shuffle_vertices out of these...
-  rmm::device_uvector<vertex_t> d_rx_edgelist_rows(0, handle.get_stream());
-  rmm::device_uvector<vertex_t> d_rx_edgelist_cols(0, handle.get_stream());
+  rmm::device_uvector<vertex_t> d_rx_edgelist_majors(0, handle.get_stream());
+  rmm::device_uvector<vertex_t> d_rx_edgelist_minors(0, handle.get_stream());
   std::optional<rmm::device_uvector<weight_t>> d_rx_edgelist_weights{std::nullopt};
   if (d_edgelist_weights) {
-    auto edge_first = thrust::make_zip_iterator(
-      thrust::make_tuple(store_transposed ? d_edgelist_cols.begin() : d_edgelist_rows.begin(),
-                         store_transposed ? d_edgelist_rows.begin() : d_edgelist_cols.begin(),
-                         (*d_edgelist_weights).begin()));
+    auto edge_first = thrust::make_zip_iterator(thrust::make_tuple(
+      d_edgelist_majors.begin(), d_edgelist_minors.begin(), (*d_edgelist_weights).begin()));
 
-    std::forward_as_tuple(std::tie(store_transposed ? d_rx_edgelist_cols : d_rx_edgelist_rows,
-                                   store_transposed ? d_rx_edgelist_rows : d_rx_edgelist_cols,
-                                   d_rx_edgelist_weights),
-                          std::ignore) =
+    std::forward_as_tuple(
+      std::tie(d_rx_edgelist_majors, d_rx_edgelist_minors, d_rx_edgelist_weights),
+      std::ignore) =
       cugraph::groupby_gpuid_and_shuffle_values(
         comm,  // handle.get_comms(),
         edge_first,
-        edge_first + d_edgelist_rows.size(),
+        edge_first + d_edgelist_majors.size(),
         [key_func =
            cugraph::detail::compute_gpu_id_from_edge_t<vertex_t>{
              comm_size, row_comm_size, col_comm_size}] __device__(auto val) {
@@ -70,16 +65,14 @@ shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
         handle.get_stream());
   } else {
     auto edge_first = thrust::make_zip_iterator(
-      thrust::make_tuple(store_transposed ? d_edgelist_cols.begin() : d_edgelist_rows.begin(),
-                         store_transposed ? d_edgelist_rows.begin() : d_edgelist_cols.begin()));
+      thrust::make_tuple(d_edgelist_majors.begin(), d_edgelist_minors.begin()));
 
-    std::forward_as_tuple(std::tie(store_transposed ? d_rx_edgelist_cols : d_rx_edgelist_rows,
-                                   store_transposed ? d_rx_edgelist_rows : d_rx_edgelist_cols),
+    std::forward_as_tuple(std::tie(d_rx_edgelist_majors, d_rx_edgelist_minors),
                           std::ignore) =
       cugraph::groupby_gpuid_and_shuffle_values(
         comm,  // handle.get_comms(),
         edge_first,
-        edge_first + d_edgelist_rows.size(),
+        edge_first + d_edgelist_majors.size(),
         [key_func =
            cugraph::detail::compute_gpu_id_from_edge_t<vertex_t>{
              comm_size, row_comm_size, col_comm_size}] __device__(auto val) {
@@ -88,49 +81,46 @@ shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
         handle.get_stream());
   }
 
-  return std::make_tuple(
-    std::move(d_rx_edgelist_rows), std::move(d_rx_edgelist_cols), std::move(d_rx_edgelist_weights));
+  return std::make_tuple(std::move(d_rx_edgelist_majors),
+                         std::move(d_rx_edgelist_minors),
+                         std::move(d_rx_edgelist_weights));
 }
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
                     std::optional<rmm::device_uvector<float>>>
 shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
-                         rmm::device_uvector<int32_t>& d_edgelist_rows,
-                         rmm::device_uvector<int32_t>& d_edgelist_cols,
-                         std::optional<rmm::device_uvector<float>>& d_edgelist_weights,
-                         bool store_transposed);
+                           rmm::device_uvector<int32_t>& d_edgelist_majors,
+                           rmm::device_uvector<int32_t>& d_edgelist_minors,
+                           std::optional<rmm::device_uvector<float>>& d_edgelist_weights);
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
                     std::optional<rmm::device_uvector<double>>>
 shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
-                         rmm::device_uvector<int32_t>& d_edgelist_rows,
-                         rmm::device_uvector<int32_t>& d_edgelist_cols,
-                         std::optional<rmm::device_uvector<double>>& d_edgelist_weights,
-                         bool store_transposed);
+                           rmm::device_uvector<int32_t>& d_edgelist_majors,
+                           rmm::device_uvector<int32_t>& d_edgelist_minors,
+                           std::optional<rmm::device_uvector<double>>& d_edgelist_weights);
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
                     std::optional<rmm::device_uvector<float>>>
 shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
-                         rmm::device_uvector<int64_t>& d_edgelist_rows,
-                         rmm::device_uvector<int64_t>& d_edgelist_cols,
-                         std::optional<rmm::device_uvector<float>>& d_edgelist_weights,
-                         bool store_transposed);
+                           rmm::device_uvector<int64_t>& d_edgelist_majors,
+                           rmm::device_uvector<int64_t>& d_edgelist_minors,
+                           std::optional<rmm::device_uvector<float>>& d_edgelist_weights);
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
                     std::optional<rmm::device_uvector<double>>>
 shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
-                         rmm::device_uvector<int64_t>& d_edgelist_rows,
-                         rmm::device_uvector<int64_t>& d_edgelist_cols,
-                         std::optional<rmm::device_uvector<double>>& d_edgelist_weights,
-                         bool store_transposed);
+                           rmm::device_uvector<int64_t>& d_edgelist_majors,
+                           rmm::device_uvector<int64_t>& d_edgelist_minors,
+                           std::optional<rmm::device_uvector<double>>& d_edgelist_weights);
 
 template <typename vertex_t>
 rmm::device_uvector<vertex_t> shuffle_vertices_by_gpu_id(raft::handle_t const& handle,
-                                               rmm::device_uvector<vertex_t>& d_vertices)
+                                                         rmm::device_uvector<vertex_t>& d_vertices)
 {
   auto& comm           = handle.get_comms();
   auto const comm_size = comm.get_size();
@@ -147,17 +137,17 @@ rmm::device_uvector<vertex_t> shuffle_vertices_by_gpu_id(raft::handle_t const& h
   return d_rx_vertices;
 }
 
-template rmm::device_uvector<int32_t> shuffle_vertices_by_gpu_id(raft::handle_t const& handle,
-                                                       rmm::device_uvector<int32_t>& d_vertices);
+template rmm::device_uvector<int32_t> shuffle_vertices_by_gpu_id(
+  raft::handle_t const& handle, rmm::device_uvector<int32_t>& d_vertices);
 
-template rmm::device_uvector<int64_t> shuffle_vertices_by_gpu_id(raft::handle_t const& handle,
-                                                       rmm::device_uvector<int64_t>& d_vertices);
+template rmm::device_uvector<int64_t> shuffle_vertices_by_gpu_id(
+  raft::handle_t const& handle, rmm::device_uvector<int64_t>& d_vertices);
 
 template <typename vertex_t, typename weight_t>
 rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   raft::handle_t const& handle,
-  rmm::device_uvector<vertex_t>& d_edgelist_rows,
-  rmm::device_uvector<vertex_t>& d_edgelist_cols,
+  rmm::device_uvector<vertex_t>& d_edgelist_majors,
+  rmm::device_uvector<vertex_t>& d_edgelist_minors,
   std::optional<rmm::device_uvector<weight_t>>& d_edgelist_weights,
   size_t number_of_local_adj_matrix_partitions)
 {
@@ -179,17 +169,17 @@ rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
              comm_size;  // global partition id to local partition id
     };
 
-  auto pair_first =
-    thrust::make_zip_iterator(thrust::make_tuple(d_edgelist_rows.begin(), d_edgelist_cols.begin()));
+  auto pair_first = thrust::make_zip_iterator(
+    thrust::make_tuple(d_edgelist_majors.begin(), d_edgelist_minors.begin()));
 
   return d_edgelist_weights ? cugraph::groupby_and_count(pair_first,
-                                                         pair_first + d_edgelist_rows.size(),
+                                                         pair_first + d_edgelist_majors.size(),
                                                          d_edgelist_weights->begin(),
                                                          local_partition_id_op,
                                                          number_of_local_adj_matrix_partitions,
                                                          handle.get_stream())
                             : cugraph::groupby_and_count(pair_first,
-                                                         pair_first + d_edgelist_rows.size(),
+                                                         pair_first + d_edgelist_majors.size(),
                                                          local_partition_id_op,
                                                          number_of_local_adj_matrix_partitions,
                                                          handle.get_stream());
@@ -197,29 +187,29 @@ rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
 
 template rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   raft::handle_t const& handle,
-  rmm::device_uvector<int32_t>& d_edgelist_rows,
-  rmm::device_uvector<int32_t>& d_edgelist_cols,
+  rmm::device_uvector<int32_t>& d_edgelist_majors,
+  rmm::device_uvector<int32_t>& d_edgelist_minors,
   std::optional<rmm::device_uvector<float>>& d_edgelist_weights,
   size_t number_of_local_adj_matrix_partitions);
 
 template rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   raft::handle_t const& handle,
-  rmm::device_uvector<int32_t>& d_edgelist_rows,
-  rmm::device_uvector<int32_t>& d_edgelist_cols,
+  rmm::device_uvector<int32_t>& d_edgelist_majors,
+  rmm::device_uvector<int32_t>& d_edgelist_minors,
   std::optional<rmm::device_uvector<double>>& d_edgelist_weights,
   size_t number_of_local_adj_matrix_partitions);
 
 template rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   raft::handle_t const& handle,
-  rmm::device_uvector<int64_t>& d_edgelist_rows,
-  rmm::device_uvector<int64_t>& d_edgelist_cols,
+  rmm::device_uvector<int64_t>& d_edgelist_majors,
+  rmm::device_uvector<int64_t>& d_edgelist_minors,
   std::optional<rmm::device_uvector<float>>& d_edgelist_weights,
   size_t number_of_local_adj_matrix_partitions);
 
 template rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   raft::handle_t const& handle,
-  rmm::device_uvector<int64_t>& d_edgelist_rows,
-  rmm::device_uvector<int64_t>& d_edgelist_cols,
+  rmm::device_uvector<int64_t>& d_edgelist_majors,
+  rmm::device_uvector<int64_t>& d_edgelist_minors,
   std::optional<rmm::device_uvector<double>>& d_edgelist_weights,
   size_t number_of_local_adj_matrix_partitions);
 

--- a/cpp/src/structure/coarsen_graph.cu
+++ b/cpp/src/structure/coarsen_graph.cu
@@ -297,7 +297,7 @@ coarsen_graph(
     // 1-2. globally shuffle
 
     std::tie(edgelist_major_vertices, edgelist_minor_vertices, edgelist_weights) =
-      cugraph::detail::shuffle_edgelist_by_edge(
+      cugraph::detail::shuffle_edgelist_by_gpu_id(
         handle, edgelist_major_vertices, edgelist_minor_vertices, edgelist_weights, false);
 
     // 1-3. append data to local adjacency matrix partitions
@@ -306,7 +306,7 @@ coarsen_graph(
     // list based on the final matrix partition (maybe add
     // groupby_adj_matrix_partition_and_shuffle_values).
 
-    auto counts = cugraph::detail::groupby_and_count_by_edge(
+    auto counts = cugraph::detail::groupby_and_count_edgelist_by_local_partition_id(
       handle,
       edgelist_major_vertices,
       edgelist_minor_vertices,
@@ -407,7 +407,7 @@ coarsen_graph(
                                     unique_labels.end())),
     handle.get_stream());
 
-  unique_labels = cugraph::detail::shuffle_vertices(handle, unique_labels);
+  unique_labels = cugraph::detail::shuffle_vertices_by_gpu_id(handle, unique_labels);
 
   thrust::sort(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
                unique_labels.begin(),

--- a/cpp/src/structure/coarsen_graph.cu
+++ b/cpp/src/structure/coarsen_graph.cu
@@ -445,6 +445,7 @@ coarsen_graph(
         major_ptrs,
         minor_ptrs,
         counts,
+        std::nullopt,
         do_expensive_check);
   }
 

--- a/cpp/src/structure/coarsen_graph.cu
+++ b/cpp/src/structure/coarsen_graph.cu
@@ -298,7 +298,7 @@ coarsen_graph(
 
     std::tie(edgelist_major_vertices, edgelist_minor_vertices, edgelist_weights) =
       cugraph::detail::shuffle_edgelist_by_gpu_id(
-        handle, edgelist_major_vertices, edgelist_minor_vertices, edgelist_weights, false);
+        handle, edgelist_major_vertices, edgelist_minor_vertices, edgelist_weights);
 
     // 1-3. append data to local adjacency matrix partitions
 

--- a/cpp/src/structure/coarsen_graph.cu
+++ b/cpp/src/structure/coarsen_graph.cu
@@ -297,8 +297,10 @@ coarsen_graph(
     // 1-2. globally shuffle
 
     std::tie(edgelist_major_vertices, edgelist_minor_vertices, edgelist_weights) =
-      cugraph::detail::shuffle_edgelist_by_gpu_id(
-        handle, edgelist_major_vertices, edgelist_minor_vertices, edgelist_weights);
+      cugraph::detail::shuffle_edgelist_by_gpu_id(handle,
+                                                  std::move(edgelist_major_vertices),
+                                                  std::move(edgelist_minor_vertices),
+                                                  std::move(edgelist_weights));
 
     // 1-3. append data to local adjacency matrix partitions
 
@@ -403,7 +405,7 @@ coarsen_graph(
                                     unique_labels.end())),
     handle.get_stream());
 
-  unique_labels = cugraph::detail::shuffle_vertices_by_gpu_id(handle, unique_labels);
+  unique_labels = cugraph::detail::shuffle_vertices_by_gpu_id(handle, std::move(unique_labels));
 
   thrust::sort(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
                unique_labels.begin(),

--- a/cpp/src/structure/coarsen_graph.cu
+++ b/cpp/src/structure/coarsen_graph.cu
@@ -307,11 +307,7 @@ coarsen_graph(
     // groupby_adj_matrix_partition_and_shuffle_values).
 
     auto counts = cugraph::detail::groupby_and_count_edgelist_by_local_partition_id(
-      handle,
-      edgelist_major_vertices,
-      edgelist_minor_vertices,
-      edgelist_weights,
-      graph_view.get_number_of_local_adj_matrix_partitions());
+      handle, edgelist_major_vertices, edgelist_minor_vertices, edgelist_weights);
 
     std::vector<size_t> h_counts(counts.size());
     raft::update_host(h_counts.data(), counts.data(), counts.size(), handle.get_stream());

--- a/cpp/src/structure/create_graph_from_edgelist.cpp
+++ b/cpp/src/structure/create_graph_from_edgelist.cpp
@@ -60,7 +60,6 @@ create_graph_from_edgelist_impl(
   auto const col_comm_size = col_comm.get_size();
 
   // 1. groupby edges to their target local adjacency matrix partition
-  std::cout << "create_graph_from_edgelist_impl 1. groupby" << std::endl;
 
   auto edge_counts = cugraph::detail::groupby_and_count_edgelist_by_local_partition_id(
     handle,
@@ -92,7 +91,6 @@ create_graph_from_edgelist_impl(
                    edgelist_displacements.begin() + 1);
 
   // 2. renumber
-  std::cout << "create_graph_from_edgelist_impl 2. renumber" << std::endl;
 
   rmm::device_uvector<vertex_t> renumber_map_labels(0, handle.get_stream());
   cugraph::partition_t<vertex_t> partition{};
@@ -123,7 +121,6 @@ create_graph_from_edgelist_impl(
   }
 
   // 3. create a graph
-  std::cout << "create_graph_from_edgelist_impl 3. create graph" << std::endl;
 
   std::vector<cugraph::edgelist_t<vertex_t, edge_t, weight_t>> edgelists(col_comm_size);
   for (int i = 0; i < col_comm_size; ++i) {

--- a/cpp/src/structure/create_graph_from_edgelist.cpp
+++ b/cpp/src/structure/create_graph_from_edgelist.cpp
@@ -66,8 +66,7 @@ create_graph_from_edgelist_impl(
     handle,
     store_transposed ? edgelist_cols : edgelist_rows,
     store_transposed ? edgelist_rows : edgelist_cols,
-    edgelist_weights,
-    col_comm_size);
+    edgelist_weights);
 
   std::vector<size_t> h_edge_counts(edge_counts.size());
   raft::update_host(

--- a/cpp/src/structure/create_graph_from_edgelist.cpp
+++ b/cpp/src/structure/create_graph_from_edgelist.cpp
@@ -59,8 +59,11 @@ create_graph_from_edgelist_impl(
   auto& col_comm           = handle.get_subcomm(cugraph::partition_2d::key_naming_t().col_name());
   auto const col_comm_size = col_comm.get_size();
 
+  // 1. groupby edges to their target local adjacency matrix partition
+std::cout << "create_graph_from_edgelist_impl 1. groupby" << std::endl;
+
   auto edge_counts =
-    cugraph::detail::groupby_and_count_by_edge(handle,
+    cugraph::detail::groupby_and_count_edgelist_by_local_partition_id(handle,
                                                store_transposed ? edgelist_cols : edgelist_rows,
                                                store_transposed ? edgelist_rows : edgelist_cols,
                                                edgelist_weights,
@@ -74,7 +77,8 @@ create_graph_from_edgelist_impl(
   std::vector<size_t> h_displacements(h_edge_counts.size(), size_t{0});
   std::partial_sum(h_edge_counts.begin(), h_edge_counts.end() - 1, h_displacements.begin() + 1);
 
-  // 3. renumber
+  // 2. renumber
+std::cout << "create_graph_from_edgelist_impl 2. renumber" << std::endl;
 
   rmm::device_uvector<vertex_t> renumber_map_labels(0, handle.get_stream());
   cugraph::partition_t<vertex_t> partition{};
@@ -98,7 +102,8 @@ create_graph_from_edgelist_impl(
         handle, optional_local_vertex_span, major_ptrs, minor_ptrs, counts);
   }
 
-  // 4. create a graph
+  // 3. create a graph
+std::cout << "create_graph_from_edgelist_impl 3. create graph" << std::endl;
 
   std::vector<cugraph::edgelist_t<vertex_t, edge_t, weight_t>> edgelists(h_edge_counts.size());
   for (size_t i = 0; i < h_edge_counts.size(); ++i) {

--- a/cpp/src/structure/create_graph_from_edgelist.cpp
+++ b/cpp/src/structure/create_graph_from_edgelist.cpp
@@ -66,15 +66,30 @@ create_graph_from_edgelist_impl(
     handle,
     store_transposed ? edgelist_cols : edgelist_rows,
     store_transposed ? edgelist_rows : edgelist_cols,
-    edgelist_weights);
+    edgelist_weights,
+    true);
 
   std::vector<size_t> h_edge_counts(edge_counts.size());
   raft::update_host(
     h_edge_counts.data(), edge_counts.data(), edge_counts.size(), handle.get_stream());
   handle.get_stream_view().synchronize();
 
-  std::vector<size_t> h_displacements(h_edge_counts.size(), size_t{0});
-  std::partial_sum(h_edge_counts.begin(), h_edge_counts.end() - 1, h_displacements.begin() + 1);
+  std::vector<edge_t> edgelist_edge_counts(col_comm_size, edge_t{0});
+  auto edgelist_intra_partition_segment_offsets =
+    std::make_optional<std::vector<std::vector<edge_t>>>(
+      col_comm_size, std::vector<edge_t>(row_comm_size + 1, edge_t{0}));
+  for (int i = 0; i < col_comm_size; ++i) {
+    edgelist_edge_counts[i] = std::accumulate(h_edge_counts.begin() + row_comm_size * i,
+                                              h_edge_counts.begin() + row_comm_size * (i + 1),
+                                              edge_t{0});
+    std::partial_sum(h_edge_counts.begin() + row_comm_size * i,
+                     h_edge_counts.begin() + row_comm_size * (i + 1),
+                     (*edgelist_intra_partition_segment_offsets)[i].begin() + 1);
+  }
+  std::vector<edge_t> edgelist_displacements(col_comm_size, edge_t{0});
+  std::partial_sum(edgelist_edge_counts.begin(),
+                   edgelist_edge_counts.end() - 1,
+                   edgelist_displacements.begin() + 1);
 
   // 2. renumber
   std::cout << "create_graph_from_edgelist_impl 2. renumber" << std::endl;
@@ -83,36 +98,42 @@ create_graph_from_edgelist_impl(
   cugraph::partition_t<vertex_t> partition{};
   vertex_t number_of_vertices{};
   edge_t number_of_edges{};
-  auto segment_offsets = std::make_optional<std::vector<vertex_t>>(0);
+  auto vertex_partition_segment_offsets = std::make_optional<std::vector<vertex_t>>(0);
   {
-    std::vector<vertex_t*> major_ptrs(h_edge_counts.size());
+    std::vector<vertex_t*> major_ptrs(col_comm_size);
     std::vector<vertex_t*> minor_ptrs(major_ptrs.size());
-    std::vector<edge_t> counts(major_ptrs.size());
-    for (size_t i = 0; i < h_edge_counts.size(); ++i) {
-      major_ptrs[i] =
-        (store_transposed ? edgelist_cols.begin() : edgelist_rows.begin()) + h_displacements[i];
-      minor_ptrs[i] =
-        (store_transposed ? edgelist_rows.begin() : edgelist_cols.begin()) + h_displacements[i];
-      counts[i] = static_cast<edge_t>(h_edge_counts[i]);
+    for (int i = 0; i < col_comm_size; ++i) {
+      major_ptrs[i] = (store_transposed ? edgelist_cols.begin() : edgelist_rows.begin()) +
+                      edgelist_displacements[i];
+      minor_ptrs[i] = (store_transposed ? edgelist_rows.begin() : edgelist_cols.begin()) +
+                      edgelist_displacements[i];
     }
-    std::tie(
-      renumber_map_labels, partition, number_of_vertices, number_of_edges, *segment_offsets) =
+    std::tie(renumber_map_labels,
+             partition,
+             number_of_vertices,
+             number_of_edges,
+             *vertex_partition_segment_offsets) =
       cugraph::renumber_edgelist<vertex_t, edge_t, multi_gpu>(
-        handle, local_vertex_span, major_ptrs, minor_ptrs, counts, std::nullopt);
+        handle,
+        local_vertex_span,
+        major_ptrs,
+        minor_ptrs,
+        edgelist_edge_counts,
+        edgelist_intra_partition_segment_offsets);
   }
 
   // 3. create a graph
   std::cout << "create_graph_from_edgelist_impl 3. create graph" << std::endl;
 
-  std::vector<cugraph::edgelist_t<vertex_t, edge_t, weight_t>> edgelists(h_edge_counts.size());
-  for (size_t i = 0; i < h_edge_counts.size(); ++i) {
+  std::vector<cugraph::edgelist_t<vertex_t, edge_t, weight_t>> edgelists(col_comm_size);
+  for (int i = 0; i < col_comm_size; ++i) {
     edgelists[i] = cugraph::edgelist_t<vertex_t, edge_t, weight_t>{
-      edgelist_rows.data() + h_displacements[i],
-      edgelist_cols.data() + h_displacements[i],
+      edgelist_rows.data() + edgelist_displacements[i],
+      edgelist_cols.data() + edgelist_displacements[i],
       edgelist_weights
-        ? std::optional<weight_t const*>{(*edgelist_weights).data() + h_displacements[i]}
+        ? std::optional<weight_t const*>{(*edgelist_weights).data() + edgelist_displacements[i]}
         : std::nullopt,
-      static_cast<edge_t>(h_edge_counts[i])};
+      static_cast<edge_t>(edgelist_edge_counts[i])};
   }
 
   return std::make_tuple(
@@ -123,7 +144,7 @@ create_graph_from_edgelist_impl(
       number_of_vertices,
       number_of_edges,
       graph_properties,
-      std::optional<std::vector<vertex_t>>{segment_offsets}),
+      vertex_partition_segment_offsets),
     std::optional<rmm::device_uvector<vertex_t>>{std::move(renumber_map_labels)});
 }
 

--- a/cpp/src/structure/create_graph_from_edgelist.cpp
+++ b/cpp/src/structure/create_graph_from_edgelist.cpp
@@ -60,14 +60,14 @@ create_graph_from_edgelist_impl(
   auto const col_comm_size = col_comm.get_size();
 
   // 1. groupby edges to their target local adjacency matrix partition
-std::cout << "create_graph_from_edgelist_impl 1. groupby" << std::endl;
+  std::cout << "create_graph_from_edgelist_impl 1. groupby" << std::endl;
 
-  auto edge_counts =
-    cugraph::detail::groupby_and_count_edgelist_by_local_partition_id(handle,
-                                               store_transposed ? edgelist_cols : edgelist_rows,
-                                               store_transposed ? edgelist_rows : edgelist_cols,
-                                               edgelist_weights,
-                                               col_comm_size);
+  auto edge_counts = cugraph::detail::groupby_and_count_edgelist_by_local_partition_id(
+    handle,
+    store_transposed ? edgelist_cols : edgelist_rows,
+    store_transposed ? edgelist_rows : edgelist_cols,
+    edgelist_weights,
+    col_comm_size);
 
   std::vector<size_t> h_edge_counts(edge_counts.size());
   raft::update_host(
@@ -78,7 +78,7 @@ std::cout << "create_graph_from_edgelist_impl 1. groupby" << std::endl;
   std::partial_sum(h_edge_counts.begin(), h_edge_counts.end() - 1, h_displacements.begin() + 1);
 
   // 2. renumber
-std::cout << "create_graph_from_edgelist_impl 2. renumber" << std::endl;
+  std::cout << "create_graph_from_edgelist_impl 2. renumber" << std::endl;
 
   rmm::device_uvector<vertex_t> renumber_map_labels(0, handle.get_stream());
   cugraph::partition_t<vertex_t> partition{};
@@ -103,7 +103,7 @@ std::cout << "create_graph_from_edgelist_impl 2. renumber" << std::endl;
   }
 
   // 3. create a graph
-std::cout << "create_graph_from_edgelist_impl 3. create graph" << std::endl;
+  std::cout << "create_graph_from_edgelist_impl 3. create graph" << std::endl;
 
   std::vector<cugraph::edgelist_t<vertex_t, edge_t, weight_t>> edgelists(h_edge_counts.size());
   for (size_t i = 0; i < h_edge_counts.size(); ++i) {

--- a/cpp/src/structure/create_graph_from_edgelist.cpp
+++ b/cpp/src/structure/create_graph_from_edgelist.cpp
@@ -59,7 +59,8 @@ create_graph_from_edgelist_impl(
   auto& col_comm           = handle.get_subcomm(cugraph::partition_2d::key_naming_t().col_name());
   auto const col_comm_size = col_comm.get_size();
 
-  // 1. groupby edges to their target local adjacency matrix partition
+  // 1. groupby edges to their target local adjacency matrix partition (and further groupby within
+  // the local partition by applying the compute_gpu_id_from_vertex_t to minor vertex IDs).
 
   auto edge_counts = cugraph::detail::groupby_and_count_edgelist_by_local_partition_id(
     handle,

--- a/cpp/src/structure/renumber_edgelist.cu
+++ b/cpp/src/structure/renumber_edgelist.cu
@@ -751,7 +751,6 @@ renumber_edgelist(
   handle.get_stream_view().synchronize();
   comm.barrier();  // currently, this is ncclAllReduce
 #endif
-  std::cout << "renumber_edgelist mnior start" << std::endl;
   if ((partition.get_matrix_partition_minor_size() >= number_of_edges / comm_size) &&
       edgelist_intra_partition_segment_offsets) {  // memory footprint dominated by the O(V/sqrt(P))
                                                    // part than the O(E/P) part
@@ -831,7 +830,6 @@ renumber_edgelist(
                         edgelist_minor_vertices[i]);
     }
   }
-  std::cout << "renumber_edgelist mnior end" << std::endl;
   // barrier is necessary here to avoid potential overlap (which can leads to deadlock) between two
   // different communicators (end of row_comm)
 #if 1

--- a/cpp/src/utilities/cython.cu
+++ b/cpp/src/utilities/cython.cu
@@ -1215,8 +1215,13 @@ std::unique_ptr<renum_tuple_t<vertex_t, edge_t>> call_renumber(
              p_ret->get_num_vertices(),
              p_ret->get_num_edges(),
              p_ret->get_segment_offsets()) =
-      cugraph::renumber_edgelist<vertex_t, edge_t, true>(
-        handle, std::nullopt, major_ptrs, minor_ptrs, edge_counts, do_expensive_check);
+      cugraph::renumber_edgelist<vertex_t, edge_t, true>(handle,
+                                                         std::nullopt,
+                                                         major_ptrs,
+                                                         minor_ptrs,
+                                                         edge_counts,
+                                                         std::nullopt,
+                                                         do_expensive_check);
   } else {
     std::tie(p_ret->get_dv(), p_ret->get_segment_offsets()) =
       cugraph::renumber_edgelist<vertex_t, edge_t, false>(handle,

--- a/cpp/tests/utilities/rmat_utilities.cpp
+++ b/cpp/tests/utilities/rmat_utilities.cpp
@@ -154,11 +154,13 @@ generate_graph_from_rmat_params(raft::handle_t const& handle,
   }
 
   if (multi_gpu) {
-    std::tie(d_edgelist_rows, d_edgelist_cols, d_edgelist_weights) =
+    std::tie(store_transposed ? d_edgelist_cols : d_edgelist_rows,
+             store_transposed ? d_edgelist_rows : d_edgelist_cols,
+             d_edgelist_weights) =
       cugraph::detail::shuffle_edgelist_by_gpu_id(
         handle,
         store_transposed ? std::move(d_edgelist_cols) : std::move(d_edgelist_rows),
-        store_transposed ? std::move(d_edgelist_cols) : std::move(d_edgelist_rows),
+        store_transposed ? std::move(d_edgelist_rows) : std::move(d_edgelist_cols),
         std::move(d_edgelist_weights));
   }
 

--- a/cpp/tests/utilities/rmat_utilities.cpp
+++ b/cpp/tests/utilities/rmat_utilities.cpp
@@ -156,7 +156,10 @@ generate_graph_from_rmat_params(raft::handle_t const& handle,
   if (multi_gpu) {
     std::tie(d_edgelist_rows, d_edgelist_cols, d_edgelist_weights) =
       cugraph::detail::shuffle_edgelist_by_gpu_id(
-        handle, d_edgelist_rows, d_edgelist_cols, d_edgelist_weights, store_transposed);
+        handle,
+        store_transposed ? d_edgelist_cols : d_edgelist_rows,
+        store_transposed ? d_edgelist_cols : d_edgelist_rows,
+        d_edgelist_weights);
   }
 
   rmm::device_uvector<vertex_t> d_vertices(0, handle.get_stream());

--- a/cpp/tests/utilities/rmat_utilities.cpp
+++ b/cpp/tests/utilities/rmat_utilities.cpp
@@ -155,7 +155,7 @@ generate_graph_from_rmat_params(raft::handle_t const& handle,
 
   if (multi_gpu) {
     std::tie(d_edgelist_rows, d_edgelist_cols, d_edgelist_weights) =
-      cugraph::detail::shuffle_edgelist_by_edge(
+      cugraph::detail::shuffle_edgelist_by_gpu_id(
         handle, d_edgelist_rows, d_edgelist_cols, d_edgelist_weights, store_transposed);
   }
 
@@ -172,7 +172,7 @@ generate_graph_from_rmat_params(raft::handle_t const& handle,
                                    partition_vertex_firsts[i]);
   }
 
-  if (multi_gpu) { d_vertices = cugraph::detail::shuffle_vertices(handle, d_vertices); }
+  if (multi_gpu) { d_vertices = cugraph::detail::shuffle_vertices_by_gpu_id(handle, d_vertices); }
 
   return cugraph::
     create_graph_from_edgelist<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>(


### PR DESCRIPTION
Partially addresses Issue https://github.com/rapidsai/cugraph/issues/1477

With the R-mat edge factor of 1 and a DGX machine with 8 GV100 GPUs (32 GB memory each), this PR improves the maximum R-mat scale we can run on the system from 30 to 31 (64 bit vertex & edge IDs).

This PR also includes few code refinements.

Key updates related to memory footprint improvements are in 
1) ```groupby_and_count_edgelist_by_local_partition_id``` (to allow optionally further groupby within a local partition by applying the compute_gpu_id_from_vertex_t to minor vertex IDs)
2) https://github.com/rapidsai/cugraph/pull/1769/files#diff-b8f50bff203b70295af567b06f68707dbd163c791e2630f8f21d4ad4b56f5262R754-R794 (renumber minor vertex IDs of each local partition in segments to limit the memory requirement).

One additional PR will be necessary to push memory bottleneck to row/column properties allocation (which currently requires O(V/sqrt(P)).
And there will be a separate PR to improve memory footprint of row/column properties when O(V/sqrt(P)) > O(E/P).