### PR TITLE
Temporary workaround for CI issues with 11.0

### DIFF
--- a/benchmarks/python_pytest_based/bench_algos.py
+++ b/benchmarks/python_pytest_based/bench_algos.py
@@ -37,17 +37,6 @@ import rmm
 
 from .params import FIXTURE_PARAMS
 
-# FIXME: WCC currently crashes on Ampere. Detect the GPU arch here and use it
-# for conditional skipping. Remove this code when the Ampere crash is resolved.
-from numba import cuda
-is_ampere = False
-device = cuda.get_current_device()
-# check for the attribute using both pre and post numba 0.53 names
-cc = getattr(device, 'COMPUTE_CAPABILITY', None) or \
-     getattr(device, 'compute_capability')
-if (cc[0] >= 8):
-    is_ampere = True
-
 ###############################################################################
 # Helpers
 def createGraph(csvFileName, graphType=None):
@@ -229,7 +218,6 @@ def bench_louvain(gpubenchmark, graphWithAdjListComputed):
     gpubenchmark(cugraph.louvain, graphWithAdjListComputed)
 
 
-@pytest.mark.skipif(is_ampere, reason="skipping on Ampere")
 def bench_weakly_connected_components(gpubenchmark,
                                       anyGraphWithAdjListComputed):
     gpubenchmark(cugraph.weakly_connected_components,

--- a/cpp/cmake/thirdparty/get_thrust.cmake
+++ b/cpp/cmake/thirdparty/get_thrust.cmake
@@ -17,6 +17,8 @@
 function(find_and_configure_thrust)
   include(${rapids-cmake-dir}/cpm/thrust.cmake)
 
+  # FIXME: Temporary workaround to our current 11.0 CI problem
+  set(CPM_DOWNLOAD_ALL ON)
   rapids_cpm_thrust(
     NAMESPACE cugraph
     BUILD_EXPORT_SET raft-exports

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -374,8 +374,7 @@ ConfigureTest(KATZ_CENTRALITY_TEST centrality/katz_centrality_test.cpp)
 
 ###################################################################################################
 # - WEAKLY CONNECTED COMPONENTS tests -------------------------------------------------------------
-# Temporarily disable this test, it seems to be failing on A100
-#ConfigureTest(WEAKLY_CONNECTED_COMPONENTS_TEST components/weakly_connected_components_test.cpp)
+ConfigureTest(WEAKLY_CONNECTED_COMPONENTS_TEST components/weakly_connected_components_test.cpp)
 
 ###################################################################################################
 # - Experimental RANDOM_WALKS tests ---------------------------------------------------------------

--- a/notebooks/components/ConnectedComponents.ipynb
+++ b/notebooks/components/ConnectedComponents.ipynb
@@ -5,7 +5,6 @@
    "metadata": {},
    "source": [
     "# Connected Components\n",
-    "# Does not run on Ampere\n",
     "\n",
     "In this notebook, we will use cuGraph to compute weakly and strongly connected components of a graph and display some useful information about the resulting components.\n",
     "\n",

--- a/python/cugraph/cugraph/tests/test_connectivity.py
+++ b/python/cugraph/cugraph/tests/test_connectivity.py
@@ -41,18 +41,6 @@ with warnings.catch_warnings():
     import networkx as nx
 
 
-# FIXME: WCC currently crashes on Ampere. Detect the GPU arch here and use it
-# for conditional skipping. Remove this code when the Ampere crash is resolved.
-from numba import cuda
-is_ampere = False
-device = cuda.get_current_device()
-# check for the attribute using both pre and post numba 0.53 names
-cc = getattr(device, 'COMPUTE_CAPABILITY', None) or \
-     getattr(device, 'compute_capability')
-if (cc[0] >= 8):
-    is_ampere = True
-
-
 print("Networkx version : {} ".format(nx.__version__))
 
 # Map of cuGraph input types to the expected output type for cuGraph
@@ -302,7 +290,6 @@ def single_dataset_nxresults_strong(request):
 # =============================================================================
 # Tests
 # =============================================================================
-@pytest.mark.skipif(is_ampere, reason="skipping on Ampere")
 @pytest.mark.parametrize("cugraph_input_type", utils.CUGRAPH_DIR_INPUT_TYPES)
 def test_weak_cc(gpubenchmark, dataset_nxresults_weak, cugraph_input_type):
     (graph_file, netx_labels,
@@ -342,7 +329,6 @@ def test_weak_cc(gpubenchmark, dataset_nxresults_weak, cugraph_input_type):
     assert nx_vertices == cg_vertices
 
 
-@pytest.mark.skipif(is_ampere, reason="skipping on Ampere")
 @pytest.mark.parametrize("cugraph_input_type",
                          utils.NX_DIR_INPUT_TYPES + utils.MATRIX_INPUT_TYPES)
 def test_weak_cc_nonnative_inputs(gpubenchmark,
@@ -406,7 +392,6 @@ def test_strong_cc_nonnative_inputs(gpubenchmark,
                    cugraph_input_type)
 
 
-@pytest.mark.skipif(is_ampere, reason="skipping on Ampere")
 def test_scipy_api_compat_weak(single_dataset_nxresults_weak):
     (graph_file, _, _, _, api_type) = single_dataset_nxresults_weak
     assert_scipy_api_compat(graph_file, api_type)
@@ -417,7 +402,6 @@ def test_scipy_api_compat_strong(single_dataset_nxresults_strong):
     assert_scipy_api_compat(graph_file, api_type)
 
 
-@pytest.mark.skipif(is_ampere, reason="skipping on Ampere")
 @pytest.mark.parametrize("connection_type", ["strong", "weak"])
 def test_scipy_api_compat(connection_type):
     if connection_type == "strong":


### PR DESCRIPTION
#1870 disabled some tests to allow us to push some things through CI.  While investigating this issue we discovered that we are having problem compiling the code in a container that uses the delivered 11.0 thrust.

This PR is a different temporary workaround.  We force downloading the desired version of thrust to be used as part of the cugraph build.  The PR also reactivates all of the WCC testing.