### PR TITLE
Updates to `libcugraph_etl` conda recipe for CUDA Enhanced Compatibility

### DIFF
--- a/conda/recipes/libcugraph_etl/meta.yaml
+++ b/conda/recipes/libcugraph_etl/meta.yaml
@@ -5,6 +5,7 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
 {% set cuda_version='.'.join(environ.get('CUDA', '9.2').split('.')[:2]) %}
+{% set cuda_major=cuda_version.split('.')[0] %}
 package:
   name: libcugraph_etl
   version: {{ version }}
@@ -14,7 +15,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: cuda{{ cuda_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - CC
     - CXX
@@ -36,7 +37,7 @@ requirements:
     - cudf {{ minor_version }}.*
     - libcugraph {{ minor_version }}.*
   run:
-    - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
+    - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
     - libcugraph {{ minor_version }}.*
     - faiss-proc=*=cuda
     - libfaiss 1.7.0 *_cuda


### PR DESCRIPTION
Updates to `libcugraph_etl` conda recipe for CUDA Enhanced Compatibility.  These were not tested locally.