### PR TITLE
Update thrust/RMM deprecated calls

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -53,13 +53,12 @@ gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 
-# FIXME: return librmm and RMM to ${MINOR_VERSION}
 gpuci_logger "Install dependencies"
 gpuci_mamba_retry install -y \
       "libcudf=${MINOR_VERSION}" \
       "cudf=${MINOR_VERSION}" \
-      "librmm=21.10.00a210812" \
-      "rmm=21.10.00a210813" \
+      "librmm=${MINOR_VERSION}" \
+      "rmm=${MINOR_VERSION}" \
       "cudatoolkit=$CUDA_REL" \
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \

--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -8,8 +8,8 @@ dependencies:
 - cudatoolkit=11.0
 - cudf=21.10.*
 - libcudf=21.10.*
-- rmm=21.10.00a210813
-- librmm=21.10.00a210812
+- rmm=21.10.*
+- librmm=21.10.*
 - dask>=2021.6.0
 - distributed>=2021.6.0
 - dask-cuda=21.10.*

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -8,8 +8,8 @@ dependencies:
 - cudatoolkit=11.2
 - cudf=21.10.*
 - libcudf=21.10.*
-- rmm=21.10.00a210813
-- librmm=21.10.00a210812
+- rmm=21.10.*
+- librmm=21.10.*
 - dask>=2021.6.0
 - distributed>=2021.6.0
 - dask-cuda=21.10.*

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -8,8 +8,8 @@ dependencies:
 - cudatoolkit=11.4
 - cudf=21.10.*
 - libcudf=21.10.*
-- rmm=21.10.00a210813
-- librmm=21.10.00a210812
+- rmm=21.10.*
+- librmm=21.10.*
 - dask>=2021.6.0
 - distributed>=2021.6.0
 - dask-cuda=21.10.*

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -29,12 +29,11 @@ build:
     - CMAKE_CXX_COMPILER_LAUNCHER
     - CMAKE_CUDA_COMPILER_LAUNCHER
 
-# FIXME: return librmm to {{ minor_version }}.*
 requirements:
   build:
     - cmake>=3.20.1
     - cudatoolkit {{ cuda_version }}.*
-    - librmm=21.10.00a210812
+    - librmm {{ minor_version }}.*
     - boost-cpp>=1.66
     - nccl>=2.9.9
     - ucx-proc=*=gpu

--- a/cpp/cmake/thirdparty/get_cuhornet.cmake
+++ b/cpp/cmake/thirdparty/get_cuhornet.cmake
@@ -21,7 +21,7 @@ function(find_and_configure_cuhornet)
     FetchContent_Declare(
         cuhornet
         GIT_REPOSITORY    https://github.com/rapidsai/cuhornet.git
-        GIT_TAG           261399356e62bd76fa7628880f1a847aee713eed
+        GIT_TAG           4a1daa18405c0242370e16ce302dfa7eb5d9e857
         SOURCE_SUBDIR     hornet
     )
     FetchContent_GetProperties(cuhornet)

--- a/cpp/cmake/thirdparty/get_rmm.cmake
+++ b/cpp/cmake/thirdparty/get_rmm.cmake
@@ -26,16 +26,14 @@ function(find_and_configure_rmm VERSION)
         return()
     endif()
 
