### PR TITLE
make C++ tests run faster (fewer tests)

### DIFF
--- a/cpp/tests/link_analysis/hits_test.cpp
+++ b/cpp/tests/link_analysis/hits_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/link_analysis/hits_test.cpp
+++ b/cpp/tests/link_analysis/hits_test.cpp
@@ -144,7 +144,7 @@ class Tests_Hits : public ::testing::TestWithParam<std::tuple<Hits_Usecase, inpu
   template <typename vertex_t, typename edge_t, typename weight_t>
   void run_current_test(std::tuple<Hits_Usecase const&, input_usecase_t const&> const& param)
   {
-    constexpr bool renumber = true;
+    constexpr bool renumber            = true;
     auto [hits_usecase, input_usecase] = param;
 
     // 1. initialize handle

--- a/cpp/tests/link_analysis/hits_test.cpp
+++ b/cpp/tests/link_analysis/hits_test.cpp
@@ -144,13 +144,8 @@ class Tests_Hits : public ::testing::TestWithParam<std::tuple<Hits_Usecase, inpu
   template <typename vertex_t, typename edge_t, typename weight_t>
   void run_current_test(std::tuple<Hits_Usecase const&, input_usecase_t const&> const& param)
   {
-    run_current_test<vertex_t, edge_t, weight_t>(std::get<0>(param), std::get<1>(param));
-  }
-
-  template <typename vertex_t, typename edge_t, typename weight_t>
-  void run_current_test(Hits_Usecase const& hits_usecase, input_usecase_t const& input_usecase)
-  {
     constexpr bool renumber = true;
+    auto [hits_usecase, input_usecase] = param;
 
     // 1. initialize handle
 

--- a/cpp/tests/link_analysis/hits_test.cpp
+++ b/cpp/tests/link_analysis/hits_test.cpp
@@ -142,6 +142,12 @@ class Tests_Hits : public ::testing::TestWithParam<std::tuple<Hits_Usecase, inpu
   virtual void TearDown() {}
 
   template <typename vertex_t, typename edge_t, typename weight_t>
+  void run_current_test(std::tuple<Hits_Usecase const&, input_usecase_t const&> const& param)
+  {
+    run_current_test<vertex_t, edge_t, weight_t>(std::get<0>(param), std::get<1>(param));
+  }
+
+  template <typename vertex_t, typename edge_t, typename weight_t>
   void run_current_test(Hits_Usecase const& hits_usecase, input_usecase_t const& input_usecase)
   {
     constexpr bool renumber = true;
@@ -270,31 +276,28 @@ class Tests_Hits : public ::testing::TestWithParam<std::tuple<Hits_Usecase, inpu
 using Tests_Hits_File = Tests_Hits<cugraph::test::File_Usecase>;
 using Tests_Hits_Rmat = Tests_Hits<cugraph::test::Rmat_Usecase>;
 
-TEST_P(Tests_Hits_File, CheckInt32Int32FloatFloat)
+TEST_P(Tests_Hits_File, CheckInt32Int32Float)
 {
-  auto param = GetParam();
-  run_current_test<int32_t, int32_t, float>(std::get<0>(param), std::get<1>(param));
-}
-
-TEST_P(Tests_Hits_Rmat, CheckInt32Int32FloatFloat)
-{
-  auto param = GetParam();
   run_current_test<int32_t, int32_t, float>(
-    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
-TEST_P(Tests_Hits_Rmat, CheckInt32Int64FloatFloat)
+TEST_P(Tests_Hits_Rmat, CheckInt32Int32Float)
 {
-  auto param = GetParam();
+  run_current_test<int32_t, int32_t, float>(
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Hits_Rmat, CheckInt32Int64Float)
+{
   run_current_test<int32_t, int64_t, float>(
-    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
-TEST_P(Tests_Hits_Rmat, CheckInt64Int64FloatFloat)
+TEST_P(Tests_Hits_Rmat, CheckInt64Int64Float)
 {
-  auto param = GetParam();
   run_current_test<int64_t, int64_t, float>(
-    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -304,9 +307,7 @@ INSTANTIATE_TEST_SUITE_P(
     // enable correctness checks
     ::testing::Values(Hits_Usecase{true, false}, Hits_Usecase{true, true}),
     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
+                      cugraph::test::File_Usecase("test/datasets/dolphins.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(rmat_small_test,
                          Tests_Hits_Rmat,
@@ -315,6 +316,18 @@ INSTANTIATE_TEST_SUITE_P(rmat_small_test,
                                                               Hits_Usecase{true, true}),
                                             ::testing::Values(cugraph::test::Rmat_Usecase(
                                               10, 16, 0.57, 0.19, 0.19, 0, false, false))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_benchmark_test, /* note that the test filename can be overridden in benchmarking (with
+                          --gtest_filter to select only the file_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one File_Usecase that differ only in filename
+                          (to avoid running same benchmarks more than once) */
+  Tests_Hits_File,
+  ::testing::Combine(
+    // disable correctness checks
+    ::testing::Values(Hits_Usecase{false, false}, Hits_Usecase{false, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
   rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with
@@ -326,6 +339,6 @@ INSTANTIATE_TEST_SUITE_P(
   // disable correctness checks for large graphs
   ::testing::Combine(
     ::testing::Values(Hits_Usecase{false, false}, Hits_Usecase{false, true}),
-    ::testing::Values(cugraph::test::Rmat_Usecase(20, 32, 0.57, 0.19, 0.19, 0, false, false))));
+    ::testing::Values(cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false))));
 
 CUGRAPH_TEST_PROGRAM_MAIN()

--- a/cpp/tests/link_analysis/pagerank_test.cpp
+++ b/cpp/tests/link_analysis/pagerank_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/link_analysis/pagerank_test.cpp
+++ b/cpp/tests/link_analysis/pagerank_test.cpp
@@ -149,14 +149,8 @@ class Tests_PageRank
   template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
   void run_current_test(std::tuple<PageRank_Usecase const&, input_usecase_t const&> const& param)
   {
-    run_current_test<vertex_t, edge_t, weight_t, result_t>(std::get<0>(param), std::get<1>(param));
-  }
-
-  template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
-  void run_current_test(PageRank_Usecase const& pagerank_usecase,
-                        input_usecase_t const& input_usecase)
-  {
     constexpr bool renumber = true;
+    auto [pagerank_usecase, input_usecase] = param;
 
     raft::handle_t handle{};
     HighResClock hr_clock{};

--- a/cpp/tests/link_analysis/pagerank_test.cpp
+++ b/cpp/tests/link_analysis/pagerank_test.cpp
@@ -149,7 +149,7 @@ class Tests_PageRank
   template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
   void run_current_test(std::tuple<PageRank_Usecase const&, input_usecase_t const&> const& param)
   {
-    constexpr bool renumber = true;
+    constexpr bool renumber                = true;
     auto [pagerank_usecase, input_usecase] = param;
 
     raft::handle_t handle{};

--- a/cpp/tests/link_analysis/pagerank_test.cpp
+++ b/cpp/tests/link_analysis/pagerank_test.cpp
@@ -147,6 +147,12 @@ class Tests_PageRank
   virtual void TearDown() {}
 
   template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
+  void run_current_test(std::tuple<PageRank_Usecase const&, input_usecase_t const&> const& param)
+  {
+    run_current_test<vertex_t, edge_t, weight_t, result_t>(std::get<0>(param), std::get<1>(param));
+  }
+
+  template <typename vertex_t, typename edge_t, typename weight_t, typename result_t>
   void run_current_test(PageRank_Usecase const& pagerank_usecase,
                         input_usecase_t const& input_usecase)
   {
@@ -407,29 +413,26 @@ using Tests_PageRank_Rmat = Tests_PageRank<cugraph::test::Rmat_Usecase>;
 // FIXME: add tests for type combinations
 TEST_P(Tests_PageRank_File, CheckInt32Int32FloatFloat)
 {
-  auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, float>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, float>(
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
 TEST_P(Tests_PageRank_Rmat, CheckInt32Int32FloatFloat)
 {
-  auto param = GetParam();
   run_current_test<int32_t, int32_t, float, float>(
-    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
-TEST_P(Tests_PageRank_Rmat, CheckInt32Int64FloatFloat)
+TEST_P(Tests_PageRank_File, CheckInt32Int64FloatFloat)
 {
-  auto param = GetParam();
   run_current_test<int32_t, int64_t, float, float>(
-    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
 TEST_P(Tests_PageRank_Rmat, CheckInt64Int64FloatFloat)
 {
-  auto param = GetParam();
   run_current_test<int64_t, int64_t, float, float>(
-    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -442,9 +445,7 @@ INSTANTIATE_TEST_SUITE_P(
                       PageRank_Usecase{0.0, true},
                       PageRank_Usecase{0.5, true}),
     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
+                      cugraph::test::File_Usecase("test/datasets/dolphins.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
   rmat_small_test,
@@ -456,6 +457,21 @@ INSTANTIATE_TEST_SUITE_P(
                       PageRank_Usecase{0.0, true},
                       PageRank_Usecase{0.5, true}),
     ::testing::Values(cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_benchmark_test, /* note that the test filename can be overridden in benchmarking (with
+                          --gtest_filter to select only the file_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one File_Usecase that differ only in filename
+                          (to avoid running same benchmarks more than once) */
+  Tests_PageRank_File,
+  ::testing::Combine(
+    // disable correctness checks
+    ::testing::Values(PageRank_Usecase{0.0, false, false},
+                      PageRank_Usecase{0.5, false, false},
+                      PageRank_Usecase{0.0, true, false},
+                      PageRank_Usecase{0.5, true, false}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
   rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with
@@ -470,6 +486,6 @@ INSTANTIATE_TEST_SUITE_P(
                       PageRank_Usecase{0.5, false, false},
                       PageRank_Usecase{0.0, true, false},
                       PageRank_Usecase{0.5, true, false}),
-    ::testing::Values(cugraph::test::Rmat_Usecase(20, 32, 0.57, 0.19, 0.19, 0, false, false))));
+    ::testing::Values(cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false))));
 
 CUGRAPH_TEST_PROGRAM_MAIN()

--- a/cpp/tests/structure/coarsen_graph_test.cpp
+++ b/cpp/tests/structure/coarsen_graph_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/structure/coarsen_graph_test.cpp
+++ b/cpp/tests/structure/coarsen_graph_test.cpp
@@ -239,6 +239,14 @@ class Tests_CoarsenGraph
   virtual void TearDown() {}
 
   template <typename vertex_t, typename edge_t, typename weight_t, bool store_transposed>
+  void run_current_test(
+    std::tuple<CoarsenGraph_Usecase const&, input_usecase_t const&> const& param)
+  {
+    run_current_test<vertex_t, edge_t, weight_t, store_transposed>(std::get<0>(param),
+                                                                   std::get<1>(param));
+  }
+
+  template <typename vertex_t, typename edge_t, typename weight_t, bool store_transposed>
   void run_current_test(CoarsenGraph_Usecase const& coarsen_graph_usecase,
                         input_usecase_t const& input_usecase)
   {
@@ -371,56 +379,50 @@ using Tests_CoarsenGraph_Rmat = Tests_CoarsenGraph<cugraph::test::Rmat_Usecase>;
 
 TEST_P(Tests_CoarsenGraph_File, CheckInt32Int32FloatTransposeFalse)
 {
-  auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, false>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, false>(
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
 TEST_P(Tests_CoarsenGraph_File, CheckInt32Int32FloatTransposeTrue)
 {
-  auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, true>(std::get<0>(param), std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, true>(
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
 TEST_P(Tests_CoarsenGraph_Rmat, CheckInt32Int32FloatTransposeFalse)
 {
-  auto param = GetParam();
   run_current_test<int32_t, int32_t, float, false>(
-    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
 TEST_P(Tests_CoarsenGraph_Rmat, CheckInt32Int32FloatTransposeTrue)
 {
-  auto param = GetParam();
   run_current_test<int32_t, int32_t, float, true>(
-    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
 TEST_P(Tests_CoarsenGraph_Rmat, CheckInt32Int64FloatTransposeFalse)
 {
-  auto param = GetParam();
   run_current_test<int32_t, int64_t, float, false>(
-    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
 TEST_P(Tests_CoarsenGraph_Rmat, CheckInt32Int64FloatTransposeTrue)
 {
-  auto param = GetParam();
   run_current_test<int32_t, int64_t, float, true>(
-    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
 TEST_P(Tests_CoarsenGraph_Rmat, CheckInt64Int64FloatTransposeFalse)
 {
-  auto param = GetParam();
   run_current_test<int64_t, int64_t, float, false>(
-    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
 TEST_P(Tests_CoarsenGraph_Rmat, CheckInt64Int64FloatTransposeTrue)
 {
-  auto param = GetParam();
   run_current_test<int64_t, int64_t, float, true>(
-    std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -430,9 +432,7 @@ INSTANTIATE_TEST_SUITE_P(
     // enable correctness check
     ::testing::Values(CoarsenGraph_Usecase{0.2, false}, CoarsenGraph_Usecase{0.2, true}),
     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
+                      cugraph::test::File_Usecase("test/datasets/dolphins.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
   rmat_small_test,
@@ -441,6 +441,17 @@ INSTANTIATE_TEST_SUITE_P(
     // enable correctness checks
     ::testing::Values(CoarsenGraph_Usecase{0.2, false}, CoarsenGraph_Usecase{0.2, true}),
     ::testing::Values(cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_benchmark_test, /* note that the test filename can be overridden in benchmarking (with
+                          --gtest_filter to select only the file_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one File_Usecase that differ only in filename
+                          (to avoid running same benchmarks more than once) */
+  Tests_CoarsenGraph_File,
+  ::testing::Combine(::testing::Values(CoarsenGraph_Usecase{0.2, false, false},
+                                       CoarsenGraph_Usecase{0.2, true, false}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
   rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with

--- a/cpp/tests/structure/coarsen_graph_test.cpp
+++ b/cpp/tests/structure/coarsen_graph_test.cpp
@@ -242,7 +242,7 @@ class Tests_CoarsenGraph
   void run_current_test(
     std::tuple<CoarsenGraph_Usecase const&, input_usecase_t const&> const& param)
   {
-    constexpr bool renumber = true;
+    constexpr bool renumber                     = true;
     auto [coarsen_graph_usecase, input_usecase] = param;
 
     raft::handle_t handle{};

--- a/cpp/tests/structure/coarsen_graph_test.cpp
+++ b/cpp/tests/structure/coarsen_graph_test.cpp
@@ -242,15 +242,8 @@ class Tests_CoarsenGraph
   void run_current_test(
     std::tuple<CoarsenGraph_Usecase const&, input_usecase_t const&> const& param)
   {
-    run_current_test<vertex_t, edge_t, weight_t, store_transposed>(std::get<0>(param),
-                                                                   std::get<1>(param));
-  }
-
-  template <typename vertex_t, typename edge_t, typename weight_t, bool store_transposed>
-  void run_current_test(CoarsenGraph_Usecase const& coarsen_graph_usecase,
-                        input_usecase_t const& input_usecase)
-  {
     constexpr bool renumber = true;
+    auto [coarsen_graph_usecase, input_usecase] = param;
 
     raft::handle_t handle{};
     HighResClock hr_clock{};

--- a/cpp/tests/structure/graph_test.cpp
+++ b/cpp/tests/structure/graph_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/structure/graph_test.cpp
+++ b/cpp/tests/structure/graph_test.cpp
@@ -86,14 +86,8 @@ class Tests_Graph : public ::testing::TestWithParam<std::tuple<Graph_Usecase, in
   template <typename vertex_t, typename edge_t, typename weight_t, bool store_transposed>
   void run_current_test(std::tuple<Graph_Usecase const&, input_usecase_t const&> const& param)
   {
-    run_current_test<vertex_t, edge_t, weight_t, store_transposed>(std::get<0>(param),
-                                                                   std::get<1>(param));
-  }
-
-  template <typename vertex_t, typename edge_t, typename weight_t, bool store_transposed>
-  void run_current_test(Graph_Usecase const& graph_usecase, input_usecase_t const& input_usecase)
-  {
     raft::handle_t handle{};
+    auto [graph_usecase, input_usecase] = param;
 
     auto [d_rows, d_cols, d_weights, d_vertices, number_of_vertices, is_symmetric] =
       input_usecase

--- a/cpp/tests/structure/graph_test.cpp
+++ b/cpp/tests/structure/graph_test.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <utilities/base_fixture.hpp>
+#include <utilities/test_graphs.hpp>
 #include <utilities/test_utilities.hpp>
 
 #include <cugraph/graph.hpp>
@@ -66,22 +67,14 @@ graph_reference(vertex_t const* p_src_vertices,
   return std::make_tuple(std::move(offsets), std::move(indices), std::move(weights));
 }
 
-typedef struct Graph_Usecase_t {
-  std::string graph_file_full_path{};
+struct Graph_Usecase {
   bool test_weighted{false};
+  bool multi_graph{false};
+  bool check_correctness{true};
+};
 
-  Graph_Usecase_t(std::string const& graph_file_path, bool test_weighted)
-    : test_weighted(test_weighted)
-  {
-    if ((graph_file_path.length() > 0) && (graph_file_path[0] != '/')) {
-      graph_file_full_path = cugraph::test::get_rapids_dataset_root_dir() + "/" + graph_file_path;
-    } else {
-      graph_file_full_path = graph_file_path;
-    }
-  };
-} Graph_Usecase;
-
-class Tests_Graph : public ::testing::TestWithParam<Graph_Usecase> {
+template <typename input_usecase_t>
+class Tests_Graph : public ::testing::TestWithParam<std::tuple<Graph_Usecase, input_usecase_t>> {
  public:
   Tests_Graph() {}
   static void SetupTestCase() {}
@@ -91,13 +84,22 @@ class Tests_Graph : public ::testing::TestWithParam<Graph_Usecase> {
   virtual void TearDown() {}
 
   template <typename vertex_t, typename edge_t, typename weight_t, bool store_transposed>
-  void run_current_test(Graph_Usecase const& configuration)
+  void run_current_test(std::tuple<Graph_Usecase const&, input_usecase_t const&> const& param)
+  {
+    run_current_test<vertex_t, edge_t, weight_t, store_transposed>(std::get<0>(param),
+                                                                   std::get<1>(param));
+  }
+
+  template <typename vertex_t, typename edge_t, typename weight_t, bool store_transposed>
+  void run_current_test(Graph_Usecase const& graph_usecase, input_usecase_t const& input_usecase)
   {
     raft::handle_t handle{};
 
-    auto [d_rows, d_cols, d_weights, d_vertices, number_of_vertices, is_symmetric] = cugraph::test::
-      read_edgelist_from_matrix_market_file<vertex_t, weight_t, store_transposed, false>(
-        handle, configuration.graph_file_full_path, configuration.test_weighted);
+    auto [d_rows, d_cols, d_weights, d_vertices, number_of_vertices, is_symmetric] =
+      input_usecase
+        .template construct_edgelist<vertex_t, edge_t, weight_t, store_transposed, false>(
+          handle, graph_usecase.test_weighted);
+
     edge_t number_of_edges = static_cast<edge_t>(d_rows.size());
 
     std::vector<vertex_t> h_rows(number_of_edges);
@@ -133,7 +135,9 @@ class Tests_Graph : public ::testing::TestWithParam<Graph_Usecase> {
       handle,
       edgelist,
       cugraph::graph_meta_t<vertex_t, edge_t, false>{
-        number_of_vertices, cugraph::graph_properties_t{is_symmetric, false}, std::nullopt},
+        number_of_vertices,
+        cugraph::graph_properties_t{is_symmetric, graph_usecase.multi_graph},
+        std::nullopt},
       true);
 
     auto graph_view = graph.view();
@@ -143,99 +147,254 @@ class Tests_Graph : public ::testing::TestWithParam<Graph_Usecase> {
     ASSERT_EQ(graph_view.get_number_of_vertices(), number_of_vertices);
     ASSERT_EQ(graph_view.get_number_of_edges(), number_of_edges);
 
-    std::vector<edge_t> h_cugraph_offsets(graph_view.get_number_of_vertices() + 1);
-    std::vector<vertex_t> h_cugraph_indices(graph_view.get_number_of_edges());
-    auto h_cugraph_weights =
-      graph.is_weighted() ? std::optional<std::vector<weight_t>>(graph_view.get_number_of_edges())
-                          : std::nullopt;
+    if (graph_usecase.check_correctness) {
+      std::vector<edge_t> h_cugraph_offsets(graph_view.get_number_of_vertices() + 1);
+      std::vector<vertex_t> h_cugraph_indices(graph_view.get_number_of_edges());
+      auto h_cugraph_weights =
+        graph.is_weighted() ? std::optional<std::vector<weight_t>>(graph_view.get_number_of_edges())
+                            : std::nullopt;
 
-    raft::update_host(h_cugraph_offsets.data(),
-                      graph_view.get_matrix_partition_view().get_offsets(),
-                      graph_view.get_number_of_vertices() + 1,
-                      handle.get_stream());
-    raft::update_host(h_cugraph_indices.data(),
-                      graph_view.get_matrix_partition_view().get_indices(),
-                      graph_view.get_number_of_edges(),
-                      handle.get_stream());
-    if (h_cugraph_weights) {
-      raft::update_host((*h_cugraph_weights).data(),
-                        *(graph_view.get_matrix_partition_view().get_weights()),
+      raft::update_host(h_cugraph_offsets.data(),
+                        graph_view.get_matrix_partition_view().get_offsets(),
+                        graph_view.get_number_of_vertices() + 1,
+                        handle.get_stream());
+      raft::update_host(h_cugraph_indices.data(),
+                        graph_view.get_matrix_partition_view().get_indices(),
                         graph_view.get_number_of_edges(),
                         handle.get_stream());
-    }
+      if (h_cugraph_weights) {
+        raft::update_host((*h_cugraph_weights).data(),
+                          *(graph_view.get_matrix_partition_view().get_weights()),
+                          graph_view.get_number_of_edges(),
+                          handle.get_stream());
+      }
 
-    CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+      CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
 
-    ASSERT_TRUE(
-      std::equal(h_reference_offsets.begin(), h_reference_offsets.end(), h_cugraph_offsets.begin()))
-      << "Graph compressed sparse format offsets do not match with the reference values.";
-    ASSERT_EQ(h_reference_weights.has_value(), h_cugraph_weights.has_value());
-    if (h_reference_weights) {
-      ASSERT_EQ((*h_reference_weights).size(), (*h_cugraph_weights).size());
-    }
-    for (vertex_t i = 0; i < number_of_vertices; ++i) {
-      auto start  = h_reference_offsets[i];
-      auto degree = h_reference_offsets[i + 1] - start;
-      if (configuration.test_weighted) {
-        std::vector<std::tuple<vertex_t, weight_t>> reference_pairs(degree);
-        std::vector<std::tuple<vertex_t, weight_t>> cugraph_pairs(degree);
-        for (edge_t j = 0; j < degree; ++j) {
-          reference_pairs[j] =
-            std::make_tuple(h_reference_indices[start + j], (*h_reference_weights)[start + j]);
-          cugraph_pairs[j] =
-            std::make_tuple(h_cugraph_indices[start + j], (*h_cugraph_weights)[start + j]);
+      ASSERT_TRUE(std::equal(
+        h_reference_offsets.begin(), h_reference_offsets.end(), h_cugraph_offsets.begin()))
+        << "Graph compressed sparse format offsets do not match with the reference values.";
+      ASSERT_EQ(h_reference_weights.has_value(), h_cugraph_weights.has_value());
+      if (h_reference_weights) {
+        ASSERT_EQ((*h_reference_weights).size(), (*h_cugraph_weights).size());
+      }
+      for (vertex_t i = 0; i < number_of_vertices; ++i) {
+        auto start  = h_reference_offsets[i];
+        auto degree = h_reference_offsets[i + 1] - start;
+        if (graph_usecase.test_weighted) {
+          std::vector<std::tuple<vertex_t, weight_t>> reference_pairs(degree);
+          std::vector<std::tuple<vertex_t, weight_t>> cugraph_pairs(degree);
+          for (edge_t j = 0; j < degree; ++j) {
+            reference_pairs[j] =
+              std::make_tuple(h_reference_indices[start + j], (*h_reference_weights)[start + j]);
+            cugraph_pairs[j] =
+              std::make_tuple(h_cugraph_indices[start + j], (*h_cugraph_weights)[start + j]);
+          }
+          std::sort(reference_pairs.begin(), reference_pairs.end());
+          std::sort(cugraph_pairs.begin(), cugraph_pairs.end());
+          ASSERT_TRUE(
+            std::equal(reference_pairs.begin(), reference_pairs.end(), cugraph_pairs.begin()))
+            << "Graph compressed sparse format indices & weights for vertex " << i
+            << " do not match with the reference values.";
+        } else {
+          std::vector<vertex_t> reference_indices(h_reference_indices.begin() + start,
+                                                  h_reference_indices.begin() + (start + degree));
+          std::vector<vertex_t> cugraph_indices(h_cugraph_indices.begin() + start,
+                                                h_cugraph_indices.begin() + (start + degree));
+          std::sort(reference_indices.begin(), reference_indices.end());
+          std::sort(cugraph_indices.begin(), cugraph_indices.end());
+          ASSERT_TRUE(
+            std::equal(reference_indices.begin(), reference_indices.end(), cugraph_indices.begin()))
+            << "Graph compressed sparse format indices for vertex " << i
+            << " do not match with the reference values.";
         }
-        std::sort(reference_pairs.begin(), reference_pairs.end());
-        std::sort(cugraph_pairs.begin(), cugraph_pairs.end());
-        ASSERT_TRUE(
-          std::equal(reference_pairs.begin(), reference_pairs.end(), cugraph_pairs.begin()))
-          << "Graph compressed sparse format indices & weights for vertex " << i
-          << " do not match with the reference values.";
-      } else {
-        std::vector<vertex_t> reference_indices(h_reference_indices.begin() + start,
-                                                h_reference_indices.begin() + (start + degree));
-        std::vector<vertex_t> cugraph_indices(h_cugraph_indices.begin() + start,
-                                              h_cugraph_indices.begin() + (start + degree));
-        std::sort(reference_indices.begin(), reference_indices.end());
-        std::sort(cugraph_indices.begin(), cugraph_indices.end());
-        ASSERT_TRUE(
-          std::equal(reference_indices.begin(), reference_indices.end(), cugraph_indices.begin()))
-          << "Graph compressed sparse format indices for vertex " << i
-          << " do not match with the reference values.";
       }
     }
   }
 };
 
-TEST_P(Tests_Graph, CheckStoreTransposedFalse)
+using Tests_Graph_File = Tests_Graph<cugraph::test::File_Usecase>;
+using Tests_Graph_Rmat = Tests_Graph<cugraph::test::Rmat_Usecase>;
+
+TEST_P(Tests_Graph_File, CheckStoreTransposedFalse_32_32_float)
 {
-  run_current_test<int32_t, int32_t, float, false>(GetParam());
-  run_current_test<int32_t, int64_t, float, false>(GetParam());
-  run_current_test<int64_t, int64_t, float, false>(GetParam());
-  run_current_test<int32_t, int32_t, double, false>(GetParam());
-  run_current_test<int32_t, int64_t, double, false>(GetParam());
-  run_current_test<int64_t, int64_t, double, false>(GetParam());
+  run_current_test<int32_t, int32_t, float, false>(
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
-TEST_P(Tests_Graph, CheckStoreTransposedTrue)
+TEST_P(Tests_Graph_File, CheckStoreTransposedFalse_32_64_float)
 {
-  run_current_test<int32_t, int32_t, float, true>(GetParam());
-  run_current_test<int32_t, int64_t, float, true>(GetParam());
-  run_current_test<int64_t, int64_t, float, true>(GetParam());
-  run_current_test<int32_t, int32_t, double, true>(GetParam());
-  run_current_test<int32_t, int64_t, double, true>(GetParam());
-  run_current_test<int64_t, int64_t, double, true>(GetParam());
+  run_current_test<int32_t, int64_t, float, false>(
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
-INSTANTIATE_TEST_SUITE_P(simple_test,
-                         Tests_Graph,
-                         ::testing::Values(Graph_Usecase("test/datasets/karate.mtx", false),
-                                           Graph_Usecase("test/datasets/karate.mtx", true),
-                                           Graph_Usecase("test/datasets/web-Google.mtx", false),
-                                           Graph_Usecase("test/datasets/web-Google.mtx", true),
-                                           Graph_Usecase("test/datasets/ljournal-2008.mtx", false),
-                                           Graph_Usecase("test/datasets/ljournal-2008.mtx", true),
-                                           Graph_Usecase("test/datasets/webbase-1M.mtx", false),
-                                           Graph_Usecase("test/datasets/webbase-1M.mtx", true)));
+TEST_P(Tests_Graph_File, CheckStoreTransposedFalse_64_64_float)
+{
+  run_current_test<int64_t, int64_t, float, false>(
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_File, CheckStoreTransposedFalse_32_32_double)
+{
+  run_current_test<int32_t, int32_t, double, false>(
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_File, CheckStoreTransposedFalse_32_64_double)
+{
+  run_current_test<int32_t, int64_t, double, false>(
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_File, CheckStoreTransposedFalse_64_64_double)
+{
+  run_current_test<int64_t, int64_t, double, false>(
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_File, CheckStoreTransposedTrue_32_32_float)
+{
+  run_current_test<int32_t, int32_t, float, true>(
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_File, CheckStoreTransposedTrue_32_64_float)
+{
+  run_current_test<int32_t, int64_t, float, true>(
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_File, CheckStoreTransposedTrue_64_64_float)
+{
+  run_current_test<int64_t, int64_t, float, true>(
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_File, CheckStoreTransposedTrue_32_32_double)
+{
+  run_current_test<int32_t, int32_t, double, true>(
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_File, CheckStoreTransposedTrue_32_64_double)
+{
+  run_current_test<int32_t, int64_t, double, true>(
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_File, CheckStoreTransposedTrue_64_64_double)
+{
+  run_current_test<int64_t, int64_t, double, true>(
+    override_File_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_Rmat, CheckStoreTransposedFalse_32_32_float)
+{
+  run_current_test<int32_t, int32_t, float, false>(
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_Rmat, CheckStoreTransposedFalse_32_64_float)
+{
+  run_current_test<int32_t, int64_t, float, false>(
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_Rmat, CheckStoreTransposedFalse_64_64_float)
+{
+  run_current_test<int64_t, int64_t, float, false>(
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_Rmat, CheckStoreTransposedFalse_32_32_double)
+{
+  run_current_test<int32_t, int32_t, double, false>(
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_Rmat, CheckStoreTransposedFalse_32_64_double)
+{
+  run_current_test<int32_t, int64_t, double, false>(
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_Rmat, CheckStoreTransposedFalse_64_64_double)
+{
+  run_current_test<int64_t, int64_t, double, false>(
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_Rmat, CheckStoreTransposedTrue_32_32_float)
+{
+  run_current_test<int32_t, int32_t, float, true>(
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_Rmat, CheckStoreTransposedTrue_32_64_float)
+{
+  run_current_test<int32_t, int64_t, float, true>(
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_Rmat, CheckStoreTransposedTrue_64_64_float)
+{
+  run_current_test<int64_t, int64_t, float, true>(
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_Rmat, CheckStoreTransposedTrue_32_32_double)
+{
+  run_current_test<int32_t, int32_t, double, true>(
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_Rmat, CheckStoreTransposedTrue_32_64_double)
+{
+  run_current_test<int32_t, int64_t, double, true>(
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+TEST_P(Tests_Graph_Rmat, CheckStoreTransposedTrue_64_64_double)
+{
+  run_current_test<int64_t, int64_t, double, true>(
+    override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  file_test,
+  Tests_Graph_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(Graph_Usecase{false}, Graph_Usecase{true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
+                      cugraph::test::File_Usecase("test/datasets/dolphins.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  rmat_small_test,
+  Tests_Graph_Rmat,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(Graph_Usecase{false, true}, Graph_Usecase{true, true}),
+    ::testing::Values(cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_benchmark_test, /* note that the test filename can be overridden in benchmarking (with
+                          --gtest_filter to select only the file_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one File_Usecase that differ only in filename
+                          (to avoid running same benchmarks more than once) */
+  Tests_Graph_File,
+  ::testing::Combine(
+    // disable correctness checks
+    ::testing::Values(Graph_Usecase{false, false, false}, Graph_Usecase{true, false, false}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  rmat_benchmark_test,
+  Tests_Graph_Rmat,
+  ::testing::Combine(
+    // disable correctness checks
+    ::testing::Values(Graph_Usecase{false, true, false}, Graph_Usecase{true, true, false}),
+    ::testing::Values(cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false))));
 
 CUGRAPH_TEST_PROGRAM_MAIN()

--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/utilities/test_graphs.hpp
+++ b/cpp/tests/utilities/test_graphs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/utilities/test_graphs.hpp
+++ b/cpp/tests/utilities/test_graphs.hpp
@@ -56,6 +56,10 @@ class File_Usecase : public detail::TranslateGraph_Usecase {
   File_Usecase(std::string const& graph_file_path, size_t base_vertex_id = 0)
     : detail::TranslateGraph_Usecase(base_vertex_id)
   {
+    set_filename(graph_file_path);
+  }
+
+  void set_filename(std::string const& graph_file_path) {
     if ((graph_file_path.length() > 0) && (graph_file_path[0] != '/')) {
       graph_file_full_path_ = cugraph::test::get_rapids_dataset_root_dir() + "/" + graph_file_path;
     } else {

--- a/cpp/tests/utilities/test_graphs.hpp
+++ b/cpp/tests/utilities/test_graphs.hpp
@@ -59,7 +59,8 @@ class File_Usecase : public detail::TranslateGraph_Usecase {
     set_filename(graph_file_path);
   }
 
-  void set_filename(std::string const& graph_file_path) {
+  void set_filename(std::string const& graph_file_path)
+  {
     if ((graph_file_path.length() > 0) && (graph_file_path[0] != '/')) {
       graph_file_full_path_ = cugraph::test::get_rapids_dataset_root_dir() + "/" + graph_file_path;
     } else {


### PR DESCRIPTION
Modified the most expensive C++ tests to run fewer tests.  Closes #1555 

Added an option (like in the rmat tests) to run a specific test file if the developer wants to manually run larger tests.  For example:

```tests/COARSEN_GRAPH_TEST --gtest_filter=file_ben* --test_file_name=test/datasets/ljournal-2008.mtx```

The smaller graphs *should* be small enough to test things.  Once we add C++ code coverage we should be able to verify this.

On my local workstation this reduced the time spent executing the C++ tests by about 25 minutes.