### PR TITLE
fix bug when calculating the number of vertices

### DIFF
--- a/python/cugraph/cugraph/structure/graph_primtypes_wrapper.pyx
+++ b/python/cugraph/cugraph/structure/graph_primtypes_wrapper.pyx
@@ -189,7 +189,9 @@ def _mg_degree(input_graph, direction=Direction.ALL):
     if input_graph.edgelist is None:
         input_graph.compute_renumber_edge_list(transposed=False)
     input_ddf = input_graph.edgelist.edgelist_df
-    num_verts = input_ddf[['src', 'dst']].max().max().compute() + 1
+    # Get the total number of vertices by summing each partition's number of vertices
+    num_verts = input_graph.renumber_map.implementation.ddf.\
+        map_partitions(len).compute().sum()
     data = DistributedDataHandler.create(data=input_ddf)
     comms = Comms.get_comms()
     client = default_client()


### PR DESCRIPTION
The number of vertices calculation in the previous implementation relied on getting the max of the source and destination's max. Each worker computes the max of its partition however, workers having empty partition attempt to do the same causing an error. This seems to be caused by a recent change on how dask handle empty partitions with the `max()` function. 

This PR calculates the total number of vertices by summing each partition's number of vertices which is inspired from our code base. 