### PR TITLE
MG WCC bug fix

### DIFF
--- a/cpp/src/structure/create_graph_from_edgelist.cpp
+++ b/cpp/src/structure/create_graph_from_edgelist.cpp
@@ -113,8 +113,10 @@ create_graph_from_edgelist_impl(raft::handle_t const& handle,
              *vertex_partition_segment_offsets) =
       cugraph::renumber_edgelist<vertex_t, edge_t, multi_gpu>(
         handle,
-        std::optional<std::tuple<vertex_t const*, vertex_t>>{std::make_tuple(
-          (*local_vertex_span).data(), static_cast<vertex_t>((*local_vertex_span).size()))},
+        local_vertex_span
+          ? std::optional<std::tuple<vertex_t const*, vertex_t>>{std::make_tuple(
+              (*local_vertex_span).data(), static_cast<vertex_t>((*local_vertex_span).size()))}
+          : std::nullopt,
         major_ptrs,
         minor_ptrs,
         edgelist_edge_counts,


### PR DESCRIPTION
create_graph_edgelist (invoked by WCC to create a graph from the edges emitted when concurrently growing BFS trees touch each other) called renumber_edgelist with a valid vertex list argument when invoked by WCC with an invalid vertex list (std::nullopt). This fix checks the validity of the vertex list and calls renumber_edgelist with a valid vertex list only when this function is called with a valid vertex list.