### PR TITLE
[BUG] Enforce renumbering for MNMG algos

### DIFF
--- a/benchmarks/python_e2e/main.py
+++ b/benchmarks/python_e2e/main.py
@@ -130,6 +130,7 @@ def run(algos,
         success = benchmark.run()
 
         algo_name = benchmark.results[1].name
+        algo_name = f"benchmarks.{algo_name}"
         algo_time = benchmark.results[1].runtime
         # Generate json files containing the benchmark results
         if benchmark_dir is not None:

--- a/python/cugraph/cugraph/structure/graph_classes.py
+++ b/python/cugraph/cugraph/structure/graph_classes.py
@@ -238,6 +238,8 @@ class Graph:
             If source and destination indices are not in range 0 to V where V
             is number of vertices, renumber argument should be True.
         """
+        if renumber is False:
+            raise ValueError("'renumber' must be set to 'True' for MNMG algos")
         if self._Impl is None:
             self._Impl = simpleDistributedGraphImpl(self.graph_properties)
         elif type(self._Impl) is not simpleDistributedGraphImpl:

--- a/python/cugraph/cugraph/tests/conftest.py
+++ b/python/cugraph/cugraph/tests/conftest.py
@@ -58,7 +58,7 @@ def dask_client():
     yield client
 
     Comms.destroy()
-    client.shutdown()
+    client.close()
     if cluster:
         cluster.close()
     print("\ndask_client fixture: client.close() called")

--- a/python/cugraph/cugraph/tests/conftest.py
+++ b/python/cugraph/cugraph/tests/conftest.py
@@ -58,7 +58,7 @@ def dask_client():
     yield client
 
     Comms.destroy()
-    client.close()
+    client.shutdown()
     if cluster:
         cluster.close()
     print("\ndask_client fixture: client.close() called")

--- a/python/cugraph/cugraph/tests/dask/test_mg_renumber.py
+++ b/python/cugraph/cugraph/tests/dask/test_mg_renumber.py
@@ -176,3 +176,47 @@ def test_dask_pagerank(dask_client):
             err = err + 1
     print("Mismatches:", err)
     assert err == 0
+
+
+@pytest.mark.skipif(
+    is_single_gpu(), reason="skipping MG testing on Single GPU system"
+)
+@pytest.mark.parametrize("renumber", [False])
+def test_digraph_renumber_false(renumber, dask_client):
+    input_data_path = (RAPIDS_DATASET_ROOT_DIR_PATH /
+                       "karate.csv").as_posix()
+    chunksize = dcg.get_chunksize(input_data_path)
+
+    ddf = dask_cudf.read_csv(
+        input_data_path,
+        chunksize=chunksize,
+        delimiter=" ",
+        names=["src", "dst", "value"],
+        dtype=["int32", "int32", "float32"],
+    )
+    dg = cugraph.DiGraph()
+
+    with pytest.raises(ValueError):
+        dg.from_dask_cudf_edgelist(ddf, "src", "dst", renumber=renumber)
+
+
+@pytest.mark.skipif(
+    is_single_gpu(), reason="skipping MG testing on Single GPU system"
+)
+@pytest.mark.parametrize("renumber", [False])
+def test_multi_digraph_renumber_false(renumber, dask_client):
+    input_data_path = (RAPIDS_DATASET_ROOT_DIR_PATH /
+                       "karate_multi_edge.csv").as_posix()
+    chunksize = dcg.get_chunksize(input_data_path)
+
+    ddf = dask_cudf.read_csv(
+        input_data_path,
+        chunksize=chunksize,
+        delimiter=" ",
+        names=["src", "dst", "value"],
+        dtype=["int32", "int32", "float32"],
+    )
+    dg = cugraph.MultiDiGraph()
+
+    with pytest.raises(ValueError):
+        dg.from_dask_cudf_edgelist(ddf, "src", "dst", renumber=renumber)

--- a/python/cugraph/cugraph/tests/dask/test_mg_renumber.py
+++ b/python/cugraph/cugraph/tests/dask/test_mg_renumber.py
@@ -14,7 +14,7 @@
 # This file test the Renumbering features
 
 import pytest
-
+import gc
 import pandas
 import numpy as np
 import dask_cudf

--- a/python/cugraph/cugraph/tests/dask/test_mg_renumber.py
+++ b/python/cugraph/cugraph/tests/dask/test_mg_renumber.py
@@ -13,8 +13,9 @@
 
 # This file test the Renumbering features
 
-import pytest
 import gc
+import pytest
+
 import pandas
 import numpy as np
 import dask_cudf

--- a/python/cugraph/cugraph/tests/dask/test_mg_renumber.py
+++ b/python/cugraph/cugraph/tests/dask/test_mg_renumber.py
@@ -183,6 +183,8 @@ def test_dask_pagerank(dask_client):
 )
 @pytest.mark.parametrize("renumber", [False])
 def test_digraph_renumber_false(renumber, dask_client):
+    gc.collect()
+
     input_data_path = (RAPIDS_DATASET_ROOT_DIR_PATH /
                        "karate.csv").as_posix()
     chunksize = dcg.get_chunksize(input_data_path)
@@ -205,6 +207,8 @@ def test_digraph_renumber_false(renumber, dask_client):
 )
 @pytest.mark.parametrize("renumber", [False])
 def test_multi_digraph_renumber_false(renumber, dask_client):
+    gc.collect()
+
     input_data_path = (RAPIDS_DATASET_ROOT_DIR_PATH /
                        "karate_multi_edge.csv").as_posix()
     chunksize = dcg.get_chunksize(input_data_path)


### PR DESCRIPTION
A bug was reported when calling a MNMG algo with unrenumbered edge list. 
This PR returns an error if `renumber=False `

Change the algo name for asv reporting 

closes #1936 