### PR TITLE
Shutdown the connected scheduler and workers

### DIFF
--- a/benchmarks/python_e2e/cugraph_dask_funcs.py
+++ b/benchmarks/python_e2e/cugraph_dask_funcs.py
@@ -182,6 +182,9 @@ def setup(dask_scheduler_file=None, rmm_pool_size=None):
 
 def teardown(client, cluster=None):
     Comms.destroy()
-    client.close()
+    # Shutdown the connected scheduler and workers
+    # therefore we will no longer rely on killing the dask cluster ID
+    # for MNMG runs
+    client.shutdown()
     if cluster:
         cluster.close()

--- a/python/cugraph/cugraph/tests/conftest.py
+++ b/python/cugraph/cugraph/tests/conftest.py
@@ -58,7 +58,10 @@ def dask_client():
     yield client
 
     Comms.destroy()
-    client.close()
+    # Shut down the connected scheduler and workers
+    # therefore we will no longer rely on killing the dask cluster ID
+    # for MNMG runs
+    client.shutdown()
     if cluster:
         cluster.close()
     print("\ndask_client fixture: client.close() called")


### PR DESCRIPTION
The MNMG tests/benchmarks runs rely on killing the dask cluster process ID to stop all python/dask processes
This PR uses `client.shutdown` to shutdown the connected scheduler and workers