### PR TITLE
[skip-ci] Pass stream to cuco::static_map

### DIFF
--- a/cpp/include/cugraph/utilities/collect_comm.cuh
+++ b/cpp/include/cugraph/utilities/collect_comm.cuh
@@ -75,10 +75,15 @@ collect_values_for_keys(raft::comms::comms_t const& comm,
              static_cast<size_t>(thrust::distance(map_key_first, map_key_last)) + 1),
     invalid_vertex_id<vertex_t>::value,
     invalid_vertex_id<vertex_t>::value,
-    stream_adapter);
+    stream_adapter,
+    stream_view);
   {
     auto pair_first = thrust::make_zip_iterator(thrust::make_tuple(map_key_first, map_value_first));
-    kv_map_ptr->insert(pair_first, pair_first + thrust::distance(map_key_first, map_key_last));
+    kv_map_ptr->insert(pair_first,
+                       pair_first + thrust::distance(map_key_first, map_key_last),
+                       cuco::detail::MurmurHash3_32<vertex_t>{},
+                       thrust::equal_to<vertex_t>{},
+                       stream_view);
   }
 
   // 2. collect values for the unique keys in [collect_key_first, collect_key_last)
@@ -107,10 +112,12 @@ collect_values_for_keys(raft::comms::comms_t const& comm,
 
     rmm::device_uvector<value_t> values_for_rx_unique_keys(rx_unique_keys.size(), stream_view);
 
-    stream_view.synchronize();  // cuco::static_map currently does not take stream
-
-    kv_map_ptr->find(
-      rx_unique_keys.begin(), rx_unique_keys.end(), values_for_rx_unique_keys.begin());
+    kv_map_ptr->find(rx_unique_keys.begin(),
+                     rx_unique_keys.end(),
+                     values_for_rx_unique_keys.begin(),
+                     cuco::detail::MurmurHash3_32<vertex_t>{},
+                     thrust::equal_to<vertex_t>{},
+                     stream_view);
 
     rmm::device_uvector<value_t> rx_values_for_unique_keys(0, stream_view);
     std::tie(rx_values_for_unique_keys, std::ignore) =
@@ -122,8 +129,6 @@ collect_values_for_keys(raft::comms::comms_t const& comm,
   // 3. re-build a cuco::static_map object for the k, v pairs in unique_keys,
   // values_for_unique_keys.
 
-  stream_view.synchronize();  // cuco::static_map currently does not take stream
-
   kv_map_ptr.reset();
 
   kv_map_ptr = std::make_unique<
@@ -133,18 +138,28 @@ collect_values_for_keys(raft::comms::comms_t const& comm,
              unique_keys.size() + 1),
     invalid_vertex_id<vertex_t>::value,
     invalid_vertex_id<vertex_t>::value,
-    stream_adapter);
+    stream_adapter,
+    stream_view);
   {
     auto pair_first = thrust::make_zip_iterator(
       thrust::make_tuple(unique_keys.begin(), values_for_unique_keys.begin()));
-    kv_map_ptr->insert(pair_first, pair_first + unique_keys.size());
+    kv_map_ptr->insert(pair_first,
+                       pair_first + unique_keys.size(),
+                       cuco::detail::MurmurHash3_32<vertex_t>{},
+                       thrust::equal_to<vertex_t>{},
+                       stream_view);
   }
 
   // 4. find values for [collect_key_first, collect_key_last)
 
   auto value_buffer = allocate_dataframe_buffer<value_t>(
     thrust::distance(collect_key_first, collect_key_last), stream_view);
-  kv_map_ptr->find(collect_key_first, collect_key_last, get_dataframe_buffer_begin(value_buffer));
+  kv_map_ptr->find(collect_key_first,
+                   collect_key_last,
+                   get_dataframe_buffer_begin(value_buffer),
+                   cuco::detail::MurmurHash3_32<vertex_t>{},
+                   thrust::equal_to<vertex_t>{},
+                   stream_view);
 
   return value_buffer;
 }
@@ -189,10 +204,15 @@ collect_values_for_unique_keys(raft::comms::comms_t const& comm,
              static_cast<size_t>(thrust::distance(map_key_first, map_key_last)) + 1),
     invalid_vertex_id<vertex_t>::value,
     invalid_vertex_id<vertex_t>::value,
