### PR TITLE
Added the reduction op input parameter to host_scalar_(all)reduce utility functions.

### DIFF
--- a/cpp/include/cugraph/prims/count_if_v.cuh
+++ b/cpp/include/cugraph/prims/count_if_v.cuh
@@ -59,7 +59,7 @@ typename GraphViewType::vertex_type count_if_v(raft::handle_t const& handle,
                      vertex_value_input_first + graph_view.get_number_of_local_vertices(),
                      v_op);
   if (GraphViewType::is_multi_gpu) {
-    count = host_scalar_allreduce(handle.get_comms(), count, handle.get_stream());
+    count = host_scalar_allreduce(handle.get_comms(), count, raft::comms::op_t::SUM, handle.get_stream());
   }
   return count;
 }
@@ -94,7 +94,7 @@ typename GraphViewType::vertex_type count_if_v(raft::handle_t const& handle,
 {
   auto count = thrust::count_if(handle.get_thrust_policy(), input_first, input_last, v_op);
   if (GraphViewType::is_multi_gpu) {
-    count = host_scalar_allreduce(handle.get_comms(), count, handle.get_stream());
+    count = host_scalar_allreduce(handle.get_comms(), count, raft::comms::op_t::SUM, handle.get_stream());
   }
   return count;
 }

--- a/cpp/include/cugraph/prims/count_if_v.cuh
+++ b/cpp/include/cugraph/prims/count_if_v.cuh
@@ -59,7 +59,8 @@ typename GraphViewType::vertex_type count_if_v(raft::handle_t const& handle,
                      vertex_value_input_first + graph_view.get_number_of_local_vertices(),
                      v_op);
   if (GraphViewType::is_multi_gpu) {
-    count = host_scalar_allreduce(handle.get_comms(), count, raft::comms::op_t::SUM, handle.get_stream());
+    count =
+      host_scalar_allreduce(handle.get_comms(), count, raft::comms::op_t::SUM, handle.get_stream());
   }
   return count;
 }
@@ -94,7 +95,8 @@ typename GraphViewType::vertex_type count_if_v(raft::handle_t const& handle,
 {
   auto count = thrust::count_if(handle.get_thrust_policy(), input_first, input_last, v_op);
   if (GraphViewType::is_multi_gpu) {
-    count = host_scalar_allreduce(handle.get_comms(), count, raft::comms::op_t::SUM, handle.get_stream());
+    count =
+      host_scalar_allreduce(handle.get_comms(), count, raft::comms::op_t::SUM, handle.get_stream());
   }
   return count;
 }

--- a/cpp/include/cugraph/prims/reduce_v.cuh
+++ b/cpp/include/cugraph/prims/reduce_v.cuh
@@ -58,7 +58,8 @@ T reduce_v(raft::handle_t const& handle,
     ((GraphViewType::is_multi_gpu) && (handle.get_comms().get_rank() == 0)) ? init : T{},
     property_add<T>());
   if (GraphViewType::is_multi_gpu) {
-    ret = host_scalar_allreduce(handle.get_comms(), ret, handle.get_stream());
+    ret =
+      host_scalar_allreduce(handle.get_comms(), ret, raft::comms::op_t::SUM, handle.get_stream());
   }
   return ret;
 }
@@ -95,7 +96,8 @@ T reduce_v(raft::handle_t const& handle,
     ((GraphViewType::is_multi_gpu) && (handle.get_comms().get_rank() == 0)) ? init : T{},
     property_add<T>());
   if (GraphViewType::is_multi_gpu) {
-    ret = host_scalar_allreduce(handle.get_comms(), ret, handle.get_stream());
+    ret =
+      host_scalar_allreduce(handle.get_comms(), ret, raft::comms::op_t::SUM, handle.get_stream());
   }
   return ret;
 }

--- a/cpp/include/cugraph/prims/transform_reduce_e.cuh
+++ b/cpp/include/cugraph/prims/transform_reduce_e.cuh
@@ -517,7 +517,8 @@ T transform_reduce_e(raft::handle_t const& handle,
                                edge_property_add);
 
   if (GraphViewType::is_multi_gpu) {
-    result = host_scalar_allreduce(handle.get_comms(), result, handle.get_stream());
+    result = host_scalar_allreduce(
+      handle.get_comms(), result, raft::comms::op_t::SUM, handle.get_stream());
   }
 
   return result;

