### PR TITLE
[gpuCI] Forward-merge branch-21.10 to branch-21.12 [skip gpuci]

### DIFF
--- a/cpp/src/community/louvain.cuh
+++ b/cpp/src/community/louvain.cuh
@@ -414,7 +414,8 @@ class Louvain {
         return thrust::make_tuple(sum, subtract);
       },
       thrust::make_tuple(weight_t{0}, weight_t{0}),
-      thrust::make_zip_iterator(old_cluster_sum_v.begin(), cluster_subtract_v.begin()));
+      thrust::make_zip_iterator(
+        thrust::make_tuple(old_cluster_sum_v.begin(), cluster_subtract_v.begin())));
 
     return std::make_tuple(std::move(old_cluster_sum_v), std::move(cluster_subtract_v));
   }


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.10` that creates a PR to keep `branch-21.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.