### PR TITLE
add rmm pool option for SNMG runs

### DIFF
--- a/benchmarks/python_e2e/cugraph_dask_funcs.py
+++ b/benchmarks/python_e2e/cugraph_dask_funcs.py
@@ -25,6 +25,8 @@ from cugraph.dask.common.mg_utils import get_visible_devices
 from cugraph.generators import rmat
 import tempfile
 
+import rmm
+
 
 def generate_edgelist(scale,
                       edgefactor,
@@ -153,7 +155,7 @@ def katz(G, alpha=None):
 ################################################################################
 # Session-wide setup and teardown
 
-def setup(dask_scheduler_file=None):
+def setup(dask_scheduler_file=None, rmm_pool_size=None):
     if dask_scheduler_file:
         cluster = None
         # Env var UCX_MAX_RNDV_RAILS=1 must be set too.
@@ -167,7 +169,7 @@ def setup(dask_scheduler_file=None):
 
     else:
         tempdir_object = tempfile.TemporaryDirectory()
-        cluster = LocalCUDACluster(local_directory=tempdir_object.name)
+        cluster = LocalCUDACluster(local_directory=tempdir_object.name, rmm_pool_size=rmm_pool_size)
         client = Client(cluster)
         # add the obj to the client so it doesn't get deleted until
         # the 'client' obj gets cleaned up
@@ -183,4 +185,3 @@ def teardown(client, cluster=None):
     client.close()
     if cluster:
         cluster.close()
-

--- a/benchmarks/python_e2e/main.py
+++ b/benchmarks/python_e2e/main.py
@@ -62,7 +62,8 @@ def run(algos,
         symmetric=False,
         edgefactor=None,
         benchmark_dir=None,
-        dask_scheduler_file=None):
+        dask_scheduler_file=None,
+        rmm_pool_size=None):
     """
     Run the nightly benchmark on cugraph.
     Return True on success, False on failure.
@@ -100,7 +101,7 @@ def run(algos,
     # Call the global setup. This is used for setting up Dask, initializing
     # output files/reports, etc.
     log("calling setup...", end="")
-    setup_objs = funcs.setup(dask_scheduler_file)
+    setup_objs = funcs.setup(dask_scheduler_file, rmm_pool_size)
 
     # If the number of GPUs is None, This is a MNMG run
     # Extract the number of gpus from the client
@@ -179,6 +180,9 @@ if __name__ == "__main__":
                     "(num_edges=num_verts*EDGEFACTOR).")
     ap.add_argument("--benchmark-dir", type=str, default=None,
                     help="directory to store the results in json files")
+    ap.add_argument("--rmm-pool-size", type=str, default=None,
+                    help="RMM pool size to initialize each worker with")
+
 
     args = ap.parse_args()
 
@@ -190,6 +194,7 @@ if __name__ == "__main__":
                    symmetric=args.symmetric_graph,
                    edgefactor=args.edgefactor,
                    benchmark_dir=args.benchmark_dir,
-                   dask_scheduler_file=args.dask_scheduler_file)
+                   dask_scheduler_file=args.dask_scheduler_file,
+                   rmm_pool_size=args.rmm_pool_size)
 
     sys.exit(exitcode)


### PR DESCRIPTION
This PR add the option to initialize workers with an RMM pool size when creating a cluster for SNMG runs
This parameter is essential for benchmarks