--- a/cpp/include/cugraph/prims/transform_reduce_v.cuh
+++ b/cpp/include/cugraph/prims/transform_reduce_v.cuh
@@ -63,7 +63,8 @@ T transform_reduce_v(raft::handle_t const& handle,
     ((GraphViewType::is_multi_gpu) && (handle.get_comms().get_rank() == 0)) ? init : T{},
     property_add<T>());
   if (GraphViewType::is_multi_gpu) {
-    ret = host_scalar_allreduce(handle.get_comms(), ret, handle.get_stream());
+    ret =
+      host_scalar_allreduce(handle.get_comms(), ret, raft::comms::op_t::SUM, handle.get_stream());
   }
   return ret;
 }
@@ -106,7 +107,8 @@ T transform_reduce_v(raft::handle_t const& handle,
     ((GraphViewType::is_multi_gpu) && (handle.get_comms().get_rank() == 0)) ? init : T{},
     property_add<T>());
   if (GraphViewType::is_multi_gpu) {
-    ret = host_scalar_allreduce(handle.get_comms(), ret, handle.get_stream());
+    ret =
+      host_scalar_allreduce(handle.get_comms(), ret, raft::comms::op_t::SUM, handle.get_stream());
   }
   return ret;
 }

--- a/cpp/include/cugraph/prims/vertex_frontier.cuh
+++ b/cpp/include/cugraph/prims/vertex_frontier.cuh
@@ -194,8 +194,10 @@ class SortedUniqueKeyBucket {
   template <bool do_aggregate = is_multi_gpu>
   std::enable_if_t<do_aggregate, size_t> aggregate_size() const
   {
-    return host_scalar_allreduce(
-      handle_ptr_->get_comms(), vertices_.size(), handle_ptr_->get_stream());
+    return host_scalar_allreduce(handle_ptr_->get_comms(),
+                                 vertices_.size(),
+                                 raft::comms::op_t::SUM,
+                                 handle_ptr_->get_stream());
   }
 
   template <bool do_aggregate = is_multi_gpu>

--- a/cpp/src/community/louvain.cuh
+++ b/cpp/src/community/louvain.cuh
@@ -251,8 +251,8 @@ class Louvain {
       thrust::plus<weight_t>());
 
     if (graph_view_t::is_multi_gpu) {
-      sum_degree_squared =
-        host_scalar_allreduce(handle_.get_comms(), sum_degree_squared, handle_.get_stream());
+      sum_degree_squared = host_scalar_allreduce(
+        handle_.get_comms(), sum_degree_squared, raft::comms::op_t::SUM, handle_.get_stream());
     }
 
     weight_t sum_internal = transform_reduce_e(

--- a/cpp/src/components/weakly_connected_components_impl.cuh
+++ b/cpp/src/components/weakly_connected_components_impl.cuh
@@ -656,7 +656,7 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
     auto aggregate_num_inserts = num_inserts;
     if (GraphViewType::is_multi_gpu) {
       auto& comm            = handle.get_comms();
-      aggregate_num_inserts = host_scalar_allreduce(comm, num_inserts, handle.get_stream());
+      aggregate_num_inserts = host_scalar_allreduce(comm, num_inserts, raft::comms::op_t::SUM, handle.get_stream());
     }
 
     if (aggregate_num_inserts > 0) {

--- a/cpp/src/components/weakly_connected_components_impl.cuh
+++ b/cpp/src/components/weakly_connected_components_impl.cuh
@@ -655,8 +655,9 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
     auto num_inserts           = num_edge_inserts.value(handle.get_stream_view());
     auto aggregate_num_inserts = num_inserts;
     if (GraphViewType::is_multi_gpu) {
-      auto& comm            = handle.get_comms();
-      aggregate_num_inserts = host_scalar_allreduce(comm, num_inserts, raft::comms::op_t::SUM, handle.get_stream());
+      auto& comm = handle.get_comms();
+      aggregate_num_inserts =
+        host_scalar_allreduce(comm, num_inserts, raft::comms::op_t::SUM, handle.get_stream());
     }
 
     if (aggregate_num_inserts > 0) {

--- a/cpp/src/link_analysis/pagerank_impl.cuh
+++ b/cpp/src/link_analysis/pagerank_impl.cuh
@@ -69,12 +69,13 @@ void pagerank(
   if (num_vertices == 0) { return; }
 
   auto aggregate_personalization_vector_size =
-    personalization_vertices
-      ? GraphViewType::is_multi_gpu
-          ? host_scalar_allreduce(
-              handle.get_comms(), *personalization_vector_size, handle.get_stream())
-          : *personalization_vector_size
-      : vertex_t{0};
+    personalization_vertices ? GraphViewType::is_multi_gpu
+                                 ? host_scalar_allreduce(handle.get_comms(),
+                                                         *personalization_vector_size,
+                                                         raft::comms::op_t::SUM,
+                                                         handle.get_stream())
+                                 : *personalization_vector_size
+                             : vertex_t{0};
 
   // 1. check input arguments
 

--- a/cpp/src/structure/graph_impl.cuh
+++ b/cpp/src/structure/graph_impl.cuh
@@ -268,8 +268,8 @@ graph_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu, std::enable_if_
                                          major_first, major_last, minor_first, minor_last}) == 0,
                       "Invalid input argument: edgelists[] have out-of-range values.");
     }
-    number_of_local_edges_sum =
-      host_scalar_allreduce(comm, number_of_local_edges_sum, default_stream_view.value());
+    number_of_local_edges_sum = host_scalar_allreduce(
+      comm, number_of_local_edges_sum, raft::comms::op_t::SUM, default_stream_view.value());
     CUGRAPH_EXPECTS(number_of_local_edges_sum == this->get_number_of_edges(),
                     "Invalid input argument: the sum of local edge counts does not match with "
                     "meta.number_of_edges.");

--- a/cpp/src/structure/graph_view_impl.cuh
+++ b/cpp/src/structure/graph_view_impl.cuh
@@ -267,8 +267,10 @@ graph_view_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu, std::enabl
                          out_of_range_t<vertex_t>{minor_first, minor_last}) == 0,
         "Internal Error: adj_matrix_partition_indices[] have out-of-range vertex IDs.");
     }