-    stream_adapter);
+    stream_adapter,
+    stream_view);
   {
     auto pair_first = thrust::make_zip_iterator(thrust::make_tuple(map_key_first, map_value_first));
-    kv_map_ptr->insert(pair_first, pair_first + thrust::distance(map_key_first, map_key_last));
+    kv_map_ptr->insert(pair_first,
+                       pair_first + thrust::distance(map_key_first, map_key_last),
+                       cuco::detail::MurmurHash3_32<vertex_t>{},
+                       thrust::equal_to<vertex_t>{},
+                       stream_view);
   }
 
   // 2. collect values for the unique keys in [collect_unique_key_first, collect_unique_key_last)
@@ -217,10 +237,12 @@ collect_values_for_unique_keys(raft::comms::comms_t const& comm,
 
     rmm::device_uvector<value_t> values_for_rx_unique_keys(rx_unique_keys.size(), stream_view);
 
-    stream_view.synchronize();  // cuco::static_map currently does not take stream
-
-    kv_map_ptr->find(
-      rx_unique_keys.begin(), rx_unique_keys.end(), values_for_rx_unique_keys.begin());
+    kv_map_ptr->find(rx_unique_keys.begin(),
+                     rx_unique_keys.end(),
+                     values_for_rx_unique_keys.begin(),
+                     cuco::detail::MurmurHash3_32<vertex_t>{},
+                     thrust::equal_to<vertex_t>{},
+                     stream_view);
 
     rmm::device_uvector<value_t> rx_values_for_unique_keys(0, stream_view);
     std::tie(rx_values_for_unique_keys, std::ignore) =
@@ -232,8 +254,6 @@ collect_values_for_unique_keys(raft::comms::comms_t const& comm,
   // 3. re-build a cuco::static_map object for the k, v pairs in unique_keys,
   // values_for_unique_keys.
 
-  stream_view.synchronize();  // cuco::static_map currently does not take stream
-
   kv_map_ptr.reset();
 
   kv_map_ptr = std::make_unique<
@@ -243,19 +263,28 @@ collect_values_for_unique_keys(raft::comms::comms_t const& comm,
              unique_keys.size() + 1),
     invalid_vertex_id<vertex_t>::value,
     invalid_vertex_id<vertex_t>::value,
-    stream_adapter);
+    stream_adapter,
+    stream_view);
   {
     auto pair_first = thrust::make_zip_iterator(
       thrust::make_tuple(unique_keys.begin(), values_for_unique_keys.begin()));
-    kv_map_ptr->insert(pair_first, pair_first + unique_keys.size());
+    kv_map_ptr->insert(pair_first,
+                       pair_first + unique_keys.size(),
+                       cuco::detail::MurmurHash3_32<vertex_t>{},
+                       thrust::equal_to<vertex_t>{},
+                       stream_view);
   }
 
   // 4. find values for [collect_unique_key_first, collect_unique_key_last)
 
   auto value_buffer = allocate_dataframe_buffer<value_t>(
     thrust::distance(collect_unique_key_first, collect_unique_key_last), stream_view);
-  kv_map_ptr->find(
-    collect_unique_key_first, collect_unique_key_last, get_dataframe_buffer_begin(value_buffer));
+  kv_map_ptr->find(collect_unique_key_first,
+                   collect_unique_key_last,
+                   get_dataframe_buffer_begin(value_buffer),
+                   cuco::detail::MurmurHash3_32<vertex_t>{},
+                   thrust::equal_to<vertex_t>{},
+                   stream_view);
 
   return value_buffer;
 }

--- a/cpp/src/structure/relabel_impl.cuh
+++ b/cpp/src/structure/relabel_impl.cuh
@@ -107,12 +107,9 @@ void relabel(raft::handle_t const& handle,
 
       // update intermediate relabel map
 
-      handle.get_stream_view().synchronize();  // cuco::static_map currently does not take stream
-
       auto poly_alloc =
         rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());
