### PR TITLE
[HOTFIX] Remove `-g` from cython compile commands

### DIFF
--- a/cpp/src/traversal/tsp.cu
+++ b/cpp/src/traversal/tsp.cu
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2014-2020, Texas State University. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/traversal/tsp.hpp
+++ b/cpp/src/traversal/tsp.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2014-2020, Texas State University. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/traversal/tsp_solver.hpp
+++ b/cpp/src/traversal/tsp_solver.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2014-2020, Texas State University. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/traversal/tsp_utils.hpp
+++ b/cpp/src/traversal/tsp_utils.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2014-2020, Texas State University. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/python/cugraph/community/__init__.py
+++ b/python/cugraph/community/__init__.py
@@ -23,42 +23,7 @@ from cugraph.community.spectral_clustering import (
 )
 from cugraph.community.subgraph_extraction import subgraph
 from cugraph.community.triangle_count import triangles
+from cugraph.community.ktruss_subgraph import ktruss_subgraph
+from cugraph.community.ktruss_subgraph import k_truss
 from cugraph.community.egonet import ego_graph
 from cugraph.community.egonet import batched_ego_graphs
-
-# FIXME: special case for ktruss on CUDA 11.4: an 11.4 bug causes ktruss to
-# crash in that environment. Allow ktruss to import on non-11.4 systems, but
-# replace ktruss with a __UnsupportedModule instance, which lazily raises an
-# exception when referenced.
-from numba import cuda
-try:
-    __cuda_version = cuda.runtime.get_version()
-except cuda.cudadrv.runtime.CudaRuntimeAPIError:
-    __cuda_version = "n/a"
-
-__ktruss_unsupported_cuda_version = (11, 4)
-
-class __UnsupportedModule:
-    def __init__(self, exception):
-        self.__exception = exception
-
-    def __getattr__(self, attr):
-        raise self.__exception
-
-    def __call__(self, *args, **kwargs):
-        raise self.__exception
-
-
-if __cuda_version != __ktruss_unsupported_cuda_version:
-    from cugraph.community.ktruss_subgraph import ktruss_subgraph
-    from cugraph.community.ktruss_subgraph import k_truss
-else:
-    __kuvs = ".".join([str(n) for n in __ktruss_unsupported_cuda_version])
-    k_truss = __UnsupportedModule(
-        NotImplementedError("k_truss is not currently supported in CUDA"
-                            f" {__kuvs} environments.")
-        )
-    ktruss_subgraph = __UnsupportedModule(
-        NotImplementedError("ktruss_subgraph is not currently supported in CUDA"
-                            f" {__kuvs} environments.")
-        )

--- a/python/setup.py
+++ b/python/setup.py
@@ -16,17 +16,26 @@ import sys
 import sysconfig
 import shutil
 
-from setuptools import setup, find_packages, Command
-from setuptools.extension import Extension
-from setuputils import use_raft_package, get_environment_option
+# Must import in this order:
+#   setuptools -> Cython.Distutils.build_ext -> setuptools.command.build_ext
+# Otherwise, setuptools.command.build_ext ends up inheriting from
+# Cython.Distutils.old_build_ext which we do not want
+import setuptools
 
 try:
-    from Cython.Distutils.build_ext import new_build_ext as build_ext
+    from Cython.Distutils.build_ext import new_build_ext as _build_ext
 except ImportError:
-    from setuptools.command.build_ext import build_ext
+    from setuptools.command.build_ext import build_ext as _build_ext
+
+from distutils.sysconfig import get_python_lib
+
+import setuptools.command.build_ext
+from setuptools import find_packages, setup, Command
+from setuptools.extension import Extension
+
+from setuputils import use_raft_package, get_environment_option
 
 import versioneer
-from distutils.sysconfig import get_python_lib
 
 
 INSTALL_REQUIRES = ['numba', 'cython']
@@ -81,36 +90,7 @@ raft_include_dir = use_raft_package(raft_path, libcugraph_path)
 if not libcugraph_path:
     libcugraph_path = conda_lib_dir
 
