### PR TITLE
Remove `IncludeCategories` from `.clang-format`

### DIFF
--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -72,15 +72,6 @@ ForEachMacros:
   - Q_FOREACH
   - BOOST_FOREACH
 IncludeBlocks: Preserve
-IncludeCategories:
-  - Regex:           '^<ext/.*\.h>'
-    Priority:        2
-  - Regex:           '^<.*\.h>'
-    Priority:        1
-  - Regex:           '^<.*'
-    Priority:        2
-  - Regex:           '.*'
-    Priority:        3
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentCaseLabels: true
 IndentPPDirectives: None

--- a/cpp/include/cugraph/detail/graph_utils.cuh
+++ b/cpp/include/cugraph/detail/graph_utils.cuh
@@ -24,10 +24,10 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuco/detail/hash_functions.cuh>
 #include <thrust/sort.h>
 #include <thrust/tabulate.h>
 #include <thrust/transform.h>
-#include <cuco/detail/hash_functions.cuh>
 
 #include <algorithm>
 #include <numeric>

--- a/cpp/include/cugraph/legacy/graph.hpp
+++ b/cpp/include/cugraph/legacy/graph.hpp
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 #pragma once
-#include <unistd.h>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
 #include <memory>
 #include <raft/handle.hpp>
 #include <rmm/device_buffer.hpp>
