### PR TITLE
Initial version of `pylibcugraph` conda package and CI build script updates

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -66,7 +66,7 @@ conda config --set ssl_verify False
 # BUILD - Conda package builds
 ###############################################################################
 
-gpuci_logger "Build conda pkg for libcugraph"
+gpuci_logger "Build conda package for libcugraph"
 if [ "$BUILD_LIBCUGRAPH" == '1' ]; then
   if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     gpuci_conda_retry build --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/libcugraph
@@ -77,7 +77,7 @@ if [ "$BUILD_LIBCUGRAPH" == '1' ]; then
   fi
 fi
 
-gpuci_logger "Build conda pkg for cugraph"
+gpuci_logger "Build conda packages for pylibcugraph and cugraph"
 if [ "$BUILD_CUGRAPH" == "1" ]; then
   if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     gpuci_conda_retry build --croot ${CONDA_BLD_DIR} conda/recipes/pylibcugraph --python=$PYTHON

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -75,8 +75,10 @@ fi
 gpuci_logger "Build conda pkg for cugraph"
 if [ "$BUILD_CUGRAPH" == "1" ]; then
   if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
+    gpuci_conda_retry build --croot ${CONDA_BLD_DIR} conda/recipes/pylibcugraph --python=$PYTHON
     gpuci_conda_retry build --croot ${CONDA_BLD_DIR} conda/recipes/cugraph --python=$PYTHON
   else
+    gpuci_conda_retry build --croot ${CONDA_BLD_DIR} conda/recipes/pylibcugraph -c ci/artifacts/cugraph/cpu/.conda-bld/ --dirty --no-remove-work-dir --python=$PYTHON
     gpuci_conda_retry build --croot ${CONDA_BLD_DIR} conda/recipes/cugraph -c ci/artifacts/cugraph/cpu/.conda-bld/ --dirty --no-remove-work-dir --python=$PYTHON
   fi
 fi

--- a/ci/cpu/upload.sh
+++ b/ci/cpu/upload.sh
@@ -31,6 +31,7 @@ fi
 gpuci_logger "Get conda file output locations"
 
 export LIBCUGRAPH_FILE=`conda build --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/libcugraph --output`
+export PYLIBCUGRAPH_FILE=`conda build --croot ${CONDA_BLD_DIR} conda/recipes/pylibcugraph --python=$PYTHON --output`
 export CUGRAPH_FILE=`conda build --croot ${CONDA_BLD_DIR} conda/recipes/cugraph --python=$PYTHON --output`
 
 ################################################################################
@@ -47,9 +48,12 @@ if [[ "$BUILD_LIBCUGRAPH" == "1" && "$UPLOAD_LIBCUGRAPH" == "1" ]]; then
 fi
 
 if [[ "$BUILD_CUGRAPH" == "1" ]]; then
+  test -e ${PYLIBCUGRAPH_FILE}
+  echo "Upload pylibcugraph"
+  echo ${PYLIBCUGRAPH_FILE}
+  gpuci_retry anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai} ${LABEL_OPTION} --skip-existing ${PYLIBCUGRAPH_FILE} --no-progress
   test -e ${CUGRAPH_FILE}
   echo "Upload cugraph"
   echo ${CUGRAPH_FILE}
   gpuci_retry anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai} ${LABEL_OPTION} --skip-existing ${CUGRAPH_FILE} --no-progress
 fi
-

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -83,7 +83,7 @@ conda config --show-sources
 conda list --show-channel-urls
 
 ################################################################################
-# BUILD - Build libcugraph and cuGraph from source
+# BUILD
 ################################################################################
 
 if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
@@ -113,7 +113,7 @@ else
 fi
 
 ################################################################################
-# TEST - Run GoogleTest and py.tests for libcugraph and cuGraph
+# TEST
 ################################################################################
 
 # Switch to +e to allow failing commands to continue the script, which is needed

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -80,12 +80,12 @@ fi
 
 echo "Python pytest for pylibcugraph..."
 cd ${CUGRAPH_ROOT}/python/pylibcugraph/pylibcugraph
