### PR TITLE
[gpuCI] Forward-merge branch-21.10 to branch-21.12 [skip gpuci]

### DIFF
--- a/cpp/cmake/thirdparty/get_cuco.cmake
+++ b/cpp/cmake/thirdparty/get_cuco.cmake
@@ -20,7 +20,7 @@ function(find_and_configure_cuco VERSION)
       GLOBAL_TARGETS cuco::cuco
       CPM_ARGS
         GIT_REPOSITORY https://github.com/NVIDIA/cuCollections.git
-        GIT_TAG        b1fea0cbe4c384160740af00f7c8760846539abb
+        GIT_TAG        a3c85ee2ea25ddfdd4596c6b9d546f7c7590743f
         OPTIONS        "BUILD_TESTS OFF"
                        "BUILD_BENCHMARKS OFF"
                        "BUILD_EXAMPLES OFF"


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.10` that creates a PR to keep `branch-21.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.