### PR TITLE
Changed code to disable `k_truss` on CUDA 11.4 differently

### DIFF
--- a/python/cugraph/conftest.py
+++ b/python/cugraph/conftest.py
@@ -24,9 +24,9 @@ from cugraph.comms import comms as Comms
 from cugraph.dask.common.mg_utils import get_visible_devices
 
 
-# session-wide fixtures
+# module-wide fixtures
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def dask_client():
     dask_scheduler_file = os.environ.get("SCHEDULER_FILE")
     cluster = None

--- a/python/cugraph/cugraph/community/__init__.py
+++ b/python/cugraph/cugraph/community/__init__.py
@@ -23,42 +23,7 @@ from cugraph.community.spectral_clustering import (
 )
 from cugraph.community.subgraph_extraction import subgraph
 from cugraph.community.triangle_count import triangles
+from cugraph.community.ktruss_subgraph import ktruss_subgraph
+from cugraph.community.ktruss_subgraph import k_truss
 from cugraph.community.egonet import ego_graph
 from cugraph.community.egonet import batched_ego_graphs
-
-# FIXME: special case for ktruss on CUDA 11.4: an 11.4 bug causes ktruss to
-# crash in that environment. Allow ktruss to import on non-11.4 systems, but
-# replace ktruss with a __UnsupportedModule instance, which lazily raises an
-# exception when referenced.
-from numba import cuda
-try:
-    __cuda_version = cuda.runtime.get_version()
-except cuda.cudadrv.runtime.CudaRuntimeAPIError:
-    __cuda_version = "n/a"
-
-__ktruss_unsupported_cuda_version = (11, 4)
-
-class __UnsupportedModule:
-    def __init__(self, exception):
-        self.__exception = exception
-
-    def __getattr__(self, attr):
-        raise self.__exception
-
-    def __call__(self, *args, **kwargs):
-        raise self.__exception
-
-
-if __cuda_version != __ktruss_unsupported_cuda_version:
-    from cugraph.community.ktruss_subgraph import ktruss_subgraph
-    from cugraph.community.ktruss_subgraph import k_truss
-else:
-    __kuvs = ".".join([str(n) for n in __ktruss_unsupported_cuda_version])
-    k_truss = __UnsupportedModule(
-        NotImplementedError("k_truss is not currently supported in CUDA"
-                            f" {__kuvs} environments.")
-        )
-    ktruss_subgraph = __UnsupportedModule(
-        NotImplementedError("ktruss_subgraph is not currently supported in CUDA"
-                            f" {__kuvs} environments.")
-        )


### PR DESCRIPTION
Changed code to disable k_truss on CUDA 11.4 to not use `numba.cuda.runtime.get_version()` at import time since this creates a CUDA context which breaks dask `LocalCUDACluster` init (causes a nccl init invaid usage exception).

This code change results in almost the same UX as before, except explicit imports of the k_truss module no longer raise the exception immediately, and instead raise only when a k_truss algo is called.

Tested by ensuring unit tests for the conditional enabling of k_truss still work and also checked that a `LocalCUDACluster` could properly be created.

Also changed `dask_client` fixture to `module` since `session` was not compatible with tests that tried to create a `LocalCUDACluster` independently within the same session (rmat tests).

cc @cjnolet @pentschev 