-      auto stream_adapter =
-        rmm::mr::make_stream_allocator_adaptor(poly_alloc, cudaStream_t{nullptr});
+      auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(poly_alloc, handle.get_stream());
       cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>
         relabel_map{// cuco::static_map requires at least one empty slot
                     std::max(static_cast<size_t>(
@@ -120,11 +117,16 @@ void relabel(raft::handle_t const& handle,
                              rx_label_pair_old_labels.size() + 1),
                     invalid_vertex_id<vertex_t>::value,
                     invalid_vertex_id<vertex_t>::value,
-                    stream_adapter};
+                    stream_adapter,
+                    handle.get_stream()};
 
       auto pair_first = thrust::make_zip_iterator(
         thrust::make_tuple(rx_label_pair_old_labels.begin(), rx_label_pair_new_labels.begin()));
-      relabel_map.insert(pair_first, pair_first + rx_label_pair_old_labels.size());
+      relabel_map.insert(pair_first,
+                         pair_first + rx_label_pair_old_labels.size(),
+                         cuco::detail::MurmurHash3_32<vertex_t>{},
+                         thrust::equal_to<vertex_t>{},
+                         handle.get_stream());
 
       rx_label_pair_old_labels.resize(0, handle.get_stream_view());
       rx_label_pair_new_labels.resize(0, handle.get_stream_view());
@@ -143,8 +145,6 @@ void relabel(raft::handle_t const& handle,
           [key_func] __device__(auto val) { return key_func(val); },
           handle.get_stream_view());
 
-        handle.get_stream_view().synchronize();  // cuco::static_map currently does not take stream
-
         if (skip_missing_labels) {
           thrust::transform(handle.get_thrust_policy(),
                             rx_unique_old_labels.begin(),
@@ -157,11 +157,13 @@ void relabel(raft::handle_t const& handle,
                                                          : old_label;
                             });
         } else {
-          relabel_map.find(
-            rx_unique_old_labels.begin(),
-            rx_unique_old_labels.end(),
-            rx_unique_old_labels.begin());  // now rx_unique_old_lables hold new labels for the
-                                            // corresponding old labels
+          relabel_map.find(rx_unique_old_labels.begin(),
+                           rx_unique_old_labels.end(),
+                           rx_unique_old_labels.begin(),
+                           cuco::detail::MurmurHash3_32<vertex_t>{},
+                           thrust::equal_to<vertex_t>{},
+                           handle.get_stream());  // now rx_unique_old_lables holds new labels for
+                                                  // the corresponding old labels
         }
 
         std::tie(new_labels_for_unique_old_labels, std::ignore) =
@@ -172,13 +174,10 @@ void relabel(raft::handle_t const& handle,
       }
     }
 
-    handle.get_stream_view().synchronize();  // cuco::static_map currently does not take stream
-
     {
       auto poly_alloc =
         rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());
-      auto stream_adapter =
-        rmm::mr::make_stream_allocator_adaptor(poly_alloc, cudaStream_t{nullptr});
+      auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(poly_alloc, handle.get_stream());
       cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>
         relabel_map{
           // cuco::static_map requires at least one empty slot
@@ -186,24 +185,43 @@ void relabel(raft::handle_t const& handle,
                    unique_old_labels.size() + 1),
           invalid_vertex_id<vertex_t>::value,
           invalid_vertex_id<vertex_t>::value,
-          stream_adapter};
+          stream_adapter,
+          handle.get_stream()};
 
       auto pair_first = thrust::make_zip_iterator(
         thrust::make_tuple(unique_old_labels.begin(), new_labels_for_unique_old_labels.begin()));
-      relabel_map.insert(pair_first, pair_first + unique_old_labels.size());
-      relabel_map.find(labels, labels + num_labels, labels);
+      relabel_map.insert(pair_first,
+                         pair_first + unique_old_labels.size(),
+                         cuco::detail::MurmurHash3_32<vertex_t>{},
+                         thrust::equal_to<vertex_t>{},
+                         handle.get_stream());
+      relabel_map.find(labels,
+                       labels + num_labels,
+                       labels,
+                       cuco::detail::MurmurHash3_32<vertex_t>{},
+                       thrust::equal_to<vertex_t>{},
+                       handle.get_stream());
     }
   } else {
-    cuco::static_map<vertex_t, vertex_t> relabel_map(
-      // cuco::static_map requires at least one empty slot
-      std::max(static_cast<size_t>(static_cast<double>(num_label_pairs) / load_factor),
-               static_cast<size_t>(num_label_pairs) + 1),
-      invalid_vertex_id<vertex_t>::value,
-      invalid_vertex_id<vertex_t>::value);
+    auto poly_alloc = rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());
+    auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(poly_alloc, handle.get_stream());
+    cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>
+      relabel_map(
+        // cuco::static_map requires at least one empty slot
+        std::max(static_cast<size_t>(static_cast<double>(num_label_pairs) / load_factor),
+                 static_cast<size_t>(num_label_pairs) + 1),
+        invalid_vertex_id<vertex_t>::value,
+        invalid_vertex_id<vertex_t>::value,
+        stream_adapter,
+        handle.get_stream());
 
     auto pair_first = thrust::make_zip_iterator(
       thrust::make_tuple(std::get<0>(old_new_label_pairs), std::get<1>(old_new_label_pairs)));
