### PR TITLE
Explicitly install cusolver version with the correct ABI version

### DIFF
--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -47,6 +47,7 @@ requirements:
     - ucx-proc=*=gpu
     - faiss-proc=*=cuda
     - libfaiss 1.7.0 *_cuda
+    - libcusolver>=11.2.1
 
 about:
   home: http://rapids.ai/


### PR DESCRIPTION
Starting with CUDA 11.1, cusolver updated the major SOVERSION from 10 to 11. To allow execution with the cudatoolkit=11.0 we
need to package the ABI 11 version.