-    # FIXME: turn GIT_SHALLOW back to TRUE when changing GIT_TAG back
-    # to branch-${MAJOR_AND_MINOR}
     rapids_cpm_find(rmm ${VERSION}
         GLOBAL_TARGETS      rmm::rmm
         BUILD_EXPORT_SET    cugraph-exports
         INSTALL_EXPORT_SET  cugraph-exports
         CPM_ARGS
             GIT_REPOSITORY  https://github.com/rapidsai/rmm.git
-            GIT_TAG         23bbe745af1d988224b5498f7b8e3fe3720532d4
-            GIT_SHALLOW     FALSE
+            GIT_TAG         branch-${MAJOR_AND_MINOR}
+            GIT_SHALLOW     TRUE
             OPTIONS         "BUILD_TESTS OFF"
                             "BUILD_BENCHMARKS OFF"
                             "CUDA_STATIC_RUNTIME ${CUDA_STATIC_RUNTIME}"

--- a/cpp/include/cugraph/compute_partition.cuh
+++ b/cpp/include/cugraph/compute_partition.cuh
@@ -19,7 +19,7 @@
 
 #include <cugraph/graph.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/include/cugraph/detail/graph_utils.cuh
+++ b/cpp/include/cugraph/detail/graph_utils.cuh
@@ -20,7 +20,7 @@
 #include <cugraph/utilities/dataframe_buffer.cuh>
 #include <cugraph/utilities/device_comm.cuh>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
 #include <rmm/device_uvector.hpp>
 
@@ -78,7 +78,7 @@ rmm::device_uvector<edge_t> compute_major_degrees(
                                 [(detail::num_sparse_segments_per_vertex_partition + 2) * i +
                                  detail::num_sparse_segments_per_vertex_partition]
               : major_last;
-    thrust::transform(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::transform(rmm::exec_policy(handle.get_stream()),
                       thrust::make_counting_iterator(vertex_t{0}),
                       thrust::make_counting_iterator(major_hypersparse_first - major_first),
                       local_degrees.begin(),
@@ -86,11 +86,11 @@ rmm::device_uvector<edge_t> compute_major_degrees(
     if (use_dcs) {
       auto p_dcs_nzd_vertices   = (*adj_matrix_partition_dcs_nzd_vertices)[i];
       auto dcs_nzd_vertex_count = (*adj_matrix_partition_dcs_nzd_vertex_counts)[i];
-      thrust::fill(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+      thrust::fill(rmm::exec_policy(handle.get_stream()),
                    local_degrees.begin() + (major_hypersparse_first - major_first),
                    local_degrees.begin() + (major_last - major_first),
                    edge_t{0});
-      thrust::for_each(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+      thrust::for_each(rmm::exec_policy(handle.get_stream()),
                        thrust::make_counting_iterator(vertex_t{0}),
                        thrust::make_counting_iterator(dcs_nzd_vertex_count),
                        [p_offsets,
@@ -123,7 +123,7 @@ rmm::device_uvector<edge_t> compute_major_degrees(raft::handle_t const& handle,
                                                   vertex_t number_of_vertices)
 {
   rmm::device_uvector<edge_t> degrees(number_of_vertices, handle.get_stream());
-  thrust::tabulate(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::tabulate(rmm::exec_policy(handle.get_stream()),
                    degrees.begin(),
                    degrees.end(),
                    [offsets] __device__(auto i) { return offsets[i + 1] - offsets[i]; });

--- a/cpp/include/cugraph/detail/graph_utils.cuh
+++ b/cpp/include/cugraph/detail/graph_utils.cuh
@@ -20,9 +20,9 @@
 #include <cugraph/utilities/dataframe_buffer.cuh>
 #include <cugraph/utilities/device_comm.cuh>
 
-#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/sort.h>
 #include <thrust/tabulate.h>

--- a/cpp/include/cugraph/prims/copy_to_adj_matrix_row_col.cuh
+++ b/cpp/include/cugraph/prims/copy_to_adj_matrix_row_col.cuh
@@ -26,7 +26,7 @@
 #include <cugraph/utilities/thrust_tuple_utils.cuh>
 #include <cugraph/vertex_partition_device_view.cuh>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
 
 #include <thrust/copy.h>
@@ -98,7 +98,7 @@ void copy_to_matrix_major(raft::handle_t const& handle,
     assert(graph_view.get_number_of_local_vertices() == GraphViewType::is_adj_matrix_transposed
              ? graph_view.get_number_of_local_adj_matrix_partition_cols()
              : graph_view.get_number_of_local_adj_matrix_partition_rows());
-    thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::copy(rmm::exec_policy(handle.get_stream()),
                  vertex_value_input_first,
                  vertex_value_input_first + graph_view.get_number_of_local_vertices(),
                  matrix_major_value_output_first);
@@ -169,7 +169,7 @@ void copy_to_matrix_major(raft::handle_t const& handle,
           });
         // FIXME: this gather (and temporary buffer) is unnecessary if NCCL directly takes a
         // permutation iterator (and directly gathers to the internal buffer)
-        thrust::gather(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::gather(rmm::exec_policy(handle.get_stream()),
                        map_first,
                        map_first + thrust::distance(vertex_first, vertex_last),
                        vertex_value_input_first,
@@ -190,7 +190,7 @@ void copy_to_matrix_major(raft::handle_t const& handle,
         // FIXME: this scatter is unnecessary if NCCL directly takes a permutation iterator (and
         // directly scatters from the internal buffer)
         thrust::scatter(
-          rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+          rmm::exec_policy(handle.get_stream()),
           rx_value_first,
           rx_value_first + rx_counts[i],
           map_first,
@@ -203,7 +203,7 @@ void copy_to_matrix_major(raft::handle_t const& handle,
         // FIXME: this scatter is unnecessary if NCCL directly takes a permutation iterator (and
         // directly scatters from the internal buffer)
         thrust::scatter(
-          rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+          rmm::exec_policy(handle.get_stream()),
           rx_value_first,
           rx_value_first + rx_counts[i],
           map_first,
@@ -226,7 +226,7 @@ void copy_to_matrix_major(raft::handle_t const& handle,
              ? graph_view.get_number_of_local_adj_matrix_partition_cols()
              : graph_view.get_number_of_local_adj_matrix_partition_rows());
     auto val_first = thrust::make_permutation_iterator(vertex_value_input_first, vertex_first);
-    thrust::scatter(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::scatter(rmm::exec_policy(handle.get_stream()),
                     val_first,
                     val_first + thrust::distance(vertex_first, vertex_last),
                     vertex_first,
@@ -290,7 +290,7 @@ void copy_to_matrix_minor(raft::handle_t const& handle,
     assert(graph_view.get_number_of_local_vertices() == GraphViewType::is_adj_matrix_transposed
              ? graph_view.get_number_of_local_adj_matrix_partition_rows()
              : graph_view.get_number_of_local_adj_matrix_partition_cols());
-    thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::copy(rmm::exec_policy(handle.get_stream()),
                  vertex_value_input_first,
                  vertex_value_input_first + graph_view.get_number_of_local_vertices(),
                  matrix_minor_value_output_first);
@@ -360,7 +360,7 @@ void copy_to_matrix_minor(raft::handle_t const& handle,
           });
         // FIXME: this gather (and temporary buffer) is unnecessary if NCCL directly takes a
         // permutation iterator (and directly gathers to the internal buffer)
-        thrust::gather(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::gather(rmm::exec_policy(handle.get_stream()),
                        map_first,
                        map_first + thrust::distance(vertex_first, vertex_last),
                        vertex_value_input_first,
@@ -380,7 +380,7 @@ void copy_to_matrix_minor(raft::handle_t const& handle,
           });
         // FIXME: this scatter is unnecessary if NCCL directly takes a permutation iterator (and
         // directly scatters from the internal buffer)
-        thrust::scatter(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::scatter(rmm::exec_policy(handle.get_stream()),
                         rx_value_first,
                         rx_value_first + rx_counts[i],
                         map_first,
@@ -392,7 +392,7 @@ void copy_to_matrix_minor(raft::handle_t const& handle,
           });
         // FIXME: this scatter is unnecessary if NCCL directly takes a permutation iterator (and
         // directly scatters from the internal buffer)
-        thrust::scatter(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::scatter(rmm::exec_policy(handle.get_stream()),
                         rx_value_first,
                         rx_value_first + rx_counts[i],
                         map_first,
@@ -414,7 +414,7 @@ void copy_to_matrix_minor(raft::handle_t const& handle,
     assert(graph_view.get_number_of_local_vertices() ==
            graph_view.get_number_of_local_adj_matrix_partition_rows());
     auto val_first = thrust::make_permutation_iterator(vertex_value_input_first, vertex_first);
-    thrust::scatter(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::scatter(rmm::exec_policy(handle.get_stream()),
                     val_first,
                     val_first + thrust::distance(vertex_first, vertex_last),
                     vertex_first,

--- a/cpp/include/cugraph/prims/copy_to_adj_matrix_row_col.cuh
+++ b/cpp/include/cugraph/prims/copy_to_adj_matrix_row_col.cuh
@@ -26,8 +26,8 @@
 #include <cugraph/utilities/thrust_tuple_utils.cuh>
 #include <cugraph/vertex_partition_device_view.cuh>
 
-#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/copy.h>
 #include <thrust/execution_policy.h>

--- a/cpp/include/cugraph/prims/copy_v_transform_reduce_in_out_nbr.cuh
+++ b/cpp/include/cugraph/prims/copy_v_transform_reduce_in_out_nbr.cuh
@@ -25,7 +25,7 @@
 #include <cugraph/utilities/host_barrier.hpp>
 
 #include <raft/cudart_utils.h>
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
 
 #include <thrust/distance.h>
@@ -439,12 +439,12 @@ void copy_v_transform_reduce_nbr(raft::handle_t const& handle,
     }
 
     if (GraphViewType::is_multi_gpu) {
-      thrust::fill(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+      thrust::fill(rmm::exec_policy(handle.get_stream()),
                    minor_buffer_first,
                    minor_buffer_first + minor_tmp_buffer_size,
                    minor_init);
     } else {
-      thrust::fill(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+      thrust::fill(rmm::exec_policy(handle.get_stream()),
                    vertex_value_output_first,
                    vertex_value_output_first + graph_view.get_number_of_local_vertices(),
                    minor_init);
@@ -546,7 +546,7 @@ void copy_v_transform_reduce_nbr(raft::handle_t const& handle,
         if constexpr (update_major) {  // this is necessary as we don't visit every vertex in the
                                        // hypersparse segment in
                                        // for_all_major_for_all_nbr_hypersparse
-          thrust::fill(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+          thrust::fill(rmm::exec_policy(handle.get_stream()),
                        output_buffer_first + (*segment_offsets)[3],
                        output_buffer_first + (*segment_offsets)[4],
                        major_init);

--- a/cpp/include/cugraph/prims/copy_v_transform_reduce_in_out_nbr.cuh
+++ b/cpp/include/cugraph/prims/copy_v_transform_reduce_in_out_nbr.cuh
@@ -25,8 +25,8 @@
 #include <cugraph/utilities/host_barrier.hpp>
 
 #include <raft/cudart_utils.h>
-#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/distance.h>
 #include <thrust/functional.h>

--- a/cpp/include/cugraph/prims/copy_v_transform_reduce_key_aggregated_out_nbr.cuh
+++ b/cpp/include/cugraph/prims/copy_v_transform_reduce_key_aggregated_out_nbr.cuh
@@ -153,7 +153,7 @@ void decompress_matrix_partition_to_fill_edgelist_majors(
     }
     if ((*segment_offsets)[3] - (*segment_offsets)[2] > 0) {
       thrust::for_each(
-        rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        rmm::exec_policy(handle.get_stream()),
         thrust::make_counting_iterator(matrix_partition.get_major_first()) + (*segment_offsets)[2],
         thrust::make_counting_iterator(matrix_partition.get_major_first()) + (*segment_offsets)[3],
         [matrix_partition, majors] __device__(auto major) {
@@ -167,7 +167,7 @@ void decompress_matrix_partition_to_fill_edgelist_majors(
     if (matrix_partition.get_dcs_nzd_vertex_count() &&
         (*(matrix_partition.get_dcs_nzd_vertex_count()) > 0)) {
       thrust::for_each(
-        rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        rmm::exec_policy(handle.get_stream()),
         thrust::make_counting_iterator(vertex_t{0}),
         thrust::make_counting_iterator(*(matrix_partition.get_dcs_nzd_vertex_count())),
         [matrix_partition, major_start_offset = (*segment_offsets)[3], majors] __device__(
@@ -183,7 +183,7 @@ void decompress_matrix_partition_to_fill_edgelist_majors(
     }
   } else {
     thrust::for_each(
-      rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+      rmm::exec_policy(handle.get_stream()),
       thrust::make_counting_iterator(matrix_partition.get_major_first()),
       thrust::make_counting_iterator(matrix_partition.get_major_first()) +
         matrix_partition.get_major_size(),
@@ -340,12 +340,12 @@ void copy_v_transform_reduce_key_aggregated_out_nbr(
     }
     // FIXME: these copies are unnecessary, better fix RAFT comm's bcast to take separate input &
     // output pointers
-    thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::copy(rmm::exec_policy(handle.get_stream()),
                  map_key_first,
                  map_key_last,
                  map_keys.begin() + map_displacements[row_comm_rank]);
     thrust::copy(
-      rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+      rmm::exec_policy(handle.get_stream()),
       map_value_first,
       map_value_first + thrust::distance(map_key_first, map_key_last),
       get_dataframe_buffer_begin<value_t>(map_value_buffer) + map_displacements[row_comm_rank]);
@@ -420,12 +420,12 @@ void copy_v_transform_reduce_key_aggregated_out_nbr(
         matrix_partition.get_indices(),
         detail::minor_to_key_t<VertexIterator0>{adj_matrix_col_key_first,
                                                 matrix_partition.get_minor_first()});
-      thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+      thrust::copy(rmm::exec_policy(handle.get_stream()),
                    minor_key_first,
                    minor_key_first + matrix_partition.get_number_of_edges(),
                    tmp_minor_keys.begin());
       if (graph_view.is_weighted()) {
-        thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::copy(rmm::exec_policy(handle.get_stream()),
                      *(matrix_partition.get_weights()),
                      *(matrix_partition.get_weights()) + matrix_partition.get_number_of_edges(),
                      tmp_key_aggregated_edge_weights.begin());
@@ -448,27 +448,27 @@ void copy_v_transform_reduce_key_aggregated_out_nbr(
       auto output_key_first = thrust::make_zip_iterator(
         thrust::make_tuple(reduced_major_vertices.begin(), reduced_minor_keys.begin()));
       if (graph_view.is_weighted()) {
-        thrust::sort_by_key(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::sort_by_key(rmm::exec_policy(handle.get_stream()),
                             input_key_first,
                             input_key_first + tmp_major_vertices.size(),
                             tmp_key_aggregated_edge_weights.begin());
         reduced_size =
           thrust::distance(output_key_first,
                            thrust::get<0>(thrust::reduce_by_key(
-                             rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+                             rmm::exec_policy(handle.get_stream()),
                              input_key_first,
                              input_key_first + tmp_major_vertices.size(),
                              tmp_key_aggregated_edge_weights.begin(),
                              output_key_first,
                              reduced_key_aggregated_edge_weights.begin())));
       } else {
-        thrust::sort(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::sort(rmm::exec_policy(handle.get_stream()),
                      input_key_first,
                      input_key_first + tmp_major_vertices.size());
         reduced_size =
           thrust::distance(output_key_first,
                            thrust::get<0>(thrust::reduce_by_key(
-                             rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+                             rmm::exec_policy(handle.get_stream()),
                              input_key_first,
                              input_key_first + tmp_major_vertices.size(),
                              thrust::make_constant_iterator(weight_t{1.0}),
@@ -517,7 +517,7 @@ void copy_v_transform_reduce_key_aggregated_out_nbr(
 
       auto pair_first = thrust::make_zip_iterator(
         thrust::make_tuple(rx_major_vertices.begin(), rx_minor_keys.begin()));
-      thrust::sort_by_key(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+      thrust::sort_by_key(rmm::exec_policy(handle.get_stream()),
                           pair_first,
                           pair_first + rx_major_vertices.size(),
                           rx_key_aggregated_edge_weights.begin());
@@ -525,7 +525,7 @@ void copy_v_transform_reduce_key_aggregated_out_nbr(
       tmp_minor_keys.resize(tmp_major_vertices.size(), handle.get_stream());
       tmp_key_aggregated_edge_weights.resize(tmp_major_vertices.size(), handle.get_stream());
       auto pair_it =
-        thrust::reduce_by_key(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::reduce_by_key(rmm::exec_policy(handle.get_stream()),
                               pair_first,
                               pair_first + rx_major_vertices.size(),
                               rx_key_aggregated_edge_weights.begin(),
@@ -549,7 +549,7 @@ void copy_v_transform_reduce_key_aggregated_out_nbr(
     auto triplet_first = thrust::make_zip_iterator(thrust::make_tuple(
       tmp_major_vertices.begin(), tmp_minor_keys.begin(), tmp_key_aggregated_edge_weights.begin()));
     thrust::transform(
-      rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+      rmm::exec_policy(handle.get_stream()),
       triplet_first,
       triplet_first + tmp_major_vertices.size(),
       tmp_e_op_result_buffer_first,
@@ -635,17 +635,17 @@ void copy_v_transform_reduce_key_aggregated_out_nbr(
 #endif
   }
 
-  thrust::fill(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::fill(rmm::exec_policy(handle.get_stream()),
                vertex_value_output_first,
                vertex_value_output_first + graph_view.get_number_of_local_vertices(),
                T{});
-  thrust::sort_by_key(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::sort_by_key(rmm::exec_policy(handle.get_stream()),
                       major_vertices.begin(),
                       major_vertices.end(),
                       get_dataframe_buffer_begin<T>(e_op_result_buffer));
 
   auto num_uniques = thrust::count_if(
-    rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    rmm::exec_policy(handle.get_stream()),
     thrust::make_counting_iterator(size_t{0}),
     thrust::make_counting_iterator(major_vertices.size()),
     [major_vertices = major_vertices.data()] __device__(auto i) {
@@ -661,13 +661,13 @@ void copy_v_transform_reduce_key_aggregated_out_nbr(
                : invalid_vertex_id<vertex_t>::value;
     });
   thrust::copy_if(
-    rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    rmm::exec_policy(handle.get_stream()),
     major_vertex_first,
     major_vertex_first + major_vertices.size(),
     unique_major_vertices.begin(),
     [] __device__(auto major) { return major != invalid_vertex_id<vertex_t>::value; });
   thrust::reduce_by_key(
-    rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    rmm::exec_policy(handle.get_stream()),
     major_vertices.begin(),
     major_vertices.end(),
     get_dataframe_buffer_begin<T>(e_op_result_buffer),
@@ -683,7 +683,7 @@ void copy_v_transform_reduce_key_aggregated_out_nbr(
     thrust::equal_to<vertex_t>{},
     reduce_op);
 
-  thrust::transform(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::transform(rmm::exec_policy(handle.get_stream()),
                     vertex_value_output_first,
                     vertex_value_output_first + graph_view.get_number_of_local_vertices(),
                     vertex_value_output_first,

--- a/cpp/include/cugraph/prims/copy_v_transform_reduce_key_aggregated_out_nbr.cuh
+++ b/cpp/include/cugraph/prims/copy_v_transform_reduce_key_aggregated_out_nbr.cuh
@@ -452,28 +452,26 @@ void copy_v_transform_reduce_key_aggregated_out_nbr(
                             input_key_first,
                             input_key_first + tmp_major_vertices.size(),
                             tmp_key_aggregated_edge_weights.begin());
-        reduced_size =
-          thrust::distance(output_key_first,
-                           thrust::get<0>(thrust::reduce_by_key(
-                             rmm::exec_policy(handle.get_stream()),
-                             input_key_first,
-                             input_key_first + tmp_major_vertices.size(),
-                             tmp_key_aggregated_edge_weights.begin(),
-                             output_key_first,
-                             reduced_key_aggregated_edge_weights.begin())));
+        reduced_size = thrust::distance(
+          output_key_first,
+          thrust::get<0>(thrust::reduce_by_key(rmm::exec_policy(handle.get_stream()),
+                                               input_key_first,
+                                               input_key_first + tmp_major_vertices.size(),
+                                               tmp_key_aggregated_edge_weights.begin(),
+                                               output_key_first,
+                                               reduced_key_aggregated_edge_weights.begin())));
       } else {
         thrust::sort(rmm::exec_policy(handle.get_stream()),
                      input_key_first,
                      input_key_first + tmp_major_vertices.size());
-        reduced_size =
-          thrust::distance(output_key_first,
-                           thrust::get<0>(thrust::reduce_by_key(
-                             rmm::exec_policy(handle.get_stream()),
-                             input_key_first,
-                             input_key_first + tmp_major_vertices.size(),
-                             thrust::make_constant_iterator(weight_t{1.0}),
-                             output_key_first,
-                             reduced_key_aggregated_edge_weights.begin())));
+        reduced_size = thrust::distance(
+          output_key_first,
+          thrust::get<0>(thrust::reduce_by_key(rmm::exec_policy(handle.get_stream()),
+                                               input_key_first,
+                                               input_key_first + tmp_major_vertices.size(),
+                                               thrust::make_constant_iterator(weight_t{1.0}),
+                                               output_key_first,
+                                               reduced_key_aggregated_edge_weights.begin())));
       }
       tmp_major_vertices              = std::move(reduced_major_vertices);
       tmp_minor_keys                  = std::move(reduced_minor_keys);
@@ -524,14 +522,13 @@ void copy_v_transform_reduce_key_aggregated_out_nbr(
       tmp_major_vertices.resize(rx_major_vertices.size(), handle.get_stream());
       tmp_minor_keys.resize(tmp_major_vertices.size(), handle.get_stream());
       tmp_key_aggregated_edge_weights.resize(tmp_major_vertices.size(), handle.get_stream());
-      auto pair_it =
-        thrust::reduce_by_key(rmm::exec_policy(handle.get_stream()),
-                              pair_first,
-                              pair_first + rx_major_vertices.size(),
-                              rx_key_aggregated_edge_weights.begin(),
-                              thrust::make_zip_iterator(thrust::make_tuple(
-                                tmp_major_vertices.begin(), tmp_minor_keys.begin())),
-                              tmp_key_aggregated_edge_weights.begin());
+      auto pair_it = thrust::reduce_by_key(rmm::exec_policy(handle.get_stream()),
+                                           pair_first,
+                                           pair_first + rx_major_vertices.size(),
+                                           rx_key_aggregated_edge_weights.begin(),
+                                           thrust::make_zip_iterator(thrust::make_tuple(
+                                             tmp_major_vertices.begin(), tmp_minor_keys.begin())),
+                                           tmp_key_aggregated_edge_weights.begin());
       tmp_major_vertices.resize(
         thrust::distance(tmp_key_aggregated_edge_weights.begin(), thrust::get<1>(pair_it)),
         handle.get_stream());

--- a/cpp/include/cugraph/prims/count_if_v.cuh
+++ b/cpp/include/cugraph/prims/count_if_v.cuh
@@ -19,7 +19,7 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/host_scalar_comm.cuh>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
 
 #include <thrust/count.h>
@@ -54,7 +54,7 @@ typename GraphViewType::vertex_type count_if_v(raft::handle_t const& handle,
                                                VertexOp v_op)
 {
   auto count =
-    thrust::count_if(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::count_if(rmm::exec_policy(handle.get_stream()),
                      vertex_value_input_first,
                      vertex_value_input_first + graph_view.get_number_of_local_vertices(),
                      v_op);
@@ -93,7 +93,7 @@ typename GraphViewType::vertex_type count_if_v(raft::handle_t const& handle,
                                                VertexOp v_op)
 {
   auto count = thrust::count_if(
-    rmm::exec_policy(handle.get_stream())->on(handle.get_stream()), input_first, input_last, v_op);
+    rmm::exec_policy(handle.get_stream()), input_first, input_last, v_op);
   if (GraphViewType::is_multi_gpu) {
     count = host_scalar_allreduce(handle.get_comms(), count, handle.get_stream());
   }

--- a/cpp/include/cugraph/prims/count_if_v.cuh
+++ b/cpp/include/cugraph/prims/count_if_v.cuh
@@ -19,8 +19,8 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/host_scalar_comm.cuh>
 
-#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>
@@ -92,8 +92,8 @@ typename GraphViewType::vertex_type count_if_v(raft::handle_t const& handle,
                                                InputIterator input_last,
                                                VertexOp v_op)
 {
-  auto count = thrust::count_if(
-    rmm::exec_policy(handle.get_stream()), input_first, input_last, v_op);
+  auto count =
+    thrust::count_if(rmm::exec_policy(handle.get_stream()), input_first, input_last, v_op);
   if (GraphViewType::is_multi_gpu) {
     count = host_scalar_allreduce(handle.get_comms(), count, handle.get_stream());
   }

--- a/cpp/include/cugraph/prims/reduce_v.cuh
+++ b/cpp/include/cugraph/prims/reduce_v.cuh
@@ -52,7 +52,7 @@ T reduce_v(raft::handle_t const& handle,
            T init)
 {
   auto ret = thrust::reduce(
-    rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    rmm::exec_policy(handle.get_stream()),
     vertex_value_input_first,
     vertex_value_input_first + graph_view.get_number_of_local_vertices(),
     ((GraphViewType::is_multi_gpu) && (handle.get_comms().get_rank() == 0)) ? init : T{},
@@ -89,7 +89,7 @@ T reduce_v(raft::handle_t const& handle,
            T init)
 {
   auto ret = thrust::reduce(
-    rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    rmm::exec_policy(handle.get_stream()),
     input_first,
     input_last,
     ((GraphViewType::is_multi_gpu) && (handle.get_comms().get_rank() == 0)) ? init : T{},

--- a/cpp/include/cugraph/prims/transform_reduce_by_adj_matrix_row_col_key_e.cuh
+++ b/cpp/include/cugraph/prims/transform_reduce_by_adj_matrix_row_col_key_e.cuh
@@ -319,12 +319,12 @@ template <typename vertex_t, typename value_t, typename BufferType>
 std::tuple<rmm::device_uvector<vertex_t>, BufferType> reduce_to_unique_kv_pairs(
   rmm::device_uvector<vertex_t>&& keys, BufferType&& value_buffer, cudaStream_t stream)
 {
-  thrust::sort_by_key(rmm::exec_policy(stream)->on(stream),
+  thrust::sort_by_key(rmm::exec_policy(stream),
                       keys.begin(),
                       keys.end(),
                       get_dataframe_buffer_begin<value_t>(value_buffer));
   auto num_uniques =
-    thrust::count_if(rmm::exec_policy(stream)->on(stream),
+    thrust::count_if(rmm::exec_policy(stream),
                      thrust::make_counting_iterator(size_t{0}),
                      thrust::make_counting_iterator(keys.size()),
                      [keys = keys.data()] __device__(auto i) {
@@ -333,7 +333,7 @@ std::tuple<rmm::device_uvector<vertex_t>, BufferType> reduce_to_unique_kv_pairs(
 
   rmm::device_uvector<vertex_t> unique_keys(num_uniques, stream);
   auto value_for_unique_key_buffer = allocate_dataframe_buffer<value_t>(unique_keys.size(), stream);
-  thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream),
+  thrust::reduce_by_key(rmm::exec_policy(stream),
                         keys.begin(),
                         keys.end(),
                         get_dataframe_buffer_begin<value_t>(value_buffer),
@@ -530,11 +530,11 @@ transform_reduce_by_adj_matrix_row_col_key_e(
       keys.resize(cur_size + tmp_keys.size(), handle.get_stream());
       resize_dataframe_buffer<T>(value_buffer, keys.size(), handle.get_stream());
 
-      thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+      thrust::copy(rmm::exec_policy(handle.get_stream()),
                    tmp_keys.begin(),
                    tmp_keys.end(),
                    keys.begin() + cur_size);
-      thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+      thrust::copy(rmm::exec_policy(handle.get_stream()),
                    get_dataframe_buffer_begin<T>(tmp_value_buffer),
                    get_dataframe_buffer_begin<T>(tmp_value_buffer) + tmp_keys.size(),
                    get_dataframe_buffer_begin<T>(value_buffer) + cur_size);

--- a/cpp/include/cugraph/prims/transform_reduce_e.cuh
+++ b/cpp/include/cugraph/prims/transform_reduce_e.cuh
@@ -21,8 +21,8 @@
 #include <cugraph/utilities/host_scalar_comm.cuh>
 
 #include <raft/cudart_utils.h>
-#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/tuple.h>
 

--- a/cpp/include/cugraph/prims/transform_reduce_e.cuh
+++ b/cpp/include/cugraph/prims/transform_reduce_e.cuh
@@ -21,7 +21,7 @@
 #include <cugraph/utilities/host_scalar_comm.cuh>
 
 #include <raft/cudart_utils.h>
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
 
 #include <thrust/tuple.h>
@@ -406,7 +406,7 @@ T transform_reduce_e(raft::handle_t const& handle,
   property_add<T> edge_property_add{};
 
   auto result_buffer = allocate_dataframe_buffer<T>(1, handle.get_stream());
-  thrust::fill(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::fill(rmm::exec_policy(handle.get_stream()),
                get_dataframe_buffer_begin<T>(result_buffer),
                get_dataframe_buffer_begin<T>(result_buffer) + 1,
                T{});
@@ -503,7 +503,7 @@ T transform_reduce_e(raft::handle_t const& handle,
     }
   }
 
-  auto result = thrust::reduce(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  auto result = thrust::reduce(rmm::exec_policy(handle.get_stream()),
                                get_dataframe_buffer_begin<T>(result_buffer),
                                get_dataframe_buffer_begin<T>(result_buffer) + 1,
                                T{},

--- a/cpp/include/cugraph/prims/transform_reduce_v.cuh
+++ b/cpp/include/cugraph/prims/transform_reduce_v.cuh
@@ -56,7 +56,7 @@ T transform_reduce_v(raft::handle_t const& handle,
                      T init)
 {
   auto ret = thrust::transform_reduce(
-    rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    rmm::exec_policy(handle.get_stream()),
     vertex_value_input_first,
     vertex_value_input_first + graph_view.get_number_of_local_vertices(),
     v_op,
@@ -99,7 +99,7 @@ T transform_reduce_v(raft::handle_t const& handle,
                      T init)
 {
   auto ret = thrust::transform_reduce(
-    rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    rmm::exec_policy(handle.get_stream()),
     input_first,
     input_last,
     v_op,

--- a/cpp/include/cugraph/prims/update_frontier_v_push_if_out_nbr.cuh
+++ b/cpp/include/cugraph/prims/update_frontier_v_push_if_out_nbr.cuh
@@ -30,9 +30,9 @@
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <raft/cudart_utils.h>
-#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
 #include <rmm/device_scalar.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/binary_search.h>
 #include <thrust/distance.h>
@@ -1285,12 +1285,11 @@ void update_frontier_v_push_if_out_nbr(
     auto bucket_key_pair_first = thrust::make_zip_iterator(
       thrust::make_tuple(bucket_indices.begin(), get_dataframe_buffer_begin<key_t>(key_buffer)));
     bucket_indices.resize(
-      thrust::distance(
-        bucket_key_pair_first,
-        thrust::remove_if(rmm::exec_policy(handle.get_stream()),
-                          bucket_key_pair_first,
-                          bucket_key_pair_first + num_buffer_elements,
-                          detail::check_invalid_bucket_idx_t<key_t>())),
+      thrust::distance(bucket_key_pair_first,
+                       thrust::remove_if(rmm::exec_policy(handle.get_stream()),
+                                         bucket_key_pair_first,
+                                         bucket_key_pair_first + num_buffer_elements,
+                                         detail::check_invalid_bucket_idx_t<key_t>())),
       handle.get_stream());
     resize_dataframe_buffer<key_t>(key_buffer, bucket_indices.size(), handle.get_stream());
     bucket_indices.shrink_to_fit(handle.get_stream());

--- a/cpp/include/cugraph/prims/update_frontier_v_push_if_out_nbr.cuh
+++ b/cpp/include/cugraph/prims/update_frontier_v_push_if_out_nbr.cuh
@@ -30,7 +30,7 @@
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <raft/cudart_utils.h>
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
 #include <rmm/device_scalar.hpp>
 
@@ -528,11 +528,11 @@ size_t sort_and_reduce_buffer_elements(raft::handle_t const& handle,
     typename optional_payload_buffer_value_type_t<BufferPayloadOutputIterator>::value;
 
   if constexpr (std::is_same_v<payload_t, void>) {
-    thrust::sort(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::sort(rmm::exec_policy(handle.get_stream()),
                  buffer_key_output_first,
                  buffer_key_output_first + num_buffer_elements);
   } else {
-    thrust::sort_by_key(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::sort_by_key(rmm::exec_policy(handle.get_stream()),
                         buffer_key_output_first,
                         buffer_key_output_first + num_buffer_elements,
                         buffer_payload_output_first);
@@ -540,7 +540,7 @@ size_t sort_and_reduce_buffer_elements(raft::handle_t const& handle,
 
   size_t num_reduced_buffer_elements{};
   if constexpr (std::is_same_v<payload_t, void>) {
-    auto it = thrust::unique(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    auto it = thrust::unique(rmm::exec_policy(handle.get_stream()),
                              buffer_key_output_first,
                              buffer_key_output_first + num_buffer_elements);
     num_reduced_buffer_elements =
@@ -548,7 +548,7 @@ size_t sort_and_reduce_buffer_elements(raft::handle_t const& handle,
   } else if constexpr (std::is_same<ReduceOp, reduce_op::any<typename ReduceOp::type>>::value) {
     // FIXME: if ReducOp is any, we may have a cheaper alternative than sort & uique (i.e. discard
     // non-first elements)
-    auto it = thrust::unique_by_key(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    auto it = thrust::unique_by_key(rmm::exec_policy(handle.get_stream()),
                                     buffer_key_output_first,
                                     buffer_key_output_first + num_buffer_elements,
                                     buffer_payload_output_first);
@@ -567,7 +567,7 @@ size_t sort_and_reduce_buffer_elements(raft::handle_t const& handle,
     rmm::device_uvector<key_t> keys(num_buffer_elements, handle.get_stream());
     auto value_buffer =
       allocate_dataframe_buffer<payload_t>(num_buffer_elements, handle.get_stream());
-    auto it = thrust::reduce_by_key(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    auto it = thrust::reduce_by_key(rmm::exec_policy(handle.get_stream()),
                                     buffer_key_output_first,
                                     buffer_key_output_first + num_buffer_elements,
                                     buffer_payload_output_first,
@@ -578,11 +578,11 @@ size_t sort_and_reduce_buffer_elements(raft::handle_t const& handle,
     num_reduced_buffer_elements =
       static_cast<size_t>(thrust::distance(keys.begin(), thrust::get<0>(it)));
     // FIXME: this copy can be replaced by move
-    thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::copy(rmm::exec_policy(handle.get_stream()),
                  keys.begin(),
                  keys.begin() + num_reduced_buffer_elements,
                  buffer_key_output_first);
-    thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::copy(rmm::exec_policy(handle.get_stream()),
                  get_dataframe_buffer_begin<payload_t>(value_buffer),
                  get_dataframe_buffer_begin<payload_t>(value_buffer) + num_reduced_buffer_elements,
                  buffer_payload_output_first);
@@ -657,7 +657,7 @@ typename GraphViewType::edge_type compute_num_out_nbrs_from_frontier(
       // FIXME: this copy is unnecessary, better fix RAFT comm's bcast to take const iterators for
       // input
       if (col_comm_rank == static_cast<int>(i)) {
-        thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::copy(rmm::exec_policy(handle.get_stream()),
                      local_frontier_vertex_first,
                      local_frontier_vertex_last,
                      frontier_vertices.begin());
@@ -678,7 +678,7 @@ typename GraphViewType::edge_type compute_num_out_nbrs_from_frontier(
       ret +=
         use_dcs
           ? thrust::transform_reduce(
-              rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+              rmm::exec_policy(handle.get_stream()),
               frontier_vertices.begin(),
               frontier_vertices.end(),
               [matrix_partition,
@@ -703,7 +703,7 @@ typename GraphViewType::edge_type compute_num_out_nbrs_from_frontier(
               edge_t{0},
               thrust::plus<edge_t>())
           : thrust::transform_reduce(
-              rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+              rmm::exec_policy(handle.get_stream()),
               frontier_vertices.begin(),
               frontier_vertices.end(),
               [matrix_partition] __device__(auto major) {
@@ -715,7 +715,7 @@ typename GraphViewType::edge_type compute_num_out_nbrs_from_frontier(
     } else {
       assert(i == 0);
       ret += thrust::transform_reduce(
-        rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        rmm::exec_policy(handle.get_stream()),
         local_frontier_vertex_first,
         local_frontier_vertex_last,
         [matrix_partition] __device__(auto major) {
@@ -894,7 +894,7 @@ void update_frontier_v_push_if_out_nbr(
         matrix_partition_frontier_key_buffer, matrix_partition_frontier_size, handle.get_stream());
 
       if (static_cast<size_t>(col_comm_rank) == i) {
-        thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::copy(rmm::exec_policy(handle.get_stream()),
                      frontier_key_first,
                      frontier_key_last,
                      get_dataframe_buffer_begin<key_t>(matrix_partition_frontier_key_buffer));
@@ -909,7 +909,7 @@ void update_frontier_v_push_if_out_nbr(
     } else {
       resize_dataframe_buffer<key_t>(
         matrix_partition_frontier_key_buffer, matrix_partition_frontier_size, handle.get_stream());
-      thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+      thrust::copy(rmm::exec_policy(handle.get_stream()),
                    frontier_key_first,
                    frontier_key_last,
                    get_dataframe_buffer_begin<key_t>(matrix_partition_frontier_key_buffer));
@@ -938,7 +938,7 @@ void update_frontier_v_push_if_out_nbr(
 
     auto max_pushes =
       use_dcs ? thrust::transform_reduce(
-                  rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+                  rmm::exec_policy(handle.get_stream()),
                   matrix_partition_frontier_row_first,
                   matrix_partition_frontier_row_last,
                   [matrix_partition,
@@ -963,7 +963,7 @@ void update_frontier_v_push_if_out_nbr(
                   edge_t{0},
                   thrust::plus<edge_t>())
               : thrust::transform_reduce(
-                  rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+                  rmm::exec_policy(handle.get_stream()),
                   matrix_partition_frontier_row_first,
                   matrix_partition_frontier_row_last,
                   [matrix_partition] __device__(auto row) {
@@ -1007,7 +1007,7 @@ void update_frontier_v_push_if_out_nbr(
       raft::update_device(
         d_thresholds.data(), h_thresholds.data(), h_thresholds.size(), handle.get_stream());
       rmm::device_uvector<vertex_t> d_offsets(d_thresholds.size(), handle.get_stream());
-      thrust::lower_bound(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+      thrust::lower_bound(rmm::exec_policy(handle.get_stream()),
                           matrix_partition_frontier_row_first,
                           matrix_partition_frontier_row_last,
                           d_thresholds.begin(),
@@ -1170,7 +1170,7 @@ void update_frontier_v_push_if_out_nbr(
       row_first =
         thrust::get<0>(get_dataframe_buffer_begin<key_t>(key_buffer).get_iterator_tuple());
     }
-    thrust::lower_bound(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::lower_bound(rmm::exec_policy(handle.get_stream()),
                         row_first,
                         row_first + num_buffer_elements,
                         d_vertex_lasts.begin(),
@@ -1234,7 +1234,7 @@ void update_frontier_v_push_if_out_nbr(
         thrust::make_tuple(get_dataframe_buffer_begin<key_t>(key_buffer),
                            detail::get_optional_payload_buffer_begin<payload_t>(payload_buffer)));
       thrust::transform(
-        rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        rmm::exec_policy(handle.get_stream()),
         key_payload_pair_first,
         key_payload_pair_first + num_buffer_elements,
         bucket_indices.begin(),
@@ -1266,7 +1266,7 @@ void update_frontier_v_push_if_out_nbr(
       shrink_to_fit_dataframe_buffer<payload_t>(payload_buffer, handle.get_stream());
     } else {
       thrust::transform(
-        rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        rmm::exec_policy(handle.get_stream()),
         get_dataframe_buffer_begin<key_t>(key_buffer),
         get_dataframe_buffer_begin<key_t>(key_buffer) + num_buffer_elements,
         bucket_indices.begin(),
@@ -1287,7 +1287,7 @@ void update_frontier_v_push_if_out_nbr(
     bucket_indices.resize(
       thrust::distance(
         bucket_key_pair_first,
-        thrust::remove_if(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::remove_if(rmm::exec_policy(handle.get_stream()),
                           bucket_key_pair_first,
                           bucket_key_pair_first + num_buffer_elements,
                           detail::check_invalid_bucket_idx_t<key_t>())),

--- a/cpp/include/cugraph/prims/vertex_frontier.cuh
+++ b/cpp/include/cugraph/prims/vertex_frontier.cuh
@@ -96,7 +96,7 @@ class SortedUniqueKeyBucket {
       tags_.resize(1, handle_ptr_->get_stream());
       auto pair_first =
         thrust::make_tuple(thrust::make_zip_iterator(vertices_.begin(), tags_.begin()));
-      thrust::fill(rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+      thrust::fill(rmm::exec_policy(handle_ptr_->get_stream()),
                    pair_first,
                    pair_first + 1,
                    key);
@@ -122,7 +122,7 @@ class SortedUniqueKeyBucket {
     if (vertices_.size() > 0) {
       rmm::device_uvector<vertex_t> merged_vertices(
         vertices_.size() + thrust::distance(vertex_first, vertex_last), handle_ptr_->get_stream());
-      thrust::merge(rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+      thrust::merge(rmm::exec_policy(handle_ptr_->get_stream()),
                     vertices_.begin(),
                     vertices_.end(),
                     vertex_first,
@@ -131,7 +131,7 @@ class SortedUniqueKeyBucket {
       merged_vertices.resize(
         thrust::distance(
           merged_vertices.begin(),
-          thrust::unique(rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+          thrust::unique(rmm::exec_policy(handle_ptr_->get_stream()),
                          merged_vertices.begin(),
                          merged_vertices.end())),
         handle_ptr_->get_stream());
@@ -139,7 +139,7 @@ class SortedUniqueKeyBucket {
       vertices_ = std::move(merged_vertices);
     } else {
       vertices_.resize(thrust::distance(vertex_first, vertex_last), handle_ptr_->get_stream());
-      thrust::copy(rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+      thrust::copy(rmm::exec_policy(handle_ptr_->get_stream()),
                    vertex_first,
                    vertex_last,
                    vertices_.begin());
@@ -170,7 +170,7 @@ class SortedUniqueKeyBucket {
         thrust::make_zip_iterator(thrust::make_tuple(vertices_.begin(), tags_.begin()));
       auto merged_pair_first =
         thrust::make_zip_iterator(thrust::make_tuple(merged_vertices.begin(), merged_tags.begin()));
-      thrust::merge(rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+      thrust::merge(rmm::exec_policy(handle_ptr_->get_stream()),
                     old_pair_first,
                     old_pair_first + vertices_.size(),
                     key_first,
@@ -179,7 +179,7 @@ class SortedUniqueKeyBucket {
       merged_vertices.resize(
         thrust::distance(
           merged_pair_first,
-          thrust::unique(rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+          thrust::unique(rmm::exec_policy(handle_ptr_->get_stream()),
                          merged_pair_first,
                          merged_pair_first + merged_vertices.size())),
         handle_ptr_->get_stream());
@@ -191,7 +191,7 @@ class SortedUniqueKeyBucket {
     } else {
       vertices_.resize(thrust::distance(key_first, key_last), handle_ptr_->get_stream());
       tags_.resize(thrust::distance(key_first, key_last), handle_ptr_->get_stream());
-      thrust::copy(rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+      thrust::copy(rmm::exec_policy(handle_ptr_->get_stream()),
                    key_first,
                    key_last,
                    thrust::make_zip_iterator(thrust::make_tuple(vertices_.begin(), tags_.begin())));
@@ -332,7 +332,7 @@ class VertexFrontier {
     static_assert(kNumBuckets <= std::numeric_limits<uint8_t>::max());
     rmm::device_uvector<uint8_t> bucket_indices(this_bucket.size(), handle_ptr_->get_stream());
     thrust::transform(
-      rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+      rmm::exec_policy(handle_ptr_->get_stream()),
       this_bucket.begin(),
       this_bucket.end(),
       bucket_indices.begin(),
@@ -348,7 +348,7 @@ class VertexFrontier {
     bucket_indices.resize(
       thrust::distance(pair_first,
                        thrust::remove_if(
-                         rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+                         rmm::exec_policy(handle_ptr_->get_stream()),
                          pair_first,
                          pair_first + bucket_indices.size(),
                          [] __device__(auto pair) {
@@ -366,7 +366,7 @@ class VertexFrontier {
     auto new_this_bucket_size = static_cast<size_t>(thrust::distance(
       pair_first,
       thrust::stable_partition(  // stalbe_partition to maintain sorted order within each bucket
-        rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+        rmm::exec_policy(handle_ptr_->get_stream()),
         pair_first,
         pair_first + bucket_indices.size(),
         [this_bucket_idx = static_cast<uint8_t>(this_bucket_idx)] __device__(auto pair) {
@@ -406,7 +406,7 @@ class VertexFrontier {
       auto next_bucket_size = static_cast<size_t>(thrust::distance(
         pair_first,
         thrust::stable_partition(  // stalbe_partition to maintain sorted order within each bucket
-          rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+          rmm::exec_policy(handle_ptr_->get_stream()),
           pair_first,
           pair_last,
           [next_bucket_idx = static_cast<uint8_t>(to_bucket_indices[0])] __device__(auto pair) {
@@ -419,14 +419,14 @@ class VertexFrontier {
         static_cast<size_t>(thrust::distance(pair_first + next_bucket_size, pair_last))};
     } else {
       thrust::stable_sort(  // stalbe_sort to maintain sorted order within each bucket
-        rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+        rmm::exec_policy(handle_ptr_->get_stream()),
         pair_first,
         pair_last,
         [] __device__(auto lhs, auto rhs) { return thrust::get<0>(lhs) < thrust::get<0>(rhs); });
       rmm::device_uvector<uint8_t> d_indices(to_bucket_indices.size(), handle_ptr_->get_stream());
       rmm::device_uvector<size_t> d_counts(d_indices.size(), handle_ptr_->get_stream());
       auto it = thrust::reduce_by_key(
-        rmm::exec_policy(handle_ptr_->get_stream())->on(handle_ptr_->get_stream()),
+        rmm::exec_policy(handle_ptr_->get_stream()),
         bucket_idx_first,
         bucket_idx_last,
         thrust::make_constant_iterator(size_t{1}),

--- a/cpp/include/cugraph/prims/vertex_frontier.cuh
+++ b/cpp/include/cugraph/prims/vertex_frontier.cuh
@@ -96,10 +96,7 @@ class SortedUniqueKeyBucket {
       tags_.resize(1, handle_ptr_->get_stream());
       auto pair_first =
         thrust::make_tuple(thrust::make_zip_iterator(vertices_.begin(), tags_.begin()));
-      thrust::fill(rmm::exec_policy(handle_ptr_->get_stream()),
-                   pair_first,
-                   pair_first + 1,
-                   key);
+      thrust::fill(rmm::exec_policy(handle_ptr_->get_stream()), pair_first, pair_first + 1, key);
     }
   }
 
@@ -129,20 +126,17 @@ class SortedUniqueKeyBucket {
                     vertex_last,
                     merged_vertices.begin());
       merged_vertices.resize(
-        thrust::distance(
-          merged_vertices.begin(),
-          thrust::unique(rmm::exec_policy(handle_ptr_->get_stream()),
-                         merged_vertices.begin(),
-                         merged_vertices.end())),
+        thrust::distance(merged_vertices.begin(),
+                         thrust::unique(rmm::exec_policy(handle_ptr_->get_stream()),
+                                        merged_vertices.begin(),
+                                        merged_vertices.end())),
         handle_ptr_->get_stream());
       merged_vertices.shrink_to_fit(handle_ptr_->get_stream());
       vertices_ = std::move(merged_vertices);
     } else {
       vertices_.resize(thrust::distance(vertex_first, vertex_last), handle_ptr_->get_stream());
-      thrust::copy(rmm::exec_policy(handle_ptr_->get_stream()),
-                   vertex_first,
-                   vertex_last,
-                   vertices_.begin());
+      thrust::copy(
+        rmm::exec_policy(handle_ptr_->get_stream()), vertex_first, vertex_last, vertices_.begin());
     }
   }
 
@@ -177,11 +171,10 @@ class SortedUniqueKeyBucket {
                     key_last,
                     merged_pair_first);
       merged_vertices.resize(
-        thrust::distance(
-          merged_pair_first,
-          thrust::unique(rmm::exec_policy(handle_ptr_->get_stream()),
-                         merged_pair_first,
-                         merged_pair_first + merged_vertices.size())),
+        thrust::distance(merged_pair_first,
+                         thrust::unique(rmm::exec_policy(handle_ptr_->get_stream()),
+                                        merged_pair_first,
+                                        merged_pair_first + merged_vertices.size())),
         handle_ptr_->get_stream());
       merged_tags.resize(merged_vertices.size(), handle_ptr_->get_stream());
       merged_vertices.shrink_to_fit(handle_ptr_->get_stream());
@@ -347,13 +340,13 @@ class VertexFrontier {
       thrust::make_zip_iterator(thrust::make_tuple(bucket_indices.begin(), this_bucket.begin()));
     bucket_indices.resize(
       thrust::distance(pair_first,
-                       thrust::remove_if(
-                         rmm::exec_policy(handle_ptr_->get_stream()),
-                         pair_first,
-                         pair_first + bucket_indices.size(),
-                         [] __device__(auto pair) {
-                           return thrust::get<0>(pair) == static_cast<uint8_t>(kInvalidBucketIdx);
-                         })),
+                       thrust::remove_if(rmm::exec_policy(handle_ptr_->get_stream()),
+                                         pair_first,
+                                         pair_first + bucket_indices.size(),
+                                         [] __device__(auto pair) {
+                                           return thrust::get<0>(pair) ==
+                                                  static_cast<uint8_t>(kInvalidBucketIdx);
+                                         })),
       handle_ptr_->get_stream());
     this_bucket.resize(bucket_indices.size());
     bucket_indices.shrink_to_fit(handle_ptr_->get_stream());
@@ -425,13 +418,12 @@ class VertexFrontier {
         [] __device__(auto lhs, auto rhs) { return thrust::get<0>(lhs) < thrust::get<0>(rhs); });
       rmm::device_uvector<uint8_t> d_indices(to_bucket_indices.size(), handle_ptr_->get_stream());
       rmm::device_uvector<size_t> d_counts(d_indices.size(), handle_ptr_->get_stream());
-      auto it = thrust::reduce_by_key(
-        rmm::exec_policy(handle_ptr_->get_stream()),
-        bucket_idx_first,
-        bucket_idx_last,
-        thrust::make_constant_iterator(size_t{1}),
-        d_indices.begin(),
-        d_counts.begin());
+      auto it = thrust::reduce_by_key(rmm::exec_policy(handle_ptr_->get_stream()),
+                                      bucket_idx_first,
+                                      bucket_idx_last,
+                                      thrust::make_constant_iterator(size_t{1}),
+                                      d_indices.begin(),
+                                      d_counts.begin());
       d_indices.resize(thrust::distance(d_indices.begin(), thrust::get<0>(it)),
                        handle_ptr_->get_stream());
       d_counts.resize(d_indices.size(), handle_ptr_->get_stream());

--- a/cpp/src/centrality/betweenness_centrality.cu
+++ b/cpp/src/centrality/betweenness_centrality.cu
@@ -25,8 +25,8 @@
 #include <cugraph/utilities/error.hpp>
 
 #include <rmm/device_scalar.hpp>
-#include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <raft/handle.hpp>
 #include "betweenness_centrality.cuh"

--- a/cpp/src/centrality/betweenness_centrality.cu
+++ b/cpp/src/centrality/betweenness_centrality.cu
@@ -26,6 +26,7 @@
 
 #include <rmm/device_scalar.hpp>
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 
 #include <raft/handle.hpp>
 #include "betweenness_centrality.cuh"

--- a/cpp/src/centrality/betweenness_centrality.cuh
+++ b/cpp/src/centrality/betweenness_centrality.cuh
@@ -17,8 +17,8 @@
 // Author: Xavier Cadet xcadet@nvidia.com
 
 #pragma once
-#include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/centrality/betweenness_centrality.cuh
+++ b/cpp/src/centrality/betweenness_centrality.cuh
@@ -17,7 +17,7 @@
 // Author: Xavier Cadet xcadet@nvidia.com
 
 #pragma once
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/centrality/betweenness_centrality.cuh
+++ b/cpp/src/centrality/betweenness_centrality.cuh
@@ -18,6 +18,7 @@
 
 #pragma once
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/centrality/katz_centrality.cu
+++ b/cpp/src/centrality/katz_centrality.cu
@@ -22,8 +22,8 @@
 #include <cugraph/prims/transform_reduce_v.cuh>
 #include <cugraph/utilities/error.hpp>
 
-#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/fill.h>
 #include <thrust/iterator/constant_iterator.h>

--- a/cpp/src/centrality/katz_centrality.cu
+++ b/cpp/src/centrality/katz_centrality.cu
@@ -22,7 +22,7 @@
 #include <cugraph/prims/transform_reduce_v.cuh>
 #include <cugraph/utilities/error.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
 
 #include <thrust/fill.h>
@@ -80,7 +80,7 @@ void katz_centrality(raft::handle_t const& handle,
   // 2. initialize katz centrality values
 
   if (!has_initial_guess) {
-    thrust::fill(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::fill(rmm::exec_policy(handle.get_stream()),
                  katz_centralities,
                  katz_centralities + pull_graph_view.get_number_of_local_vertices(),
                  result_t{0.0});
@@ -115,7 +115,7 @@ void katz_centrality(raft::handle_t const& handle,
 
     if (betas != nullptr) {
       auto val_first = thrust::make_zip_iterator(thrust::make_tuple(new_katz_centralities, betas));
-      thrust::transform(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+      thrust::transform(rmm::exec_policy(handle.get_stream()),
                         val_first,
                         val_first + pull_graph_view.get_number_of_local_vertices(),
                         new_katz_centralities,
@@ -143,7 +143,7 @@ void katz_centrality(raft::handle_t const& handle,
   }
 
   if (new_katz_centralities != katz_centralities) {
-    thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::copy(rmm::exec_policy(handle.get_stream()),
                  new_katz_centralities,
                  new_katz_centralities + pull_graph_view.get_number_of_local_vertices(),
                  katz_centralities);
@@ -159,7 +159,7 @@ void katz_centrality(raft::handle_t const& handle,
     l2_norm = std::sqrt(l2_norm);
     CUGRAPH_EXPECTS(l2_norm > 0.0,
                     "L2 norm of the computed Katz Centrality values should be positive.");
-    thrust::transform(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::transform(rmm::exec_policy(handle.get_stream()),
                       katz_centralities,
                       katz_centralities + pull_graph_view.get_number_of_local_vertices(),
                       katz_centralities,

--- a/cpp/src/community/flatten_dendrogram.cuh
+++ b/cpp/src/community/flatten_dendrogram.cuh
@@ -18,8 +18,8 @@
 #include <cugraph/dendrogram.hpp>
 #include <cugraph/graph_functions.hpp>
 
-#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cugraph {
 

--- a/cpp/src/community/flatten_dendrogram.cuh
+++ b/cpp/src/community/flatten_dendrogram.cuh
@@ -18,7 +18,7 @@
 #include <cugraph/dendrogram.hpp>
 #include <cugraph/graph_functions.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
 
 namespace cugraph {
@@ -40,7 +40,7 @@ void partition_at_level(raft::handle_t const& handle,
     thrust::make_counting_iterator<size_t>(level),
     [&handle, &dendrogram, &local_vertex_ids_v, d_vertex_ids, &d_partition, local_num_verts](
       size_t l) {
-      thrust::sequence(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+      thrust::sequence(rmm::exec_policy(handle.get_stream()),
                        local_vertex_ids_v.begin(),
                        local_vertex_ids_v.begin() + dendrogram.get_level_size_nocheck(l),
                        dendrogram.get_level_first_index_nocheck(l));

--- a/cpp/src/community/legacy/egonet.cu
+++ b/cpp/src/community/legacy/egonet.cu
@@ -23,7 +23,7 @@
 
 #include <rmm/exec_policy.hpp>
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 
 #include <thrust/transform.h>
 #include <ctime>

--- a/cpp/src/community/legacy/egonet.cu
+++ b/cpp/src/community/legacy/egonet.cu
@@ -21,9 +21,9 @@
 #include <tuple>
 #include <utility>
 
-#include <rmm/exec_policy.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/transform.h>
 #include <ctime>

--- a/cpp/src/community/legacy/egonet.cu
+++ b/cpp/src/community/legacy/egonet.cu
@@ -21,7 +21,7 @@
 #include <tuple>
 #include <utility>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 

--- a/cpp/src/community/legacy/extract_subgraph_by_vertex.cu
+++ b/cpp/src/community/legacy/extract_subgraph_by_vertex.cu
@@ -18,9 +18,9 @@
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 
-#include <rmm/exec_policy.hpp>
-#include <rmm/device_vector.hpp>
 #include <raft/device_atomics.cuh>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace {
 

--- a/cpp/src/community/legacy/extract_subgraph_by_vertex.cu
+++ b/cpp/src/community/legacy/extract_subgraph_by_vertex.cu
@@ -19,6 +19,7 @@
 #include <cugraph/utilities/error.hpp>
 
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 #include <raft/device_atomics.cuh>
 
 namespace {

--- a/cpp/src/community/legacy/extract_subgraph_by_vertex.cu
+++ b/cpp/src/community/legacy/extract_subgraph_by_vertex.cu
@@ -18,7 +18,7 @@
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <raft/device_atomics.cuh>
 
 namespace {
@@ -39,7 +39,7 @@ std::unique_ptr<cugraph::legacy::GraphCOO<vertex_t, edge_t, weight_t>> extract_s
   int64_t* d_error_count  = error_count_v.data().get();
 
   thrust::for_each(
-    rmm::exec_policy(stream)->on(stream),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<vertex_t>(0),
     thrust::make_counting_iterator<vertex_t>(num_vertices),
     [vertices, d_vertex_used, d_error_count, graph_num_verts] __device__(vertex_t idx) {
@@ -60,7 +60,7 @@ std::unique_ptr<cugraph::legacy::GraphCOO<vertex_t, edge_t, weight_t>> extract_s
 
   // iterate over the edges and count how many make it into the output
   int64_t count = thrust::count_if(
-    rmm::exec_policy(stream)->on(stream),
+    rmm::exec_policy(stream),
     thrust::make_counting_iterator<edge_t>(0),
     thrust::make_counting_iterator<edge_t>(graph.number_of_edges),
     [graph_src, graph_dst, d_vertex_used, num_vertices] __device__(edge_t e) {
@@ -78,7 +78,7 @@ std::unique_ptr<cugraph::legacy::GraphCOO<vertex_t, edge_t, weight_t>> extract_s
     weight_t* d_new_weight = result->edge_data();
 
     //  reusing error_count as a vertex counter...
-    thrust::for_each(rmm::exec_policy(stream)->on(stream),
+    thrust::for_each(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<edge_t>(0),
                      thrust::make_counting_iterator<edge_t>(graph.number_of_edges),
                      [graph_src,

--- a/cpp/src/community/legacy/leiden.cu
+++ b/cpp/src/community/legacy/leiden.cu
@@ -39,7 +39,7 @@ std::pair<size_t, weight_t> leiden(raft::handle_t const& handle,
 
   rmm::device_uvector<vertex_t> vertex_ids_v(graph.number_of_vertices, handle.get_stream());
 
-  thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::copy(rmm::exec_policy(handle.get_stream()),
                thrust::make_counting_iterator<vertex_t>(0),  // MNMG - base vertex id
                thrust::make_counting_iterator<vertex_t>(
                  graph.number_of_vertices),  // MNMG - base vertex id + number_of_vertices

--- a/cpp/src/community/legacy/spectral_clustering.cu
+++ b/cpp/src/community/legacy/spectral_clustering.cu
@@ -23,6 +23,7 @@
 #include <cugraph/algorithms.hpp>
 
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 #include <thrust/transform.h>
 #include <ctime>
 

--- a/cpp/src/community/legacy/spectral_clustering.cu
+++ b/cpp/src/community/legacy/spectral_clustering.cu
@@ -22,7 +22,7 @@
 
 #include <cugraph/algorithms.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <thrust/transform.h>
 #include <ctime>
 
@@ -71,7 +71,7 @@ void balancedCutClustering_impl(legacy::GraphCSRView<vertex_t, edge_t, weight_t>
   raft::handle_t handle;
   auto stream  = handle.get_stream();
   auto exec    = rmm::exec_policy(stream);
-  auto t_exe_p = exec->on(stream);
+  auto t_exe_p = exec;
 
   int evs_max_it{4000};
   int kmean_max_it{200};
@@ -142,7 +142,7 @@ void spectralModularityMaximization_impl(
   raft::handle_t handle;
   auto stream  = handle.get_stream();
   auto exec    = rmm::exec_policy(stream);
-  auto t_exe_p = exec->on(stream);
+  auto t_exe_p = exec;
 
   int evs_max_it{4000};
   int kmean_max_it{200};
@@ -195,7 +195,7 @@ void analyzeModularityClustering_impl(legacy::GraphCSRView<vertex_t, edge_t, wei
   raft::handle_t handle;
   auto stream  = handle.get_stream();
   auto exec    = rmm::exec_policy(stream);
-  auto t_exe_p = exec->on(stream);
+  auto t_exe_p = exec;
 
   using index_type = vertex_t;
   using value_type = weight_t;
@@ -217,7 +217,7 @@ void analyzeBalancedCut_impl(legacy::GraphCSRView<vertex_t, edge_t, weight_t> co
   raft::handle_t handle;
   auto stream  = handle.get_stream();
   auto exec    = rmm::exec_policy(stream);
-  auto t_exe_p = exec->on(stream);
+  auto t_exe_p = exec;
 
   RAFT_EXPECTS(n_clusters <= graph.number_of_vertices,
                "API error: number of clusters must be <= number of vertices");

--- a/cpp/src/community/legacy/spectral_clustering.cu
+++ b/cpp/src/community/legacy/spectral_clustering.cu
@@ -22,10 +22,10 @@
 
 #include <cugraph/algorithms.hpp>
 
-#include <rmm/exec_policy.hpp>
-#include <rmm/device_vector.hpp>
 #include <thrust/transform.h>
 #include <ctime>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>

--- a/cpp/src/community/legacy/triangles_counting.cu
+++ b/cpp/src/community/legacy/triangles_counting.cu
@@ -23,6 +23,7 @@
 #include <cugraph/utilities/error.hpp>
 
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 #include <rmm/device_buffer.hpp>
 
 #include <thrust/iterator/counting_iterator.h>

--- a/cpp/src/community/legacy/triangles_counting.cu
+++ b/cpp/src/community/legacy/triangles_counting.cu
@@ -22,7 +22,7 @@
 
 #include <cugraph/utilities/error.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <rmm/device_buffer.hpp>
 
 #include <thrust/iterator/counting_iterator.h>

--- a/cpp/src/community/legacy/triangles_counting.cu
+++ b/cpp/src/community/legacy/triangles_counting.cu
@@ -22,9 +22,9 @@
 
 #include <cugraph/utilities/error.hpp>
 
-#include <rmm/exec_policy.hpp>
-#include <rmm/device_vector.hpp>
 #include <rmm/device_buffer.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 

--- a/cpp/src/community/louvain.cu
+++ b/cpp/src/community/louvain.cu
@@ -81,7 +81,7 @@ void flatten_dendrogram(raft::handle_t const& handle,
 {
   rmm::device_uvector<vertex_t> vertex_ids_v(graph_view.number_of_vertices, handle.get_stream());
 
-  thrust::sequence(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::sequence(rmm::exec_policy(handle.get_stream()),
                    vertex_ids_v.begin(),
                    vertex_ids_v.end(),
                    vertex_t{0});
@@ -100,7 +100,7 @@ void flatten_dendrogram(
   rmm::device_uvector<vertex_t> vertex_ids_v(graph_view.get_number_of_vertices(),
                                              handle.get_stream());
 
-  thrust::sequence(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::sequence(rmm::exec_policy(handle.get_stream()),
                    vertex_ids_v.begin(),
                    vertex_ids_v.end(),
                    graph_view.get_local_vertex_first());

--- a/cpp/src/community/louvain.cu
+++ b/cpp/src/community/louvain.cu
@@ -81,10 +81,8 @@ void flatten_dendrogram(raft::handle_t const& handle,
 {
   rmm::device_uvector<vertex_t> vertex_ids_v(graph_view.number_of_vertices, handle.get_stream());
 
-  thrust::sequence(rmm::exec_policy(handle.get_stream()),
-                   vertex_ids_v.begin(),
-                   vertex_ids_v.end(),
-                   vertex_t{0});
+  thrust::sequence(
+    rmm::exec_policy(handle.get_stream()), vertex_ids_v.begin(), vertex_ids_v.end(), vertex_t{0});
 
   partition_at_level<vertex_t, false>(
     handle, dendrogram, vertex_ids_v.data(), clustering, dendrogram.num_levels());

--- a/cpp/src/components/weak_cc.cuh
+++ b/cpp/src/components/weak_cc.cuh
@@ -28,7 +28,7 @@
 #include <raft/cudart_utils.h>
 #include <raft/device_atomics.cuh>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include "utils.h"
 
 namespace MLCommon {

--- a/cpp/src/components/weak_cc.cuh
+++ b/cpp/src/components/weak_cc.cuh
@@ -29,6 +29,7 @@
 #include <raft/device_atomics.cuh>
 
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 #include "utils.h"
 
 namespace MLCommon {

--- a/cpp/src/components/weak_cc.cuh
+++ b/cpp/src/components/weak_cc.cuh
@@ -28,8 +28,8 @@
 #include <raft/cudart_utils.h>
 #include <raft/device_atomics.cuh>
 
-#include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 #include "utils.h"
 
 namespace MLCommon {

--- a/cpp/src/converters/permute_graph.cuh
+++ b/cpp/src/converters/permute_graph.cuh
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <utilities/graph_utils.cuh>
@@ -59,7 +59,7 @@ void permute_graph(legacy::GraphCSRView<vertex_t, edge_t, weight_t> const& graph
   graph.get_source_indices(d_src);
 
   if (graph.has_data())
-    thrust::copy(rmm::exec_policy(stream)->on(stream),
+    thrust::copy(rmm::exec_policy(stream),
                  graph.edge_data,
                  graph.edge_data + graph.number_of_edges,
                  d_weights);
@@ -67,10 +67,10 @@ void permute_graph(legacy::GraphCSRView<vertex_t, edge_t, weight_t> const& graph
   // Permute the src_indices
   permutation_functor<vertex_t> pf(permutation);
   thrust::transform(
-    rmm::exec_policy(stream)->on(stream), d_src, d_src + graph.number_of_edges, d_src, pf);
+    rmm::exec_policy(stream), d_src, d_src + graph.number_of_edges, d_src, pf);
 
   // Permute the destination indices
-  thrust::transform(rmm::exec_policy(stream)->on(stream),
+  thrust::transform(rmm::exec_policy(stream),
                     graph.indices,
                     graph.indices + graph.number_of_edges,
                     d_dst,

--- a/cpp/src/converters/permute_graph.cuh
+++ b/cpp/src/converters/permute_graph.cuh
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <utilities/graph_utils.cuh>

--- a/cpp/src/converters/permute_graph.cuh
+++ b/cpp/src/converters/permute_graph.cuh
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <rmm/exec_policy.hpp>
-#include <rmm/device_vector.hpp>
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 #include <utilities/graph_utils.cuh>
 #include "converters/COOtoCSR.cuh"
 
@@ -67,15 +67,11 @@ void permute_graph(legacy::GraphCSRView<vertex_t, edge_t, weight_t> const& graph
 
   // Permute the src_indices
   permutation_functor<vertex_t> pf(permutation);
-  thrust::transform(
-    rmm::exec_policy(stream), d_src, d_src + graph.number_of_edges, d_src, pf);
+  thrust::transform(rmm::exec_policy(stream), d_src, d_src + graph.number_of_edges, d_src, pf);
 
   // Permute the destination indices
-  thrust::transform(rmm::exec_policy(stream),
-                    graph.indices,
-                    graph.indices + graph.number_of_edges,
-                    d_dst,
-                    pf);
+  thrust::transform(
+    rmm::exec_policy(stream), graph.indices, graph.indices + graph.number_of_edges, d_dst, pf);
 
   legacy::GraphCOOView<vertex_t, edge_t, weight_t> graph_coo;
 

--- a/cpp/src/cores/core_number.cu
+++ b/cpp/src/cores/core_number.cu
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include <rmm/device_vector.hpp>
-#include <rmm/exec_policy.hpp>
 #include <Hornet.hpp>
 #include <Static/CoreNumber/CoreNumber.cuh>
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 //#include <nvgraph_gdf.h>
 
 namespace cugraph {

--- a/cpp/src/cores/core_number.cu
+++ b/cpp/src/cores/core_number.cu
@@ -15,6 +15,7 @@
  */
 
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 #include <Hornet.hpp>
 #include <Static/CoreNumber/CoreNumber.cuh>
 #include <cugraph/legacy/graph.hpp>

--- a/cpp/src/cores/core_number.cu
+++ b/cpp/src/cores/core_number.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <Hornet.hpp>
 #include <Static/CoreNumber/CoreNumber.cuh>
 #include <cugraph/legacy/graph.hpp>
@@ -66,7 +66,7 @@ void extract_edges(legacy::GraphCOOView<VT, ET, WT> const& i_graph,
       thrust::make_tuple(i_graph.src_indices, i_graph.dst_indices, i_graph.edge_data));
     auto outEdge = thrust::make_zip_iterator(
       thrust::make_tuple(o_graph.src_indices, o_graph.dst_indices, o_graph.edge_data));
-    auto ptr = thrust::copy_if(rmm::exec_policy(stream)->on(stream),
+    auto ptr = thrust::copy_if(rmm::exec_policy(stream),
                                inEdge,
                                inEdge + i_graph.number_of_edges,
                                outEdge,
@@ -79,7 +79,7 @@ void extract_edges(legacy::GraphCOOView<VT, ET, WT> const& i_graph,
       thrust::make_zip_iterator(thrust::make_tuple(i_graph.src_indices, i_graph.dst_indices));
     auto outEdge =
       thrust::make_zip_iterator(thrust::make_tuple(o_graph.src_indices, o_graph.dst_indices));
-    auto ptr = thrust::copy_if(rmm::exec_policy(stream)->on(stream),
+    auto ptr = thrust::copy_if(rmm::exec_policy(stream),
                                inEdge,
                                inEdge + i_graph.number_of_edges,
                                outEdge,
@@ -110,7 +110,7 @@ std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> extract_subgraph(
   rmm::device_vector<VT> sorted_core_num(in_graph.number_of_vertices);
 
   thrust::scatter(
-    rmm::exec_policy(stream)->on(stream), core_num, core_num + len, vid, sorted_core_num.begin());
+    rmm::exec_policy(stream), core_num, core_num + len, vid, sorted_core_num.begin());
 
   VT* d_sorted_core_num = sorted_core_num.data().get();
 
@@ -121,7 +121,7 @@ std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> extract_subgraph(
 
   auto out_graph = std::make_unique<legacy::GraphCOO<VT, ET, WT>>(
     in_graph.number_of_vertices,
-    thrust::count_if(rmm::exec_policy(stream)->on(stream),
+    thrust::count_if(rmm::exec_policy(stream),
                      edge,
                      edge + in_graph.number_of_edges,
                      detail::FilterEdges(k, d_sorted_core_num)),

--- a/cpp/src/cores/core_number.cu
+++ b/cpp/src/cores/core_number.cu
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 #include <Hornet.hpp>
 #include <Static/CoreNumber/CoreNumber.cuh>
 #include <cugraph/legacy/graph.hpp>
@@ -110,8 +110,7 @@ std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> extract_subgraph(
 
   rmm::device_vector<VT> sorted_core_num(in_graph.number_of_vertices);
 
-  thrust::scatter(
-    rmm::exec_policy(stream), core_num, core_num + len, vid, sorted_core_num.begin());
+  thrust::scatter(rmm::exec_policy(stream), core_num, core_num + len, vid, sorted_core_num.begin());
 
   VT* d_sorted_core_num = sorted_core_num.data().get();
 

--- a/cpp/src/link_analysis/pagerank.cu
+++ b/cpp/src/link_analysis/pagerank.cu
@@ -24,7 +24,7 @@
 #include <cugraph/prims/transform_reduce_v.cuh>
 #include <cugraph/utilities/error.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
 
 #include <thrust/fill.h>
@@ -157,13 +157,13 @@ void pagerank(
     CUGRAPH_EXPECTS(sum > 0.0,
                     "Invalid input argument: sum of the PageRank initial "
                     "guess values should be positive.");
-    thrust::transform(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::transform(rmm::exec_policy(handle.get_stream()),
                       pageranks,
                       pageranks + pull_graph_view.get_number_of_local_vertices(),
                       pageranks,
                       [sum] __device__(auto val) { return val / sum; });
   } else {
-    thrust::fill(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::fill(rmm::exec_policy(handle.get_stream()),
                  pageranks,
                  pageranks + pull_graph_view.get_number_of_local_vertices(),
                  result_t{1.0} / static_cast<result_t>(num_vertices));
@@ -192,7 +192,7 @@ void pagerank(
     pull_graph_view.get_number_of_local_adj_matrix_partition_rows(), handle.get_stream());
   size_t iter{0};
   while (true) {
-    thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::copy(rmm::exec_policy(handle.get_stream()),
                  pageranks,
                  pageranks + pull_graph_view.get_number_of_local_vertices(),
                  old_pageranks.data());
@@ -211,7 +211,7 @@ void pagerank(
       },
       result_t{0.0});
 
-    thrust::transform(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::transform(rmm::exec_policy(handle.get_stream()),
                       vertex_val_first,
                       vertex_val_first + pull_graph_view.get_number_of_local_vertices(),
                       pageranks,
@@ -247,7 +247,7 @@ void pagerank(
       auto val_first = thrust::make_zip_iterator(
         thrust::make_tuple(*personalization_vertices, *personalization_values));
       thrust::for_each(
-        rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        rmm::exec_policy(handle.get_stream()),
         val_first,
         val_first + *personalization_vector_size,
         [vertex_partition, pageranks, dangling_sum, personalization_sum, alpha] __device__(

--- a/cpp/src/link_analysis/pagerank.cu
+++ b/cpp/src/link_analysis/pagerank.cu
@@ -24,8 +24,8 @@
 #include <cugraph/prims/transform_reduce_v.cuh>
 #include <cugraph/utilities/error.hpp>
 
-#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/fill.h>
 #include <thrust/for_each.h>

--- a/cpp/src/link_prediction/overlap.cu
+++ b/cpp/src/link_prediction/overlap.cu
@@ -19,7 +19,7 @@
  * @file jaccard.cu
  * ---------------------------------------------------------------------------**/
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <utilities/graph_utils.cuh>

--- a/cpp/src/link_prediction/overlap.cu
+++ b/cpp/src/link_prediction/overlap.cu
@@ -19,10 +19,10 @@
  * @file jaccard.cu
  * ---------------------------------------------------------------------------**/
 
-#include <rmm/exec_policy.hpp>
-#include <rmm/device_vector.hpp>
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 #include <utilities/graph_utils.cuh>
 
 namespace cugraph {

--- a/cpp/src/link_prediction/overlap.cu
+++ b/cpp/src/link_prediction/overlap.cu
@@ -20,6 +20,7 @@
  * ---------------------------------------------------------------------------**/
 
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <utilities/graph_utils.cuh>

--- a/cpp/src/serialization/serializer.cu
+++ b/cpp/src/serialization/serializer.cu
@@ -23,7 +23,7 @@
 
 #include <raft/device_atomics.cuh>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 
 #include <rmm/exec_policy.hpp>
 

--- a/cpp/src/structure/coarsen_graph.cu
+++ b/cpp/src/structure/coarsen_graph.cu
@@ -24,9 +24,9 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/host_barrier.hpp>
 
-#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/copy.h>
 #include <thrust/iterator/discard_iterator.h>
@@ -89,10 +89,8 @@ edge_t groupby_e_and_coarsen_edgelist(vertex_t* edgelist_major_vertices /* [INOU
     thrust::make_zip_iterator(thrust::make_tuple(edgelist_major_vertices, edgelist_minor_vertices));
 
   if (edgelist_weights) {
-    thrust::sort_by_key(rmm::exec_policy(stream),
-                        pair_first,
-                        pair_first + number_of_edges,
-                        *edgelist_weights);
+    thrust::sort_by_key(
+      rmm::exec_policy(stream), pair_first, pair_first + number_of_edges, *edgelist_weights);
 
     rmm::device_uvector<vertex_t> tmp_edgelist_major_vertices(number_of_edges, stream);
     rmm::device_uvector<vertex_t> tmp_edgelist_minor_vertices(tmp_edgelist_major_vertices.size(),
@@ -124,8 +122,7 @@ edge_t groupby_e_and_coarsen_edgelist(vertex_t* edgelist_major_vertices /* [INOU
     thrust::sort(rmm::exec_policy(stream), pair_first, pair_first + number_of_edges);
     return static_cast<edge_t>(thrust::distance(
       pair_first,
-      thrust::unique(
-        rmm::exec_policy(stream), pair_first, pair_first + number_of_edges)));
+      thrust::unique(rmm::exec_policy(stream), pair_first, pair_first + number_of_edges)));
   }
 }
 
@@ -395,27 +392,21 @@ coarsen_graph(
                labels,
                labels + unique_labels.size(),
                unique_labels.begin());
-  thrust::sort(rmm::exec_policy(handle.get_stream()),
-               unique_labels.begin(),
-               unique_labels.end());
-  unique_labels.resize(
-    thrust::distance(unique_labels.begin(),
-                     thrust::unique(rmm::exec_policy(handle.get_stream()),
-                                    unique_labels.begin(),
-                                    unique_labels.end())),
-    handle.get_stream());
+  thrust::sort(rmm::exec_policy(handle.get_stream()), unique_labels.begin(), unique_labels.end());
+  unique_labels.resize(thrust::distance(unique_labels.begin(),
+                                        thrust::unique(rmm::exec_policy(handle.get_stream()),
+                                                       unique_labels.begin(),
+                                                       unique_labels.end())),
+                       handle.get_stream());
 
   unique_labels = cugraph::detail::shuffle_vertices_by_gpu_id(handle, std::move(unique_labels));
 
-  thrust::sort(rmm::exec_policy(handle.get_stream()),
-               unique_labels.begin(),
-               unique_labels.end());
-  unique_labels.resize(
-    thrust::distance(unique_labels.begin(),
-                     thrust::unique(rmm::exec_policy(handle.get_stream()),
-                                    unique_labels.begin(),
-                                    unique_labels.end())),
-    handle.get_stream());
+  thrust::sort(rmm::exec_policy(handle.get_stream()), unique_labels.begin(), unique_labels.end());
+  unique_labels.resize(thrust::distance(unique_labels.begin(),
+                                        thrust::unique(rmm::exec_policy(handle.get_stream()),
+                                                       unique_labels.begin(),
+                                                       unique_labels.end())),
+                       handle.get_stream());
 
   // 4. renumber
 
@@ -514,15 +505,12 @@ coarsen_graph(
                labels,
                labels + unique_labels.size(),
                unique_labels.begin());
-  thrust::sort(rmm::exec_policy(handle.get_stream()),
-               unique_labels.begin(),
-               unique_labels.end());
-  unique_labels.resize(
-    thrust::distance(unique_labels.begin(),
-                     thrust::unique(rmm::exec_policy(handle.get_stream()),
-                                    unique_labels.begin(),
-                                    unique_labels.end())),
-    handle.get_stream());
+  thrust::sort(rmm::exec_policy(handle.get_stream()), unique_labels.begin(), unique_labels.end());
+  unique_labels.resize(thrust::distance(unique_labels.begin(),
+                                        thrust::unique(rmm::exec_policy(handle.get_stream()),
+                                                       unique_labels.begin(),
+                                                       unique_labels.end())),
+                       handle.get_stream());
 
   auto [renumber_map_labels, segment_offsets] = renumber_edgelist<vertex_t, edge_t, multi_gpu>(
     handle,

--- a/cpp/src/structure/create_graph_from_edgelist.cpp
+++ b/cpp/src/structure/create_graph_from_edgelist.cpp
@@ -19,7 +19,7 @@
 #include <cugraph/partition_manager.hpp>
 #include <cugraph/utilities/error.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/functional.h>
 #include <thrust/transform_reduce.h>

--- a/cpp/src/structure/renumber_edgelist.cu
+++ b/cpp/src/structure/renumber_edgelist.cu
@@ -356,7 +356,7 @@ std::tuple<rmm::device_uvector<vertex_t>, std::vector<vertex_t>> compute_renumbe
   d_segment_offsets.set_element_async(
     num_segments_per_vertex_partition, vertex_count, handle.get_stream());
 
-  thrust::upper_bound(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::upper_bound(rmm::exec_policy(handle.get_stream()),
                       counts.begin(),
                       counts.end(),
                       d_thresholds.begin(),

--- a/cpp/src/traversal/bfs.cu
+++ b/cpp/src/traversal/bfs.cu
@@ -22,8 +22,8 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
 
-#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/fill.h>
 #include <thrust/iterator/constant_iterator.h>

--- a/cpp/src/traversal/bfs.cu
+++ b/cpp/src/traversal/bfs.cu
@@ -22,7 +22,7 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <raft/handle.hpp>
 
 #include <thrust/fill.h>
@@ -78,7 +78,7 @@ void bfs(raft::handle_t const& handle,
   auto constexpr invalid_vertex   = invalid_vertex_id<vertex_t>::value;
 
   auto val_first = thrust::make_zip_iterator(thrust::make_tuple(distances, predecessor_first));
-  thrust::transform(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::transform(rmm::exec_policy(handle.get_stream()),
                     thrust::make_counting_iterator(push_graph_view.get_local_vertex_first()),
                     thrust::make_counting_iterator(push_graph_view.get_local_vertex_last()),
                     val_first,

--- a/cpp/src/traversal/legacy/bfs.cuh
+++ b/cpp/src/traversal/legacy/bfs.cuh
@@ -11,9 +11,9 @@
 
 #pragma once
 
-#include <rmm/exec_policy.hpp>
-#include <rmm/device_vector.hpp>
 #include <climits>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #define TRAVERSAL_DEFAULT_ALPHA 15
 

--- a/cpp/src/traversal/legacy/bfs.cuh
+++ b/cpp/src/traversal/legacy/bfs.cuh
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <climits>
 
 #define TRAVERSAL_DEFAULT_ALPHA 15

--- a/cpp/src/traversal/legacy/bfs.cuh
+++ b/cpp/src/traversal/legacy/bfs.cuh
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 #include <climits>
 
 #define TRAVERSAL_DEFAULT_ALPHA 15

--- a/cpp/src/traversal/legacy/mg/bfs.cuh
+++ b/cpp/src/traversal/legacy/mg/bfs.cuh
@@ -83,7 +83,7 @@ void bfs_traverse(raft::handle_t const& handle,
     input_frontier.swap(output_frontier);
 
     // Clear output frontier bitmap
-    thrust::fill(rmm::exec_policy(stream)->on(stream),
+    thrust::fill(rmm::exec_policy(stream),
                  output_frontier_bmap.begin(),
                  output_frontier_bmap.end(),
                  static_cast<uint32_t>(0));
@@ -129,7 +129,7 @@ void bfs(raft::handle_t const& handle,
   cudaStream_t stream = handle.get_stream();
 
   // Set all predecessors to be invalid vertex ids
-  thrust::fill(rmm::exec_policy(stream)->on(stream),
+  thrust::fill(rmm::exec_policy(stream),
                predecessors,
                predecessors + global_number_of_vertices,
                cugraph::legacy::invalid_idx<vertex_t>::value);

--- a/cpp/src/traversal/legacy/mg/bfs.cuh
+++ b/cpp/src/traversal/legacy/mg/bfs.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <rmm/device_vector.hpp>
 #include <raft/handle.hpp>
+#include <rmm/device_vector.hpp>
 #include "../traversal_common.cuh"
 #include "common_utils.cuh"
 #include "frontier_expand.cuh"

--- a/cpp/src/traversal/legacy/mg/bfs.cuh
+++ b/cpp/src/traversal/legacy/mg/bfs.cuh
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <rmm/device_vector.hpp>
 #include <raft/handle.hpp>
 #include "../traversal_common.cuh"
 #include "common_utils.cuh"

--- a/cpp/src/traversal/legacy/mg/common_utils.cuh
+++ b/cpp/src/traversal/legacy/mg/common_utils.cuh
@@ -19,6 +19,7 @@
 #include "../traversal_common.cuh"
 
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 #include <thrust/host_vector.h>
 #include <cub/cub.cuh>
 

--- a/cpp/src/traversal/legacy/mg/frontier_expand.cuh
+++ b/cpp/src/traversal/legacy/mg/frontier_expand.cuh
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <rmm/device_vector.hpp>
 #include <cugraph/legacy/graph.hpp>
 #include "frontier_expand_kernels.cuh"
 #include "vertex_binning.cuh"

--- a/cpp/src/traversal/legacy/mg/frontier_expand.cuh
+++ b/cpp/src/traversal/legacy/mg/frontier_expand.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <rmm/device_vector.hpp>
 #include <cugraph/legacy/graph.hpp>
+#include <rmm/device_vector.hpp>
 #include "frontier_expand_kernels.cuh"
 #include "vertex_binning.cuh"
 

--- a/cpp/src/traversal/legacy/mg/vertex_binning.cuh
+++ b/cpp/src/traversal/legacy/mg/vertex_binning.cuh
@@ -96,8 +96,7 @@ template <typename vertex_t, typename edge_t>
 LogDistribution<vertex_t, edge_t> VertexBinner<vertex_t, edge_t>::run(
   rmm::device_vector<vertex_t>& reorganized_vertices, cudaStream_t stream)
 {
-  thrust::fill(
-    rmm::exec_policy(stream), bin_offsets_.begin(), bin_offsets_.end(), edge_t{0});
+  thrust::fill(rmm::exec_policy(stream), bin_offsets_.begin(), bin_offsets_.end(), edge_t{0});
   thrust::fill(rmm::exec_policy(stream), tempBins_.begin(), tempBins_.end(), edge_t{0});
   bin_vertices(reorganized_vertices,
                bin_offsets_,

--- a/cpp/src/traversal/legacy/mg/vertex_binning.cuh
+++ b/cpp/src/traversal/legacy/mg/vertex_binning.cuh
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <rmm/device_vector.hpp>
 #include "common_utils.cuh"
 #include "vertex_binning_kernels.cuh"
 

--- a/cpp/src/traversal/legacy/mg/vertex_binning.cuh
+++ b/cpp/src/traversal/legacy/mg/vertex_binning.cuh
@@ -96,8 +96,8 @@ LogDistribution<vertex_t, edge_t> VertexBinner<vertex_t, edge_t>::run(
   rmm::device_vector<vertex_t>& reorganized_vertices, cudaStream_t stream)
 {
   thrust::fill(
-    rmm::exec_policy(stream)->on(stream), bin_offsets_.begin(), bin_offsets_.end(), edge_t{0});
-  thrust::fill(rmm::exec_policy(stream)->on(stream), tempBins_.begin(), tempBins_.end(), edge_t{0});
+    rmm::exec_policy(stream), bin_offsets_.begin(), bin_offsets_.end(), edge_t{0});
+  thrust::fill(rmm::exec_policy(stream), tempBins_.begin(), tempBins_.end(), edge_t{0});
   bin_vertices(reorganized_vertices,
                bin_offsets_,
                tempBins_,

--- a/cpp/src/traversal/legacy/mg/vertex_binning_kernels.cuh
+++ b/cpp/src/traversal/legacy/mg/vertex_binning_kernels.cuh
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 #include "../traversal_common.cuh"
 
 namespace cugraph {

--- a/cpp/src/traversal/legacy/mg/vertex_binning_kernels.cuh
+++ b/cpp/src/traversal/legacy/mg/vertex_binning_kernels.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 #include "../traversal_common.cuh"
 
 namespace cugraph {

--- a/cpp/src/traversal/legacy/mg/vertex_binning_kernels.cuh
+++ b/cpp/src/traversal/legacy/mg/vertex_binning_kernels.cuh
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include "../traversal_common.cuh"
 
 namespace cugraph {

--- a/cpp/src/traversal/legacy/sssp.cu
+++ b/cpp/src/traversal/legacy/sssp.cu
@@ -17,8 +17,8 @@
 // Author: Prasun Gera pgera@nvidia.com
 
 #include <algorithm>
-#include <rmm/device_vector.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <rmm/device_vector.hpp>
 
 #include <cugraph/legacy/graph.hpp>
 

--- a/cpp/src/traversal/legacy/sssp.cu
+++ b/cpp/src/traversal/legacy/sssp.cu
@@ -17,6 +17,7 @@
 // Author: Prasun Gera pgera@nvidia.com
 
 #include <algorithm>
+#include <rmm/device_vector.hpp>
 #include <cugraph/utilities/error.hpp>
 
 #include <cugraph/legacy/graph.hpp>

--- a/cpp/src/traversal/legacy/sssp.cuh
+++ b/cpp/src/traversal/legacy/sssp.cuh
@@ -17,8 +17,8 @@
 // Author: Prasun Gera pgera@nvidia.com
 
 #pragma once
-#include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/traversal/legacy/sssp.cuh
+++ b/cpp/src/traversal/legacy/sssp.cuh
@@ -17,7 +17,7 @@
 // Author: Prasun Gera pgera@nvidia.com
 
 #pragma once
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/traversal/legacy/sssp.cuh
+++ b/cpp/src/traversal/legacy/sssp.cuh
@@ -18,6 +18,7 @@
 
 #pragma once
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/traversal/legacy/traversal_common.cuh
+++ b/cpp/src/traversal/legacy/traversal_common.cuh
@@ -426,7 +426,7 @@ template <typename IndexType>
 void exclusive_sum(IndexType* d_in, IndexType* d_out, IndexType num_items, cudaStream_t m_stream)
 {
   if (num_items <= 1) return;  // DeviceScan fails if n==1
-  thrust::exclusive_scan(rmm::exec_policy(m_stream)->on(m_stream), d_in, d_in + num_items, d_out);
+  thrust::exclusive_scan(rmm::exec_policy(m_stream), d_in, d_in + num_items, d_out);
 }
 
 //

--- a/cpp/src/traversal/sssp.cu
+++ b/cpp/src/traversal/sssp.cu
@@ -26,7 +26,7 @@
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <raft/cudart_utils.h>
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/fill.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -93,7 +93,7 @@ void sssp(raft::handle_t const& handle,
   auto constexpr invalid_vertex   = invalid_vertex_id<vertex_t>::value;
 
   auto val_first = thrust::make_zip_iterator(thrust::make_tuple(distances, predecessor_first));
-  thrust::transform(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::transform(rmm::exec_policy(handle.get_stream()),
                     thrust::make_counting_iterator(push_graph_view.get_local_vertex_first()),
                     thrust::make_counting_iterator(push_graph_view.get_local_vertex_last()),
                     val_first,
@@ -143,7 +143,7 @@ void sssp(raft::handle_t const& handle,
   if (!vertex_and_adj_matrix_row_ranges_coincide) {
     adj_matrix_row_distances.resize(push_graph_view.get_number_of_local_adj_matrix_partition_rows(),
                                     handle.get_stream());
-    thrust::fill(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::fill(rmm::exec_policy(handle.get_stream()),
                  adj_matrix_row_distances.begin(),
                  adj_matrix_row_distances.end(),
                  std::numeric_limits<weight_t>::max());

--- a/cpp/src/traversal/tsp.hpp
+++ b/cpp/src/traversal/tsp.hpp
@@ -21,7 +21,7 @@
 #include <raft/cudart_utils.h>
 #include <raft/handle.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 

--- a/cpp/src/traversal/tsp.hpp
+++ b/cpp/src/traversal/tsp.hpp
@@ -21,9 +21,9 @@
 #include <raft/cudart_utils.h>
 #include <raft/handle.hpp>
 
-#include <rmm/exec_policy.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/traversal/two_hop_neighbors.cu
+++ b/cpp/src/traversal/two_hop_neighbors.cu
@@ -19,11 +19,11 @@
  * @file two_hop_neighbors.cu
  * ---------------------------------------------------------------------------**/
 
-#include <rmm/exec_policy.hpp>
-#include <rmm/device_vector.hpp>
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 #include "two_hop_neighbors.cuh"
 
 #include <thrust/execution_policy.h>
@@ -100,11 +100,8 @@ std::unique_ptr<legacy::GraphCOO<VT, ET, WT>> get_two_hop_neighbors(
   auto tuple_start = thrust::make_zip_iterator(thrust::make_tuple(d_first_pair, d_second_pair));
   auto tuple_end   = tuple_start + output_size;
   thrust::sort(rmm::exec_policy(stream), tuple_start, tuple_end);
-  tuple_end = thrust::copy_if(rmm::exec_policy(stream),
-                              tuple_start,
-                              tuple_end,
-                              tuple_start,
-                              self_loop_flagger<VT>());
+  tuple_end = thrust::copy_if(
+    rmm::exec_policy(stream), tuple_start, tuple_end, tuple_start, self_loop_flagger<VT>());
   tuple_end = thrust::unique(rmm::exec_policy(stream), tuple_start, tuple_end);
 
   // Get things ready to return

--- a/cpp/src/traversal/two_hop_neighbors.cu
+++ b/cpp/src/traversal/two_hop_neighbors.cu
@@ -20,6 +20,7 @@
  * ---------------------------------------------------------------------------**/
 
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>

--- a/cpp/src/tree/mst.cu
+++ b/cpp/src/tree/mst.cu
@@ -24,7 +24,7 @@
 #include <memory>
 #include <utility>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <thrust/transform.h>
 #include <ctime>
 

--- a/cpp/src/tree/mst.cu
+++ b/cpp/src/tree/mst.cu
@@ -24,9 +24,9 @@
 #include <memory>
 #include <utility>
 
-#include <rmm/exec_policy.hpp>
 #include <thrust/transform.h>
 #include <ctime>
+#include <rmm/exec_policy.hpp>
 
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>

--- a/cpp/src/utilities/cython.cu
+++ b/cpp/src/utilities/cython.cu
@@ -30,8 +30,8 @@
 
 #include <raft/handle.hpp>
 
-#include <rmm/exec_policy.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/copy.h>
 #include <thrust/fill.h>
@@ -101,10 +101,8 @@ std::vector<edge_t> compute_edge_counts(raft::handle_t const& handle,
   if (static_cast<size_t>(thrust::distance(d_local_partition_ids.begin(), thrust::get<0>(it))) <
       num_local_partitions) {
     rmm::device_uvector<edge_t> d_counts(num_local_partitions, handle.get_stream());
-    thrust::fill(rmm::exec_policy(handle.get_stream()),
-                 d_counts.begin(),
-                 d_counts.end(),
-                 edge_t{0});
+    thrust::fill(
+      rmm::exec_policy(handle.get_stream()), d_counts.begin(), d_counts.end(), edge_t{0});
     thrust::scatter(rmm::exec_policy(handle.get_stream()),
                     d_edge_counts.begin(),
                     thrust::get<1>(it),

--- a/cpp/src/utilities/cython.cu
+++ b/cpp/src/utilities/cython.cu
@@ -30,7 +30,7 @@
 
 #include <raft/handle.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/copy.h>
@@ -92,7 +92,7 @@ std::vector<edge_t> compute_edge_counts(raft::handle_t const& handle,
     major_vertices, compute_local_partition_id_t<vertex_t>{d_lasts.data(), num_local_partitions});
   rmm::device_uvector<size_t> d_local_partition_ids(num_local_partitions, handle.get_stream());
   rmm::device_uvector<edge_t> d_edge_counts(d_local_partition_ids.size(), handle.get_stream());
-  auto it = thrust::reduce_by_key(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  auto it = thrust::reduce_by_key(rmm::exec_policy(handle.get_stream()),
                                   key_first,
                                   key_first + graph_container.num_local_edges,
                                   thrust::make_constant_iterator(edge_t{1}),
@@ -101,11 +101,11 @@ std::vector<edge_t> compute_edge_counts(raft::handle_t const& handle,
   if (static_cast<size_t>(thrust::distance(d_local_partition_ids.begin(), thrust::get<0>(it))) <
       num_local_partitions) {
     rmm::device_uvector<edge_t> d_counts(num_local_partitions, handle.get_stream());
-    thrust::fill(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::fill(rmm::exec_policy(handle.get_stream()),
                  d_counts.begin(),
                  d_counts.end(),
                  edge_t{0});
-    thrust::scatter(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::scatter(rmm::exec_policy(handle.get_stream()),
                     d_edge_counts.begin(),
                     thrust::get<1>(it),
                     d_local_partition_ids.begin(),
@@ -510,7 +510,7 @@ class louvain_functor {
   std::pair<size_t, weight_t> operator()(raft::handle_t const& handle,
                                          graph_view_t const& graph_view)
   {
-    thrust::copy(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::copy(rmm::exec_policy(handle.get_stream()),
                  thrust::make_counting_iterator(graph_view.get_local_vertex_first()),
                  thrust::make_counting_iterator(graph_view.get_local_vertex_last()),
                  reinterpret_cast<typename graph_view_t::vertex_type*>(identifiers_));

--- a/cpp/src/utilities/path_retrieval.cu
+++ b/cpp/src/utilities/path_retrieval.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <raft/handle.hpp>
@@ -74,10 +74,10 @@ void get_traversed_cost_impl(raft::handle_t const& handle,
   vertex_t* vtx_keys = vtx_keys_v.data();
   raft::copy(vtx_keys, vertices, num_vertices, stream);
 
-  thrust::sequence(rmm::exec_policy(stream)->on(stream), vtx_map, vtx_map + num_vertices);
+  thrust::sequence(rmm::exec_policy(stream), vtx_map, vtx_map + num_vertices);
 
   thrust::stable_sort_by_key(
-    rmm::exec_policy(stream)->on(stream), vtx_keys, vtx_keys + num_vertices, vtx_map);
+    rmm::exec_policy(stream), vtx_keys, vtx_keys + num_vertices, vtx_map);
 
   get_traversed_cost_kernel<<<nblocks, nthreads>>>(
     vertices, preds, vtx_map, info_weights, out, stop_vertex, num_vertices);

--- a/cpp/src/utilities/path_retrieval.cu
+++ b/cpp/src/utilities/path_retrieval.cu
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <rmm/exec_policy.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <raft/handle.hpp>
 
@@ -76,8 +76,7 @@ void get_traversed_cost_impl(raft::handle_t const& handle,
 
   thrust::sequence(rmm::exec_policy(stream), vtx_map, vtx_map + num_vertices);
 
-  thrust::stable_sort_by_key(
-    rmm::exec_policy(stream), vtx_keys, vtx_keys + num_vertices, vtx_map);
+  thrust::stable_sort_by_key(rmm::exec_policy(stream), vtx_keys, vtx_keys + num_vertices, vtx_map);
 
   get_traversed_cost_kernel<<<nblocks, nthreads>>>(
     vertices, preds, vtx_map, info_weights, out, stop_vertex, num_vertices);

--- a/cpp/src/utilities/spmv_1D.cuh
+++ b/cpp/src/utilities/spmv_1D.cuh
@@ -15,10 +15,10 @@
  */
 
 #pragma once
-#include <rmm/exec_policy.hpp>
-#include <rmm/device_vector.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <raft/handle.hpp>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cugraph {
 namespace mg {

--- a/cpp/src/utilities/spmv_1D.cuh
+++ b/cpp/src/utilities/spmv_1D.cuh
@@ -15,7 +15,7 @@
  */
 
 #pragma once
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <raft/handle.hpp>
 

--- a/cpp/src/utilities/spmv_1D.cuh
+++ b/cpp/src/utilities/spmv_1D.cuh
@@ -16,6 +16,7 @@
 
 #pragma once
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <raft/handle.hpp>
 

--- a/cpp/tests/centrality/legacy/betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/legacy/betweenness_centrality_test.cu
@@ -24,6 +24,8 @@
 #include <raft/error.hpp>
 #include <raft/handle.hpp>
 
+#include <rmm/device_vector.hpp>
+
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 

--- a/cpp/tests/centrality/legacy/edge_betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/legacy/edge_betweenness_centrality_test.cu
@@ -21,6 +21,8 @@
 #include <raft/error.hpp>
 #include <raft/handle.hpp>
 
+#include <rmm/device_vector.hpp>
+
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 

--- a/cpp/tests/centrality/legacy/katz_centrality_test.cu
+++ b/cpp/tests/centrality/legacy/katz_centrality_test.cu
@@ -46,8 +46,8 @@ std::vector<int> getTopKIds(double* p_katz, int count, int k = 10)
 {
   cudaStream_t stream = nullptr;
   rmm::device_vector<int> id(count);
-  thrust::sequence(rmm::exec_policy(stream)->on(stream), id.begin(), id.end());
-  thrust::sort_by_key(rmm::exec_policy(stream)->on(stream),
+  thrust::sequence(rmm::exec_policy(stream), id.begin(), id.end());
+  thrust::sort_by_key(rmm::exec_policy(stream),
                       p_katz,
                       p_katz + count,
                       id.begin(),
@@ -65,7 +65,7 @@ int getMaxDegree(cugraph::legacy::GraphCSRView<VT, ET, WT> const& g)
   rmm::device_vector<ET> degree_vector(g.number_of_vertices);
   ET* p_degree = degree_vector.data().get();
   g.degree(p_degree, cugraph::legacy::DegreeDirection::OUT);
-  ET max_out_degree = thrust::reduce(rmm::exec_policy(stream)->on(stream),
+  ET max_out_degree = thrust::reduce(rmm::exec_policy(stream),
                                      p_degree,
                                      p_degree + g.number_of_vertices,
                                      static_cast<ET>(-1),

--- a/cpp/tests/centrality/legacy/katz_centrality_test.cu
+++ b/cpp/tests/centrality/legacy/katz_centrality_test.cu
@@ -49,11 +49,8 @@ std::vector<int> getTopKIds(double* p_katz, int count, int k = 10)
   cudaStream_t stream = nullptr;
   rmm::device_vector<int> id(count);
   thrust::sequence(rmm::exec_policy(stream), id.begin(), id.end());
-  thrust::sort_by_key(rmm::exec_policy(stream),
-                      p_katz,
-                      p_katz + count,
-                      id.begin(),
-                      thrust::greater<double>());
+  thrust::sort_by_key(
+    rmm::exec_policy(stream), p_katz, p_katz + count, id.begin(), thrust::greater<double>());
   std::vector<int> topK(k);
   thrust::copy(id.begin(), id.begin() + k, topK.begin());
   return topK;

--- a/cpp/tests/centrality/legacy/katz_centrality_test.cu
+++ b/cpp/tests/centrality/legacy/katz_centrality_test.cu
@@ -20,6 +20,8 @@
 
 #include <converters/COOtoCSR.cuh>
 
+#include <rmm/device_vector.hpp>
+
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>
 

--- a/cpp/tests/community/balanced_edge_test.cpp
+++ b/cpp/tests/community/balanced_edge_test.cpp
@@ -12,7 +12,7 @@
 
 #include <cugraph/algorithms.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 
 TEST(balanced_edge, success)
 {

--- a/cpp/tests/community/balanced_edge_test.cpp
+++ b/cpp/tests/community/balanced_edge_test.cpp
@@ -13,6 +13,7 @@
 #include <cugraph/algorithms.hpp>
 
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 
 TEST(balanced_edge, success)
 {

--- a/cpp/tests/community/balanced_edge_test.cpp
+++ b/cpp/tests/community/balanced_edge_test.cpp
@@ -12,8 +12,8 @@
 
 #include <cugraph/algorithms.hpp>
 
-#include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 TEST(balanced_edge, success)
 {

--- a/cpp/tests/community/ecg_test.cpp
+++ b/cpp/tests/community/ecg_test.cpp
@@ -13,8 +13,8 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>
 
-#include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 // FIXME:  Temporarily disable this test.  Something is wrong with
 //         ECG, or the expectation of this test.  If I run ensemble size

--- a/cpp/tests/community/ecg_test.cpp
+++ b/cpp/tests/community/ecg_test.cpp
@@ -13,7 +13,7 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 
 // FIXME:  Temporarily disable this test.  Something is wrong with
 //         ECG, or the expectation of this test.  If I run ensemble size

--- a/cpp/tests/community/ecg_test.cpp
+++ b/cpp/tests/community/ecg_test.cpp
@@ -14,6 +14,7 @@
 #include <cugraph/legacy/graph.hpp>
 
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 
 // FIXME:  Temporarily disable this test.  Something is wrong with
 //         ECG, or the expectation of this test.  If I run ensemble size

--- a/cpp/tests/community/egonet_test.cu
+++ b/cpp/tests/community/egonet_test.cu
@@ -30,7 +30,7 @@
 #include <gtest/gtest.h>
 
 #include <raft/cudart_utils.h>
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <algorithm>
 #include <tuple>
 #include <vector>

--- a/cpp/tests/community/egonet_test.cu
+++ b/cpp/tests/community/egonet_test.cu
@@ -30,8 +30,8 @@
 #include <gtest/gtest.h>
 
 #include <raft/cudart_utils.h>
-#include <rmm/exec_policy.hpp>
 #include <algorithm>
+#include <rmm/exec_policy.hpp>
 #include <tuple>
 #include <vector>
 

--- a/cpp/tests/community/leiden_test.cpp
+++ b/cpp/tests/community/leiden_test.cpp
@@ -15,7 +15,7 @@
 
 #include <thrust/extrema.h>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 
 TEST(leiden_karate, success)
 {

--- a/cpp/tests/community/mg_louvain_helper.cu
+++ b/cpp/tests/community/mg_louvain_helper.cu
@@ -22,7 +22,7 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/host_scalar_comm.cuh>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/for_each.h>
 #include <thrust/reduce.h>
@@ -40,19 +40,19 @@ void single_gpu_renumber_edgelist_given_number_map(raft::handle_t const& handle,
   rmm::device_uvector<T> index_v(renumber_map_gathered_v.size(), handle.get_stream());
 
   thrust::for_each(
-    rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    rmm::exec_policy(handle.get_stream()),
     thrust::make_counting_iterator<size_t>(0),
     thrust::make_counting_iterator<size_t>(renumber_map_gathered_v.size()),
     [d_renumber_map_gathered = renumber_map_gathered_v.data(), d_index = index_v.data()] __device__(
       auto idx) { d_index[d_renumber_map_gathered[idx]] = idx; });
 
-  thrust::transform(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::transform(rmm::exec_policy(handle.get_stream()),
                     edgelist_rows_v.begin(),
                     edgelist_rows_v.end(),
                     edgelist_rows_v.begin(),
                     [d_index = index_v.data()] __device__(auto v) { return d_index[v]; });
 
-  thrust::transform(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::transform(rmm::exec_policy(handle.get_stream()),
                     edgelist_cols_v.begin(),
                     edgelist_cols_v.end(),
                     edgelist_cols_v.begin(),
@@ -84,7 +84,7 @@ compressed_sparse_to_edgelist(edge_t const* compressed_sparse_offsets,
   // FIXME: this is highly inefficient for very high-degree vertices, for better performance, we can
   // fill high-degree vertices using one CUDA block per vertex, mid-degree vertices using one CUDA
   // warp per vertex, and low-degree vertices using one CUDA thread per block
-  thrust::for_each(rmm::exec_policy(stream)->on(stream),
+  thrust::for_each(rmm::exec_policy(stream),
                    thrust::make_counting_iterator(major_first),
                    thrust::make_counting_iterator(major_last),
                    [compressed_sparse_offsets,
@@ -94,12 +94,12 @@ compressed_sparse_to_edgelist(edge_t const* compressed_sparse_offsets,
                      auto last  = compressed_sparse_offsets[v - major_first + 1];
                      thrust::fill(thrust::seq, p_majors + first, p_majors + last, v);
                    });
-  thrust::copy(rmm::exec_policy(stream)->on(stream),
+  thrust::copy(rmm::exec_policy(stream),
                compressed_sparse_indices,
                compressed_sparse_indices + number_of_edges,
                edgelist_minor_vertices.begin());
   if (compressed_sparse_weights) {
-    thrust::copy(rmm::exec_policy(stream)->on(stream),
+    thrust::copy(rmm::exec_policy(stream),
                  (*compressed_sparse_weights),
                  (*compressed_sparse_weights) + number_of_edges,
                  (*edgelist_weights).data());
@@ -122,7 +122,7 @@ void sort_and_coarsen_edgelist(
 
   size_t number_of_edges{0};
   if (edgelist_weights) {
-    thrust::sort_by_key(rmm::exec_policy(stream)->on(stream),
+    thrust::sort_by_key(rmm::exec_policy(stream),
                         pair_first,
                         pair_first + edgelist_major_vertices.size(),
                         (*edgelist_weights).begin());
@@ -133,7 +133,7 @@ void sort_and_coarsen_edgelist(
                                                               stream);
     rmm::device_uvector<weight_t> tmp_edgelist_weights(tmp_edgelist_major_vertices.size(), stream);
     auto it = thrust::reduce_by_key(
-      rmm::exec_policy(stream)->on(stream),
+      rmm::exec_policy(stream),
       pair_first,
       pair_first + edgelist_major_vertices.size(),
       (*edgelist_weights).begin(),
@@ -146,10 +146,10 @@ void sort_and_coarsen_edgelist(
     edgelist_minor_vertices = std::move(tmp_edgelist_minor_vertices);
     (*edgelist_weights)     = std::move(tmp_edgelist_weights);
   } else {
-    thrust::sort(rmm::exec_policy(stream)->on(stream),
+    thrust::sort(rmm::exec_policy(stream),
                  pair_first,
                  pair_first + edgelist_major_vertices.size());
-    auto it         = thrust::unique(rmm::exec_policy(stream)->on(stream),
+    auto it         = thrust::unique(rmm::exec_policy(stream),
                              pair_first,
                              pair_first + edgelist_major_vertices.size());
     number_of_edges = thrust::distance(pair_first, it);
@@ -195,7 +195,7 @@ compressed_sparse_to_relabeled_and_sorted_and_coarsened_edgelist(
   auto pair_first = thrust::make_zip_iterator(
     thrust::make_tuple(edgelist_major_vertices.begin(), edgelist_minor_vertices.begin()));
   thrust::transform(
-    rmm::exec_policy(stream)->on(stream),
+    rmm::exec_policy(stream),
     pair_first,
     pair_first + edgelist_major_vertices.size(),
     pair_first,
@@ -247,7 +247,7 @@ coarsen_graph(
   edgelist.number_of_edges = static_cast<edge_t>(coarsened_edgelist_major_vertices.size());
 
   vertex_t new_number_of_vertices =
-    1 + thrust::reduce(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    1 + thrust::reduce(rmm::exec_policy(handle.get_stream()),
                        labels,
                        labels + graph_view.get_number_of_vertices(),
                        vertex_t{0},

--- a/cpp/tests/community/mg_louvain_helper.cu
+++ b/cpp/tests/community/mg_louvain_helper.cu
@@ -146,12 +146,9 @@ void sort_and_coarsen_edgelist(
     edgelist_minor_vertices = std::move(tmp_edgelist_minor_vertices);
     (*edgelist_weights)     = std::move(tmp_edgelist_weights);
   } else {
-    thrust::sort(rmm::exec_policy(stream),
-                 pair_first,
-                 pair_first + edgelist_major_vertices.size());
-    auto it         = thrust::unique(rmm::exec_policy(stream),
-                             pair_first,
-                             pair_first + edgelist_major_vertices.size());
+    thrust::sort(rmm::exec_policy(stream), pair_first, pair_first + edgelist_major_vertices.size());
+    auto it = thrust::unique(
+      rmm::exec_policy(stream), pair_first, pair_first + edgelist_major_vertices.size());
     number_of_edges = thrust::distance(pair_first, it);
   }
 
@@ -246,12 +243,11 @@ coarsen_graph(
                                : std::nullopt;
   edgelist.number_of_edges = static_cast<edge_t>(coarsened_edgelist_major_vertices.size());
 
-  vertex_t new_number_of_vertices =
-    1 + thrust::reduce(rmm::exec_policy(handle.get_stream()),
-                       labels,
-                       labels + graph_view.get_number_of_vertices(),
-                       vertex_t{0},
-                       thrust::maximum<vertex_t>());
+  vertex_t new_number_of_vertices = 1 + thrust::reduce(rmm::exec_policy(handle.get_stream()),
+                                                       labels,
+                                                       labels + graph_view.get_number_of_vertices(),
+                                                       vertex_t{0},
+                                                       thrust::maximum<vertex_t>());
 
   return std::make_unique<cugraph::graph_t<vertex_t, edge_t, weight_t, store_transposed, false>>(
     handle,

--- a/cpp/tests/community/triangle_test.cu
+++ b/cpp/tests/community/triangle_test.cu
@@ -13,8 +13,8 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>
 
-#include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 TEST(triangle, dolphin)
 {

--- a/cpp/tests/community/triangle_test.cu
+++ b/cpp/tests/community/triangle_test.cu
@@ -14,6 +14,7 @@
 #include <cugraph/legacy/graph.hpp>
 
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 
 TEST(triangle, dolphin)
 {

--- a/cpp/tests/community/triangle_test.cu
+++ b/cpp/tests/community/triangle_test.cu
@@ -13,7 +13,7 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 
 TEST(triangle, dolphin)
 {

--- a/cpp/tests/components/con_comp_test.cu
+++ b/cpp/tests/components/con_comp_test.cu
@@ -18,6 +18,8 @@
 
 #include <cuda_profiler_api.h>
 
+#include <rmm/device_vector.hpp>
+
 #include <converters/COOtoCSR.cuh>
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>

--- a/cpp/tests/components/scc_test.cu
+++ b/cpp/tests/components/scc_test.cu
@@ -16,6 +16,8 @@
 #include <utilities/base_fixture.hpp>
 #include <utilities/test_utilities.hpp>
 
+#include <rmm/device_vector.hpp>
+
 #include <components/scc_matrix.cuh>
 #include <converters/COOtoCSR.cuh>
 #include <cugraph/algorithms.hpp>

--- a/cpp/tests/generators/erdos_renyi_test.cpp
+++ b/cpp/tests/generators/erdos_renyi_test.cpp
@@ -20,6 +20,7 @@
 #include <cugraph/graph.hpp>
 #include <cugraph/graph_generators.hpp>
 
+#include <thrust/execution_policy.h>
 #include <thrust/sort.h>
 
 #include <gtest/gtest.h>

--- a/cpp/tests/layout/force_atlas2_test.cu
+++ b/cpp/tests/layout/force_atlas2_test.cu
@@ -20,8 +20,8 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>
 
-#include <rmm/exec_policy.hpp>
 #include <raft/error.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <cuda_profiler_api.h>
 

--- a/cpp/tests/layout/force_atlas2_test.cu
+++ b/cpp/tests/layout/force_atlas2_test.cu
@@ -20,7 +20,7 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <raft/error.hpp>
 
 #include <cuda_profiler_api.h>

--- a/cpp/tests/linear_assignment/hungarian_test.cu
+++ b/cpp/tests/linear_assignment/hungarian_test.cu
@@ -359,7 +359,7 @@ void random_test(int32_t num_rows, int32_t num_cols, int32_t upper_bound, int re
   //int64_t seed{85};
   int64_t seed{time(nullptr)};
 
-  thrust::for_each(rmm::exec_policy(stream)->on(stream),
+  thrust::for_each(rmm::exec_policy(stream),
                    thrust::make_counting_iterator<int32_t>(0),
                    thrust::make_counting_iterator<int32_t>(num_rows * num_cols),
                    [d_data, seed, upper_bound] __device__ (int32_t e) {

--- a/cpp/tests/prims/mg_count_if_v.cu
+++ b/cpp/tests/prims/mg_count_if_v.cu
@@ -138,7 +138,7 @@ class Tests_MG_CountIfV
           handle, true, false);
       auto sg_graph_view = sg_graph.view();
       auto expected_vertex_count =
-        thrust::count_if(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::count_if(rmm::exec_policy(handle.get_stream()),
                          thrust::make_counting_iterator(sg_graph_view.get_local_vertex_first()),
                          thrust::make_counting_iterator(sg_graph_view.get_local_vertex_last()),
                          test_predicate<vertex_t>(hash_bin_count));

--- a/cpp/tests/prims/mg_reduce_v.cu
+++ b/cpp/tests/prims/mg_reduce_v.cu
@@ -92,7 +92,7 @@ struct generate_impl {
   {
     auto data = std::make_tuple(rmm::device_uvector<Args>(labels.size(), handle.get_stream())...);
     auto zip  = get_zip_iterator(data);
-    thrust::transform(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::transform(rmm::exec_policy(handle.get_stream()),
                       labels.begin(),
                       labels.end(),
                       zip,
@@ -108,7 +108,7 @@ struct generate_impl {
     auto length = thrust::distance(begin, end);
     auto data   = std::make_tuple(rmm::device_uvector<Args>(length, handle.get_stream())...);
     auto zip    = get_zip_iterator(data);
-    thrust::transform(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+    thrust::transform(rmm::exec_policy(handle.get_stream()),
                       begin,
                       end,
                       zip,
@@ -272,7 +272,7 @@ class Tests_MG_ReduceV
       using property_t      = decltype(property_initial_value);
 
       auto expected_result =
-        thrust::reduce(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::reduce(rmm::exec_policy(handle.get_stream()),
                        sg_property_iter,
                        sg_property_iter + sg_graph_view.get_number_of_local_vertices(),
                        property_initial_value,

--- a/cpp/tests/prims/mg_transform_reduce_v.cu
+++ b/cpp/tests/prims/mg_transform_reduce_v.cu
@@ -211,7 +211,7 @@ class Tests_MG_TransformReduceV
       using property_t   = decltype(property_initial_value);
 
       auto expected_result = thrust::transform_reduce(
-        rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        rmm::exec_policy(handle.get_stream()),
         thrust::make_counting_iterator(sg_graph_view.get_local_vertex_first()),
         thrust::make_counting_iterator(sg_graph_view.get_local_vertex_last()),
         prop,

--- a/cpp/tests/sampling/random_walks_profiling.cu
+++ b/cpp/tests/sampling/random_walks_profiling.cu
@@ -24,7 +24,7 @@
 #include <raft/handle.hpp>
 #include <raft/random/rng.cuh>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 
 #include <cuda_profiler_api.h>
 #include <thrust/random.h>
@@ -47,7 +47,7 @@ void fill_start(raft::handle_t const& handle,
 {
   index_t num_paths = d_start.size();
 
-  thrust::transform(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::transform(rmm::exec_policy(handle.get_stream()),
                     thrust::make_counting_iterator<index_t>(0),
                     thrust::make_counting_iterator<index_t>(num_paths),
 

--- a/cpp/tests/sampling/random_walks_test.cu
+++ b/cpp/tests/sampling/random_walks_test.cu
@@ -20,8 +20,8 @@
 #include <utilities/base_fixture.hpp>
 #include <utilities/test_utilities.hpp>
 
-#include <rmm/exec_policy.hpp>
 #include <thrust/random.h>
+#include <rmm/exec_policy.hpp>
 
 #include <cugraph/algorithms.hpp>
 #include <sampling/random_walks.cuh>

--- a/cpp/tests/sampling/random_walks_test.cu
+++ b/cpp/tests/sampling/random_walks_test.cu
@@ -20,7 +20,7 @@
 #include <utilities/base_fixture.hpp>
 #include <utilities/test_utilities.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <thrust/random.h>
 
 #include <cugraph/algorithms.hpp>
@@ -47,7 +47,7 @@ void fill_start(raft::handle_t const& handle,
 {
   index_t num_paths = d_start.size();
 
-  thrust::transform(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::transform(rmm::exec_policy(handle.get_stream()),
                     thrust::make_counting_iterator<index_t>(0),
                     thrust::make_counting_iterator<index_t>(num_paths),
 

--- a/cpp/tests/sampling/random_walks_utils.cuh
+++ b/cpp/tests/sampling/random_walks_utils.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <sampling/random_walks.cuh>
 
 #include <raft/handle.hpp>

--- a/cpp/tests/sampling/rw_biased_seg_sort.cu
+++ b/cpp/tests/sampling/rw_biased_seg_sort.cu
@@ -20,7 +20,7 @@
 #include <utilities/base_fixture.hpp>
 #include <utilities/test_utilities.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 
 #include <cugraph/algorithms.hpp>
 

--- a/cpp/tests/sampling/rw_low_level_test.cu
+++ b/cpp/tests/sampling/rw_low_level_test.cu
@@ -21,8 +21,8 @@
 #include <utilities/base_fixture.hpp>
 #include <utilities/test_utilities.hpp>
 
-#include <rmm/exec_policy.hpp>
 #include <thrust/random.h>
+#include <rmm/exec_policy.hpp>
 
 #include <cugraph/algorithms.hpp>
 #include <sampling/random_walks.cuh>

--- a/cpp/tests/sampling/rw_low_level_test.cu
+++ b/cpp/tests/sampling/rw_low_level_test.cu
@@ -21,7 +21,7 @@
 #include <utilities/base_fixture.hpp>
 #include <utilities/test_utilities.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <thrust/random.h>
 
 #include <cugraph/algorithms.hpp>

--- a/cpp/tests/serialization/un_serialize_test.cpp
+++ b/cpp/tests/serialization/un_serialize_test.cpp
@@ -19,8 +19,8 @@
 #include <utilities/base_fixture.hpp>
 #include <utilities/test_utilities.hpp>
 
-#include <rmm/exec_policy.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <cugraph/serialization/serializer.hpp>
 

--- a/cpp/tests/serialization/un_serialize_test.cpp
+++ b/cpp/tests/serialization/un_serialize_test.cpp
@@ -19,7 +19,7 @@
 #include <utilities/base_fixture.hpp>
 #include <utilities/test_utilities.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cugraph/serialization/serializer.hpp>

--- a/cpp/tests/traversal/legacy/bfs_test.cu
+++ b/cpp/tests/traversal/legacy/bfs_test.cu
@@ -22,6 +22,7 @@
 #include <cugraph/algorithms.hpp>
 
 #include <rmm/exec_policy.hpp>
+#include <rmm/device_vector.hpp>
 
 #include <raft/handle.hpp>
 

--- a/cpp/tests/traversal/legacy/bfs_test.cu
+++ b/cpp/tests/traversal/legacy/bfs_test.cu
@@ -21,8 +21,8 @@
 
 #include <cugraph/algorithms.hpp>
 
-#include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <raft/handle.hpp>
 

--- a/cpp/tests/traversal/legacy/bfs_test.cu
+++ b/cpp/tests/traversal/legacy/bfs_test.cu
@@ -21,7 +21,7 @@
 
 #include <cugraph/algorithms.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 
 #include <raft/handle.hpp>
 

--- a/cpp/tests/traversal/legacy/sssp_test.cu
+++ b/cpp/tests/traversal/legacy/sssp_test.cu
@@ -13,6 +13,8 @@
 #include <utilities/base_fixture.hpp>
 #include <utilities/test_utilities.hpp>
 
+#include <rmm/device_vector.hpp>
+
 #include <converters/COOtoCSR.cuh>
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>

--- a/cpp/tests/traversal/ms_bfs_test.cpp
+++ b/cpp/tests/traversal/ms_bfs_test.cpp
@@ -31,9 +31,9 @@
 
 #include <cuda_profiler_api.h>
 #include <raft/cudart_utils.h>
-#include <rmm/exec_policy.hpp>
 #include <algorithm>
 #include <iostream>
+#include <rmm/exec_policy.hpp>
 #include <tuple>
 #include <vector>
 

--- a/cpp/tests/traversal/ms_bfs_test.cpp
+++ b/cpp/tests/traversal/ms_bfs_test.cpp
@@ -31,7 +31,7 @@
 
 #include <cuda_profiler_api.h>
 #include <raft/cudart_utils.h>
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <algorithm>
 #include <iostream>
 #include <tuple>

--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -20,7 +20,7 @@
 #include <utilities/cxxopts.hpp>
 #include <utilities/test_graphs.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 #include <rmm/mr/device/binning_memory_resource.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>

--- a/cpp/tests/utilities/matrix_market_file_utilities.cu
+++ b/cpp/tests/utilities/matrix_market_file_utilities.cu
@@ -335,10 +335,8 @@ read_graph_from_matrix_market_file(raft::handle_t const& handle,
       handle, graph_file_full_path, test_weighted);
 
   rmm::device_uvector<vertex_t> d_vertices(number_of_vertices, handle.get_stream());
-  thrust::sequence(rmm::exec_policy(handle.get_stream()),
-                   d_vertices.begin(),
-                   d_vertices.end(),
-                   vertex_t{0});
+  thrust::sequence(
+    rmm::exec_policy(handle.get_stream()), d_vertices.begin(), d_vertices.end(), vertex_t{0});
   handle.get_stream_view().synchronize();
 
   if (multi_gpu) {
@@ -352,14 +350,12 @@ read_graph_from_matrix_market_file(raft::handle_t const& handle,
 
     auto vertex_key_func = cugraph::detail::compute_gpu_id_from_vertex_t<vertex_t>{comm_size};
     d_vertices.resize(
-      thrust::distance(
-        d_vertices.begin(),
-        thrust::remove_if(rmm::exec_policy(handle.get_stream()),
-                          d_vertices.begin(),
-                          d_vertices.end(),
-                          [comm_rank, key_func = vertex_key_func] __device__(auto val) {
-                            return key_func(val) != comm_rank;
-                          })),
+      thrust::distance(d_vertices.begin(),
+                       thrust::remove_if(rmm::exec_policy(handle.get_stream()),
+                                         d_vertices.begin(),
+                                         d_vertices.end(),
+                                         [comm_rank, key_func = vertex_key_func] __device__(
+                                           auto val) { return key_func(val) != comm_rank; })),
       handle.get_stream());
     d_vertices.shrink_to_fit(handle.get_stream());
 

--- a/cpp/tests/utilities/matrix_market_file_utilities.cu
+++ b/cpp/tests/utilities/matrix_market_file_utilities.cu
@@ -23,7 +23,7 @@
 #include <cugraph/utilities/error.hpp>
 
 #include <raft/cudart_utils.h>
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/sequence.h>
 
@@ -335,7 +335,7 @@ read_graph_from_matrix_market_file(raft::handle_t const& handle,
       handle, graph_file_full_path, test_weighted);
 
   rmm::device_uvector<vertex_t> d_vertices(number_of_vertices, handle.get_stream());
-  thrust::sequence(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+  thrust::sequence(rmm::exec_policy(handle.get_stream()),
                    d_vertices.begin(),
                    d_vertices.end(),
                    vertex_t{0});
@@ -354,7 +354,7 @@ read_graph_from_matrix_market_file(raft::handle_t const& handle,
     d_vertices.resize(
       thrust::distance(
         d_vertices.begin(),
-        thrust::remove_if(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::remove_if(rmm::exec_policy(handle.get_stream()),
                           d_vertices.begin(),
                           d_vertices.end(),
                           [comm_rank, key_func = vertex_key_func] __device__(auto val) {
@@ -371,7 +371,7 @@ read_graph_from_matrix_market_file(raft::handle_t const& handle,
         d_edgelist_rows.begin(), d_edgelist_cols.begin(), (*d_edgelist_weights).begin()));
       number_of_local_edges = thrust::distance(
         edge_first,
-        thrust::remove_if(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::remove_if(rmm::exec_policy(handle.get_stream()),
                           edge_first,
                           edge_first + d_edgelist_rows.size(),
                           [comm_rank, key_func = edge_key_func] __device__(auto e) {
@@ -384,7 +384,7 @@ read_graph_from_matrix_market_file(raft::handle_t const& handle,
         thrust::make_tuple(d_edgelist_rows.begin(), d_edgelist_cols.begin()));
       number_of_local_edges = thrust::distance(
         edge_first,
-        thrust::remove_if(rmm::exec_policy(handle.get_stream())->on(handle.get_stream()),
+        thrust::remove_if(rmm::exec_policy(handle.get_stream()),
                           edge_first,
                           edge_first + d_edgelist_rows.size(),
                           [comm_rank, key_func = edge_key_func] __device__(auto e) {


### PR DESCRIPTION
PR essentially backports the fixes in #1707 for the deprecated RMM exec policy, and unpins the RMM nighlty to unblock local builds and CI and local development. Conflicts with the bigger PR should be minimal, and mainly around a single change:

```
rmm::exec_policy(handle.get_stream())
```

to 

```
handle.get_thrust_policy()
```