### PR TITLE
Fix compile error due to recent RAFT update (rng.cuh => rng.hpp)

### DIFF
--- a/cpp/src/detail/shuffle_wrappers.cu
+++ b/cpp/src/detail/shuffle_wrappers.cu
@@ -18,8 +18,6 @@
 #include <cugraph/partition_manager.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
 
-#include <raft/random/rng.cuh>
-
 #include <rmm/exec_policy.hpp>
 
 #include <tuple>

--- a/cpp/src/detail/utility_wrappers.cu
+++ b/cpp/src/detail/utility_wrappers.cu
@@ -15,7 +15,7 @@
  */
 #include <cugraph/detail/utility_wrappers.hpp>
 
-#include <raft/random/rng.cuh>
+#include <raft/random/rng.hpp>
 
 #include <thrust/sequence.h>
 #include <rmm/exec_policy.hpp>

--- a/cpp/src/sampling/rw_traversals.hpp
+++ b/cpp/src/sampling/rw_traversals.hpp
@@ -29,7 +29,7 @@
 
 #include <raft/device_atomics.cuh>
 #include <raft/handle.hpp>
-#include <raft/random/rng.cuh>
+#include <raft/random/rng.hpp>
 
 #include <rmm/device_uvector.hpp>
 

--- a/cpp/tests/sampling/random_walks_profiling.cu
+++ b/cpp/tests/sampling/random_walks_profiling.cu
@@ -22,7 +22,7 @@
 #include <sampling/random_walks.cuh>
 
 #include <raft/handle.hpp>
-#include <raft/random/rng.cuh>
+#include <raft/random/rng.hpp>
 
 #include <rmm/exec_policy.hpp>
 

--- a/cpp/tests/sampling/random_walks_test.cu
+++ b/cpp/tests/sampling/random_walks_test.cu
@@ -27,7 +27,7 @@
 #include <sampling/random_walks.cuh>
 
 #include <raft/handle.hpp>
-#include <raft/random/rng.cuh>
+#include <raft/random/rng.hpp>
 
 #include "random_walks_utils.cuh"
 

--- a/cpp/tests/sampling/rw_low_level_test.cu
+++ b/cpp/tests/sampling/rw_low_level_test.cu
@@ -28,7 +28,7 @@
 #include <sampling/random_walks.cuh>
 
 #include <raft/handle.hpp>
-#include <raft/random/rng.cuh>
+#include <raft/random/rng.hpp>
 
 #include "random_walks_utils.cuh"
 


### PR DESCRIPTION
In the recent raft PR (https://github.com/rapidsai/raft/pull/356), rng.cuh is renamed to rng.hpp and cugraph is no longer compiling.

This PR fixes the compile error.