-pytest --cache-clear --junitxml=${CUGRAPH_ROOT}/junit-cugraph.xml -v --cov-config=.coveragerc --cov=pylibcugraph --cov-report=xml:${WORKSPACE}/python/pylibcugraph/pylibcugraph-coverage.xml --cov-report term --ignore=raft --benchmark-disable
+pytest --cache-clear --junitxml=${CUGRAPH_ROOT}/junit-pylibcugraph-pytests.xml -v --cov-config=.coveragerc --cov=pylibcugraph --cov-report=xml:${WORKSPACE}/python/pylibcugraph/pylibcugraph-coverage.xml --cov-report term --ignore=raft --benchmark-disable
 echo "Ran Python pytest for pylibcugraph : return code was: $?, test script exit code is now: $EXITCODE"
 
 echo "Python pytest for cuGraph..."
 cd ${CUGRAPH_ROOT}/python/cugraph/cugraph
-pytest --cache-clear --junitxml=${CUGRAPH_ROOT}/junit-cugraph.xml -v --cov-config=.coveragerc --cov=cugraph --cov-report=xml:${WORKSPACE}/python/cugraph/cugraph-coverage.xml --cov-report term --ignore=raft --benchmark-disable
+pytest --cache-clear --junitxml=${CUGRAPH_ROOT}/junit-cugraph-pytests.xml -v --cov-config=.coveragerc --cov=cugraph --cov-report=xml:${WORKSPACE}/python/cugraph/cugraph-coverage.xml --cov-report term --ignore=raft --benchmark-disable
 echo "Ran Python pytest for cugraph : return code was: $?, test script exit code is now: $EXITCODE"
 
 echo "Python benchmarks for cuGraph (running as tests)..."

--- a/conda/recipes/pylibcugraph/build.sh
+++ b/conda/recipes/pylibcugraph/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# This assumes the script is executed from the root of the repo directory
+./build.sh pylibcugraph

--- a/conda/recipes/pylibcugraph/build.sh
+++ b/conda/recipes/pylibcugraph/build.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+# Copyright (c) 2021, NVIDIA CORPORATION.
+
 # This assumes the script is executed from the root of the repo directory
 ./build.sh pylibcugraph