-    relabel_map.insert(pair_first, pair_first + num_label_pairs);
+    relabel_map.insert(pair_first,
+                       pair_first + num_label_pairs,
+                       cuco::detail::MurmurHash3_32<vertex_t>{},
+                       thrust::equal_to<vertex_t>{},
+                       handle.get_stream());
     if (skip_missing_labels) {
       thrust::transform(handle.get_thrust_policy(),
                         labels,
@@ -216,7 +234,12 @@ void relabel(raft::handle_t const& handle,
                                                      : old_label;
                         });
     } else {
-      relabel_map.find(labels, labels + num_labels, labels);
+      relabel_map.find(labels,
+                       labels + num_labels,
+                       labels,
+                       cuco::detail::MurmurHash3_32<vertex_t>{},
+                       thrust::equal_to<vertex_t>{},
+                       handle.get_stream());
     }
   }
 

--- a/cpp/src/structure/renumber_utils_impl.cuh
+++ b/cpp/src/structure/renumber_utils_impl.cuh
@@ -189,13 +189,9 @@ void unrenumber_local_int_edges(
                    i,
                    handle.get_stream());
 
-      CUDA_TRY(cudaStreamSynchronize(
-        handle.get_stream()));  // cuco::static_map currently does not take stream
-
       auto poly_alloc =
         rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());
-      auto stream_adapter =
-        rmm::mr::make_stream_allocator_adaptor(poly_alloc, cudaStream_t{nullptr});
+      auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(poly_alloc, handle.get_stream());
       cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>
         renumber_map{// cuco::static_map requires at least one empty slot
                      std::max(static_cast<size_t>(static_cast<double>(matrix_partition_major_size) /
@@ -203,13 +199,22 @@ void unrenumber_local_int_edges(
                               static_cast<size_t>(matrix_partition_major_size) + 1),
                      invalid_vertex_id<vertex_t>::value,
                      invalid_vertex_id<vertex_t>::value,
-                     stream_adapter};
+                     stream_adapter,
+                     handle.get_stream()};
       auto pair_first = thrust::make_zip_iterator(
         thrust::make_tuple(thrust::make_counting_iterator(matrix_partition_major_first),
                            renumber_map_major_labels.begin()));
-      renumber_map.insert(pair_first, pair_first + matrix_partition_major_size);
-      renumber_map.find(
-        edgelist_majors[i], edgelist_majors[i] + edgelist_edge_counts[i], edgelist_majors[i]);
+      renumber_map.insert(pair_first,
+                          pair_first + matrix_partition_major_size,
+                          cuco::detail::MurmurHash3_32<vertex_t>{},
+                          thrust::equal_to<vertex_t>{},
+                          handle.get_stream());
+      renumber_map.find(edgelist_majors[i],
+                        edgelist_majors[i] + edgelist_edge_counts[i],
+                        edgelist_majors[i],
+                        cuco::detail::MurmurHash3_32<vertex_t>{},
+                        thrust::equal_to<vertex_t>{},
+                        handle.get_stream());
     }
   }
 
@@ -248,29 +253,33 @@ void unrenumber_local_int_edges(
                    i,
                    handle.get_stream());
 
-      CUDA_TRY(cudaStreamSynchronize(
-        handle.get_stream()));  // cuco::static_map currently does not take stream
-
       auto poly_alloc =
         rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());
-      auto stream_adapter =
-        rmm::mr::make_stream_allocator_adaptor(poly_alloc, cudaStream_t{nullptr});
+      auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(poly_alloc, handle.get_stream());
       cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>
         renumber_map{// cuco::static_map requires at least one empty slot
                      std::max(static_cast<size_t>(static_cast<double>(segment_size) / load_factor),
                               static_cast<size_t>(segment_size) + 1),
                      invalid_vertex_id<vertex_t>::value,
                      invalid_vertex_id<vertex_t>::value,
-                     stream_adapter};
+                     stream_adapter,
+                     handle.get_stream()};
       auto pair_first = thrust::make_zip_iterator(
         thrust::make_tuple(thrust::make_counting_iterator(vertex_partition_minor_first),
                            renumber_map_minor_labels.begin()));
