### PR TITLE
Make sure we keep the rapids-cmake and cugraph cal version in sync

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -40,6 +40,7 @@ function sed_runner() {
 
 # CMakeLists update
 sed_runner 's/'"CUGRAPH VERSION .* LANGUAGES C CXX CUDA)"'/'"CUGRAPH VERSION ${NEXT_FULL_TAG} LANGUAGES C CXX CUDA)"'/g' cpp/CMakeLists.txt
+sed_runner 's/'"branch-.*\/RAPIDS.cmake"'/'"branch-${NEXT_SHORT_TAG}\/RAPIDS.cmake"'/g' cpp/CMakeLists.txt
 
 # RTD update
 sed_runner 's/version = .*/version = '"'${NEXT_SHORT_TAG}'"'/g' docs/cugraph/source/conf.py


### PR DESCRIPTION
When we make a new cugraph version, we need to also bump the rapids-cmake version at the same time. Otherwise we will get the previous releases dependencies by mistake.