--- a/conda/recipes/pylibcugraph/meta.yaml
+++ b/conda/recipes/pylibcugraph/meta.yaml
@@ -1,0 +1,40 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.
+
+# Usage:
+#   conda build -c nvidia -c rapidsai -c conda-forge  .
+{% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
+{% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
+{% set cuda_version='.'.join(environ.get('CUDA', 'unknown').split('.')[:2]) %}
+{% set py_version=environ.get('CONDA_PY', 36) %}
+package:
+  name: pylibcugraph
+  version: {{ version }}
+
+source:
+  git_url: ../../..
+
+build:
+  number: {{ GIT_DESCRIBE_NUMBER }}
+  string: cuda{{ cuda_version }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  script_env:
+    - CC
+    - CXX
+    - CUDAHOSTCXX
+    - PARALLEL_LEVEL
+
+requirements:
+  build:
+    - python x.x
+    - cython>=0.29,<0.30
+    - libcugraph={{ version }}
+    - cudatoolkit {{ cuda_version }}.*
+  run:
+    - python x.x
+    - libcugraph={{ version }}
+    - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
+
+about:
+  home: http://rapids.ai/
+  license: Apache-2.0
+  license_file: ../../../LICENSE
+  summary: pylibcugraph library

--- a/conda/recipes/pylibcugraph/meta.yaml
+++ b/conda/recipes/pylibcugraph/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - python x.x
     - cython>=0.29,<0.30
     - libcugraph={{ version }}
+    - ucx-py 0.22
+    - ucx-proc=*=gpu
     - cudatoolkit {{ cuda_version }}.*
   run:
     - python x.x

--- a/python/pylibcugraph/setup.py
+++ b/python/pylibcugraph/setup.py
@@ -18,7 +18,7 @@ import shutil
 
 from setuptools import setup, find_packages, Command
 from setuptools.extension import Extension
-from setuputils import get_environment_option
+from setuputils import use_raft_package, get_environment_option
 
 try:
     from Cython.Distutils.build_ext import new_build_ext as build_ext
@@ -69,6 +69,13 @@ cuda_lib_dir = os.path.join(CUDA_HOME, "lib64")
 
 # Optional location of C++ build folder that can be configured by the user
 libcugraph_path = get_environment_option('CUGRAPH_BUILD_PATH')
+# Optional location of RAFT that can be confugred by the user
+raft_path = get_environment_option('RAFT_PATH')
+
+# FIXME: This could clone RAFT, even if it's not needed (eg. running --clean).
+# deprecated: This functionality will go away after
+# https://github.com/rapidsai/raft/issues/83
+raft_include_dir = use_raft_package(raft_path, libcugraph_path)
 
 if not libcugraph_path:
     libcugraph_path = conda_lib_dir
@@ -90,6 +97,7 @@ class CleanCommand(Command):
         os.system('rm -rf build')
         os.system('rm -rf dist')
         os.system('rm -rf dask-worker-space')
+        os.system('rm -f pylibcugraph/raft')
         os.system('find . -name "__pycache__" -type d -exec rm -rf {} +')
         os.system('rm -rf *.egg-info')
         os.system('find . -name "*.cpp" -type f -delete')
@@ -109,6 +117,7 @@ EXTENSIONS = [
                   ucx_include_dir,
                   "../../cpp/include",
                   "../../thirdparty/cub",
+                  raft_include_dir,
                   os.path.join(conda_include_dir, "libcudacxx"),
                   cuda_include_dir,
                   os.path.dirname(sysconfig.get_path("include"))

--- a/python/pylibcugraph/setup.py
+++ b/python/pylibcugraph/setup.py
@@ -18,7 +18,7 @@ import shutil
 
 from setuptools import setup, find_packages, Command
 from setuptools.extension import Extension
-from setuputils import use_raft_package, get_environment_option
+from setuputils import get_environment_option
 
 try:
     from Cython.Distutils.build_ext import new_build_ext as build_ext
@@ -29,7 +29,6 @@ import versioneer
 from distutils.sysconfig import get_python_lib
 
 
-INSTALL_REQUIRES = ['numba', 'cython']
 CYTHON_FILES = ['pylibcugraph/**/*.pyx']
 
 UCX_HOME = get_environment_option("UCX_HOME")
@@ -70,13 +69,6 @@ cuda_lib_dir = os.path.join(CUDA_HOME, "lib64")
 
 # Optional location of C++ build folder that can be configured by the user
 libcugraph_path = get_environment_option('CUGRAPH_BUILD_PATH')
-# Optional location of RAFT that can be confugred by the user
-raft_path = get_environment_option('RAFT_PATH')
-
-# FIXME: This could clone RAFT, even if it's not needed (eg. running --clean).
-# deprecated: This functionality will go away after
-# https://github.com/rapidsai/raft/issues/83
-raft_include_dir = use_raft_package(raft_path, libcugraph_path)
 
 if not libcugraph_path:
     libcugraph_path = conda_lib_dir
@@ -98,7 +90,6 @@ class CleanCommand(Command):
         os.system('rm -rf build')
         os.system('rm -rf dist')
         os.system('rm -rf dask-worker-space')
-        os.system('rm -f pylibcugraph/raft')
         os.system('find . -name "__pycache__" -type d -exec rm -rf {} +')
         os.system('rm -rf *.egg-info')
         os.system('find . -name "*.cpp" -type f -delete')
@@ -118,7 +109,6 @@ EXTENSIONS = [
                   ucx_include_dir,
                   "../../cpp/include",
                   "../../thirdparty/cub",
-                  raft_include_dir,
                   os.path.join(conda_include_dir, "libcudacxx"),
                   cuda_include_dir,
                   os.path.dirname(sysconfig.get_path("include"))
@@ -157,7 +147,6 @@ setup(name='pylibcugraph',
       setup_requires=['cython'],
       ext_modules=EXTENSIONS,
       packages=find_packages(include=['pylibcugraph', 'pylibcugraph.*']),
-      install_requires=INSTALL_REQUIRES,
       license="Apache",
       cmdclass=cmdclass,
       zip_safe=False)


### PR DESCRIPTION
Initial version of `pylibcugraph` conda recipe, and changes to CI scripts resulting in CI building and uploading the new `pylibcugraph` conda package as part of the "cpu" build.

Note that `pylibcugraph` build and testing was already taking place as part of the "gpu" build.

Tested the recipe by doing a local build, but I modified several parts of the recipe and build script to accommodate local settings that were different than CI, so full coverage was not achieved locally.