### PR TITLE
Updated error message and using a proper TypeError exception when an invalid MultiGraph is passed in

### DIFF
--- a/python/cugraph/cugraph/structure/graph_classes.py
+++ b/python/cugraph/cugraph/structure/graph_classes.py
@@ -58,7 +58,7 @@ class Graph:
         self._Impl = None
         self.graph_properties = Graph.Properties(directed)
         if m_graph is not None:
-            if m_graph.is_multigraph():
+            if isinstance(m_graph, MultiGraph):
                 elist = m_graph.view_edge_list()
                 if m_graph.is_weighted():
                     weights = "weights"
@@ -69,10 +69,8 @@ class Graph:
                                         destination="dst",
                                         edge_attr=weights)
             else:
-                msg = (
-                    "Graph can only be initialized using MultiGraph "
-                )
-                raise Exception(msg)
+                raise TypeError("m_graph can only be an instance of a "
+                                f"cugraph.MultiGraph, got {type(m_graph)}")
 
     def __getattr__(self, name):
         if self._Impl is None:

--- a/python/cugraph/cugraph/structure/graph_classes.py
+++ b/python/cugraph/cugraph/structure/graph_classes.py
@@ -35,8 +35,8 @@ class Graph:
 
     Parameters
     ----------
-    m_graph : cuGraph.Graph object or None
-        Initialize the graph from another Multigraph object
+    m_graph : cuGraph.MultiGraph object or None
+        Initialize the graph from a cugraph.MultiGraph object
     directed : boolean
         Indicated is the graph is directed.
         Default is False - Undirected

--- a/python/cugraph/cugraph/tests/test_graph.py
+++ b/python/cugraph/cugraph/tests/test_graph.py
@@ -668,17 +668,19 @@ def test_neighbors(graph_file):
 
 def test_graph_init_with_multigraph():
     """
-    Ensures only a valid MultiGraph instance can be used to initialize a Graph.
+    Ensures only a valid MultiGraph instance can be used to initialize a Graph
+    by checking if either the correct exception is raised or no exception at
+    all.
     """
     nxMG = nx.MultiGraph()
     with pytest.raises(TypeError):
-        G = cugraph.Graph(m_graph=nxMG)
+        cugraph.Graph(m_graph=nxMG)
 
     gdf = cudf.DataFrame({"src": [0, 1, 2], "dst": [1, 2, 3]})
     cMG = cugraph.MultiGraph()
     cMG.from_cudf_edgelist(gdf, source="src", destination="dst")
-    G = cugraph.Graph(m_graph=cMG)
+    cugraph.Graph(m_graph=cMG)
 
     cDiMG = cugraph.MultiDiGraph()  # deprecated, but should still work
     cDiMG.from_cudf_edgelist(gdf, source="src", destination="dst")
-    G = cugraph.Graph(m_graph=cDiMG)
+    cugraph.Graph(m_graph=cDiMG)

--- a/python/cugraph/cugraph/tests/test_graph.py
+++ b/python/cugraph/cugraph/tests/test_graph.py
@@ -664,3 +664,21 @@ def test_neighbors(graph_file):
         cu_neighbors.sort()
         nx_neighbors.sort()
         assert cu_neighbors == nx_neighbors
+
+
+def test_graph_init_with_multigraph():
+    """
+    Ensures only a valid MultiGraph instance can be used to initialize a Graph.
+    """
+    nxMG = nx.MultiGraph()
+    with pytest.raises(TypeError):
+        G = cugraph.Graph(m_graph=nxMG)
+
+    gdf = cudf.DataFrame({"src": [0, 1, 2], "dst": [1, 2, 3]})
+    cMG = cugraph.MultiGraph()
+    cMG.from_cudf_edgelist(gdf, source="src", destination="dst")
+    G = cugraph.Graph(m_graph=cMG)
+
+    cDiMG = cugraph.MultiDiGraph()  # deprecated, but should still work
+    cDiMG.from_cudf_edgelist(gdf, source="src", destination="dst")
+    G = cugraph.Graph(m_graph=cDiMG)


### PR DESCRIPTION
* Updated error message and using a proper TypeError exception when an invalid MultiGraph is passed in.
* Added test to verify.

This PR replaces #1914 since that one is not passing the style check and the author has not responded.