-
-class CleanCommand(Command):
-    """Custom clean command to tidy up the project root."""
-    user_options = [('all', None, None), ]
-
-    def initialize_options(self):
-        self.all = None
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        setupFileDir = os.path.dirname(os.path.abspath(__file__))
-        os.chdir(setupFileDir)
-        os.system('rm -rf build')
-        os.system('rm -rf dist')
-        os.system('rm -rf dask-worker-space')
-        os.system('rm -f cugraph/raft')
-        os.system('find . -name "__pycache__" -type d -exec rm -rf {} +')
-        os.system('rm -rf *.egg-info')
-        os.system('find . -name "*.cpp" -type f -delete')
-        os.system('find . -name "*.cpython*.so" -type f -delete')
-
-
-cmdclass = dict()
-cmdclass.update(versioneer.get_cmdclass())
-cmdclass["build_ext"] = build_ext
-cmdclass["clean"] = CleanCommand
-
-EXTENSIONS = [
+extensions = [
     Extension("*",
               sources=CYTHON_FILES,
               include_dirs=[
@@ -136,10 +116,73 @@ EXTENSIONS = [
               extra_compile_args=['-std=c++17'])
 ]
 
-for e in EXTENSIONS:
-    e.cython_directives = dict(
-        profile=False, language_level=3, embedsignature=True
-    )
+
+class CleanCommand(Command):
+    """Custom clean command to tidy up the project root."""
+    user_options = [('all', None, None), ]
+
+    def initialize_options(self):
+        self.all = None
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        setupFileDir = os.path.dirname(os.path.abspath(__file__))
+        os.chdir(setupFileDir)
+        os.system('rm -rf build')
+        os.system('rm -rf dist')
+        os.system('rm -rf dask-worker-space')
+        os.system('rm -f cugraph/raft')
+        os.system('find . -name "__pycache__" -type d -exec rm -rf {} +')
+        os.system('rm -rf *.egg-info')
+        os.system('find . -name "*.cpp" -type f -delete')
+        os.system('find . -name "*.cpython*.so" -type f -delete')
+
+
+class build_ext_no_debug(_build_ext):
+
+    def build_extensions(self):
+        def remove_flags(compiler, *flags):
+            for flag in flags:
+                try:
+                    compiler.compiler_so = list(
+                        filter((flag).__ne__, compiler.compiler_so)
+                    )
+                except Exception:
+                    pass
+        # Full optimization
+        self.compiler.compiler_so.append("-O3")
+        # No debug symbols, full optimization, no '-Wstrict-prototypes' warning
+        remove_flags(
+            self.compiler, "-g", "-G", "-O1", "-O2", "-Wstrict-prototypes"
+        )
+        super().build_extensions()
+
+    def finalize_options(self):
+        if self.distribution.ext_modules:
+            # Delay import this to allow for Cython-less installs
+            from Cython.Build.Dependencies import cythonize
+
+            nthreads = getattr(self, "parallel", None)  # -j option in Py3.5+
+            nthreads = int(nthreads) if nthreads else None
+            self.distribution.ext_modules = cythonize(
+                self.distribution.ext_modules,
+                nthreads=nthreads,
+                force=self.force,
+                gdb_debug=False,
+                compiler_directives=dict(
+                    profile=False, language_level=3, embedsignature=True
+                ),
+            )
+        # Skip calling super() and jump straight to setuptools
+        setuptools.command.build_ext.build_ext.finalize_options(self)
+
+
+cmdclass = dict()
+cmdclass.update(versioneer.get_cmdclass())
+cmdclass["build_ext"] = build_ext_no_debug
+cmdclass["clean"] = CleanCommand
 
 setup(name='cugraph',
       description="cuGraph - GPU Graph Analytics",
@@ -154,8 +197,8 @@ setup(name='cugraph',
       ],
       # Include the separately-compiled shared library
       author="NVIDIA Corporation",
-      setup_requires=['cython'],
-      ext_modules=EXTENSIONS,
+      setup_requires=['Cython>=0.29,<0.30'],
+      ext_modules=extensions,
       packages=find_packages(include=['cugraph', 'cugraph.*']),
       install_requires=INSTALL_REQUIRES,
       license="Apache",

--- a/thirdparty/LICENSES/LICENSE.texas_state_university
+++ b/thirdparty/LICENSES/LICENSE.texas_state_university
@@ -1,0 +1,24 @@
+Copyright (c) 2014-2020, Texas State University. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   * Neither the name of Texas State University nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL TEXAS STATE UNIVERSITY BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Removes `-g` from the compile commands generated by distutils to compile Cython files.

This will make our container images, conda packages, and python wheels smaller.