### PR TITLE
Also building cpp MG tests as part of conda/CI libcugraph builds

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -6,7 +6,12 @@
 set -e
 
 # Set path and build parallel level
-export PATH=/opt/conda/bin:/usr/local/cuda/bin:$PATH
+# openmpi dir is required on CentOS for finding MPI libs from cmake
+if [[ -e /etc/os-release ]] && (grep -qi centos /etc/os-release); then
+    export PATH=/opt/conda/bin:/usr/local/cuda/bin:/usr/lib64/openmpi/bin:$PATH
+else
+    export PATH=/opt/conda/bin:/usr/local/cuda/bin:$PATH
+fi
 export PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 
 # Set home to the job's workspace

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -69,8 +69,8 @@ set +e
 if (python ${CUGRAPH_ROOT}/ci/utils/is_pascal.py); then
     echo "WARNING: skipping C++ tests on Pascal GPU arch."
 else
-    echo "C++ gtests for cuGraph..."
-    for gt in tests/*_TEST; do
+    echo "C++ gtests for cuGraph (single-GPU only)..."
+    for gt in $(find ./tests -name "*_TEST" | grep -v "MG_" || true); do
         test_name=$(basename $gt)
         echo "Running gtest $test_name"
         ${gt} ${GTEST_FILTER} ${GTEST_ARGS}

--- a/conda/recipes/libcugraph/build.sh
+++ b/conda/recipes/libcugraph/build.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 
 # This assumes the script is executed from the root of the repo directory
-./build.sh libcugraph -v --allgpuarch
+
+# NOTE: the "libcugraph" target also builds all single-gpu gtest binaries, and
+# the "cpp-mgtests" target builds the multi-gpu gtest binaries (and installs
+# some MG dependencies via cmake). The conda package does NOT include these test
+# binaries or extra dependencies, but these are built here for use in CI runs.
+
+./build.sh libcugraph cpp-mgtests -v --allgpuarch

--- a/conda/recipes/libcugraph/build.sh
+++ b/conda/recipes/libcugraph/build.sh
@@ -5,8 +5,8 @@
 # This assumes the script is executed from the root of the repo directory
 
 # NOTE: the "libcugraph" target also builds all single-gpu gtest binaries, and
-# the "cpp-mgtests" target builds the multi-gpu gtest binaries (and installs
-# some MG dependencies via cmake). The conda package does NOT include these test
+# the "cpp-mgtests" target builds the multi-gpu gtest binaries (and requires the
+# openmpi build dependencies). The conda package does NOT include these test
 # binaries or extra dependencies, but these are built here for use in CI runs.
 
 ./build.sh libcugraph cpp-mgtests -v --allgpuarch

--- a/conda/recipes/libcugraph/build.sh
+++ b/conda/recipes/libcugraph/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
+
 # This assumes the script is executed from the root of the repo directory
 
 # NOTE: the "libcugraph" target also builds all single-gpu gtest binaries, and


### PR DESCRIPTION
Also building cpp MG tests as part of conda/CI libcugraph builds.

This addresses recent issues where commits were merged that broke MG test builds that were not caught in CI.

Tested locally using both a CentOS and Ubuntu `gpuCI` container to run the same build command in the recipe, but did not run the actual `conda build` command on the recipe.  This required additional system packages to be installed in the `gpuCI` containers:
CentOS:
```
yum install openmpi-devel
export PATH=/usr/lib64/openmpi/bin:$PATH
```
Ubuntu:
```
apt install libopenmpi-dev openmpi-bin
```
