### PR TITLE
[gpuCI] Forward-merge branch-21.10 to branch-21.12 [skip gpuci]

### DIFF
--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -10,8 +10,8 @@ dependencies:
 - libcudf=21.10.*
 - rmm=21.10.*
 - librmm=21.10.*
-- dask>=2021.6.0
-- distributed>=2021.6.0
+- dask=2021.09.1
+- distributed=2021.09.1
 - dask-cuda=21.10.*
 - dask-cudf=21.10.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -10,8 +10,8 @@ dependencies:
 - libcudf=21.10.*
 - rmm=21.10.*
 - librmm=21.10.*
-- dask>=2021.6.0
-- distributed>=2021.6.0
+- dask=2021.09.1
+- distributed=2021.09.1
 - dask-cuda=21.10.*
 - dask-cudf=21.10.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -10,8 +10,8 @@ dependencies:
 - libcudf=21.10.*
 - rmm=21.10.*
 - librmm=21.10.*
-- dask>=2021.6.0
-- distributed>=2021.6.0
+- dask=2021.09.1
+- distributed=2021.09.1
 - dask-cuda=21.10.*
 - dask-cudf=21.10.*
 - nccl>=2.9.9

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -37,8 +37,8 @@ requirements:
     - cudf={{ minor_version }}
     - dask-cudf {{ minor_version }}
     - dask-cuda {{ minor_version }}
-    - dask>=2021.6.0
-    - distributed>=2021.6.0
+    - dask=2021.09.1
+    - distributed=2021.09.1
     - ucx-py 0.22
     - ucx-proc=*=gpu
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.10` that creates a PR to keep `branch-21.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.