-      renumber_map.insert(pair_first, pair_first + segment_size);
+      renumber_map.insert(pair_first,
+                          pair_first + segment_size,
+                          cuco::detail::MurmurHash3_32<vertex_t>{},
+                          thrust::equal_to<vertex_t>{},
+                          handle.get_stream());
       for (size_t j = 0; j < edgelist_minors.size(); ++j) {
         renumber_map.find(
           edgelist_minors[j] + (*edgelist_intra_partition_segment_offsets)[j][i],
           edgelist_minors[j] + (*edgelist_intra_partition_segment_offsets)[j][i + 1],
-          edgelist_minors[j] + (*edgelist_intra_partition_segment_offsets)[j][i]);
+          edgelist_minors[j] + (*edgelist_intra_partition_segment_offsets)[j][i],
+          cuco::detail::MurmurHash3_32<vertex_t>{},
+          thrust::equal_to<vertex_t>{},
+          handle.get_stream());
       }
     }
   } else {
@@ -297,11 +306,8 @@ void unrenumber_local_int_edges(
                       displacements,
                       handle.get_stream());
 
-    CUDA_TRY(cudaStreamSynchronize(
-      handle.get_stream()));  // cuco::static_map currently does not take stream
-
     auto poly_alloc = rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());
-    auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(poly_alloc, cudaStream_t{nullptr});
+    auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(poly_alloc, handle.get_stream());
     cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>
       renumber_map{// cuco::static_map requires at least one empty slot
                    std::max(static_cast<size_t>(
@@ -309,14 +315,23 @@ void unrenumber_local_int_edges(
                             renumber_map_minor_labels.size() + 1),
                    invalid_vertex_id<vertex_t>::value,
                    invalid_vertex_id<vertex_t>::value,
-                   stream_adapter};
+                   stream_adapter,
+                   handle.get_stream()};
     auto pair_first = thrust::make_zip_iterator(
       thrust::make_tuple(thrust::make_counting_iterator(matrix_partition_minor_first),
                          renumber_map_minor_labels.begin()));
-    renumber_map.insert(pair_first, pair_first + renumber_map_minor_labels.size());
+    renumber_map.insert(pair_first,
+                        pair_first + renumber_map_minor_labels.size(),
+                        cuco::detail::MurmurHash3_32<vertex_t>{},
+                        thrust::equal_to<vertex_t>{},
+                        handle.get_stream());
     for (size_t i = 0; i < edgelist_minors.size(); ++i) {
-      renumber_map.find(
-        edgelist_minors[i], edgelist_minors[i] + edgelist_edge_counts[i], edgelist_minors[i]);
+      renumber_map.find(edgelist_minors[i],
+                        edgelist_minors[i] + edgelist_edge_counts[i],
+                        edgelist_minors[i],
+                        cuco::detail::MurmurHash3_32<vertex_t>{},
+                        thrust::equal_to<vertex_t>{},
+                        handle.get_stream());
     }
   }
 }
@@ -348,13 +363,14 @@ void renumber_ext_vertices(raft::handle_t const& handle,
   }
 
   auto poly_alloc = rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());
-  auto stream_adapter   = rmm::mr::make_stream_allocator_adaptor(poly_alloc, cudaStream_t{nullptr});
+  auto stream_adapter   = rmm::mr::make_stream_allocator_adaptor(poly_alloc, handle.get_stream());
   auto renumber_map_ptr = std::make_unique<
     cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>>(
     size_t{0},
     invalid_vertex_id<vertex_t>::value,
     invalid_vertex_id<vertex_t>::value,
-    stream_adapter);
+    stream_adapter,
+    handle.get_stream());
   if (multi_gpu) {
     auto& comm           = handle.get_comms();
     auto const comm_size = comm.get_size();
@@ -390,8 +406,6 @@ void renumber_ext_vertices(raft::handle_t const& handle,
       detail::compute_gpu_id_from_vertex_t<vertex_t>{comm_size},
       handle.get_stream_view());
 
-    handle.get_stream_view().synchronize();  // cuco::static_map currently does not take stream
-
     renumber_map_ptr.reset();
 
     renumber_map_ptr = std::make_unique<
@@ -402,14 +416,17 @@ void renumber_ext_vertices(raft::handle_t const& handle,
         sorted_unique_ext_vertices.size() + 1),
       invalid_vertex_id<vertex_t>::value,
       invalid_vertex_id<vertex_t>::value,
-      stream_adapter);
+      stream_adapter,
+      handle.get_stream());
 
     auto kv_pair_first = thrust::make_zip_iterator(thrust::make_tuple(
       sorted_unique_ext_vertices.begin(), int_vertices_for_sorted_unique_ext_vertices.begin()));
