### PR TITLE
Use collections.abc.Sequence instead of deprecated collections.Sequence.

### DIFF
--- a/python/cugraph/cugraph/dask/common/part_utils.py
+++ b/python/cugraph/cugraph/dask/common/part_utils.py
@@ -93,7 +93,7 @@ async def _extract_partitions(dask_obj, client=None, batch_enabled=False):
                     worker_list)]
         parts = futures_of(persisted)
     # iterable of dask collections (need to colocate them)
-    elif isinstance(dask_obj, collections.Sequence):
+    elif isinstance(dask_obj, collections.abc.Sequence):
         # NOTE: We colocate (X, y) here by zipping delayed
         # n partitions of them as (X1, y1), (X2, y2)...
         # and asking client to compute a single future for


### PR DESCRIPTION
Hi cuGraph team! I was looking at a couple things across RAPIDS related to Python 3.10 compatibility. There is one spot where the deprecated name `collections.Sequence` is used. This was moved to `collections.abc.Sequence` in Python 3.3 and has been deprecated for a while. In Python 3.10 the deprecated names for abstract base classes like `collections.Sequence` were removed.

This PR fixes that module path to help with eventual compatibility with Python 3.10+. I think this is the only instance of this deprecated name across RAPIDS packages.

(I don't have permissions to set labels or project boards, so the label checker will fail until someone else does that.)