-    number_of_local_edges_sum = host_scalar_allreduce(
-      this->get_handle_ptr()->get_comms(), number_of_local_edges_sum, default_stream_view.value());
+    number_of_local_edges_sum = host_scalar_allreduce(this->get_handle_ptr()->get_comms(),
+                                                      number_of_local_edges_sum,
+                                                      raft::comms::op_t::SUM,
+                                                      default_stream_view.value());
     CUGRAPH_EXPECTS(number_of_local_edges_sum == this->get_number_of_edges(),
                     "Internal Error: the sum of local edges counts does not match with "
                     "number_of_local_edges.");

--- a/cpp/src/structure/renumber_edgelist_impl.cuh
+++ b/cpp/src/structure/renumber_edgelist_impl.cuh
@@ -669,6 +669,7 @@ renumber_edgelist(
   auto number_of_edges    = host_scalar_allreduce(
     comm,
     std::accumulate(edgelist_edge_counts.begin(), edgelist_edge_counts.end(), edge_t{0}),
+    raft::comms::op_t::SUM,
     handle.get_stream());
 
   // 3. renumber edges

--- a/cpp/src/traversal/bfs_impl.cuh
+++ b/cpp/src/traversal/bfs_impl.cuh
@@ -71,7 +71,8 @@ void bfs(raft::handle_t const& handle,
 
   auto aggregate_n_sources =
     GraphViewType::is_multi_gpu
-      ? host_scalar_allreduce(handle.get_comms(), n_sources, handle.get_stream())
+      ? host_scalar_allreduce(
+          handle.get_comms(), n_sources, raft::comms::op_t::SUM, handle.get_stream())
       : n_sources;
   CUGRAPH_EXPECTS(aggregate_n_sources > 0,
                   "Invalid input argument: input should have at least one source");

--- a/cpp/src/utilities/cython.cu
+++ b/cpp/src/utilities/cython.cu
@@ -580,9 +580,9 @@ void call_pagerank(raft::handle_t const& handle,
                    bool has_guess)
 {
   if (graph_container.is_multi_gpu) {
-    auto& comm = handle.get_comms();
-    auto aggregate_personalization_subset_size =
-      cugraph::host_scalar_allreduce(comm, personalization_subset_size, handle.get_stream());
+    auto& comm                                 = handle.get_comms();
+    auto aggregate_personalization_subset_size = cugraph::host_scalar_allreduce(
+      comm, personalization_subset_size, raft::comms::op_t::SUM, handle.get_stream());
 
     if (graph_container.edgeType == numberTypeEnum::int32Type) {
       auto graph =


### PR DESCRIPTION
Currently, host_scalar_(all)reduce assumes SUM reduction. Adding this input parameter will be necessary for other types of reductions (e.g. MAX).