### PR TITLE
[gpuCI] Forward-merge branch-21.12 to branch-22.02 [skip gpuci]

### DIFF
--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -19,8 +19,8 @@ dependencies:
 - ucx-proc=*=gpu
 - scipy
 - networkx>=2.5.1
-- clang=11.0.0
-- clang-tools=11.0.0
+- clang=11.1.0
+- clang-tools=11.1.0
 - cmake>=3.20.1
 - python>=3.6,<3.9
 - notebook>=0.5.0

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -19,8 +19,8 @@ dependencies:
 - ucx-proc=*=gpu
 - scipy
 - networkx>=2.5.1
-- clang=11.0.0
-- clang-tools=11.0.0
+- clang=11.1.0
+- clang-tools=11.1.0
 - cmake>=3.20.1
 - python>=3.6,<3.9
 - notebook>=0.5.0

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -19,8 +19,8 @@ dependencies:
 - ucx-proc=*=gpu
 - scipy
 - networkx>=2.5.1
-- clang=11.0.0
-- clang-tools=11.0.0
+- clang=11.1.0
+- clang-tools=11.1.0
 - cmake>=3.20.1
 - python>=3.6,<3.9
 - notebook>=0.5.0

--- a/cpp/scripts/run-clang-format.py
+++ b/cpp/scripts/run-clang-format.py
@@ -22,7 +22,7 @@ import argparse
 import tempfile
 
 
-EXPECTED_VERSION = "11.0.0"
+EXPECTED_VERSION = "11.1.0"
 VERSION_REGEX = re.compile(r"clang-format version ([0-9.]+)")
 # NOTE: populate this list with more top-level dirs as we add more of them to the cugraph repo
 DEFAULT_DIRS = ["cpp/include",


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.12` that creates a PR to keep `branch-22.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.