### PR TITLE
[gpuCI] Forward-merge branch-21.12 to branch-22.02 [skip gpuci]

### DIFF
--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -10,8 +10,8 @@ dependencies:
 - libcudf=21.12.*
 - rmm=21.12.*
 - librmm=21.12.*
-- dask>=2021.09.1
-- distributed>=2021.09.1
+- dask>=2021.09.1,<=2021.11.2
+- distributed>=2021.09.1,<=2021.11.2
 - dask-cuda=21.12.*
 - dask-cudf=21.12.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -10,8 +10,8 @@ dependencies:
 - libcudf=21.12.*
 - rmm=21.12.*
 - librmm=21.12.*
-- dask>=2021.09.1
-- distributed>=2021.09.1
+- dask>=2021.09.1,<=2021.11.2
+- distributed>=2021.09.1,<=2021.11.2
 - dask-cuda=21.12.*
 - dask-cudf=21.12.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -10,8 +10,8 @@ dependencies:
 - libcudf=21.12.*
 - rmm=21.12.*
 - librmm=21.12.*
-- dask>=2021.09.1
-- distributed>=2021.09.1
+- dask>=2021.09.1,<=2021.11.2
+- distributed>=2021.09.1,<=2021.11.2
 - dask-cuda=21.12.*
 - dask-cudf=21.12.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.5.yml
+++ b/conda/environments/cugraph_dev_cuda11.5.yml
@@ -10,8 +10,8 @@ dependencies:
 - libcudf=21.12.*
 - rmm=21.12.*
 - librmm=21.12.*
-- dask>=2021.09.1
-- distributed>=2021.09.1
+- dask>=2021.09.1,<=2021.11.2
+- distributed>=2021.09.1,<=2021.11.2
 - dask-cuda=21.12.*
 - dask-cudf=21.12.*
 - nccl>=2.9.9

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -38,8 +38,8 @@ requirements:
     - cudf={{ minor_version }}
     - dask-cudf {{ minor_version }}
     - dask-cuda {{ minor_version }}
-    - dask>=2021.09.1
-    - distributed>=2021.09.1
+    - dask>=2021.09.1,<=2021.11.2
+    - distributed>=2021.09.1,<=2021.11.2
     - ucx-py 0.23
     - ucx-proc=*=gpu
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.12` that creates a PR to keep `branch-22.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.