### PR TITLE
Remove unnecessary explicit template instantiation

### DIFF
--- a/cpp/src/structure/graph_view_mg.cu
+++ b/cpp/src/structure/graph_view_mg.cu
@@ -31,9 +31,5 @@ template class graph_view_t<int64_t, int64_t, float, true, true>;
 template class graph_view_t<int64_t, int64_t, float, false, true>;
 template class graph_view_t<int64_t, int64_t, double, true, true>;
 template class graph_view_t<int64_t, int64_t, double, false, true>;
-template class graph_view_t<int64_t, int32_t, float, true, true>;
-template class graph_view_t<int64_t, int32_t, float, false, true>;
-template class graph_view_t<int64_t, int32_t, double, true, true>;
-template class graph_view_t<int64_t, int32_t, double, false, true>;
 
 }  // namespace cugraph

--- a/cpp/src/structure/graph_view_sg.cu
+++ b/cpp/src/structure/graph_view_sg.cu
@@ -31,9 +31,5 @@ template class graph_view_t<int64_t, int64_t, float, true, false>;
 template class graph_view_t<int64_t, int64_t, float, false, false>;
 template class graph_view_t<int64_t, int64_t, double, true, false>;
 template class graph_view_t<int64_t, int64_t, double, false, false>;
-template class graph_view_t<int64_t, int32_t, float, true, false>;
-template class graph_view_t<int64_t, int32_t, float, false, false>;
-template class graph_view_t<int64_t, int32_t, double, true, false>;
-template class graph_view_t<int64_t, int32_t, double, false, false>;
 
 }  // namespace cugraph


### PR DESCRIPTION
No need to instantiate for vertex_t=int64_t and edge_t=int32_t