### PR TITLE
Temporarily pin RMM while refactor removes deprecated calls

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -58,7 +58,7 @@ gpuci_logger "Install dependencies"
 gpuci_mamba_retry install -y \
       "libcudf=${MINOR_VERSION}" \
       "cudf=${MINOR_VERSION}" \
-      "librmm=21.10.00a210813" \
+      "librmm=21.10.00a210812" \
       "rmm=21.10.00a210813" \
       "cudatoolkit=$CUDA_REL" \
       "dask-cudf=${MINOR_VERSION}" \

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -53,12 +53,13 @@ gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 
+# FIXME: return librmm and RMM to ${MINOR_VERSION}
 gpuci_logger "Install dependencies"
 gpuci_mamba_retry install -y \
       "libcudf=${MINOR_VERSION}" \
       "cudf=${MINOR_VERSION}" \
-      "librmm=${MINOR_VERSION}" \
-      "rmm=${MINOR_VERSION}" \
+      "librmm=21.10.00a210813" \
+      "rmm=21.10.00a210813" \
       "cudatoolkit=$CUDA_REL" \
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \

--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -9,7 +9,7 @@ dependencies:
 - cudf=21.10.*
 - libcudf=21.10.*
 - rmm=21.10.00a210813
-- librmm=21.10.00a210813
+- librmm=21.10.00a210812
 - dask>=2021.6.0
 - distributed>=2021.6.0
 - dask-cuda=21.10.*

--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -8,8 +8,8 @@ dependencies:
 - cudatoolkit=11.0
 - cudf=21.10.*
 - libcudf=21.10.*
-- rmm=21.10.*
-- librmm=21.10.*
+- rmm=21.10.00a210813
+- librmm=21.10.00a210813
 - dask>=2021.6.0
 - distributed>=2021.6.0
 - dask-cuda=21.10.*

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -9,7 +9,7 @@ dependencies:
 - cudf=21.10.*
 - libcudf=21.10.*
 - rmm=21.10.00a210813
-- librmm=21.10.00a210813
+- librmm=21.10.00a210812
 - dask>=2021.6.0
 - distributed>=2021.6.0
 - dask-cuda=21.10.*

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -8,8 +8,8 @@ dependencies:
 - cudatoolkit=11.2
 - cudf=21.10.*
 - libcudf=21.10.*
-- rmm=21.10.*
-- librmm=21.10.*
+- rmm=21.10.00a210813
+- librmm=21.10.00a210813
 - dask>=2021.6.0
 - distributed>=2021.6.0
 - dask-cuda=21.10.*

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -34,7 +34,7 @@ requirements:
   build:
     - cmake>=3.20.1
     - cudatoolkit {{ cuda_version }}.*
-    - librmm=21.10.00a210813
+    - librmm=21.10.00a210812
     - boost-cpp>=1.66
     - nccl>=2.9.9
     - ucx-proc=*=gpu

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -29,11 +29,12 @@ build:
     - CMAKE_CXX_COMPILER_LAUNCHER
     - CMAKE_CUDA_COMPILER_LAUNCHER
 
+# FIXME: return librmm to {{ minor_version }}.*
 requirements:
   build:
     - cmake>=3.20.1
     - cudatoolkit {{ cuda_version }}.*
-    - librmm {{ minor_version }}.*
+    - librmm=21.10.00a210813
     - boost-cpp>=1.66
     - nccl>=2.9.9
     - ucx-proc=*=gpu

--- a/cpp/cmake/thirdparty/get_rmm.cmake
+++ b/cpp/cmake/thirdparty/get_rmm.cmake
@@ -26,6 +26,8 @@ function(find_and_configure_rmm VERSION)
         return()
     endif()
 
+    # FIXME: turn GIT_SHALLOW back to TRUE when changing GIT_TAG back
+    # to branch-${MAJOR_AND_MINOR}
     rapids_cpm_find(rmm ${VERSION}
         GLOBAL_TARGETS      rmm::rmm
         BUILD_EXPORT_SET    cugraph-exports

--- a/cpp/cmake/thirdparty/get_rmm.cmake
+++ b/cpp/cmake/thirdparty/get_rmm.cmake
@@ -32,8 +32,8 @@ function(find_and_configure_rmm VERSION)
         INSTALL_EXPORT_SET  cugraph-exports
         CPM_ARGS
             GIT_REPOSITORY  https://github.com/rapidsai/rmm.git
-            GIT_TAG         branch-${MAJOR_AND_MINOR}
-            GIT_SHALLOW     TRUE
+            GIT_TAG         23bbe745af1d988224b5498f7b8e3fe3720532d4
+            GIT_SHALLOW     FALSE
             OPTIONS         "BUILD_TESTS OFF"
                             "BUILD_BENCHMARKS OFF"
                             "CUDA_STATIC_RUNTIME ${CUDA_STATIC_RUNTIME}"


### PR DESCRIPTION
This should unblock build locally and in CI. Needs to be undone after #1707 is merged. 

cc @ChuckHastings 