### PR TITLE
Match python R-mat parameters to Graph 500

### DIFF
--- a/python/cugraph/cugraph/generators/rmat.py
+++ b/python/cugraph/cugraph/generators/rmat.py
@@ -296,9 +296,9 @@ def rmat(
     >>> df = rmat(
     ...    scale,
     ...    (2**scale)*edgefactor,
-    ...    0.1,
-    ...    0.2,
-    ...    0.3,
+    ...    0.57,
+    ...    0.19,
+    ...    0.19,
     ...    seed or 42,
     ...    clip_and_flip=False,
     ...    scramble_vertex_ids=True,

--- a/python/cugraph/cugraph/tests/generators/test_rmat.py
+++ b/python/cugraph/cugraph/tests/generators/test_rmat.py
@@ -46,9 +46,9 @@ def _call_rmat(scale, num_edges, create_using, mg):
     """
     return rmat(scale=scale,
                 num_edges=num_edges,
-                a=0.1,
-                b=0.2,
-                c=0.3,
+                a=0.57,
+                b=0.19,
+                c=0.19,
                 seed=24,
                 clip_and_flip=False,
                 scramble_vertex_ids=True,


### PR DESCRIPTION
Python tests currently use a=0.1, b=0.2, c=0.3 and this doesn't match with the Graph 500 specification. This matches the parameters with Graph 500.