### PR TITLE
[BUG] force_atlas2 to support nx hypercube_graph

### DIFF
--- a/python/cugraph/layout/force_atlas2.py
+++ b/python/cugraph/layout/force_atlas2.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 from cugraph.layout import force_atlas2_wrapper
+import cugraph
 
 
 def force_atlas2(
@@ -106,6 +107,7 @@ def force_atlas2(
             GPU data frame of size V containing three columns:
             the vertex identifiers and the x and y positions.
     """
+    input_graph, isNx = cugraph.utilities.check_nx_graph(input_graph)
 
     if pos_list is not None:
         if input_graph.renumbered is True:

--- a/python/cugraph/utilities/nx_factory.py
+++ b/python/cugraph/utilities/nx_factory.py
@@ -37,6 +37,7 @@ def convert_from_nx(nxG, weight=None):
 
     pdf = nx.to_pandas_edgelist(nxG)
     # Convert vertex columns to strings if they are not integers
+    # This allows support for any vertex input type
     if pdf["source"].dtype not in [np.int32, np.int64] or \
             pdf["target"].dtype not in [np.int32, np.int64]:
         pdf['source'] = pdf['source'].astype(str)

--- a/python/cugraph/utilities/nx_factory.py
+++ b/python/cugraph/utilities/nx_factory.py
@@ -36,6 +36,7 @@ def convert_from_nx(nxG, weight=None):
         raise ValueError("nxG does not appear to be a NetworkX graph type")
 
     pdf = nx.to_pandas_edgelist(nxG)
+    # Convert vertex columns to strings if they are not integers
     if pdf["source"].dtype not in [np.int32, np.int64] or \
             pdf["target"].dtype not in [np.int32, np.int64]:
         pdf['source'] = pdf['source'].astype(str)

--- a/python/cugraph/utilities/nx_factory.py
+++ b/python/cugraph/utilities/nx_factory.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -14,6 +14,7 @@
 import cugraph
 from .utils import import_optional
 from cudf import from_pandas
+import numpy as np
 
 nx = import_optional("networkx")
 
@@ -35,6 +36,11 @@ def convert_from_nx(nxG, weight=None):
         raise ValueError("nxG does not appear to be a NetworkX graph type")
 
     pdf = nx.to_pandas_edgelist(nxG)
+    if pdf["source"].dtype not in [np.int32, np.int64] or \
+            pdf["target"].dtype not in [np.int32, np.int64]:
+        pdf['source'] = pdf['source'].astype(str)
+        pdf['target'] = pdf['target'].astype(str)
+
     num_col = len(pdf.columns)
 
     if num_col < 2:


### PR DESCRIPTION
Allow `force_atlas2` to support hypercube_graph
The example provided in the issue linked to this PR works
closes #1767