### PR TITLE
Changed pylibcugraph connected_components APIs to use duck typing for CAI inputs, added doc placeholders

### DIFF
--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -52,4 +52,4 @@ about:
   home: http://rapids.ai/
   license: Apache-2.0
   license_file: ../../../LICENSE
-  summary: libgraph library
+  summary: libcugraph library

--- a/docs/cugraph/source/api_docs/index.rst
+++ b/docs/cugraph/source/api_docs/index.rst
@@ -24,4 +24,4 @@ This page provides a list of all publicly accessible modules, methods and classe
     generator
     helper_functions
     dask-cugraph.rst
-
+    pylibcugraph.rst

--- a/docs/cugraph/source/api_docs/pylibcugraph.rst
+++ b/docs/cugraph/source/api_docs/pylibcugraph.rst
@@ -1,0 +1,15 @@
+~~~~~~~~~~~~~~~~~~~~~~
+pylibcugraph
+~~~~~~~~~~~~~~~~~~~~~~
+
+pylibcugraph
+
+.. currentmodule:: pylibcugraph
+
+Methods
+-------
+.. autosummary::
+   :toctree: api/
+
+   pylibcugraph.components.strongly_connected_components
+   pylibcugraph.components.weakly_connected_components

--- a/python/pylibcugraph/pylibcugraph/components/_connectivity.pyx
+++ b/python/pylibcugraph/pylibcugraph/components/_connectivity.pyx
@@ -17,16 +17,37 @@ from libcpp.memory cimport unique_ptr
 from pylibcugraph.components._connectivity cimport *
 
 
+def _ensure_arg_types(**kwargs):
+    """
+    Ensure all args have a __cuda_array_interface__ attr
+    """
+    for (arg_name, arg_val) in kwargs.items():
+        # FIXME: remove this special case when weights are supported: weights
+        # can only be None
+        if arg_name is "weights":
+            if arg_val is not None:
+                raise TypeError("weights are currently not supported and must "
+                                "be None")
+        elif not(hasattr(arg_val, "__cuda_array_interface__")):
+            raise TypeError(f"{arg_name} must support __cuda_array_interface__")
+
+
 def weakly_connected_components(src, dst, weights, num_verts, num_edges, labels):
+    """
+    This is the docstring for weakly_connected_components
+    FIXME: write this docstring
+    """
+    _ensure_arg_types(src=src, dst=dst,
+                      weights=weights, labels=labels)
 
     cdef unique_ptr[handle_t] handle_ptr
     handle_ptr.reset(new handle_t())
     handle_ = handle_ptr.get()
 
-    cdef uintptr_t c_src_vertices    = src['data'][0]
-    cdef uintptr_t c_dst_vertices    = dst['data'][0]
+    cdef uintptr_t c_src_vertices = src.__cuda_array_interface__['data'][0]
+    cdef uintptr_t c_dst_vertices = dst.__cuda_array_interface__['data'][0]
     cdef uintptr_t c_edge_weights = <uintptr_t>NULL
-    cdef uintptr_t c_labels_val = labels['data'][0]
+    cdef uintptr_t c_labels_val = labels.__cuda_array_interface__['data'][0]
 
     cdef graph_container_t graph_container
     populate_graph_container(graph_container,
@@ -51,14 +72,21 @@ def weakly_connected_components(src, dst, weights, num_verts, num_edges, labels)
 
 
 def strongly_connected_components(offsets, indices, weights, num_verts, num_edges, labels):
+    """
+    This is the docstring for strongly_connected_components
+    FIXME: write this docstring
+    """
+    _ensure_arg_types(offsets=offsets, indices=indices,
+                      weights=weights, labels=labels)
+
     cdef unique_ptr[handle_t] handle_ptr
     handle_ptr.reset(new handle_t())
     handle_ = handle_ptr.get()
 
-    cdef uintptr_t c_offsets    = offsets['data'][0]
-    cdef uintptr_t c_indices    = indices['data'][0]
+    cdef uintptr_t c_offsets = offsets.__cuda_array_interface__['data'][0]
+    cdef uintptr_t c_indices = indices.__cuda_array_interface__['data'][0]
     cdef uintptr_t c_edge_weights = <uintptr_t>NULL
-    cdef uintptr_t c_labels_val = labels['data'][0]
+    cdef uintptr_t c_labels_val = labels.__cuda_array_interface__['data'][0]
 
     cdef GraphCSRView[int,int,float] g
 


### PR DESCRIPTION
* Changed API to use duck-typing on `__cuda_array_interface__` types instead of requiring users to access and pass the `__cuda_array_interface__` object in directly.
* Added initial placeholder for pylibcugraph docs and docstrings to cython file
* Updated tests to not access the `__cuda_array_interface__` attr directly, added fixtures for easier code reuse, added test for invalid inputs, added FIXMEs to track tech debt in how return values are checked.

Tested API changes by running new unit tests, and tested docs by running `./build.sh docs` and inspecting the html locally in a browser.

NOTE: since this package is still limited to nightly releases (ie. it has not been part of a release yet), it is using the "non-breaking" label even though the user API has changed.

attn: @BradReesWork and @raydouglass for the `pylibcugraph` placeholder docs in this PR
![image](https://user-images.githubusercontent.com/3039903/132440516-f3310756-d080-49bf-898a-0bc6581525eb.png)
![image](https://user-images.githubusercontent.com/3039903/132440640-920cf86a-6971-45bb-8d9d-c93229c762c4.png)