-    renumber_map_ptr->insert(kv_pair_first, kv_pair_first + sorted_unique_ext_vertices.size());
+    renumber_map_ptr->insert(kv_pair_first,
+                             kv_pair_first + sorted_unique_ext_vertices.size(),
+                             cuco::detail::MurmurHash3_32<vertex_t>{},
+                             thrust::equal_to<vertex_t>{},
+                             handle.get_stream());
   } else {
-    handle.get_stream_view().synchronize();  // cuco::static_map currently does not take stream
-
     renumber_map_ptr.reset();
 
     renumber_map_ptr = std::make_unique<
@@ -420,12 +437,16 @@ void renumber_ext_vertices(raft::handle_t const& handle,
                static_cast<size_t>(local_int_vertex_last - local_int_vertex_first) + 1),
       invalid_vertex_id<vertex_t>::value,
       invalid_vertex_id<vertex_t>::value,
-      stream_adapter);
+      stream_adapter,
+      handle.get_stream());
 
     auto pair_first = thrust::make_zip_iterator(
       thrust::make_tuple(renumber_map_labels, thrust::make_counting_iterator(vertex_t{0})));
     renumber_map_ptr->insert(pair_first,
-                             pair_first + (local_int_vertex_last - local_int_vertex_first));
+                             pair_first + (local_int_vertex_last - local_int_vertex_first),
+                             cuco::detail::MurmurHash3_32<vertex_t>{},
+                             thrust::equal_to<vertex_t>{},
+                             handle.get_stream());
   }
 
   if (do_expensive_check) {
@@ -578,10 +599,8 @@ void unrenumber_int_vertices(raft::handle_t const& handle,
     std::tie(rx_ext_vertices_for_sorted_unique_int_vertices, std::ignore) =
       shuffle_values(comm, tx_ext_vertices.begin(), rx_int_vertex_counts, handle.get_stream_view());
 
-    handle.get_stream_view().synchronize();  // cuco::static_map currently does not take stream
-
     auto poly_alloc = rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());
-    auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(poly_alloc, cudaStream_t{nullptr});
+    auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(poly_alloc, handle.get_stream());
     cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>
       renumber_map{// cuco::static_map requires at least one empty slot
                    std::max(static_cast<size_t>(
@@ -589,12 +608,22 @@ void unrenumber_int_vertices(raft::handle_t const& handle,
                             sorted_unique_int_vertices.size() + 1),
                    invalid_vertex_id<vertex_t>::value,
                    invalid_vertex_id<vertex_t>::value,
-                   stream_adapter};
+                   stream_adapter,
+                   handle.get_stream()};
 
     auto pair_first = thrust::make_zip_iterator(thrust::make_tuple(
       sorted_unique_int_vertices.begin(), rx_ext_vertices_for_sorted_unique_int_vertices.begin()));
-    renumber_map.insert(pair_first, pair_first + sorted_unique_int_vertices.size());
-    renumber_map.find(vertices, vertices + num_vertices, vertices);
+    renumber_map.insert(pair_first,
+                        pair_first + sorted_unique_int_vertices.size(),
+                        cuco::detail::MurmurHash3_32<vertex_t>{},
+                        thrust::equal_to<vertex_t>{},
+                        handle.get_stream());
+    renumber_map.find(vertices,
+                      vertices + num_vertices,
+                      vertices,
+                      cuco::detail::MurmurHash3_32<vertex_t>{},
+                      thrust::equal_to<vertex_t>{},
+                      handle.get_stream());
   } else {
     unrenumber_local_int_vertices(handle,
                                   vertices,


### PR DESCRIPTION
Should not be merged before we update cmake to pull a cuCollection version after cuCollection PR113.

cuCollection added stream support for static_map in https://github.com/NVIDIA/cuCollections/pull/113

This allows us to avoid unnecessary stream/device synchronizations and also allows to enable multi-stream execution without unnecessary serialization.

This PR updates libcugraph code to pass `handle.get_stream()` to `cuco::static_map`. 