### PR TITLE
Fix unused variables/parameters warnings

### DIFF
--- a/cpp/src/centrality/betweenness_centrality.cu
+++ b/cpp/src/centrality/betweenness_centrality.cu
@@ -66,7 +66,7 @@ void edge_betweenness_centrality_impl(raft::handle_t const& handle,
                                       weight_t const* weight,
                                       vertex_t number_of_sources,
                                       vertex_t const* sources,
-                                      vertex_t total_number_of_sources)
+                                      vertex_t /* total_number_of_sources */)
 {
   // Current Implementation relies on BFS
   // FIXME: For SSSP version

--- a/cpp/src/community/legacy/egonet.cu
+++ b/cpp/src/community/legacy/egonet.cu
@@ -66,7 +66,6 @@ extract(raft::handle_t const& handle,
         vertex_t radius)
 {
   auto v                = csr_view.get_number_of_vertices();
-  auto e                = csr_view.get_number_of_edges();
   auto user_stream_view = handle.get_stream_view();
   rmm::device_vector<size_t> neighbors_offsets(n_subgraphs + 1);
   rmm::device_vector<vertex_t> neighbors;

--- a/cpp/src/components/weakly_connected_components.cu
+++ b/cpp/src/components/weakly_connected_components.cu
@@ -183,7 +183,7 @@ struct v_op_t {
 
   template <bool multi_gpu = GraphViewType::is_multi_gpu>
   __device__ std::enable_if_t<multi_gpu, thrust::optional<thrust::tuple<size_t, std::byte>>>
-  operator()(thrust::tuple<vertex_type, vertex_type> tagged_v, int v_val /* dummy */) const
+  operator()(thrust::tuple<vertex_type, vertex_type> tagged_v, int /* v_val */) const
   {
     auto tag = thrust::get<1>(tagged_v);
     auto v_offset =
@@ -205,7 +205,7 @@ struct v_op_t {
 
   template <bool multi_gpu = GraphViewType::is_multi_gpu>
   __device__ std::enable_if_t<!multi_gpu, thrust::optional<thrust::tuple<size_t, std::byte>>>
-  operator()(thrust::tuple<vertex_type, vertex_type> tagged_v, int v_val /* dummy */) const
+  operator()(thrust::tuple<vertex_type, vertex_type> /* tagged_v */, int /* v_val */) const
   {
     return thrust::optional<thrust::tuple<size_t, std::byte>>{
       thrust::make_tuple(next_bucket_idx, std::byte{0} /* dummy */)};

--- a/cpp/src/components/weakly_connected_components.cu
+++ b/cpp/src/components/weakly_connected_components.cu
@@ -549,10 +549,8 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
          col_first      = level_graph_view.get_local_adj_matrix_partition_col_first(),
          edge_buffer_first =
            get_dataframe_buffer_begin<thrust::tuple<vertex_t, vertex_t>>(edge_buffer),
-         num_edge_inserts = num_edge_inserts.data()] __device__(auto tagged_src,
-                                                                vertex_t dst,
-                                                                auto src_val,
-                                                                auto dst_val) {
+         num_edge_inserts =
+           num_edge_inserts.data()] __device__(auto tagged_src, vertex_t dst, auto, auto) {
           auto tag        = thrust::get<1>(tagged_src);
           auto col_offset = dst - col_first;
           // FIXME: better switch to atomic_ref after

--- a/cpp/src/structure/graph.cu
+++ b/cpp/src/structure/graph.cu
@@ -68,8 +68,8 @@ compress_edgelist(edgelist_t<vertex_t, edge_t, weight_t> const& edgelist,
                   vertex_t major_first,
                   std::optional<vertex_t> major_hypersparse_first,
                   vertex_t major_last,
-                  vertex_t minor_first,
-                  vertex_t minor_last,
+                  vertex_t /* minor_first */,
+                  vertex_t /* minor_last */,
                   rmm::cuda_stream_view stream_view)
 {
   rmm::device_uvector<edge_t> offsets((major_last - major_first) + 1, stream_view);

--- a/cpp/src/structure/graph_view.cu
+++ b/cpp/src/structure/graph_view.cu
@@ -94,9 +94,7 @@ rmm::device_uvector<edge_t> compute_minor_degrees(
       graph_view,
       thrust::make_constant_iterator(0) /* dummy */,
       thrust::make_constant_iterator(0) /* dummy */,
-      [] __device__(vertex_t src, vertex_t dst, weight_t w, auto src_val, auto dst_val) {
-        return edge_t{1};
-      },
+      [] __device__(vertex_t, vertex_t, weight_t, auto, auto) { return edge_t{1}; },
       edge_t{0},
       minor_degrees.data());
   } else {
@@ -105,9 +103,7 @@ rmm::device_uvector<edge_t> compute_minor_degrees(
       graph_view,
       thrust::make_constant_iterator(0) /* dummy */,
       thrust::make_constant_iterator(0) /* dummy */,
-      [] __device__(vertex_t src, vertex_t dst, weight_t w, auto src_val, auto dst_val) {
-        return edge_t{1};
-      },
+      [] __device__(vertex_t, vertex_t, weight_t, auto, auto) { return edge_t{1}; },
       edge_t{0},
       minor_degrees.data());
   }
@@ -133,9 +129,7 @@ rmm::device_uvector<weight_t> compute_weight_sums(
       graph_view,
       thrust::make_constant_iterator(0) /* dummy */,
       thrust::make_constant_iterator(0) /* dummy */,
-      [] __device__(vertex_t src, vertex_t dst, weight_t w, auto src_val, auto dst_val) {
-        return w;
-      },
+      [] __device__(vertex_t, vertex_t, weight_t w, auto, auto) { return w; },
       weight_t{0.0},
       weight_sums.data());
   } else {
@@ -144,9 +138,7 @@ rmm::device_uvector<weight_t> compute_weight_sums(
       graph_view,
       thrust::make_constant_iterator(0) /* dummy */,
       thrust::make_constant_iterator(0) /* dummy */,
-      [] __device__(vertex_t src, vertex_t dst, weight_t w, auto src_val, auto dst_val) {
-        return w;
-      },
+      [] __device__(vertex_t, vertex_t, weight_t w, auto, auto) { return w; },
       weight_t{0.0},
       weight_sums.data());
   }


### PR DESCRIPTION
CUDA 11.4 reports additional warnings. Fix cuGraph warnings in this PR (still, there are many warnings coming from RAFT).