+#include <unistd.h>
 
 namespace cugraph {
 namespace legacy {

--- a/cpp/include/cugraph/prims/copy_v_transform_reduce_in_out_nbr.cuh
+++ b/cpp/include/cugraph/prims/copy_v_transform_reduce_in_out_nbr.cuh
@@ -28,12 +28,12 @@
 #include <raft/handle.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cub/cub.cuh>
 #include <thrust/distance.h>
 #include <thrust/functional.h>
 #include <thrust/transform_reduce.h>
 #include <thrust/tuple.h>
 #include <thrust/type_traits/integer_sequence.h>
-#include <cub/cub.cuh>
 
 #include <type_traits>
 #include <utility>

--- a/cpp/include/cugraph/prims/property_op_utils.cuh
+++ b/cpp/include/cugraph/prims/property_op_utils.cuh
@@ -20,10 +20,10 @@
 #include <raft/comms/comms.hpp>
 #include <raft/device_atomics.cuh>
 
+#include <cub/cub.cuh>
 #include <thrust/detail/type_traits/iterator/is_discard_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/tuple.h>
-#include <cub/cub.cuh>
 
 #include <array>
 #include <type_traits>

--- a/cpp/include/cugraph/prims/update_frontier_v_push_if_out_nbr.cuh
+++ b/cpp/include/cugraph/prims/update_frontier_v_push_if_out_nbr.cuh
@@ -33,6 +33,7 @@
 #include <rmm/device_scalar.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cub/cub.cuh>
 #include <thrust/binary_search.h>
 #include <thrust/distance.h>
 #include <thrust/functional.h>
@@ -41,7 +42,6 @@
 #include <thrust/transform_reduce.h>
 #include <thrust/tuple.h>
 #include <thrust/type_traits/integer_sequence.h>
-#include <cub/cub.cuh>
 
 #include <algorithm>
 #include <cstdlib>

--- a/cpp/include/cugraph/utilities/thrust_tuple_utils.cuh
+++ b/cpp/include/cugraph/utilities/thrust_tuple_utils.cuh
@@ -19,9 +19,9 @@
 #include <raft/device_atomics.cuh>
 #include <rmm/device_uvector.hpp>
 
+#include <cub/cub.cuh>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/tuple.h>
-#include <cub/cub.cuh>
 
 #include <array>
 #include <type_traits>

--- a/cpp/include/cugraph/visitors/cascaded_dispatch.hpp
+++ b/cpp/include/cugraph/visitors/cascaded_dispatch.hpp
@@ -31,8 +31,8 @@
 #include "enum_mapping.hpp"
 #include "graph_enum_mapping.hpp"
 
-#include <cugraph/utilities/graph_traits.hpp>
 #include "graph_factory.hpp"
+#include <cugraph/utilities/graph_traits.hpp>
 
 namespace cugraph {
 namespace visitors {

--- a/cpp/include/cugraph/visitors/graph_enum_mapping.hpp
+++ b/cpp/include/cugraph/visitors/graph_enum_mapping.hpp
@@ -19,8 +19,8 @@
 
 #pragma once
 
-#include <cugraph/graph.hpp>
 #include "graph_enum.hpp"
+#include <cugraph/graph.hpp>
 
 namespace cugraph {
 namespace visitors {

--- a/cpp/src/c_api/cugraph_api.cpp
+++ b/cpp/src/c_api/cugraph_api.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <cugraph_c/cugraph_api.h>
 #include <cugraph/api_helpers.hpp>
+#include <cugraph_c/cugraph_api.h>
 
 #include <cugraph/visitors/rw_visitor.hpp>
 

--- a/cpp/src/c_api/error.cpp
+++ b/cpp/src/c_api/error.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <cugraph_c/error.h>
 #include <c_api/error.hpp>
+#include <cugraph_c/error.h>
 
 extern "C" const char* cugraph_error_message(const cugraph_error_t* error)
 {

--- a/cpp/src/c_api/graph.hpp
+++ b/cpp/src/c_api/graph.hpp
@@ -15,9 +15,9 @@
  */
 #pragma once
 
-#include <cugraph_c/graph.h>
 #include <c_api/array.hpp>
 #include <c_api/error.hpp>
+#include <cugraph_c/graph.h>
 
 #include <cugraph/graph.hpp>
 

--- a/cpp/src/c_api/graph_sg.cpp
+++ b/cpp/src/c_api/graph_sg.cpp
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
+#include <cugraph/detail/utility_wrappers.hpp>
+#include <cugraph/graph_functions.hpp>
+#include <cugraph/visitors/generic_cascaded_dispatch.hpp>
+#include <cugraph_c/graph.h>
+
 #include <c_api/abstract_functor.hpp>
 #include <c_api/array.hpp>
 #include <c_api/error.hpp>
 #include <c_api/graph.hpp>
-#include <cugraph_c/graph.h>
-
-#include <cugraph/detail/utility_wrappers.hpp>
-#include <cugraph/graph_functions.hpp>
-#include <cugraph/visitors/generic_cascaded_dispatch.hpp>
 
 #include <raft/handle.hpp>
 

--- a/cpp/src/c_api/graph_sg.cpp
+++ b/cpp/src/c_api/graph_sg.cpp
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#include <cugraph_c/graph.h>
 #include <c_api/abstract_functor.hpp>
 #include <c_api/array.hpp>
 #include <c_api/error.hpp>
 #include <c_api/graph.hpp>
+#include <cugraph_c/graph.h>
 
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/graph_functions.hpp>

--- a/cpp/src/centrality/betweenness_centrality.cu
+++ b/cpp/src/centrality/betweenness_centrality.cu
@@ -27,9 +27,9 @@
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_vector.hpp>
 
-#include <raft/handle.hpp>
 #include "betweenness_centrality.cuh"
 #include "betweenness_centrality_kernels.cuh"
+#include <raft/handle.hpp>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/community/legacy/ecg.cu
+++ b/cpp/src/community/legacy/ecg.cu
@@ -20,8 +20,8 @@
 #include <cugraph/utilities/error.hpp>
 #include <utilities/graph_utils.cuh>
 
-#include <thrust/random.h>
 #include <rmm/exec_policy.hpp>
+#include <thrust/random.h>
 
 #include <ctime>
 

--- a/cpp/src/community/legacy/egonet.cu
+++ b/cpp/src/community/legacy/egonet.cu
@@ -25,8 +25,8 @@
 #include <rmm/device_vector.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <thrust/transform.h>
 #include <ctime>
+#include <thrust/transform.h>
 
 #include <cugraph/legacy/graph.hpp>
 

--- a/cpp/src/community/legacy/ktruss.cu
+++ b/cpp/src/community/legacy/ktruss.cu
@@ -23,10 +23,10 @@
 
 #include <cugraph/utilities/error.hpp>
 
+#include "Static/KTruss/KTruss.cuh"
 #include <Hornet.hpp>
 #include <StandardAPI.hpp>
 #include <cugraph/algorithms.hpp>
-#include "Static/KTruss/KTruss.cuh"
 
 using namespace hornets_nest;
 

--- a/cpp/src/community/legacy/spectral_clustering.cu
+++ b/cpp/src/community/legacy/spectral_clustering.cu
@@ -22,10 +22,10 @@
 
 #include <cugraph/algorithms.hpp>
 
-#include <thrust/transform.h>
 #include <ctime>
 #include <rmm/device_vector.hpp>
 #include <rmm/exec_policy.hpp>
+#include <thrust/transform.h>
 
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>

--- a/cpp/src/community/legacy/triangles_counting.cu
+++ b/cpp/src/community/legacy/triangles_counting.cu
@@ -16,10 +16,10 @@
 
 #include <cuda_runtime.h>
 
-#include <raft/cudart_utils.h>
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <raft/cudart_utils.h>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_vector.hpp>
 

--- a/cpp/src/components/utils.h
+++ b/cpp/src/components/utils.h
@@ -16,9 +16,9 @@
 
 #pragma once
 
+#include <cstdio>
 #include <cuda_runtime.h>
 #include <execinfo.h>
-#include <cstdio>
 #include <iostream>
 #include <memory>
 #include <sstream>

--- a/cpp/src/components/weak_cc.cuh
+++ b/cpp/src/components/weak_cc.cuh
@@ -28,8 +28,8 @@
 #include <raft/cudart_utils.h>
 #include <raft/device_atomics.cuh>
 
-#include <rmm/device_vector.hpp>
 #include "utils.h"
+#include <rmm/device_vector.hpp>
 
 namespace MLCommon {
 

--- a/cpp/src/converters/COOtoCSR.cu
+++ b/cpp/src/converters/COOtoCSR.cu
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <cugraph/functions.hpp>
 #include "COOtoCSR.cuh"
+#include <cugraph/functions.hpp>
 
 namespace cugraph {
 

--- a/cpp/src/converters/COOtoCSR.cuh
+++ b/cpp/src/converters/COOtoCSR.cuh
@@ -22,12 +22,12 @@
 
 #pragma once
 
+#include <algorithm>
 #include <thrust/extrema.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/scan.h>
 #include <thrust/sort.h>
 #include <thrust/tuple.h>
-#include <algorithm>
 
 #include <cugraph/utilities/error.hpp>
 #include <rmm/exec_policy.hpp>

--- a/cpp/src/converters/permute_graph.cuh
+++ b/cpp/src/converters/permute_graph.cuh
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "converters/COOtoCSR.cuh"
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <rmm/device_vector.hpp>
 #include <rmm/exec_policy.hpp>
 #include <utilities/graph_utils.cuh>
-#include "converters/COOtoCSR.cuh"
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/detail/utility_wrappers.cu
+++ b/cpp/src/detail/utility_wrappers.cu
@@ -17,8 +17,8 @@
 
 #include <raft/random/rng.hpp>
 
-#include <thrust/sequence.h>
 #include <rmm/exec_policy.hpp>
+#include <thrust/sequence.h>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/sampling/random_walks.cu
+++ b/cpp/src/sampling/random_walks.cu
@@ -16,8 +16,8 @@
 
 // Andrei Schaffer, aschaffer@nvidia.com
 //
-#include <cugraph/algorithms.hpp>
 #include "random_walks.cuh"
+#include <cugraph/algorithms.hpp>
 
 namespace cugraph {
 // template explicit instantiation directives (EIDir's):

--- a/cpp/src/traversal/legacy/bfs.cu
+++ b/cpp/src/traversal/legacy/bfs.cu
@@ -9,19 +9,19 @@
  *
  */
 
+#include "bfs.cuh"
 #include <algorithm>
 #include <iomanip>
 #include <limits>
-#include "bfs.cuh"
 
 #include <cugraph/legacy/graph.hpp>
 
-#include <cugraph/utilities/error.hpp>
-#include <utilities/graph_utils.cuh>
 #include "bfs_kernels.cuh"
 #include "mg/bfs.cuh"
 #include "mg/common_utils.cuh"
 #include "traversal_common.cuh"
+#include <cugraph/utilities/error.hpp>
+#include <utilities/graph_utils.cuh>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/traversal/legacy/bfs_kernels.cuh
+++ b/cpp/src/traversal/legacy/bfs_kernels.cuh
@@ -15,11 +15,11 @@
  */
 #include <iostream>
 
-#include <raft/cudart_utils.h>
 #include <cub/cub.cuh>
+#include <raft/cudart_utils.h>
 
-#include <cugraph/legacy/graph.hpp>
 #include "traversal_common.cuh"
+#include <cugraph/legacy/graph.hpp>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/traversal/legacy/mg/bfs.cuh
+++ b/cpp/src/traversal/legacy/mg/bfs.cuh
@@ -16,11 +16,11 @@
 
 #pragma once
 
-#include <raft/handle.hpp>
-#include <rmm/device_vector.hpp>
 #include "../traversal_common.cuh"
 #include "common_utils.cuh"
 #include "frontier_expand.cuh"
+#include <raft/handle.hpp>
+#include <rmm/device_vector.hpp>
 
 namespace cugraph {
 

--- a/cpp/src/traversal/legacy/mg/common_utils.cuh
+++ b/cpp/src/traversal/legacy/mg/common_utils.cuh
@@ -18,14 +18,14 @@
 
 #include "../traversal_common.cuh"
 
-#include <thrust/host_vector.h>
 #include <cub/cub.cuh>
 #include <rmm/device_vector.hpp>
 #include <rmm/exec_policy.hpp>
+#include <thrust/host_vector.h>
 
 #include <raft/cudart_utils.h>
-#include <raft/integer_utils.h>
 #include <raft/handle.hpp>
+#include <raft/integer_utils.h>
 
 namespace cugraph {
 

--- a/cpp/src/traversal/legacy/mg/frontier_expand.cuh
+++ b/cpp/src/traversal/legacy/mg/frontier_expand.cuh
@@ -16,10 +16,10 @@
 
 #pragma once
 
-#include <cugraph/legacy/graph.hpp>
-#include <rmm/device_vector.hpp>
 #include "frontier_expand_kernels.cuh"
 #include "vertex_binning.cuh"
+#include <cugraph/legacy/graph.hpp>
+#include <rmm/device_vector.hpp>
 
 namespace cugraph {
 

--- a/cpp/src/traversal/legacy/mg/frontier_expand_kernels.cuh
+++ b/cpp/src/traversal/legacy/mg/frontier_expand_kernels.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <cugraph/legacy/graph.hpp>
 #include "vertex_binning.cuh"
+#include <cugraph/legacy/graph.hpp>
 
 namespace cugraph {
 

--- a/cpp/src/traversal/legacy/mg/vertex_binning.cuh
+++ b/cpp/src/traversal/legacy/mg/vertex_binning.cuh
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include <rmm/device_vector.hpp>
 #include "common_utils.cuh"
 #include "vertex_binning_kernels.cuh"
+#include <rmm/device_vector.hpp>
 
 #include <thrust/host_vector.h>
 

--- a/cpp/src/traversal/legacy/mg/vertex_binning_kernels.cuh
+++ b/cpp/src/traversal/legacy/mg/vertex_binning_kernels.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <rmm/device_vector.hpp>
 #include "../traversal_common.cuh"
+#include <rmm/device_vector.hpp>
 
 namespace cugraph {
 

--- a/cpp/src/traversal/legacy/sssp_kernels.cuh
+++ b/cpp/src/traversal/legacy/sssp_kernels.cuh
@@ -18,9 +18,9 @@
 
 #include <iostream>
 
+#include "traversal_common.cuh"
 #include <cub/cub.cuh>
 #include <cugraph/utilities/error.hpp>
-#include "traversal_common.cuh"
 namespace cugraph {
 namespace detail {
 namespace sssp_kernels {

--- a/cpp/src/traversal/two_hop_neighbors.cu
+++ b/cpp/src/traversal/two_hop_neighbors.cu
@@ -19,12 +19,12 @@
  * @file two_hop_neighbors.cu
  * ---------------------------------------------------------------------------**/
 
+#include "two_hop_neighbors.cuh"
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <rmm/device_vector.hpp>
 #include <rmm/exec_policy.hpp>
-#include "two_hop_neighbors.cuh"
 
 #include <thrust/scan.h>
 #include <thrust/transform.h>

--- a/cpp/src/tree/mst.cu
+++ b/cpp/src/tree/mst.cu
@@ -24,9 +24,9 @@
 #include <memory>
 #include <utility>
 
-#include <thrust/transform.h>
 #include <ctime>
 #include <rmm/exec_policy.hpp>
+#include <thrust/transform.h>
 
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>

--- a/cpp/src/utilities/spmv_1D.cu
+++ b/cpp/src/utilities/spmv_1D.cu
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <raft/spectral/matrix_wrappers.hpp>
 #include "spmv_1D.cuh"
+#include <raft/spectral/matrix_wrappers.hpp>
 
 namespace cugraph {
 namespace mg {

--- a/cpp/tests/bcast/mg_graph_bcast.cpp
+++ b/cpp/tests/bcast/mg_graph_bcast.cpp
@@ -23,9 +23,9 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/partition_manager.hpp>
 
-#include <raft/cudart_utils.h>
 #include <raft/comms/comms.hpp>
 #include <raft/comms/mpi_comms.hpp>
+#include <raft/cudart_utils.h>
 #include <raft/handle.hpp>
 
 #include <gtest/gtest.h>

--- a/cpp/tests/centrality/katz_centrality_test.cpp
+++ b/cpp/tests/centrality/katz_centrality_test.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/centrality/legacy/katz_centrality_test.cu
+++ b/cpp/tests/centrality/legacy/katz_centrality_test.cu
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_utilities.hpp>
 
 #include <converters/COOtoCSR.cuh>

--- a/cpp/tests/centrality/mg_katz_centrality_test.cpp
+++ b/cpp/tests/centrality/mg_katz_centrality_test.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/community/egonet_test.cu
+++ b/cpp/tests/community/egonet_test.cu
@@ -29,8 +29,8 @@
 
 #include <gtest/gtest.h>
 
-#include <raft/cudart_utils.h>
 #include <algorithm>
+#include <raft/cudart_utils.h>
 #include <rmm/exec_policy.hpp>
 #include <tuple>
 #include <vector>

--- a/cpp/tests/community/mg_louvain_test.cpp
+++ b/cpp/tests/community/mg_louvain_test.cpp
@@ -24,9 +24,9 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/partition_manager.hpp>
 
-#include <raft/cudart_utils.h>
 #include <raft/comms/comms.hpp>
 #include <raft/comms/mpi_comms.hpp>
+#include <raft/cudart_utils.h>
 #include <raft/handle.hpp>
 
 #include <thrust/execution_policy.h>

--- a/cpp/tests/components/con_comp_test.cu
+++ b/cpp/tests/components/con_comp_test.cu
@@ -12,8 +12,8 @@
 // connected components tests
 // Author: Andrei Schaffer aschaffer@nvidia.com
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_utilities.hpp>
 
 #include <cuda_profiler_api.h>

--- a/cpp/tests/components/mg_weakly_connected_components_test.cpp
+++ b/cpp/tests/components/mg_weakly_connected_components_test.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/thrust_wrapper.hpp>
 

--- a/cpp/tests/components/scc_test.cu
+++ b/cpp/tests/components/scc_test.cu
@@ -12,8 +12,8 @@
 // strongly connected components tests
 // Author: Andrei Schaffer aschaffer@nvidia.com
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_utilities.hpp>
 
 #include <rmm/device_vector.hpp>

--- a/cpp/tests/components/weakly_connected_components_test.cpp
+++ b/cpp/tests/components/weakly_connected_components_test.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/thrust_wrapper.hpp>
 

--- a/cpp/tests/cores/core_number_test.cpp
+++ b/cpp/tests/cores/core_number_test.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/cores/mg_core_number_test.cpp
+++ b/cpp/tests/cores/mg_core_number_test.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/layout/force_atlas2_test.cu
+++ b/cpp/tests/layout/force_atlas2_test.cu
@@ -12,13 +12,13 @@
 // Force_Atlas2 tests
 // Author: Hugo Linsenmaier hlinsenmaier@nvidia.com
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_utilities.hpp>
 
-#include <layout/trust_worthiness.h>
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>
+#include <layout/trust_worthiness.h>
 
 #include <raft/error.hpp>
 #include <rmm/exec_policy.hpp>

--- a/cpp/tests/link_analysis/hits_test.cpp
+++ b/cpp/tests/link_analysis/hits_test.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>
@@ -32,15 +32,15 @@
 
 #include <gtest/gtest.h>
 
-#include <thrust/execution_policy.h>
-#include <thrust/host_vector.h>
-#include <thrust/iterator/constant_iterator.h>
-#include <thrust/sort.h>
 #include <algorithm>
 #include <iterator>
 #include <limits>
 #include <numeric>
 #include <random>
+#include <thrust/execution_policy.h>
+#include <thrust/host_vector.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/sort.h>
 #include <vector>
 
 template <typename result_t, typename vertex_t, typename edge_t>

--- a/cpp/tests/link_analysis/mg_hits_test.cpp
+++ b/cpp/tests/link_analysis/mg_hits_test.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/link_analysis/mg_pagerank_test.cpp
+++ b/cpp/tests/link_analysis/mg_pagerank_test.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/link_analysis/pagerank_test.cpp
+++ b/cpp/tests/link_analysis/pagerank_test.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/prims/mg_copy_v_transform_reduce_inout_nbr.cu
+++ b/cpp/tests/prims/mg_copy_v_transform_reduce_inout_nbr.cu
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>
@@ -32,14 +32,14 @@
 #include <cugraph/prims/copy_v_transform_reduce_in_out_nbr.cuh>
 #include <cugraph/prims/row_col_properties.cuh>
 
-#include <thrust/count.h>
-#include <thrust/equal.h>
 #include <raft/comms/comms.hpp>
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/handle.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 #include <sstream>
+#include <thrust/count.h>
+#include <thrust/equal.h>
 
 #include <gtest/gtest.h>
 

--- a/cpp/tests/prims/mg_count_if_e.cu
+++ b/cpp/tests/prims/mg_count_if_e.cu
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>
@@ -32,12 +32,12 @@
 #include <cugraph/prims/count_if_e.cuh>
 #include <cugraph/prims/row_col_properties.cuh>
 
-#include <thrust/count.h>
 #include <raft/comms/comms.hpp>
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/handle.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+#include <thrust/count.h>
 
 #include <gtest/gtest.h>
 

--- a/cpp/tests/prims/mg_count_if_v.cu
+++ b/cpp/tests/prims/mg_count_if_v.cu
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>
@@ -28,12 +28,12 @@
 #include <cugraph/graph_view.hpp>
 #include <cugraph/prims/count_if_v.cuh>
 
-#include <thrust/count.h>
 #include <raft/comms/comms.hpp>
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/handle.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+#include <thrust/count.h>
 
 #include <gtest/gtest.h>
 

--- a/cpp/tests/prims/mg_extract_if_e.cu
+++ b/cpp/tests/prims/mg_extract_if_e.cu
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>
@@ -30,13 +30,13 @@
 #include <cugraph/prims/extract_if_e.cuh>
 #include <cugraph/prims/property_op_utils.cuh>
 
-#include <thrust/equal.h>
-#include <thrust/reduce.h>
 #include <raft/comms/comms.hpp>
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/handle.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+#include <thrust/equal.h>
+#include <thrust/reduce.h>
 
 #include <gtest/gtest.h>
 

--- a/cpp/tests/prims/mg_reduce_v.cu
+++ b/cpp/tests/prims/mg_reduce_v.cu
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>
@@ -29,12 +29,12 @@
 #include <cugraph/prims/property_op_utils.cuh>
 #include <cugraph/prims/reduce_v.cuh>
 
-#include <thrust/reduce.h>
 #include <raft/comms/comms.hpp>
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/handle.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+#include <thrust/reduce.h>
 
 #include <gtest/gtest.h>
 

--- a/cpp/tests/prims/mg_transform_reduce_e.cu
+++ b/cpp/tests/prims/mg_transform_reduce_e.cu
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>
@@ -32,12 +32,12 @@
 #include <cugraph/prims/row_col_properties.cuh>
 #include <cugraph/prims/transform_reduce_e.cuh>
 
-#include <thrust/count.h>
 #include <raft/comms/comms.hpp>
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/handle.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+#include <thrust/count.h>
 
 #include <gtest/gtest.h>
 

--- a/cpp/tests/prims/mg_transform_reduce_v.cu
+++ b/cpp/tests/prims/mg_transform_reduce_v.cu
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>
@@ -28,12 +28,12 @@
 #include <cugraph/graph_view.hpp>
 #include <cugraph/prims/transform_reduce_v.cuh>
 
-#include <thrust/count.h>
 #include <raft/comms/comms.hpp>
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/handle.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+#include <thrust/count.h>
 
 #include <gtest/gtest.h>
 

--- a/cpp/tests/prims/mg_update_frontier_v_push_if_out_nbr.cu
+++ b/cpp/tests/prims/mg_update_frontier_v_push_if_out_nbr.cu
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>
@@ -33,16 +33,16 @@
 #include <cugraph/prims/update_frontier_v_push_if_out_nbr.cuh>
 #include <cugraph/prims/vertex_frontier.cuh>
 
-#include <thrust/copy.h>
-#include <thrust/count.h>
-#include <thrust/equal.h>
-#include <thrust/iterator/permutation_iterator.h>
 #include <raft/comms/comms.hpp>
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/handle.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 #include <sstream>
+#include <thrust/copy.h>
+#include <thrust/count.h>
+#include <thrust/equal.h>
+#include <thrust/iterator/permutation_iterator.h>
 
 #include <gtest/gtest.h>
 

--- a/cpp/tests/sampling/random_walks_test.cu
+++ b/cpp/tests/sampling/random_walks_test.cu
@@ -20,8 +20,8 @@
 #include <utilities/base_fixture.hpp>
 #include <utilities/test_utilities.hpp>
 
-#include <thrust/random.h>
 #include <rmm/exec_policy.hpp>
+#include <thrust/random.h>
 
 #include <cugraph/algorithms.hpp>
 #include <sampling/random_walks.cuh>

--- a/cpp/tests/sampling/rw_low_level_test.cu
+++ b/cpp/tests/sampling/rw_low_level_test.cu
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
 #include "cuda_profiler_api.h"
+#include <gtest/gtest.h>
 
 #include <topology/topology.cuh>
 #include <utilities/base_fixture.hpp>
 #include <utilities/test_utilities.hpp>
 
-#include <thrust/random.h>
 #include <rmm/exec_policy.hpp>
+#include <thrust/random.h>
 
 #include <cugraph/algorithms.hpp>
 #include <sampling/random_walks.cuh>

--- a/cpp/tests/serialization/un_serialize_test.cpp
+++ b/cpp/tests/serialization/un_serialize_test.cpp
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <gtest/gtest.h>
 #include "cuda_profiler_api.h"
+#include <gtest/gtest.h>
 
 #include <utilities/base_fixture.hpp>
 #include <utilities/test_utilities.hpp>

--- a/cpp/tests/structure/coarsen_graph_test.cpp
+++ b/cpp/tests/structure/coarsen_graph_test.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_utilities.hpp>
 
 #include <cugraph/algorithms.hpp>

--- a/cpp/tests/structure/count_self_loops_and_multi_edges_test.cpp
+++ b/cpp/tests/structure/count_self_loops_and_multi_edges_test.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/structure/mg_count_self_loops_and_multi_edges_test.cpp
+++ b/cpp/tests/structure/mg_count_self_loops_and_multi_edges_test.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/structure/mg_symmetrize_test.cpp
+++ b/cpp/tests/structure/mg_symmetrize_test.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/structure/mg_transpose_storage_test.cpp
+++ b/cpp/tests/structure/mg_transpose_storage_test.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/structure/mg_transpose_test.cpp
+++ b/cpp/tests/structure/mg_transpose_test.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/structure/renumbering_test.cpp
+++ b/cpp/tests/structure/renumbering_test.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/structure/streams.cu
+++ b/cpp/tests/structure/streams.cu
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+#include "gtest/gtest.h"
 #include <raft/cudart_utils.h>
-#include <thrust/transform.h>
 #include <raft/handle.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
-#include "gtest/gtest.h"
+#include <thrust/transform.h>
 struct StreamTest : public ::testing::Test {
 };
 TEST_F(StreamTest, basic_test)

--- a/cpp/tests/structure/symmetrize_test.cpp
+++ b/cpp/tests/structure/symmetrize_test.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_utilities.hpp>
 
 #include <cugraph/graph.hpp>

--- a/cpp/tests/structure/transpose_storage_test.cpp
+++ b/cpp/tests/structure/transpose_storage_test.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_utilities.hpp>
 
 #include <cugraph/graph.hpp>

--- a/cpp/tests/structure/transpose_test.cpp
+++ b/cpp/tests/structure/transpose_test.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_utilities.hpp>
 
 #include <cugraph/graph.hpp>

--- a/cpp/tests/traversal/bfs_test.cpp
+++ b/cpp/tests/traversal/bfs_test.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/traversal/extract_bfs_paths_test.cu
+++ b/cpp/tests/traversal/extract_bfs_paths_test.cu
@@ -15,8 +15,8 @@
  */
 #include "randomly_select_destinations.cuh"
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/traversal/legacy/sssp_test.cu
+++ b/cpp/tests/traversal/legacy/sssp_test.cu
@@ -9,8 +9,8 @@
  *
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_utilities.hpp>
 
 #include <rmm/device_vector.hpp>

--- a/cpp/tests/traversal/mg_bfs_test.cpp
+++ b/cpp/tests/traversal/mg_bfs_test.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/traversal/mg_extract_bfs_paths_test.cu
+++ b/cpp/tests/traversal/mg_extract_bfs_paths_test.cu
@@ -15,8 +15,8 @@
  */
 #include "randomly_select_destinations.cuh"
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/traversal/mg_sssp_test.cpp
+++ b/cpp/tests/traversal/mg_sssp_test.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
 #include <utilities/device_comm_wrapper.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/traversal/sssp_test.cpp
+++ b/cpp/tests/traversal/sssp_test.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 #include <utilities/thrust_wrapper.hpp>

--- a/cpp/tests/tree/mst_test.cu
+++ b/cpp/tests/tree/mst_test.cu
@@ -17,8 +17,8 @@
 // Mst solver tests
 // Author: Alex Fender afender@nvidia.com
 
-#include <utilities/high_res_clock.h>
 #include <utilities/base_fixture.hpp>
+#include <utilities/high_res_clock.h>
 #include <utilities/test_utilities.hpp>
 
 #include <cugraph/algorithms.hpp>
@@ -31,9 +31,9 @@
 
 #include <cmath>
 
+#include "../src/converters/COOtoCSR.cuh"
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/reduce.h>
-#include "../src/converters/COOtoCSR.cuh"
 
 typedef struct Mst_Usecase_t {
   std::string matrix_file;

--- a/cpp/tests/utilities/high_res_clock.h
+++ b/cpp/tests/utilities/high_res_clock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/utilities/high_res_clock.h
+++ b/cpp/tests/utilities/high_res_clock.h
@@ -17,9 +17,9 @@
 // Michael A. Frumkin (mfrumkin@nvidia.com)
 #pragma once
 
-#include <time.h>
 #include <iostream>
 #include <string>
+#include <time.h>
 
 class HighResClock {
  public:

--- a/cpp/tests/utilities/test_utilities.hpp
+++ b/cpp/tests/utilities/test_utilities.hpp
@@ -19,10 +19,10 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/legacy/graph.hpp>
 
-#include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
 #include <raft/handle.hpp>
 #include <rmm/device_uvector.hpp>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/tuple.h>
 
 #include <numeric>
 #include <optional>


### PR DESCRIPTION
It was recently noticed that the `IncludeCategories`:
```
IncludeCategories:
  - Regex:           '^<ext/.*\.h>'
    Priority:        2
  - Regex:           '^<.*\.h>'
    Priority:        1
  - Regex:           '^<.*'
    Priority:        2
  - Regex:           '.*'
    Priority:        3
```
In the `.clang-format` are not really necessary as `ext` has no meaning in RAPIDS. This PR removes these.

Note these changes are being made in all repos:
* `cudf`: https://github.com/rapidsai/cudf/pull/9876
* `rmm`: https://github.com/rapidsai/rmm/pull/933
* `cuml`: https://github.com/rapidsai/cuml/pull/4438