### PR TITLE
Update references to CHECK_CUDA, CUDA_CHECK and CUDA_TRY to use new RAFT_ names

### DIFF
--- a/cpp/include/cugraph/prims/update_frontier_v_push_if_out_nbr.cuh
+++ b/cpp/include/cugraph/prims/update_frontier_v_push_if_out_nbr.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cugraph/prims/update_frontier_v_push_if_out_nbr.cuh
+++ b/cpp/include/cugraph/prims/update_frontier_v_push_if_out_nbr.cuh
@@ -956,7 +956,7 @@ void update_frontier_v_push_if_out_nbr(
                           d_offsets.begin());
       std::vector<vertex_t> h_offsets(d_offsets.size());
       raft::update_host(h_offsets.data(), d_offsets.data(), d_offsets.size(), handle.get_stream());
-      CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+      RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
       h_offsets.push_back(matrix_partition_frontier_size);
       // FIXME: we may further improve performance by 1) concurrently running kernels on different
       // segments; 2) individually tuning block sizes for different segments; and 3) adding one more

--- a/cpp/src/centrality/betweenness_centrality.cu
+++ b/cpp/src/centrality/betweenness_centrality.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/centrality/betweenness_centrality.cu
+++ b/cpp/src/centrality/betweenness_centrality.cu
@@ -237,7 +237,8 @@ void BC<vertex_t, edge_t, weight_t, result_t>::compute_single_source(vertex_t so
   auto current_max_depth =
     thrust::max_element(handle_.get_thrust_policy(), distances_, distances_ + number_of_vertices_);
   vertex_t max_depth = 0;
-  RAFT_CUDA_TRY(cudaMemcpy(&max_depth, current_max_depth, sizeof(vertex_t), cudaMemcpyDeviceToHost));
+  RAFT_CUDA_TRY(
+    cudaMemcpy(&max_depth, current_max_depth, sizeof(vertex_t), cudaMemcpyDeviceToHost));
   // Step 2) Dependency accumulation
   accumulate(source_vertex, max_depth);
 }

--- a/cpp/src/centrality/betweenness_centrality.cu
+++ b/cpp/src/centrality/betweenness_centrality.cu
@@ -95,7 +95,7 @@ vertex_t get_total_number_of_sources(raft::handle_t const& handle, vertex_t loca
                                  raft::comms::op_t::SUM,
                                  handle.get_stream());
     total_number_of_sources_used = d_number_of_sources.value(handle.get_stream());
-    // CUDA_TRY(
+    // RAFT_CUDA_TRY(
     // cudaMemcpy(&total_number_of_sources_used, data, sizeof(vertex_t), cudaMemcpyDeviceToHost));
   }
   return total_number_of_sources_used;
@@ -237,7 +237,7 @@ void BC<vertex_t, edge_t, weight_t, result_t>::compute_single_source(vertex_t so
   auto current_max_depth =
     thrust::max_element(handle_.get_thrust_policy(), distances_, distances_ + number_of_vertices_);
   vertex_t max_depth = 0;
-  CUDA_TRY(cudaMemcpy(&max_depth, current_max_depth, sizeof(vertex_t), cudaMemcpyDeviceToHost));
+  RAFT_CUDA_TRY(cudaMemcpy(&max_depth, current_max_depth, sizeof(vertex_t), cudaMemcpyDeviceToHost));
   // Step 2) Dependency accumulation
   accumulate(source_vertex, max_depth);
 }

--- a/cpp/src/community/legacy/triangles_counting.cu
+++ b/cpp/src/community/legacy/triangles_counting.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/components/utils.h
+++ b/cpp/src/components/utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/components/utils.h
+++ b/cpp/src/components/utils.h
@@ -118,7 +118,8 @@ void updateHost(Type* hPtr, const Type* dPtr, size_t len, cudaStream_t stream)
 template <typename Type>
 void copyAsync(Type* dPtr1, const Type* dPtr2, size_t len, cudaStream_t stream)
 {
-  RAFT_CUDA_TRY(cudaMemcpyAsync(dPtr1, dPtr2, len * sizeof(Type), cudaMemcpyDeviceToDevice, stream));
+  RAFT_CUDA_TRY(
+    cudaMemcpyAsync(dPtr1, dPtr2, len * sizeof(Type), cudaMemcpyDeviceToDevice, stream));
 }
 /** @} */
 
@@ -189,7 +190,8 @@ void myPrintDevVector(const char* variableName,
                       OutStream& out)
 {
   std::vector<T> hostMem(componentsCount);
-  RAFT_CUDA_TRY(cudaMemcpy(hostMem.data(), devMem, componentsCount * sizeof(T), cudaMemcpyDeviceToHost));
+  RAFT_CUDA_TRY(
+    cudaMemcpy(hostMem.data(), devMem, componentsCount * sizeof(T), cudaMemcpyDeviceToHost));
   myPrintHostVector(variableName, hostMem.data(), componentsCount, out);
 }
 

--- a/cpp/src/components/utils.h
+++ b/cpp/src/components/utils.h
@@ -92,7 +92,7 @@ class Exception : public std::exception {
 template <typename Type>
 void copy(Type* dst, const Type* src, size_t len, cudaStream_t stream)
 {
-  CUDA_TRY(cudaMemcpyAsync(dst, src, len * sizeof(Type), cudaMemcpyDefault, stream));
+  RAFT_CUDA_TRY(cudaMemcpyAsync(dst, src, len * sizeof(Type), cudaMemcpyDefault, stream));
 }
 
 /**
@@ -118,7 +118,7 @@ void updateHost(Type* hPtr, const Type* dPtr, size_t len, cudaStream_t stream)
 template <typename Type>
 void copyAsync(Type* dPtr1, const Type* dPtr2, size_t len, cudaStream_t stream)
 {
-  CUDA_TRY(cudaMemcpyAsync(dPtr1, dPtr2, len * sizeof(Type), cudaMemcpyDeviceToDevice, stream));
+  RAFT_CUDA_TRY(cudaMemcpyAsync(dPtr1, dPtr2, len * sizeof(Type), cudaMemcpyDeviceToDevice, stream));
 }
 /** @} */
 
@@ -189,7 +189,7 @@ void myPrintDevVector(const char* variableName,
                       OutStream& out)
 {
   std::vector<T> hostMem(componentsCount);
-  CUDA_TRY(cudaMemcpy(hostMem.data(), devMem, componentsCount * sizeof(T), cudaMemcpyDeviceToHost));
+  RAFT_CUDA_TRY(cudaMemcpy(hostMem.data(), devMem, componentsCount * sizeof(T), cudaMemcpyDeviceToHost));
   myPrintHostVector(variableName, hostMem.data(), componentsCount, out);
 }
 

--- a/cpp/src/components/weak_cc.cuh
+++ b/cpp/src/components/weak_cc.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/components/weak_cc.cuh
+++ b/cpp/src/components/weak_cc.cuh
@@ -165,22 +165,22 @@ void weak_cc_label_batched(vertex_t* labels,
   weak_cc_init_label_kernel<vertex_t, TPB_X>
     <<<blocks, threads, 0, stream>>>(labels, startVertexId, batchSize, MAX_LABEL, filter_op);
 
-  CUDA_TRY(cudaPeekAtLastError());
+  RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   int n_iters = 0;
   do {
-    CUDA_TRY(cudaMemsetAsync(state.m, false, sizeof(bool), stream));
+    RAFT_CUDA_TRY(cudaMemsetAsync(state.m, false, sizeof(bool), stream));
 
     weak_cc_label_device<vertex_t, edge_t, TPB_X><<<blocks, threads, 0, stream>>>(
       labels, offsets, indices, nnz, state.fa, state.xa, state.m, startVertexId, batchSize);
-    CUDA_TRY(cudaPeekAtLastError());
-    CUDA_TRY(cudaStreamSynchronize(stream));
+    RAFT_CUDA_TRY(cudaPeekAtLastError());
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
 
     thrust::swap(state.fa, state.xa);
 
     //** Updating m *
     MLCommon::updateHost(&host_m, state.m, 1, stream);
-    CUDA_TRY(cudaStreamSynchronize(stream));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
 
     n_iters++;
   } while (host_m);
@@ -235,7 +235,7 @@ void weak_cc_batched(vertex_t* labels,
   if (startVertexId == 0) {
     weak_cc_init_all_kernel<vertex_t, TPB_X>
       <<<blocks, threads, 0, stream>>>(labels, state.fa, state.xa, N, MAX_LABEL);
-    CUDA_TRY(cudaPeekAtLastError());
+    RAFT_CUDA_TRY(cudaPeekAtLastError());
   }
 
   weak_cc_label_batched<vertex_t, edge_t, TPB_X>(

--- a/cpp/src/converters/COOtoCSR.cuh
+++ b/cpp/src/converters/COOtoCSR.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/converters/COOtoCSR.cuh
+++ b/cpp/src/converters/COOtoCSR.cuh
@@ -69,27 +69,27 @@ VT sort(legacy::GraphCOOView<VT, ET, WT>& graph, rmm::cuda_stream_view stream_vi
       graph.dst_indices,
       graph.dst_indices + graph.number_of_edges,
       thrust::make_zip_iterator(thrust::make_tuple(graph.src_indices, graph.edge_data)));
-    CUDA_TRY(cudaMemcpy(
+    RAFT_CUDA_TRY(cudaMemcpy(
       &max_dst_id, &(graph.dst_indices[graph.number_of_edges - 1]), sizeof(VT), cudaMemcpyDefault));
     thrust::stable_sort_by_key(
       rmm::exec_policy(stream_view),
       graph.src_indices,
       graph.src_indices + graph.number_of_edges,
       thrust::make_zip_iterator(thrust::make_tuple(graph.dst_indices, graph.edge_data)));
-    CUDA_TRY(cudaMemcpy(
+    RAFT_CUDA_TRY(cudaMemcpy(
       &max_src_id, &(graph.src_indices[graph.number_of_edges - 1]), sizeof(VT), cudaMemcpyDefault));
   } else {
     thrust::stable_sort_by_key(rmm::exec_policy(stream_view),
                                graph.dst_indices,
                                graph.dst_indices + graph.number_of_edges,
                                graph.src_indices);
-    CUDA_TRY(cudaMemcpy(
+    RAFT_CUDA_TRY(cudaMemcpy(
       &max_dst_id, &(graph.dst_indices[graph.number_of_edges - 1]), sizeof(VT), cudaMemcpyDefault));
     thrust::stable_sort_by_key(rmm::exec_policy(stream_view),
                                graph.src_indices,
                                graph.src_indices + graph.number_of_edges,
                                graph.dst_indices);
-    CUDA_TRY(cudaMemcpy(
+    RAFT_CUDA_TRY(cudaMemcpy(
       &max_src_id, &(graph.src_indices[graph.number_of_edges - 1]), sizeof(VT), cudaMemcpyDefault));
   }
   return std::max(max_src_id, max_dst_id) + 1;
@@ -177,10 +177,10 @@ void coo_to_csr_inplace(legacy::GraphCOOView<VT, ET, WT>& graph,
                       graph.number_of_edges,
                       stream_view);
 
-  CUDA_TRY(cudaMemcpy(
+  RAFT_CUDA_TRY(cudaMemcpy(
     result.indices, graph.dst_indices, sizeof(VT) * graph.number_of_edges, cudaMemcpyDefault));
   if (graph.has_data())
-    CUDA_TRY(cudaMemcpy(
+    RAFT_CUDA_TRY(cudaMemcpy(
       result.edge_data, graph.edge_data, sizeof(WT) * graph.number_of_edges, cudaMemcpyDefault));
 }
 

--- a/cpp/src/layout/barnes_hut.cuh
+++ b/cpp/src/layout/barnes_hut.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/layout/exact_fa2.cuh
+++ b/cpp/src/layout/exact_fa2.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/layout/exact_fa2.cuh
+++ b/cpp/src/layout/exact_fa2.cuh
@@ -88,10 +88,10 @@ void exact_fa2(raft::handle_t const& handle,
 
   // Sort COO for coalesced memory access.
   sort(graph, stream_view.value());
-  CHECK_CUDA(stream_view.value());
+  RAFT_CHECK_CUDA(stream_view.value());
 
   graph.degree(d_mass, cugraph::legacy::DegreeDirection::OUT);
-  CHECK_CUDA(stream_view.value());
+  RAFT_CHECK_CUDA(stream_view.value());
 
   const vertex_t* row = graph.src_indices;
   const vertex_t* col = graph.dst_indices;

--- a/cpp/src/layout/exact_repulsion.cuh
+++ b/cpp/src/layout/exact_repulsion.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/layout/exact_repulsion.cuh
+++ b/cpp/src/layout/exact_repulsion.cuh
@@ -65,7 +65,7 @@ void apply_repulsion(const float* restrict x_pos,
 
   repulsion_kernel<vertex_t>
     <<<nblocks, nthreads, 0, stream>>>(x_pos, y_pos, repel_x, repel_y, mass, scaling_ratio, n);
-  CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream);
 }
 
 }  // namespace detail

--- a/cpp/src/layout/fa2_kernels.cuh
+++ b/cpp/src/layout/fa2_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/layout/fa2_kernels.cuh
+++ b/cpp/src/layout/fa2_kernels.cuh
@@ -112,7 +112,7 @@ void apply_attraction(const vertex_t* restrict row,
                                        edge_weight_influence,
                                        coef);
 
-  CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream);
 }
 
 template <typename vertex_t>
@@ -183,7 +183,7 @@ void apply_gravity(const float* restrict x_pos,
     linear_gravity_kernel<vertex_t>
       <<<nblocks, nthreads, 0, stream>>>(x_pos, y_pos, attract_x, attract_y, mass, gravity, n);
   }
-  CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream);
 }
 
 template <typename vertex_t>
@@ -232,7 +232,7 @@ void compute_local_speed(const float* restrict repel_x,
 
   local_speed_kernel<<<nblocks, nthreads, 0, stream>>>(
     repel_x, repel_y, attract_x, attract_y, old_dx, old_dy, mass, swinging, traction, n);
-  CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream);
 }
 
 template <typename vertex_t>
@@ -321,7 +321,7 @@ void apply_forces(float* restrict x_pos,
 
   update_positions_kernel<vertex_t><<<nblocks, nthreads, 0, stream>>>(
     x_pos, y_pos, repel_x, repel_y, attract_x, attract_y, old_dx, old_dy, swinging, speed, n);
-  CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream);
 }
 
 }  // namespace detail

--- a/cpp/src/layout/utils.hpp
+++ b/cpp/src/layout/utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/layout/utils.hpp
+++ b/cpp/src/layout/utils.hpp
@@ -25,9 +25,9 @@ namespace detail {
 inline int getMultiProcessorCount()
 {
   int devId;
-  CUDA_TRY(cudaGetDevice(&devId));
+  RAFT_CUDA_TRY(cudaGetDevice(&devId));
   int mpCount;
-  CUDA_TRY(cudaDeviceGetAttribute(&mpCount, cudaDevAttrMultiProcessorCount, devId));
+  RAFT_CUDA_TRY(cudaDeviceGetAttribute(&mpCount, cudaDevAttrMultiProcessorCount, devId));
   return mpCount;
 }
 

--- a/cpp/src/sampling/random_walks.cuh
+++ b/cpp/src/sampling/random_walks.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/sampling/random_walks.cuh
+++ b/cpp/src/sampling/random_walks.cuh
@@ -970,7 +970,7 @@ struct coo_convertor_t {
       handle_.get_thrust_policy(), d_sizes.begin(), d_sizes.end(), d_scan.begin());
 
     index_t total_sz{0};
-    CUDA_TRY(cudaMemcpy(
+    RAFT_CUDA_TRY(cudaMemcpy(
       &total_sz, raw_ptr(d_scan) + num_paths_ - 1, sizeof(index_t), cudaMemcpyDeviceToHost));
 
     device_vec_t<int> d_stencil(total_sz, handle_.get_stream());

--- a/cpp/src/structure/graph_view_impl.cuh
+++ b/cpp/src/structure/graph_view_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/graph_view_impl.cuh
+++ b/cpp/src/structure/graph_view_impl.cuh
@@ -76,7 +76,7 @@ std::vector<edge_t> update_adj_matrix_partition_edge_counts(
                       1,
                       stream);
   }
-  CUDA_TRY(cudaStreamSynchronize(stream));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
   return adj_matrix_partition_edge_counts;
 }
 

--- a/cpp/src/structure/renumber_edgelist_impl.cuh
+++ b/cpp/src/structure/renumber_edgelist_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/renumber_edgelist_impl.cuh
+++ b/cpp/src/structure/renumber_edgelist_impl.cuh
@@ -665,7 +665,7 @@ renumber_edgelist(
                    i,
                    handle.get_stream());
 
-      CUDA_TRY(cudaStreamSynchronize(
+      RAFT_CUDA_TRY(cudaStreamSynchronize(
         handle.get_stream()));  // cuco::static_map currently does not take stream
 
       auto poly_alloc =
@@ -709,7 +709,7 @@ renumber_edgelist(
                    i,
                    handle.get_stream());
 
-      CUDA_TRY(cudaStreamSynchronize(
+      RAFT_CUDA_TRY(cudaStreamSynchronize(
         handle.get_stream()));  // cuco::static_map currently does not take stream
 
       auto poly_alloc =
@@ -751,7 +751,7 @@ renumber_edgelist(
                       displacements,
                       handle.get_stream());
 
-    CUDA_TRY(cudaStreamSynchronize(
+    RAFT_CUDA_TRY(cudaStreamSynchronize(
       handle.get_stream()));  // cuco::static_map currently does not take stream
 
     auto poly_alloc = rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());

--- a/cpp/src/structure/renumber_utils_impl.cuh
+++ b/cpp/src/structure/renumber_utils_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/renumber_utils_impl.cuh
+++ b/cpp/src/structure/renumber_utils_impl.cuh
@@ -189,7 +189,7 @@ void unrenumber_local_int_edges(
                    i,
                    handle.get_stream());
 
-      CUDA_TRY(cudaStreamSynchronize(
+      RAFT_CUDA_TRY(cudaStreamSynchronize(
         handle.get_stream()));  // cuco::static_map currently does not take stream
 
       auto poly_alloc =
@@ -248,7 +248,7 @@ void unrenumber_local_int_edges(
                    i,
                    handle.get_stream());
 
-      CUDA_TRY(cudaStreamSynchronize(
+      RAFT_CUDA_TRY(cudaStreamSynchronize(
         handle.get_stream()));  // cuco::static_map currently does not take stream
 
       auto poly_alloc =
@@ -297,7 +297,7 @@ void unrenumber_local_int_edges(
                       displacements,
                       handle.get_stream());
 
-    CUDA_TRY(cudaStreamSynchronize(
+    RAFT_CUDA_TRY(cudaStreamSynchronize(
       handle.get_stream()));  // cuco::static_map currently does not take stream
 
     auto poly_alloc = rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());

--- a/cpp/src/traversal/bfs_impl.cuh
+++ b/cpp/src/traversal/bfs_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/traversal/bfs_impl.cuh
+++ b/cpp/src/traversal/bfs_impl.cuh
@@ -185,7 +185,7 @@ void bfs(raft::handle_t const& handle,
     if (depth >= depth_limit) { break; }
   }
 
-  CUDA_TRY(cudaStreamSynchronize(
+  RAFT_CUDA_TRY(cudaStreamSynchronize(
     handle.get_stream()));  // this is as necessary vertex_frontier will become out-of-scope once
                             // this function returns (FIXME: should I stream sync in VertexFrontier
                             // destructor?)

--- a/cpp/src/traversal/legacy/bfs.cu
+++ b/cpp/src/traversal/legacy/bfs.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.  All rights reserved.
  *
  * NVIDIA CORPORATION and its licensors retain all intellectual property
  * and proprietary rights in and to this software, related documentation

--- a/cpp/src/traversal/legacy/bfs.cu
+++ b/cpp/src/traversal/legacy/bfs.cu
@@ -358,7 +358,7 @@ void BFS<IndexType>::traverse(IndexType source_vertex)
         mu -= mf;
 
         cudaMemcpyAsync(&nf, d_new_frontier_cnt, sizeof(IndexType), cudaMemcpyDeviceToHost, stream);
-        CHECK_CUDA(stream);
+        RAFT_CHECK_CUDA(stream);
 
         // We need nf
         cudaStreamSynchronize(stream);
@@ -415,7 +415,7 @@ void BFS<IndexType>::traverse(IndexType source_vertex)
                           sizeof(IndexType),
                           cudaMemcpyDeviceToHost,
                           stream);
-          CHECK_CUDA(stream);
+          RAFT_CHECK_CUDA(stream);
           // We need last_left_unvisited_size
           cudaStreamSynchronize(stream);
           bfs_kernels::bottom_up_large(left_unvisited_queue,
@@ -433,7 +433,7 @@ void BFS<IndexType>::traverse(IndexType source_vertex)
                                        deterministic);
         }
         cudaMemcpyAsync(&nf, d_new_frontier_cnt, sizeof(IndexType), cudaMemcpyDeviceToHost, stream);
-        CHECK_CUDA(stream);
+        RAFT_CHECK_CUDA(stream);
 
         // We will need nf
         cudaStreamSynchronize(stream);

--- a/cpp/src/traversal/legacy/bfs_kernels.cuh
+++ b/cpp/src/traversal/legacy/bfs_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/traversal/legacy/bfs_kernels.cuh
+++ b/cpp/src/traversal/legacy/bfs_kernels.cuh
@@ -168,7 +168,7 @@ void fill_unvisited_queue(int* visited_bmap,
 
   fill_unvisited_queue_kernel<<<grid, block, 0, m_stream>>>(
     visited_bmap, visited_bmap_nints, n, unvisited, unvisited_cnt);
-  CHECK_CUDA(m_stream);
+  RAFT_CHECK_CUDA(m_stream);
 }
 
 //
@@ -228,7 +228,7 @@ void count_unvisited_edges(const IndexType* potentially_unvisited,
 
   count_unvisited_edges_kernel<<<grid, block, 0, m_stream>>>(
     potentially_unvisited, potentially_unvisited_size, visited_bmap, node_degree, mu);
-  CHECK_CUDA(m_stream);
+  RAFT_CHECK_CUDA(m_stream);
 }
 
 //
@@ -522,7 +522,7 @@ void bottom_up_main(IndexType* unvisited,
                                                      distances,
                                                      predecessors,
                                                      edge_mask);
-  CHECK_CUDA(m_stream);
+  RAFT_CHECK_CUDA(m_stream);
 }
 
 //
@@ -642,7 +642,7 @@ void bottom_up_large(IndexType* left_unvisited,
                                                               distances,
                                                               predecessors,
                                                               edge_mask);
-  CHECK_CUDA(m_stream);
+  RAFT_CHECK_CUDA(m_stream);
 }
 
 //
@@ -1155,7 +1155,7 @@ void frontier_expand(const IndexType* row_ptr,
     edge_mask,
     isolated_bmap,
     directed);
-  CHECK_CUDA(m_stream);
+  RAFT_CHECK_CUDA(m_stream);
 }
 
 }  // namespace bfs_kernels

--- a/cpp/src/traversal/legacy/mg/common_utils.cuh
+++ b/cpp/src/traversal/legacy/mg/common_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/traversal/legacy/mg/common_utils.cuh
+++ b/cpp/src/traversal/legacy/mg/common_utils.cuh
@@ -176,13 +176,13 @@ return_t collect_vectors(raft::handle_t const& handle,
                          return_t local_count,
                          rmm::device_vector<return_t>& global)
 {
-  CHECK_CUDA(handle.get_stream());
+  RAFT_CHECK_CUDA(handle.get_stream());
   buffer_len.resize(handle.get_comms().get_size());
   auto my_rank        = handle.get_comms().get_rank();
   buffer_len[my_rank] = static_cast<size_t>(local_count);
   handle.get_comms().allgather(
     buffer_len.data().get() + my_rank, buffer_len.data().get(), 1, handle.get_stream());
-  CHECK_CUDA(handle.get_stream());
+  RAFT_CHECK_CUDA(handle.get_stream());
   // buffer_len now contains the lengths of all local buffers
   // for all ranks
 
@@ -201,7 +201,7 @@ return_t collect_vectors(raft::handle_t const& handle,
                                 h_buffer_len.data(),
                                 h_buffer_offsets.data(),
                                 handle.get_stream());
-  CHECK_CUDA(handle.get_stream());
+  RAFT_CHECK_CUDA(handle.get_stream());
   return global_buffer_len;
 }
 
@@ -214,7 +214,7 @@ void add_to_bitmap(raft::handle_t const& handle,
   cudaStream_t stream = handle.get_stream();
   thrust::for_each(
     handle.get_thrust_policy(), id.begin(), id.begin() + count, set_nth_bit(bmap.data().get()));
-  CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream);
 }
 
 // For all vertex ids i which are isolated (out degree is 0), set
@@ -380,7 +380,7 @@ return_t remove_duplicates(raft::handle_t const& handle,
                                                                     data_len,
                                                                     out_data.data().get(),
                                                                     unique_count.data().get());
-  CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream);
   return static_cast<return_t>(unique_count[0]);
 }
 
@@ -412,7 +412,7 @@ vertex_t preprocess_input_frontier(
                                                                     input_frontier_len,
                                                                     output_frontier.data().get(),
                                                                     unique_count.data().get());
-  CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream);
   return static_cast<vertex_t>(unique_count[0]);
 }
 
@@ -442,7 +442,7 @@ vertex_t preprocess_input_frontier(
                                                                     input_frontier_len,
                                                                     output_frontier.data().get(),
                                                                     unique_count.data().get());
-  CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream);
   return static_cast<vertex_t>(unique_count[0]);
 }
 

--- a/cpp/src/traversal/legacy/mg/frontier_expand_kernels.cuh
+++ b/cpp/src/traversal/legacy/mg/frontier_expand_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/traversal/legacy/mg/frontier_expand_kernels.cuh
+++ b/cpp/src/traversal/legacy/mg/frontier_expand_kernels.cuh
@@ -191,7 +191,7 @@ void large_vertex_lb(cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> c
                                                output_vertex_ids,
                                                output_vertex_ids_offset,
                                                op);
-    CHECK_CUDA(stream);
+    RAFT_CHECK_CUDA(stream);
   }
 }
 
@@ -218,7 +218,7 @@ void medium_vertex_lb(cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> 
                                                output_vertex_ids,
                                                output_vertex_ids_offset,
                                                op);
-    CHECK_CUDA(stream);
+    RAFT_CHECK_CUDA(stream);
   }
 }
 
@@ -290,7 +290,7 @@ void small_vertex_lb(cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> c
                                                                      output_vertex_ids_offset,
                                                                      op);
   }
-  CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream);
 }
 
 }  // namespace detail

--- a/cpp/src/traversal/legacy/sssp.cu
+++ b/cpp/src/traversal/legacy/sssp.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/traversal/legacy/sssp.cu
+++ b/cpp/src/traversal/legacy/sssp.cu
@@ -213,7 +213,7 @@ void SSSP<IndexType, DistType>::traverse(IndexType source_vertex)
       distances, next_distances, n * sizeof(DistType), cudaMemcpyDeviceToDevice, stream);
 
     // We need nf for the loop
-    CUDA_TRY(cudaStreamSynchronize(stream));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
 
     // Swap frontiers
     // IndexType *tmp = frontier;

--- a/cpp/src/traversal/legacy/sssp_kernels.cuh
+++ b/cpp/src/traversal/legacy/sssp_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/traversal/legacy/sssp_kernels.cuh
+++ b/cpp/src/traversal/legacy/sssp_kernels.cuh
@@ -547,7 +547,7 @@ void frontier_expand(const IndexType* row_ptr,
     predecessors,
     edge_mask);
 
-  CHECK_CUDA(m_stream);
+  RAFT_CHECK_CUDA(m_stream);
 }
 }  // namespace sssp_kernels
 }  // namespace detail

--- a/cpp/src/traversal/legacy/traversal_common.cuh
+++ b/cpp/src/traversal/legacy/traversal_common.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/traversal/legacy/traversal_common.cuh
+++ b/cpp/src/traversal/legacy/traversal_common.cuh
@@ -198,7 +198,7 @@ void fill_vec(ValueType* vec, SizeType n, ValueType val, cudaStream_t stream)
   grid.x  = (n + block.x - 1) / block.x;
 
   fill_vec_kernel<<<grid, block, 0, stream>>>(vec, n, val);
-  CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream);
 }
 
 template <typename IndexType>
@@ -379,7 +379,7 @@ void flag_isolated_vertices(IndexType n,
 
   flag_isolated_vertices_kernel<<<grid, block, 0, m_stream>>>(
     n, isolated_bmap, row_ptr, degrees, nisolated);
-  CHECK_CUDA(m_stream);
+  RAFT_CHECK_CUDA(m_stream);
 }
 
 template <typename IndexType>
@@ -406,7 +406,7 @@ void set_frontier_degree(IndexType* frontier_degree,
   block.x = 256;
   grid.x  = min((n + block.x - 1) / block.x, (IndexType)MAXBLOCKS);
   set_frontier_degree_kernel<<<grid, block, 0, m_stream>>>(frontier_degree, frontier, degree, n);
-  CHECK_CUDA(m_stream);
+  RAFT_CHECK_CUDA(m_stream);
 }
 
 template <typename IndexType>
@@ -471,7 +471,7 @@ void compute_bucket_offsets(IndexType* cumul,
 
   compute_bucket_offsets_kernel<<<grid, block, 0, m_stream>>>(
     cumul, bucket_offsets, frontier_size, total_degree);
-  CHECK_CUDA(m_stream);
+  RAFT_CHECK_CUDA(m_stream);
 }
 }  // namespace traversal
 }  // namespace detail

--- a/cpp/src/traversal/sssp_impl.cuh
+++ b/cpp/src/traversal/sssp_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/traversal/sssp_impl.cuh
+++ b/cpp/src/traversal/sssp_impl.cuh
@@ -242,7 +242,7 @@ void sssp(raft::handle_t const& handle,
     }
   }
 
-  CUDA_TRY(cudaStreamSynchronize(
+  RAFT_CUDA_TRY(cudaStreamSynchronize(
     handle.get_stream()));  // this is as necessary vertex_frontier will become out-of-scope once
                             // this function returns (FIXME: should I stream sync in VertexFrontier
                             // destructor?)

--- a/cpp/src/utilities/graph_utils.cuh
+++ b/cpp/src/utilities/graph_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.  All rights reserved.
  *
  * NVIDIA CORPORATION and its licensors retain all intellectual property
  * and proprietary rights in and to this software, related documentation

--- a/cpp/src/utilities/spmv_1D.cu
+++ b/cpp/src/utilities/spmv_1D.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/utilities/spmv_1D.cu
+++ b/cpp/src/utilities/spmv_1D.cu
@@ -38,7 +38,7 @@ MGcsrmv<vertex_t, edge_t, weight_t>::MGcsrmv(raft::handle_t const& handle,
   v_glob_ = part_off_[p_ - 1] + local_vertices_[p_ - 1];
   v_loc_  = local_vertices_[i_];
   vertex_t tmp;
-  CUDA_TRY(cudaMemcpy(&tmp, &off_[v_loc_], sizeof(vertex_t), cudaMemcpyDeviceToHost));
+  RAFT_CUDA_TRY(cudaMemcpy(&tmp, &off_[v_loc_], sizeof(vertex_t), cudaMemcpyDeviceToHost));
   e_loc_ = tmp;
   y_loc_.resize(v_loc_);
 }

--- a/cpp/tests/centrality/katz_centrality_test.cpp
+++ b/cpp/tests/centrality/katz_centrality_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/centrality/katz_centrality_test.cpp
+++ b/cpp/tests/centrality/katz_centrality_test.cpp
@@ -118,7 +118,7 @@ class Tests_KatzCentrality
     HighResClock hr_clock{};
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -127,7 +127,7 @@ class Tests_KatzCentrality
         handle, input_usecase, katz_usecase.test_weighted, renumber);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -149,7 +149,7 @@ class Tests_KatzCentrality
                                                       handle.get_stream());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -165,7 +165,7 @@ class Tests_KatzCentrality
                              true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "Katz Centrality took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/centrality/legacy/betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/legacy/betweenness_centrality_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/centrality/legacy/betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/legacy/betweenness_centrality_test.cu
@@ -327,7 +327,7 @@ class Tests_BC : public ::testing::TestWithParam<BC_Usecase> {
     cudaDeviceSynchronize();
     cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> G = csr->view();
     G.prop.directed                                             = is_directed;
-    CUDA_TRY(cudaGetLastError());
+    RAFT_CUDA_TRY(cudaGetLastError());
     std::vector<result_t> result(G.number_of_vertices, 0);
     std::vector<result_t> expected(G.number_of_vertices, 0);
 
@@ -360,7 +360,7 @@ class Tests_BC : public ::testing::TestWithParam<BC_Usecase> {
                                     configuration.number_of_sources_,
                                     sources_ptr);
     cudaDeviceSynchronize();
-    CUDA_TRY(cudaMemcpy(result.data(),
+    RAFT_CUDA_TRY(cudaMemcpy(result.data(),
                         d_result.data().get(),
                         sizeof(result_t) * G.number_of_vertices,
                         cudaMemcpyDeviceToHost));

--- a/cpp/tests/centrality/legacy/betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/legacy/betweenness_centrality_test.cu
@@ -361,9 +361,9 @@ class Tests_BC : public ::testing::TestWithParam<BC_Usecase> {
                                     sources_ptr);
     cudaDeviceSynchronize();
     RAFT_CUDA_TRY(cudaMemcpy(result.data(),
-                        d_result.data().get(),
-                        sizeof(result_t) * G.number_of_vertices,
-                        cudaMemcpyDeviceToHost));
+                             d_result.data().get(),
+                             sizeof(result_t) * G.number_of_vertices,
+                             cudaMemcpyDeviceToHost));
     cudaDeviceSynchronize();
     for (int i = 0; i < G.number_of_vertices; ++i)
       EXPECT_TRUE(compare_close(result[i], expected[i], TEST_EPSILON, TEST_ZERO_THRESHOLD))

--- a/cpp/tests/centrality/legacy/edge_betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/legacy/edge_betweenness_centrality_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/centrality/legacy/edge_betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/legacy/edge_betweenness_centrality_test.cu
@@ -253,7 +253,7 @@ class Tests_EdgeBC : public ::testing::TestWithParam<EdgeBC_Usecase> {
     cudaDeviceSynchronize();
     cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> G = csr->view();
     G.prop.directed                                             = is_directed;
-    CUDA_TRY(cudaGetLastError());
+    RAFT_CUDA_TRY(cudaGetLastError());
     std::vector<result_t> result(G.number_of_edges, 0);
     std::vector<result_t> expected(G.number_of_edges, 0);
 
@@ -284,7 +284,7 @@ class Tests_EdgeBC : public ::testing::TestWithParam<EdgeBC_Usecase> {
                                          static_cast<weight_t*>(nullptr),
                                          configuration.number_of_sources_,
                                          sources_ptr);
-    CUDA_TRY(cudaMemcpy(result.data(),
+    RAFT_CUDA_TRY(cudaMemcpy(result.data(),
                         d_result.data().get(),
                         sizeof(result_t) * G.number_of_edges,
                         cudaMemcpyDeviceToHost));

--- a/cpp/tests/centrality/legacy/edge_betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/legacy/edge_betweenness_centrality_test.cu
@@ -285,9 +285,9 @@ class Tests_EdgeBC : public ::testing::TestWithParam<EdgeBC_Usecase> {
                                          configuration.number_of_sources_,
                                          sources_ptr);
     RAFT_CUDA_TRY(cudaMemcpy(result.data(),
-                        d_result.data().get(),
-                        sizeof(result_t) * G.number_of_edges,
-                        cudaMemcpyDeviceToHost));
+                             d_result.data().get(),
+                             sizeof(result_t) * G.number_of_edges,
+                             cudaMemcpyDeviceToHost));
     for (int i = 0; i < G.number_of_edges; ++i)
       EXPECT_TRUE(compare_close(result[i], expected[i], TEST_EPSILON, TEST_ZERO_THRESHOLD))
         << "[MISMATCH] vaid = " << i << ", cugraph = " << result[i]

--- a/cpp/tests/centrality/mg_katz_centrality_test.cpp
+++ b/cpp/tests/centrality/mg_katz_centrality_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/centrality/mg_katz_centrality_test.cpp
+++ b/cpp/tests/centrality/mg_katz_centrality_test.cpp
@@ -75,7 +75,7 @@ class Tests_MGKatzCentrality
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -85,7 +85,7 @@ class Tests_MGKatzCentrality
         handle, input_usecase, katz_usecase.test_weighted, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -108,7 +108,7 @@ class Tests_MGKatzCentrality
       mg_graph_view.get_number_of_local_vertices(), handle.get_stream());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -124,7 +124,7 @@ class Tests_MGKatzCentrality
                              false);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/community/ecg_test.cpp
+++ b/cpp/tests/community/ecg_test.cpp
@@ -135,7 +135,7 @@ TEST(ecg, dolphin)
 
     raft::update_host(cluster_id.data(), result_v.data(), num_verts, stream);
 
-    CUDA_TRY(cudaDeviceSynchronize());
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());
 
     int max = *max_element(cluster_id.begin(), cluster_id.end());
     int min = *min_element(cluster_id.begin(), cluster_id.end());

--- a/cpp/tests/community/ecg_test.cpp
+++ b/cpp/tests/community/ecg_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.  All rights reserved.
  *
  * NVIDIA CORPORATION and its licensors retain all intellectual property
  * and proprietary rights in and to this software, related documentation

--- a/cpp/tests/community/induced_subgraph_test.cpp
+++ b/cpp/tests/community/induced_subgraph_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/community/induced_subgraph_test.cpp
+++ b/cpp/tests/community/induced_subgraph_test.cpp
@@ -141,7 +141,7 @@ class Tests_InducedSubgraph : public ::testing::TestWithParam<InducedSubgraph_Us
                         graph_view.get_number_of_edges(),
                         handle.get_stream());
     }
-    CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
 
     std::vector<size_t> h_subgraph_offsets(configuration.subgraph_sizes.size() + 1, 0);
     std::partial_sum(configuration.subgraph_sizes.begin(),
@@ -193,7 +193,7 @@ class Tests_InducedSubgraph : public ::testing::TestWithParam<InducedSubgraph_Us
         graph_view.get_number_of_vertices(),
         configuration.subgraph_sizes.size());
 
-    CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
 
     // FIXME: turn-off do_expensive_check once verified.
     auto [d_subgraph_edgelist_majors,
@@ -207,7 +207,7 @@ class Tests_InducedSubgraph : public ::testing::TestWithParam<InducedSubgraph_Us
                                          configuration.subgraph_sizes.size(),
                                          true);
 
-    CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
 
     std::vector<vertex_t> h_cugraph_subgraph_edgelist_majors(d_subgraph_edgelist_majors.size());
     std::vector<vertex_t> h_cugraph_subgraph_edgelist_minors(d_subgraph_edgelist_minors.size());
@@ -235,7 +235,7 @@ class Tests_InducedSubgraph : public ::testing::TestWithParam<InducedSubgraph_Us
                       d_subgraph_edge_offsets.data(),
                       d_subgraph_edge_offsets.size(),
                       handle.get_stream());
-    CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
 
     ASSERT_TRUE(h_reference_subgraph_edge_offsets.size() == h_cugraph_subgraph_edge_offsets.size())
       << "Returned subgraph edge offset vector has an invalid size.";

--- a/cpp/tests/community/induced_subgraph_test.cpp
+++ b/cpp/tests/community/induced_subgraph_test.cpp
@@ -141,7 +141,7 @@ class Tests_InducedSubgraph : public ::testing::TestWithParam<InducedSubgraph_Us
                         graph_view.get_number_of_edges(),
                         handle.get_stream());
     }
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    handle.sync_stream();
 
     std::vector<size_t> h_subgraph_offsets(configuration.subgraph_sizes.size() + 1, 0);
     std::partial_sum(configuration.subgraph_sizes.begin(),
@@ -235,7 +235,7 @@ class Tests_InducedSubgraph : public ::testing::TestWithParam<InducedSubgraph_Us
                       d_subgraph_edge_offsets.data(),
                       d_subgraph_edge_offsets.size(),
                       handle.get_stream());
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    handle.sync_stream();
 
     ASSERT_TRUE(h_reference_subgraph_edge_offsets.size() == h_cugraph_subgraph_edge_offsets.size())
       << "Returned subgraph edge offset vector has an invalid size.";

--- a/cpp/tests/community/leiden_test.cpp
+++ b/cpp/tests/community/leiden_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.  All rights reserved.
  *
  * NVIDIA CORPORATION and its licensors retain all intellectual property
  * and proprietary rights in and to this software, related documentation

--- a/cpp/tests/community/leiden_test.cpp
+++ b/cpp/tests/community/leiden_test.cpp
@@ -77,7 +77,7 @@ TEST(leiden_karate, success)
 
     raft::update_host(cluster_id.data(), result_v.data(), num_verts, stream);
 
-    CUDA_TRY(cudaDeviceSynchronize());
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());
 
     int min = *min_element(cluster_id.begin(), cluster_id.end());
 

--- a/cpp/tests/community/louvain_test.cpp
+++ b/cpp/tests/community/louvain_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.  All rights reserved.
  *
  * NVIDIA CORPORATION and its licensors retain all intellectual property
  * and proprietary rights in and to this software, related documentation

--- a/cpp/tests/community/louvain_test.cpp
+++ b/cpp/tests/community/louvain_test.cpp
@@ -63,7 +63,7 @@ class Tests_Louvain
     // this is the behavior while we still support Pascal (device_prop.major < 7)
     //
     cudaDeviceProp device_prop;
-    CUDA_CHECK(cudaGetDeviceProperties(&device_prop, 0));
+    RAFT_CUDA_TRY(cudaGetDeviceProperties(&device_prop, 0));
 
     if (device_prop.major < 7) {
       EXPECT_THROW(louvain(graph_view,
@@ -103,7 +103,7 @@ class Tests_Louvain
     // this is the behavior while we still support Pascal (device_prop.major < 7)
     //
     cudaDeviceProp device_prop;
-    CUDA_CHECK(cudaGetDeviceProperties(&device_prop, 0));
+    RAFT_CUDA_TRY(cudaGetDeviceProperties(&device_prop, 0));
 
     if (device_prop.major < 7) {
       EXPECT_THROW(louvain(graph_view,

--- a/cpp/tests/community/louvain_test.cpp
+++ b/cpp/tests/community/louvain_test.cpp
@@ -140,7 +140,7 @@ class Tests_Louvain
     std::tie(level, modularity) =
       cugraph::louvain(handle, graph_view, clustering_v.data(), size_t{100}, weight_t{1});
 
-    CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
 
     float compare_modularity = static_cast<float>(modularity);
 
@@ -216,7 +216,7 @@ TEST(louvain_legacy, success)
 
     raft::update_host(cluster_id.data(), result_v.data(), num_verts, stream);
 
-    CUDA_TRY(cudaDeviceSynchronize());
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());
 
     int min = *min_element(cluster_id.begin(), cluster_id.end());
 
@@ -287,7 +287,7 @@ TEST(louvain_legacy_renumbered, success)
 
     raft::update_host(cluster_id.data(), result_v.data(), num_verts, stream);
 
-    CUDA_TRY(cudaDeviceSynchronize());
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());
 
     int min = *min_element(cluster_id.begin(), cluster_id.end());
 

--- a/cpp/tests/community/mg_louvain_helper.cu
+++ b/cpp/tests/community/mg_louvain_helper.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/community/mg_louvain_helper.cu
+++ b/cpp/tests/community/mg_louvain_helper.cu
@@ -74,7 +74,7 @@ compressed_sparse_to_edgelist(edge_t const* compressed_sparse_offsets,
   edge_t number_of_edges{0};
   raft::update_host(
     &number_of_edges, compressed_sparse_offsets + (major_last - major_first), 1, stream);
-  CUDA_TRY(cudaStreamSynchronize(stream));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
   rmm::device_uvector<vertex_t> edgelist_major_vertices(number_of_edges, stream);
   rmm::device_uvector<vertex_t> edgelist_minor_vertices(number_of_edges, stream);
   auto edgelist_weights =

--- a/cpp/tests/components/mg_weakly_connected_components_test.cpp
+++ b/cpp/tests/components/mg_weakly_connected_components_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/components/mg_weakly_connected_components_test.cpp
+++ b/cpp/tests/components/mg_weakly_connected_components_test.cpp
@@ -79,7 +79,7 @@ class Tests_MGWeaklyConnectedComponents
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -89,7 +89,7 @@ class Tests_MGWeaklyConnectedComponents
         handle, input_usecase, false, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -104,7 +104,7 @@ class Tests_MGWeaklyConnectedComponents
                                                   handle.get_stream());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -112,7 +112,7 @@ class Tests_MGWeaklyConnectedComponents
     cugraph::weakly_connected_components(handle, mg_graph_view, d_mg_components.data());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/components/weakly_connected_components_test.cpp
+++ b/cpp/tests/components/weakly_connected_components_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/components/weakly_connected_components_test.cpp
+++ b/cpp/tests/components/weakly_connected_components_test.cpp
@@ -107,7 +107,7 @@ class Tests_WeaklyConnectedComponent
     HighResClock hr_clock{};
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -116,7 +116,7 @@ class Tests_WeaklyConnectedComponent
         handle, input_usecase, false, renumber);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -130,14 +130,14 @@ class Tests_WeaklyConnectedComponent
                                                handle.get_stream());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
     cugraph::weakly_connected_components(handle, graph_view, d_components.data());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "weakly_connected_components took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/cores/core_number_test.cpp
+++ b/cpp/tests/cores/core_number_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/cores/core_number_test.cpp
+++ b/cpp/tests/cores/core_number_test.cpp
@@ -223,7 +223,7 @@ class Tests_CoreNumber
     HighResClock hr_clock{};
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -232,7 +232,7 @@ class Tests_CoreNumber
         handle, input_usecase, false, renumber, true, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -246,7 +246,7 @@ class Tests_CoreNumber
                                                handle.get_stream());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -258,7 +258,7 @@ class Tests_CoreNumber
                          core_number_usecase.k_last);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "Core Number took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/cores/mg_core_number_test.cpp
+++ b/cpp/tests/cores/mg_core_number_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/cores/mg_core_number_test.cpp
+++ b/cpp/tests/cores/mg_core_number_test.cpp
@@ -84,7 +84,7 @@ class Tests_MGCoreNumber
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -94,7 +94,7 @@ class Tests_MGCoreNumber
         handle, input_usecase, false, true, true, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -109,7 +109,7 @@ class Tests_MGCoreNumber
                                                   handle.get_stream());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -122,7 +122,7 @@ class Tests_MGCoreNumber
                          core_number_usecase.k_last);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/generators/generate_rmat_test.cpp
+++ b/cpp/tests/generators/generate_rmat_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/generators/generate_rmat_test.cpp
+++ b/cpp/tests/generators/generate_rmat_test.cpp
@@ -196,7 +196,7 @@ class Tests_GenerateRmat : public ::testing::TestWithParam<GenerateRmat_Usecase>
 
       raft::update_host(h_cugraph_srcs.data(), d_srcs.data(), d_srcs.size(), handle.get_stream());
       raft::update_host(h_cugraph_dsts.data(), d_dsts.data(), d_dsts.size(), handle.get_stream());
-      RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+      handle.sync_stream();
 
       ASSERT_TRUE(
         (h_cugraph_srcs.size() == (size_t{1} << configuration.scale) * configuration.edge_factor) &&

--- a/cpp/tests/generators/generate_rmat_test.cpp
+++ b/cpp/tests/generators/generate_rmat_test.cpp
@@ -176,7 +176,7 @@ class Tests_GenerateRmat : public ::testing::TestWithParam<GenerateRmat_Usecase>
       rmm::device_uvector<vertex_t> d_srcs(0, handle.get_stream());
       rmm::device_uvector<vertex_t> d_dsts(0, handle.get_stream());
 
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
 
       std::tie(d_srcs, d_dsts) = cugraph::generate_rmat_edgelist<vertex_t>(
         handle,
@@ -189,14 +189,14 @@ class Tests_GenerateRmat : public ::testing::TestWithParam<GenerateRmat_Usecase>
         configuration.clip_and_flip);
       // static_cast<bool>(scramble));
 
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
 
       std::vector<vertex_t> h_cugraph_srcs(d_srcs.size());
       std::vector<vertex_t> h_cugraph_dsts(d_dsts.size());
 
       raft::update_host(h_cugraph_srcs.data(), d_srcs.data(), d_srcs.size(), handle.get_stream());
       raft::update_host(h_cugraph_dsts.data(), d_dsts.data(), d_dsts.size(), handle.get_stream());
-      CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+      RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
 
       ASSERT_TRUE(
         (h_cugraph_srcs.size() == (size_t{1} << configuration.scale) * configuration.edge_factor) &&
@@ -318,7 +318,7 @@ class Tests_GenerateRmats : public ::testing::TestWithParam<GenerateRmats_Usecas
   {
     raft::handle_t handle{};
 
-    CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
 
     auto outputs = cugraph::generate_rmat_edgelists<vertex_t>(handle,
                                                               configuration.n_edgelists,
@@ -329,7 +329,7 @@ class Tests_GenerateRmats : public ::testing::TestWithParam<GenerateRmats_Usecas
                                                               configuration.edge_distribution,
                                                               uint64_t{0});
 
-    CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
     ASSERT_EQ(configuration.n_edgelists, outputs.size());
     for (auto i = outputs.begin(); i != outputs.end(); ++i) {
       ASSERT_EQ(std::get<0>(*i).size(), std::get<1>(*i).size());

--- a/cpp/tests/layout/force_atlas2_test.cu
+++ b/cpp/tests/layout/force_atlas2_test.cu
@@ -136,9 +136,9 @@ class Tests_Force_Atlas2 : public ::testing::TestWithParam<Force_Atlas2_Usecase>
     T* weights = weights_v.data();
 
     // FIXME: RAFT error handling mechanism should be used instead
-    CUDA_TRY(cudaMemcpy(srcs, &cooRowInd[0], sizeof(int) * nnz, cudaMemcpyDefault));
-    CUDA_TRY(cudaMemcpy(dests, &cooColInd[0], sizeof(int) * nnz, cudaMemcpyDefault));
-    CUDA_TRY(cudaMemcpy(weights, &cooVal[0], sizeof(T) * nnz, cudaMemcpyDefault));
+    RAFT_CUDA_TRY(cudaMemcpy(srcs, &cooRowInd[0], sizeof(int) * nnz, cudaMemcpyDefault));
+    RAFT_CUDA_TRY(cudaMemcpy(dests, &cooColInd[0], sizeof(int) * nnz, cudaMemcpyDefault));
+    RAFT_CUDA_TRY(cudaMemcpy(weights, &cooVal[0], sizeof(T) * nnz, cudaMemcpyDefault));
     cugraph::legacy::GraphCOOView<int, int, T> G(srcs, dests, weights, m, nnz);
 
     const int max_iter                    = 500;
@@ -205,7 +205,7 @@ class Tests_Force_Atlas2 : public ::testing::TestWithParam<Force_Atlas2_Usecase>
 
     // Copy pos to host
     std::vector<float> h_pos(m * 2);
-    CUDA_TRY(cudaMemcpy(&h_pos[0], pos.data(), sizeof(float) * m * 2, cudaMemcpyDeviceToHost));
+    RAFT_CUDA_TRY(cudaMemcpy(&h_pos[0], pos.data(), sizeof(float) * m * 2, cudaMemcpyDeviceToHost));
 
     // Transpose the data
     std::vector<std::vector<double>> C_contiguous_embedding(m, std::vector<double>(2));

--- a/cpp/tests/layout/force_atlas2_test.cu
+++ b/cpp/tests/layout/force_atlas2_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.  All rights reserved.
  *
  * NVIDIA CORPORATION and its licensors retain all intellectual property
  * and proprietary rights in and to this software, related documentation

--- a/cpp/tests/link_analysis/hits_test.cpp
+++ b/cpp/tests/link_analysis/hits_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/link_analysis/hits_test.cpp
+++ b/cpp/tests/link_analysis/hits_test.cpp
@@ -154,7 +154,7 @@ class Tests_Hits : public ::testing::TestWithParam<std::tuple<Hits_Usecase, inpu
     // 2. create SG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -163,7 +163,7 @@ class Tests_Hits : public ::testing::TestWithParam<std::tuple<Hits_Usecase, inpu
         handle, input_usecase, false, renumber);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -190,7 +190,7 @@ class Tests_Hits : public ::testing::TestWithParam<std::tuple<Hits_Usecase, inpu
     }
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -205,7 +205,7 @@ class Tests_Hits : public ::testing::TestWithParam<std::tuple<Hits_Usecase, inpu
                                 hits_usecase.check_initial_input);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "HITS took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/link_analysis/mg_hits_test.cpp
+++ b/cpp/tests/link_analysis/mg_hits_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/link_analysis/mg_hits_test.cpp
+++ b/cpp/tests/link_analysis/mg_hits_test.cpp
@@ -71,7 +71,7 @@ class Tests_MGHits : public ::testing::TestWithParam<std::tuple<Hits_Usecase, in
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -81,7 +81,7 @@ class Tests_MGHits : public ::testing::TestWithParam<std::tuple<Hits_Usecase, in
         handle, input_usecase, false, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -112,7 +112,7 @@ class Tests_MGHits : public ::testing::TestWithParam<std::tuple<Hits_Usecase, in
     }
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -128,7 +128,7 @@ class Tests_MGHits : public ::testing::TestWithParam<std::tuple<Hits_Usecase, in
                                 hits_usecase.check_initial_input);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/link_analysis/mg_pagerank_test.cpp
+++ b/cpp/tests/link_analysis/mg_pagerank_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/link_analysis/mg_pagerank_test.cpp
+++ b/cpp/tests/link_analysis/mg_pagerank_test.cpp
@@ -79,7 +79,7 @@ class Tests_MGPageRank
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -89,7 +89,7 @@ class Tests_MGPageRank
         handle, input_usecase, pagerank_usecase.test_weighted, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -154,7 +154,7 @@ class Tests_MGPageRank
                                                  handle.get_stream());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -179,7 +179,7 @@ class Tests_MGPageRank
       false);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/link_analysis/pagerank_test.cpp
+++ b/cpp/tests/link_analysis/pagerank_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/link_analysis/pagerank_test.cpp
+++ b/cpp/tests/link_analysis/pagerank_test.cpp
@@ -156,7 +156,7 @@ class Tests_PageRank
     HighResClock hr_clock{};
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -165,7 +165,7 @@ class Tests_PageRank
         handle, input_usecase, pagerank_usecase.test_weighted, renumber);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -230,7 +230,7 @@ class Tests_PageRank
                                               handle.get_stream());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -253,7 +253,7 @@ class Tests_PageRank
       false);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "PageRank took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/prims/mg_copy_v_transform_reduce_inout_nbr.cu
+++ b/cpp/tests/prims/mg_copy_v_transform_reduce_inout_nbr.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/prims/mg_copy_v_transform_reduce_inout_nbr.cu
+++ b/cpp/tests/prims/mg_copy_v_transform_reduce_inout_nbr.cu
@@ -256,7 +256,7 @@ class Tests_MG_CopyVTransformReduceInOutNbr
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -265,7 +265,7 @@ class Tests_MG_CopyVTransformReduceInOutNbr
         handle, input_usecase, prims_usecase.test_weighted, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -292,7 +292,7 @@ class Tests_MG_CopyVTransformReduceInOutNbr
       mg_graph_view.get_number_of_local_vertices(), handle.get_stream());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -313,7 +313,7 @@ class Tests_MG_CopyVTransformReduceInOutNbr
       cugraph::get_dataframe_buffer_begin(in_result));
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -321,7 +321,7 @@ class Tests_MG_CopyVTransformReduceInOutNbr
     }
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -342,7 +342,7 @@ class Tests_MG_CopyVTransformReduceInOutNbr
       cugraph::get_dataframe_buffer_begin(out_result));
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/prims/mg_count_if_e.cu
+++ b/cpp/tests/prims/mg_count_if_e.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/prims/mg_count_if_e.cu
+++ b/cpp/tests/prims/mg_count_if_e.cu
@@ -200,7 +200,7 @@ class Tests_MG_TransformCountIfE
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -209,7 +209,7 @@ class Tests_MG_TransformCountIfE
         handle, input_usecase, prims_usecase.test_weighted, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -229,7 +229,7 @@ class Tests_MG_TransformCountIfE
     auto row_prop = generate<result_t>::row_property(handle, mg_graph_view, vertex_property_data);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -243,7 +243,7 @@ class Tests_MG_TransformCountIfE
         return row_property < col_property;
       });
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/prims/mg_count_if_v.cu
+++ b/cpp/tests/prims/mg_count_if_v.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/prims/mg_count_if_v.cu
+++ b/cpp/tests/prims/mg_count_if_v.cu
@@ -89,7 +89,7 @@ class Tests_MG_CountIfV
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -98,7 +98,7 @@ class Tests_MG_CountIfV
         handle, input_usecase, true, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -112,7 +112,7 @@ class Tests_MG_CountIfV
     // 3. run MG count if
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -122,7 +122,7 @@ class Tests_MG_CountIfV
       count_if_v(handle, mg_graph_view, data, test_predicate<vertex_t>(hash_bin_count));
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/prims/mg_extract_if_e.cu
+++ b/cpp/tests/prims/mg_extract_if_e.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/prims/mg_extract_if_e.cu
+++ b/cpp/tests/prims/mg_extract_if_e.cu
@@ -159,7 +159,7 @@ class Tests_MG_ExtractIfE
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -169,7 +169,7 @@ class Tests_MG_ExtractIfE
         handle, input_usecase, true, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -206,7 +206,7 @@ class Tests_MG_ExtractIfE
                            mg_dst_properties);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -221,7 +221,7 @@ class Tests_MG_ExtractIfE
                    });
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/prims/mg_reduce_v.cu
+++ b/cpp/tests/prims/mg_reduce_v.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/prims/mg_reduce_v.cu
+++ b/cpp/tests/prims/mg_reduce_v.cu
@@ -213,7 +213,7 @@ class Tests_MG_ReduceV
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -223,7 +223,7 @@ class Tests_MG_ReduceV
         handle, input_usecase, true, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -250,7 +250,7 @@ class Tests_MG_ReduceV
 
     for (auto op : ops) {
       if (cugraph::test::g_perf) {
-        CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+        RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
         handle.get_comms().barrier();
         hr_clock.start();
       }
@@ -263,7 +263,7 @@ class Tests_MG_ReduceV
                              op);
 
       if (cugraph::test::g_perf) {
-        CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+        RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
         handle.get_comms().barrier();
         double elapsed_time{0.0};
         hr_clock.stop(&elapsed_time);

--- a/cpp/tests/prims/mg_transform_reduce_e.cu
+++ b/cpp/tests/prims/mg_transform_reduce_e.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/prims/mg_transform_reduce_e.cu
+++ b/cpp/tests/prims/mg_transform_reduce_e.cu
@@ -238,7 +238,7 @@ class Tests_MG_TransformReduceE
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -247,7 +247,7 @@ class Tests_MG_TransformReduceE
         handle, input_usecase, prims_usecase.test_weighted, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -270,7 +270,7 @@ class Tests_MG_TransformReduceE
     auto row_prop = generate<result_t>::row_property(handle, mg_graph_view, vertex_property_data);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -290,7 +290,7 @@ class Tests_MG_TransformReduceE
       property_initial_value);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/prims/mg_transform_reduce_v.cu
+++ b/cpp/tests/prims/mg_transform_reduce_v.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/prims/mg_transform_reduce_v.cu
+++ b/cpp/tests/prims/mg_transform_reduce_v.cu
@@ -163,7 +163,7 @@ class Tests_MG_TransformReduceV
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -172,7 +172,7 @@ class Tests_MG_TransformReduceV
         handle, input_usecase, true, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -196,7 +196,7 @@ class Tests_MG_TransformReduceV
 
     for (auto op : ops) {
       if (cugraph::test::g_perf) {
-        CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+        RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
         handle.get_comms().barrier();
         hr_clock.start();
       }
@@ -205,7 +205,7 @@ class Tests_MG_TransformReduceV
         handle, mg_graph_view, d_mg_renumber_map_labels->begin(), prop, property_initial_value, op);
 
       if (cugraph::test::g_perf) {
-        CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+        RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
         handle.get_comms().barrier();
         double elapsed_time{0.0};
         hr_clock.stop(&elapsed_time);

--- a/cpp/tests/prims/mg_update_frontier_v_push_if_out_nbr.cu
+++ b/cpp/tests/prims/mg_update_frontier_v_push_if_out_nbr.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/prims/mg_update_frontier_v_push_if_out_nbr.cu
+++ b/cpp/tests/prims/mg_update_frontier_v_push_if_out_nbr.cu
@@ -124,7 +124,7 @@ class Tests_MG_UpdateFrontierVPushIfOutNbr
     constexpr bool store_transposed =
       false;  // needs to be false for using update_frontier_v_push_if_out_nbr
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -133,7 +133,7 @@ class Tests_MG_UpdateFrontierVPushIfOutNbr
         handle, input_usecase, false, renumber);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -180,7 +180,7 @@ class Tests_MG_UpdateFrontierVPushIfOutNbr
       .insert(sources.begin(), sources.end());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -208,7 +208,7 @@ class Tests_MG_UpdateFrontierVPushIfOutNbr
       });
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/structure/coarsen_graph_test.cpp
+++ b/cpp/tests/structure/coarsen_graph_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/structure/coarsen_graph_test.cpp
+++ b/cpp/tests/structure/coarsen_graph_test.cpp
@@ -253,7 +253,7 @@ class Tests_CoarsenGraph
     }
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -262,7 +262,7 @@ class Tests_CoarsenGraph
         handle, input_usecase, coarsen_graph_usecase.test_weighted, renumber);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -286,10 +286,10 @@ class Tests_CoarsenGraph
     rmm::device_uvector<vertex_t> d_labels(h_labels.size(), handle.get_stream());
     raft::update_device(d_labels.data(), h_labels.data(), h_labels.size(), handle.get_stream());
 
-    CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -297,7 +297,7 @@ class Tests_CoarsenGraph
       cugraph::coarsen_graph(handle, graph_view, d_labels.begin());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "coarsen_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -350,7 +350,7 @@ class Tests_CoarsenGraph
                         coarse_vertices_to_labels.size(),
                         handle.get_stream());
 
-      CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+      RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
 
       check_coarsened_graph_results(h_org_offsets.data(),
                                     h_org_indices.data(),

--- a/cpp/tests/structure/coarsen_graph_test.cpp
+++ b/cpp/tests/structure/coarsen_graph_test.cpp
@@ -286,7 +286,7 @@ class Tests_CoarsenGraph
     rmm::device_uvector<vertex_t> d_labels(h_labels.size(), handle.get_stream());
     raft::update_device(d_labels.data(), h_labels.data(), h_labels.size(), handle.get_stream());
 
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    handle.sync_stream();
 
     if (cugraph::test::g_perf) {
       RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
@@ -350,7 +350,7 @@ class Tests_CoarsenGraph
                         coarse_vertices_to_labels.size(),
                         handle.get_stream());
 
-      RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+      handle.sync_stream();
 
       check_coarsened_graph_results(h_org_offsets.data(),
                                     h_org_indices.data(),

--- a/cpp/tests/structure/count_self_loops_and_multi_edges_test.cpp
+++ b/cpp/tests/structure/count_self_loops_and_multi_edges_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/structure/count_self_loops_and_multi_edges_test.cpp
+++ b/cpp/tests/structure/count_self_loops_and_multi_edges_test.cpp
@@ -85,7 +85,7 @@ class Tests_CountSelfLoopsAndMultiEdges
     HighResClock hr_clock{};
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -94,7 +94,7 @@ class Tests_CountSelfLoopsAndMultiEdges
         handle, input_usecase, false, renumber);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -103,28 +103,28 @@ class Tests_CountSelfLoopsAndMultiEdges
     auto graph_view = graph.view();
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
     auto num_self_loops = graph_view.count_self_loops(handle);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "Counting self-loops took " << elapsed_time * 1e-6 << " s.\n";
     }
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
     auto num_multi_edges = graph_view.count_multi_edges(handle);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "Counting multi-edges took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/structure/degree_test.cpp
+++ b/cpp/tests/structure/degree_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/structure/degree_test.cpp
+++ b/cpp/tests/structure/degree_test.cpp
@@ -99,7 +99,7 @@ class Tests_Degree : public ::testing::TestWithParam<Degree_Usecase> {
                       graph_view.get_matrix_partition_view().get_indices(),
                       graph_view.get_number_of_edges(),
                       handle.get_stream());
-    CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
 
     std::vector<edge_t> h_reference_in_degrees(graph_view.get_number_of_vertices());
     std::vector<edge_t> h_reference_out_degrees(graph_view.get_number_of_vertices());
@@ -116,12 +116,12 @@ class Tests_Degree : public ::testing::TestWithParam<Degree_Usecase> {
                      graph_view.get_number_of_vertices(),
                      !store_transposed);
 
-    CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
 
     auto d_in_degrees  = graph_view.compute_in_degrees(handle);
     auto d_out_degrees = graph_view.compute_out_degrees(handle);
 
-    CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
 
     std::vector<edge_t> h_cugraph_in_degrees(graph_view.get_number_of_vertices());
     std::vector<edge_t> h_cugraph_out_degrees(graph_view.get_number_of_vertices());
@@ -132,7 +132,7 @@ class Tests_Degree : public ::testing::TestWithParam<Degree_Usecase> {
                       d_out_degrees.data(),
                       d_out_degrees.size(),
                       handle.get_stream());
-    CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
 
     ASSERT_TRUE(std::equal(
       h_reference_in_degrees.begin(), h_reference_in_degrees.end(), h_cugraph_in_degrees.begin()))

--- a/cpp/tests/structure/degree_test.cpp
+++ b/cpp/tests/structure/degree_test.cpp
@@ -99,7 +99,7 @@ class Tests_Degree : public ::testing::TestWithParam<Degree_Usecase> {
                       graph_view.get_matrix_partition_view().get_indices(),
                       graph_view.get_number_of_edges(),
                       handle.get_stream());
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    handle.sync_stream();
 
     std::vector<edge_t> h_reference_in_degrees(graph_view.get_number_of_vertices());
     std::vector<edge_t> h_reference_out_degrees(graph_view.get_number_of_vertices());
@@ -132,7 +132,7 @@ class Tests_Degree : public ::testing::TestWithParam<Degree_Usecase> {
                       d_out_degrees.data(),
                       d_out_degrees.size(),
                       handle.get_stream());
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    handle.sync_stream();
 
     ASSERT_TRUE(std::equal(
       h_reference_in_degrees.begin(), h_reference_in_degrees.end(), h_cugraph_in_degrees.begin()))

--- a/cpp/tests/structure/graph_test.cpp
+++ b/cpp/tests/structure/graph_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/structure/graph_test.cpp
+++ b/cpp/tests/structure/graph_test.cpp
@@ -111,7 +111,7 @@ class Tests_Graph : public ::testing::TestWithParam<Graph_Usecase> {
       raft::update_host(
         (*h_weights).data(), (*d_weights).data(), number_of_edges, handle.get_stream());
     }
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    handle.sync_stream();
 
     auto [h_reference_offsets, h_reference_indices, h_reference_weights] =
       graph_reference<store_transposed>(
@@ -164,7 +164,7 @@ class Tests_Graph : public ::testing::TestWithParam<Graph_Usecase> {
                         handle.get_stream());
     }
 
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    handle.sync_stream();
 
     ASSERT_TRUE(
       std::equal(h_reference_offsets.begin(), h_reference_offsets.end(), h_cugraph_offsets.begin()))

--- a/cpp/tests/structure/graph_test.cpp
+++ b/cpp/tests/structure/graph_test.cpp
@@ -111,7 +111,7 @@ class Tests_Graph : public ::testing::TestWithParam<Graph_Usecase> {
       raft::update_host(
         (*h_weights).data(), (*d_weights).data(), number_of_edges, handle.get_stream());
     }
-    CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
 
     auto [h_reference_offsets, h_reference_indices, h_reference_weights] =
       graph_reference<store_transposed>(
@@ -127,7 +127,7 @@ class Tests_Graph : public ::testing::TestWithParam<Graph_Usecase> {
       d_weights ? std::optional<weight_t const*>{(*d_weights).data()} : std::nullopt,
       number_of_edges};
 
-    CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
 
     auto graph = cugraph::graph_t<vertex_t, edge_t, weight_t, store_transposed, false>(
       handle,
@@ -138,7 +138,7 @@ class Tests_Graph : public ::testing::TestWithParam<Graph_Usecase> {
 
     auto graph_view = graph.view();
 
-    CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
 
     ASSERT_EQ(graph_view.get_number_of_vertices(), number_of_vertices);
     ASSERT_EQ(graph_view.get_number_of_edges(), number_of_edges);
@@ -164,7 +164,7 @@ class Tests_Graph : public ::testing::TestWithParam<Graph_Usecase> {
                         handle.get_stream());
     }
 
-    CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
 
     ASSERT_TRUE(
       std::equal(h_reference_offsets.begin(), h_reference_offsets.end(), h_cugraph_offsets.begin()))

--- a/cpp/tests/structure/mg_count_self_loops_and_multi_edges_test.cpp
+++ b/cpp/tests/structure/mg_count_self_loops_and_multi_edges_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/structure/mg_count_self_loops_and_multi_edges_test.cpp
+++ b/cpp/tests/structure/mg_count_self_loops_and_multi_edges_test.cpp
@@ -80,7 +80,7 @@ class Tests_MGCountSelfLoopsAndMultiEdges
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -90,7 +90,7 @@ class Tests_MGCountSelfLoopsAndMultiEdges
         handle, input_usecase, false, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -102,7 +102,7 @@ class Tests_MGCountSelfLoopsAndMultiEdges
     // 3. run MG count_self_loops & count_multi_edges
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -110,7 +110,7 @@ class Tests_MGCountSelfLoopsAndMultiEdges
     auto num_self_loops = mg_graph_view.count_self_loops(handle);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -118,7 +118,7 @@ class Tests_MGCountSelfLoopsAndMultiEdges
     }
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -126,7 +126,7 @@ class Tests_MGCountSelfLoopsAndMultiEdges
     auto num_multi_edges = mg_graph_view.count_multi_edges(handle);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/structure/mg_symmetrize_test.cpp
+++ b/cpp/tests/structure/mg_symmetrize_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/structure/mg_symmetrize_test.cpp
+++ b/cpp/tests/structure/mg_symmetrize_test.cpp
@@ -75,7 +75,7 @@ class Tests_MGSymmetrize
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -85,7 +85,7 @@ class Tests_MGSymmetrize
         handle, input_usecase, symmetrize_usecase.test_weighted, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -95,7 +95,7 @@ class Tests_MGSymmetrize
     // 3. run MG symmetrize
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -104,7 +104,7 @@ class Tests_MGSymmetrize
       handle, std::move(*d_mg_renumber_map_labels), symmetrize_usecase.reciprocal);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/structure/mg_transpose_storage_test.cpp
+++ b/cpp/tests/structure/mg_transpose_storage_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/structure/mg_transpose_storage_test.cpp
+++ b/cpp/tests/structure/mg_transpose_storage_test.cpp
@@ -74,7 +74,7 @@ class Tests_MGTransposeStorage
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -84,7 +84,7 @@ class Tests_MGTransposeStorage
         handle, input_usecase, transpose_storage_usecase.test_weighted, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -94,7 +94,7 @@ class Tests_MGTransposeStorage
     // 3. run MG transpose storage
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -105,7 +105,7 @@ class Tests_MGTransposeStorage
       mg_graph.transpose_storage(handle, std::move(*d_mg_renumber_map_labels));
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/structure/mg_transpose_test.cpp
+++ b/cpp/tests/structure/mg_transpose_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/structure/mg_transpose_test.cpp
+++ b/cpp/tests/structure/mg_transpose_test.cpp
@@ -74,7 +74,7 @@ class Tests_MGTranspose
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -84,7 +84,7 @@ class Tests_MGTranspose
         handle, input_usecase, transpose_usecase.test_weighted, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -94,7 +94,7 @@ class Tests_MGTranspose
     // 3. run MG transpose
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -102,7 +102,7 @@ class Tests_MGTranspose
     *d_mg_renumber_map_labels = mg_graph.transpose(handle, std::move(*d_mg_renumber_map_labels));
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/structure/renumbering_test.cpp
+++ b/cpp/tests/structure/renumbering_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/structure/renumbering_test.cpp
+++ b/cpp/tests/structure/renumbering_test.cpp
@@ -83,7 +83,7 @@ class Tests_Renumbering
     }
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -92,7 +92,7 @@ class Tests_Renumbering
         handle, std::nullopt, src_v.begin(), dst_v.begin(), src_v.size());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "renumbering took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/structure/symmetrize_test.cpp
+++ b/cpp/tests/structure/symmetrize_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/structure/symmetrize_test.cpp
+++ b/cpp/tests/structure/symmetrize_test.cpp
@@ -192,7 +192,7 @@ class Tests_Symmetrize
     HighResClock hr_clock{};
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -201,7 +201,7 @@ class Tests_Symmetrize
         handle, input_usecase, symmetrize_usecase.test_weighted, renumber);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -216,7 +216,7 @@ class Tests_Symmetrize
     }
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -224,7 +224,7 @@ class Tests_Symmetrize
       graph.symmetrize(handle, std::move(d_renumber_map_labels), symmetrize_usecase.reciprocal);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "Symmetrize took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/structure/transpose_storage_test.cpp
+++ b/cpp/tests/structure/transpose_storage_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/structure/transpose_storage_test.cpp
+++ b/cpp/tests/structure/transpose_storage_test.cpp
@@ -57,7 +57,7 @@ class Tests_TransposeStorage
     HighResClock hr_clock{};
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -66,7 +66,7 @@ class Tests_TransposeStorage
         handle, input_usecase, transpose_storage_usecase.test_weighted, renumber);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -81,7 +81,7 @@ class Tests_TransposeStorage
     }
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -91,7 +91,7 @@ class Tests_TransposeStorage
       graph.transpose_storage(handle, std::move(d_renumber_map_labels));
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "Transpose storage took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/structure/transpose_test.cpp
+++ b/cpp/tests/structure/transpose_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/structure/transpose_test.cpp
+++ b/cpp/tests/structure/transpose_test.cpp
@@ -57,7 +57,7 @@ class Tests_Transpose
     HighResClock hr_clock{};
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -66,7 +66,7 @@ class Tests_Transpose
         handle, input_usecase, transpose_usecase.test_weighted, renumber);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -81,14 +81,14 @@ class Tests_Transpose
     }
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
     d_renumber_map_labels = graph.transpose(handle, std::move(d_renumber_map_labels));
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "Transpose took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/structure/weight_sum_test.cpp
+++ b/cpp/tests/structure/weight_sum_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/structure/weight_sum_test.cpp
+++ b/cpp/tests/structure/weight_sum_test.cpp
@@ -106,7 +106,7 @@ class Tests_WeightSum : public ::testing::TestWithParam<WeightSum_Usecase> {
                       *(graph_view.get_matrix_partition_view().get_weights()),
                       graph_view.get_number_of_edges(),
                       handle.get_stream());
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    handle.sync_stream();
 
     std::vector<weight_t> h_reference_in_weight_sums(graph_view.get_number_of_vertices());
     std::vector<weight_t> h_reference_out_weight_sums(graph_view.get_number_of_vertices());
@@ -143,7 +143,7 @@ class Tests_WeightSum : public ::testing::TestWithParam<WeightSum_Usecase> {
                       d_out_weight_sums.data(),
                       d_out_weight_sums.size(),
                       handle.get_stream());
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    handle.sync_stream();
 
     auto threshold_ratio     = weight_t{1e-4};
     auto threshold_magnitude = std::numeric_limits<weight_t>::min();

--- a/cpp/tests/structure/weight_sum_test.cpp
+++ b/cpp/tests/structure/weight_sum_test.cpp
@@ -106,7 +106,7 @@ class Tests_WeightSum : public ::testing::TestWithParam<WeightSum_Usecase> {
                       *(graph_view.get_matrix_partition_view().get_weights()),
                       graph_view.get_number_of_edges(),
                       handle.get_stream());
-    CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
 
     std::vector<weight_t> h_reference_in_weight_sums(graph_view.get_number_of_vertices());
     std::vector<weight_t> h_reference_out_weight_sums(graph_view.get_number_of_vertices());
@@ -125,12 +125,12 @@ class Tests_WeightSum : public ::testing::TestWithParam<WeightSum_Usecase> {
                          graph_view.get_number_of_vertices(),
                          !store_transposed);
 
-    CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
 
     auto d_in_weight_sums  = graph_view.compute_in_weight_sums(handle);
     auto d_out_weight_sums = graph_view.compute_out_weight_sums(handle);
 
-    CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
 
     std::vector<weight_t> h_cugraph_in_weight_sums(graph_view.get_number_of_vertices());
     std::vector<weight_t> h_cugraph_out_weight_sums(graph_view.get_number_of_vertices());
@@ -143,7 +143,7 @@ class Tests_WeightSum : public ::testing::TestWithParam<WeightSum_Usecase> {
                       d_out_weight_sums.data(),
                       d_out_weight_sums.size(),
                       handle.get_stream());
-    CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
 
     auto threshold_ratio     = weight_t{1e-4};
     auto threshold_magnitude = std::numeric_limits<weight_t>::min();

--- a/cpp/tests/traversal/bfs_test.cpp
+++ b/cpp/tests/traversal/bfs_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/traversal/bfs_test.cpp
+++ b/cpp/tests/traversal/bfs_test.cpp
@@ -104,7 +104,7 @@ class Tests_BFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, input_
     HighResClock hr_clock{};
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -113,7 +113,7 @@ class Tests_BFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, input_
         handle, input_usecase, true, renumber);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -130,7 +130,7 @@ class Tests_BFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, input_
                                                  handle.get_stream());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -146,7 +146,7 @@ class Tests_BFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, input_
                  std::numeric_limits<vertex_t>::max());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "BFS took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/traversal/extract_bfs_paths_test.cu
+++ b/cpp/tests/traversal/extract_bfs_paths_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/traversal/extract_bfs_paths_test.cu
+++ b/cpp/tests/traversal/extract_bfs_paths_test.cu
@@ -68,7 +68,7 @@ class Tests_ExtractBfsPaths
     HighResClock hr_clock{};
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -77,7 +77,7 @@ class Tests_ExtractBfsPaths
         handle, input_usecase, true, renumber);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -128,11 +128,11 @@ class Tests_ExtractBfsPaths
     rmm::device_uvector<vertex_t> d_paths(0, handle.get_stream());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
-    CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
 
     int32_t max_path_length{};
 
@@ -144,7 +144,7 @@ class Tests_ExtractBfsPaths
                                                            d_destinations.size());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "extract_bfs_paths took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/traversal/legacy/bfs_test.cu
+++ b/cpp/tests/traversal/legacy/bfs_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/traversal/legacy/bfs_test.cu
+++ b/cpp/tests/traversal/legacy/bfs_test.cu
@@ -111,9 +111,9 @@ class Tests_BFS : public ::testing::TestWithParam<BFS_Usecase> {
     std::vector<VT> indices(number_of_edges);
     std::vector<ET> offsets(number_of_vertices + 1);
 
-    CUDA_TRY(
+    RAFT_CUDA_TRY(
       cudaMemcpy(indices.data(), G.indices, sizeof(VT) * indices.size(), cudaMemcpyDeviceToHost));
-    CUDA_TRY(
+    RAFT_CUDA_TRY(
       cudaMemcpy(offsets.data(), G.offsets, sizeof(ET) * offsets.size(), cudaMemcpyDeviceToHost));
 
     std::queue<VT> Q;
@@ -150,17 +150,17 @@ class Tests_BFS : public ::testing::TestWithParam<BFS_Usecase> {
                              (return_sp_counter) ? d_cugraph_sigmas.data().get() : nullptr,
                              source,
                              G.prop.directed);
-    CUDA_TRY(cudaMemcpy(cugraph_dist.data(),
+    RAFT_CUDA_TRY(cudaMemcpy(cugraph_dist.data(),
                         d_cugraph_dist.data().get(),
                         sizeof(VT) * d_cugraph_dist.size(),
                         cudaMemcpyDeviceToHost));
-    CUDA_TRY(cudaMemcpy(cugraph_pred.data(),
+    RAFT_CUDA_TRY(cudaMemcpy(cugraph_pred.data(),
                         d_cugraph_pred.data().get(),
                         sizeof(VT) * d_cugraph_pred.size(),
                         cudaMemcpyDeviceToHost));
 
     if (return_sp_counter) {
-      CUDA_TRY(cudaMemcpy(cugraph_sigmas.data(),
+      RAFT_CUDA_TRY(cudaMemcpy(cugraph_sigmas.data(),
                           d_cugraph_sigmas.data().get(),
                           sizeof(double) * d_cugraph_sigmas.size(),
                           cudaMemcpyDeviceToHost));

--- a/cpp/tests/traversal/legacy/bfs_test.cu
+++ b/cpp/tests/traversal/legacy/bfs_test.cu
@@ -151,19 +151,19 @@ class Tests_BFS : public ::testing::TestWithParam<BFS_Usecase> {
                              source,
                              G.prop.directed);
     RAFT_CUDA_TRY(cudaMemcpy(cugraph_dist.data(),
-                        d_cugraph_dist.data().get(),
-                        sizeof(VT) * d_cugraph_dist.size(),
-                        cudaMemcpyDeviceToHost));
+                             d_cugraph_dist.data().get(),
+                             sizeof(VT) * d_cugraph_dist.size(),
+                             cudaMemcpyDeviceToHost));
     RAFT_CUDA_TRY(cudaMemcpy(cugraph_pred.data(),
-                        d_cugraph_pred.data().get(),
-                        sizeof(VT) * d_cugraph_pred.size(),
-                        cudaMemcpyDeviceToHost));
+                             d_cugraph_pred.data().get(),
+                             sizeof(VT) * d_cugraph_pred.size(),
+                             cudaMemcpyDeviceToHost));
 
     if (return_sp_counter) {
       RAFT_CUDA_TRY(cudaMemcpy(cugraph_sigmas.data(),
-                          d_cugraph_sigmas.data().get(),
-                          sizeof(double) * d_cugraph_sigmas.size(),
-                          cudaMemcpyDeviceToHost));
+                               d_cugraph_sigmas.data().get(),
+                               sizeof(double) * d_cugraph_sigmas.size(),
+                               cudaMemcpyDeviceToHost));
     }
 
     for (VT i = 0; i < number_of_vertices; ++i) {

--- a/cpp/tests/traversal/mg_bfs_test.cpp
+++ b/cpp/tests/traversal/mg_bfs_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/traversal/mg_bfs_test.cpp
+++ b/cpp/tests/traversal/mg_bfs_test.cpp
@@ -78,7 +78,7 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -88,7 +88,7 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
         handle, input_usecase, false, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -109,7 +109,7 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
                                                     handle.get_stream());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -129,7 +129,7 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
                  std::numeric_limits<vertex_t>::max());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/traversal/mg_extract_bfs_paths_test.cu
+++ b/cpp/tests/traversal/mg_extract_bfs_paths_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/traversal/mg_extract_bfs_paths_test.cu
+++ b/cpp/tests/traversal/mg_extract_bfs_paths_test.cu
@@ -84,7 +84,7 @@ class Tests_ExtractBfsPaths
       subcomm_factory(handle, row_comm_size);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -93,7 +93,7 @@ class Tests_ExtractBfsPaths
         handle, input_usecase, true, renumber);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -151,11 +151,11 @@ class Tests_ExtractBfsPaths
     rmm::device_uvector<vertex_t> d_mg_paths(0, handle.get_stream());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
-    CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
 
     vertex_t mg_max_path_length{0};
 
@@ -167,7 +167,7 @@ class Tests_ExtractBfsPaths
                                                                  d_mg_destinations.size());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "extract_bfs_paths took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/traversal/mg_sssp_test.cpp
+++ b/cpp/tests/traversal/mg_sssp_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/traversal/mg_sssp_test.cpp
+++ b/cpp/tests/traversal/mg_sssp_test.cpp
@@ -75,7 +75,7 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
     // 2. create MG graph
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -85,7 +85,7 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
         handle, input_usecase, true, true);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
@@ -106,7 +106,7 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
                                                     handle.get_stream());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       hr_clock.start();
     }
@@ -119,7 +119,7 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
                   std::numeric_limits<weight_t>::max());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       handle.get_comms().barrier();
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);

--- a/cpp/tests/traversal/sssp_test.cpp
+++ b/cpp/tests/traversal/sssp_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/traversal/sssp_test.cpp
+++ b/cpp/tests/traversal/sssp_test.cpp
@@ -106,7 +106,7 @@ class Tests_SSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, inpu
     HighResClock hr_clock{};
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -115,7 +115,7 @@ class Tests_SSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, inpu
         handle, input_usecase, true, renumber);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "construct_graph took " << elapsed_time * 1e-6 << " s.\n";
@@ -132,7 +132,7 @@ class Tests_SSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, inpu
                                                  handle.get_stream());
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       hr_clock.start();
     }
 
@@ -145,7 +145,7 @@ class Tests_SSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, inpu
                   false);
 
     if (cugraph::test::g_perf) {
-      CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
       double elapsed_time{0.0};
       hr_clock.stop(&elapsed_time);
       std::cout << "SSSP took " << elapsed_time * 1e-6 << " s.\n";

--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -194,8 +194,8 @@ inline auto parse_test_options(int argc, char** argv)
     MPI_TRY(MPI_Comm_rank(MPI_COMM_WORLD, &comm_rank));                         \
     MPI_TRY(MPI_Comm_size(MPI_COMM_WORLD, &comm_size));                         \
     int num_gpus_per_node{};                                                    \
-    CUDA_TRY(cudaGetDeviceCount(&num_gpus_per_node));                           \
-    CUDA_TRY(cudaSetDevice(comm_rank % num_gpus_per_node));                     \
+    RAFT_CUDA_TRY(cudaGetDeviceCount(&num_gpus_per_node));                      \
+    RAFT_CUDA_TRY(cudaSetDevice(comm_rank % num_gpus_per_node));                \
     ::testing::InitGoogleTest(&argc, argv);                                     \
     auto const cmd_opts = parse_test_options(argc, argv);                       \
     auto const rmm_mode = cmd_opts["rmm_mode"].as<std::string>();               \

--- a/cpp/tests/visitors/bfs_test.cpp
+++ b/cpp/tests/visitors/bfs_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/visitors/bfs_test.cpp
+++ b/cpp/tests/visitors/bfs_test.cpp
@@ -165,7 +165,7 @@ class Tests_BFS : public ::testing::TestWithParam<BFS_Usecase> {
                       graph_view.get_matrix_partition_view().get_indices(),
                       graph_view.get_number_of_edges(),
                       handle.get_stream());
-    CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
 
     ASSERT_TRUE(configuration.source >= 0 &&
                 configuration.source <= graph_view.get_number_of_vertices())
@@ -188,7 +188,7 @@ class Tests_BFS : public ::testing::TestWithParam<BFS_Usecase> {
     rmm::device_uvector<vertex_t> d_predecessors(graph_view.get_number_of_vertices(),
                                                  handle.get_stream());
 
-    CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
     {
       // visitors version:
       //
@@ -242,7 +242,7 @@ class Tests_BFS : public ::testing::TestWithParam<BFS_Usecase> {
       return_t ret = cugraph::api::bfs(graph_envelope, ep);
     }
 
-    CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+    RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
 
     std::vector<vertex_t> h_cugraph_distances(graph_view.get_number_of_vertices());
     std::vector<vertex_t> h_cugraph_predecessors(graph_view.get_number_of_vertices());
@@ -253,7 +253,7 @@ class Tests_BFS : public ::testing::TestWithParam<BFS_Usecase> {
                       d_predecessors.data(),
                       d_predecessors.size(),
                       handle.get_stream());
-    CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
 
     ASSERT_TRUE(std::equal(
       h_reference_distances.begin(), h_reference_distances.end(), h_cugraph_distances.begin()))

--- a/cpp/tests/visitors/bfs_test.cpp
+++ b/cpp/tests/visitors/bfs_test.cpp
@@ -165,7 +165,7 @@ class Tests_BFS : public ::testing::TestWithParam<BFS_Usecase> {
                       graph_view.get_matrix_partition_view().get_indices(),
                       graph_view.get_number_of_edges(),
                       handle.get_stream());
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    handle.sync_stream();
 
     ASSERT_TRUE(configuration.source >= 0 &&
                 configuration.source <= graph_view.get_number_of_vertices())
@@ -253,7 +253,7 @@ class Tests_BFS : public ::testing::TestWithParam<BFS_Usecase> {
                       d_predecessors.data(),
                       d_predecessors.size(),
                       handle.get_stream());
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
+    handle.sync_stream();
 
     ASSERT_TRUE(std::equal(
       h_reference_distances.begin(), h_reference_distances.end(), h_cugraph_distances.begin()))

--- a/python/cugraph/cugraph/tests/test_renumber.py
+++ b/python/cugraph/cugraph/tests/test_renumber.py
@@ -45,20 +45,27 @@ def test_renumber_ips():
     gdf["source_as_int"] = gdf["source_list"].str.ip2int()
     gdf["dest_as_int"] = gdf["dest_list"].str.ip2int()
 
-    renumbered_gdf, renumber_map = NumberMap.renumber(gdf,
-                                                      "source_as_int",
-                                                      "dest_as_int",
-                                                      preserve_order=True)
+    renumbered_gdf, renumber_map = NumberMap.renumber(
+        gdf, "source_as_int", "dest_as_int", preserve_order=True
+    )
 
     input_check = renumbered_gdf.merge(gdf, on=["source_list", "dest_list"])
 
-    output_check = renumber_map.from_internal_vertex_id(renumbered_gdf, "src", external_column_names=["check_src"])
-    output_check = renumber_map.from_internal_vertex_id(output_check, "dst", external_column_names=["check_dst"])
+    output_check = renumber_map.from_internal_vertex_id(
+        renumbered_gdf, "src", external_column_names=["check_src"]
+    )
+    output_check = renumber_map.from_internal_vertex_id(
+        output_check, "dst", external_column_names=["check_dst"]
+    )
 
     merged = output_check.merge(input_check, on=["source_list", "dest_list"])
 
-    assert_series_equal(merged["check_src"], merged["source_as_int"], check_names=False)
-    assert_series_equal(merged["check_dst"], merged["dest_as_int"], check_names=False)
+    assert_series_equal(
+        merged["check_src"], merged["source_as_int"], check_names=False
+    )
+    assert_series_equal(
+        merged["check_dst"], merged["dest_as_int"], check_names=False
+    )
 
 
 def test_renumber_ips_cols():
@@ -83,20 +90,27 @@ def test_renumber_ips_cols():
     gdf["source_as_int"] = gdf["source_list"].str.ip2int()
     gdf["dest_as_int"] = gdf["dest_list"].str.ip2int()
 
-    renumbered_gdf, renumber_map = NumberMap.renumber(gdf,
-                                                      ["source_as_int"],
-                                                      ["dest_as_int"],
-                                                      preserve_order=True)
+    renumbered_gdf, renumber_map = NumberMap.renumber(
+        gdf, ["source_as_int"], ["dest_as_int"], preserve_order=True
+    )
 
     input_check = renumbered_gdf.merge(gdf, on=["source_list", "dest_list"])
 
-    output_check = renumber_map.from_internal_vertex_id(renumbered_gdf, "src", external_column_names=["check_src"])
-    output_check = renumber_map.from_internal_vertex_id(output_check, "dst", external_column_names=["check_dst"])
+    output_check = renumber_map.from_internal_vertex_id(
+        renumbered_gdf, "src", external_column_names=["check_src"]
+    )
+    output_check = renumber_map.from_internal_vertex_id(
+        output_check, "dst", external_column_names=["check_dst"]
+    )
 
     merged = output_check.merge(input_check, on=["source_list", "dest_list"])
 
-    assert_series_equal(merged["check_src"], merged["source_as_int"], check_names=False)
-    assert_series_equal(merged["check_dst"], merged["dest_as_int"], check_names=False)
+    assert_series_equal(
+        merged["check_src"], merged["source_as_int"], check_names=False
+    )
+    assert_series_equal(
+        merged["check_dst"], merged["dest_as_int"], check_names=False
+    )
 
 
 def test_renumber_negative():
@@ -106,23 +120,34 @@ def test_renumber_negative():
     df = pd.DataFrame({"source_list": source_list, "dest_list": dest_list})
 
     gdf = cudf.DataFrame.from_pandas(df[["source_list", "dest_list"]])
-    gdf['original_src'] = gdf['source_list']
-    gdf['original_dst'] = gdf['dest_list']
+    gdf["original_src"] = gdf["source_list"]
+    gdf["original_dst"] = gdf["dest_list"]
 
-    renumbered_gdf, renumber_map = NumberMap.renumber(gdf,
-                                                      "source_list",
-                                                      "dest_list",
-                                                      preserve_order=True)
+    renumbered_gdf, renumber_map = NumberMap.renumber(
+        gdf, "source_list", "dest_list", preserve_order=True
+    )
 
-    input_check = renumbered_gdf.merge(gdf, on=["original_src", "original_dst"])
+    input_check = renumbered_gdf.merge(
+        gdf, on=["original_src", "original_dst"]
+    )
 
-    output_check = renumber_map.from_internal_vertex_id(renumbered_gdf, "src", external_column_names=["check_src"])
-    output_check = renumber_map.from_internal_vertex_id(output_check, "dst", external_column_names=["check_dst"])
+    output_check = renumber_map.from_internal_vertex_id(
+        renumbered_gdf, "src", external_column_names=["check_src"]
+    )
+    output_check = renumber_map.from_internal_vertex_id(
+        output_check, "dst", external_column_names=["check_dst"]
+    )
 
-    merged = output_check.merge(input_check, on=["original_src", "original_dst"])
+    merged = output_check.merge(
+        input_check, on=["original_src", "original_dst"]
+    )
 
-    assert_series_equal(merged["check_src"], merged["original_src"], check_names=False)
-    assert_series_equal(merged["check_dst"], merged["original_dst"], check_names=False)
+    assert_series_equal(
+        merged["check_src"], merged["original_src"], check_names=False
+    )
+    assert_series_equal(
+        merged["check_dst"], merged["original_dst"], check_names=False
+    )
 
 
 def test_renumber_negative_col():
@@ -132,57 +157,34 @@ def test_renumber_negative_col():
     df = pd.DataFrame({"source_list": source_list, "dest_list": dest_list})
 
     gdf = cudf.DataFrame.from_pandas(df[["source_list", "dest_list"]])
-    gdf['original_src'] = gdf['source_list']
-    gdf['original_dst'] = gdf['dest_list']
+    gdf["original_src"] = gdf["source_list"]
+    gdf["original_dst"] = gdf["dest_list"]
 
-    renumbered_gdf, renumber_map = NumberMap.renumber(gdf,
-                                                      ["source_list"],
-                                                      ["dest_list"],
-                                                      preserve_order=True)
+    renumbered_gdf, renumber_map = NumberMap.renumber(
+        gdf, ["source_list"], ["dest_list"], preserve_order=True
+    )
 
-    input_check = renumbered_gdf.merge(gdf, on=["original_src", "original_dst"])
+    input_check = renumbered_gdf.merge(
+        gdf, on=["original_src", "original_dst"]
+    )
 
-    output_check = renumber_map.from_internal_vertex_id(renumbered_gdf, "src", external_column_names=["check_src"])
-    output_check = renumber_map.from_internal_vertex_id(output_check, "dst", external_column_names=["check_dst"])
+    output_check = renumber_map.from_internal_vertex_id(
+        renumbered_gdf, "src", external_column_names=["check_src"]
+    )
+    output_check = renumber_map.from_internal_vertex_id(
+        output_check, "dst", external_column_names=["check_dst"]
+    )
 
-    merged = output_check.merge(input_check, on=["original_src", "original_dst"])
+    merged = output_check.merge(
+        input_check, on=["original_src", "original_dst"]
+    )
 
-    assert_series_equal(merged["check_src"], merged["original_src"], check_names=False)
-    assert_series_equal(merged["check_dst"], merged["original_dst"], check_names=False)
-
-
-@pytest.mark.skip(reason="temporarily dropped string support")
-def test_renumber_ips_str_cols():
-
-    source_list = [
-        "192.168.1.1",
-        "172.217.5.238",
-        "216.228.121.209",
-        "192.16.31.23",
-    ]
-    dest_list = [
-        "172.217.5.238",
-        "216.228.121.209",
-        "192.16.31.23",
-        "192.168.1.1",
-    ]
-
-    pdf = pd.DataFrame({"source_list": source_list, "dest_list": dest_list})
-
-    gdf = cudf.from_pandas(pdf)
-
-    renumbered_gdf, renumber_map = NumberMap.renumber(gdf,
-                                                      ["source_as_int"],
-                                                      ["dest_as_int"],
-                                                      preserve_order=True)
-
-    check_src = renumber_map.add_internal_vertex_id(renumbered_gdf['src'],
-                                                    preserve_order=True)["0"]
-    check_dst = renumber_map.add_internal_vertex_id(renumbered_gdf['dst'],
-                                                    preserve_order=True)["0"]
-
-    assert_series_equal(check_src, gdf["source_list"], check_names=False)
-    assert_series_equal(check_dst, gdf["dest_list"], check_names=False)
+    assert_series_equal(
+        merged["check_src"], merged["original_src"], check_names=False
+    )
+    assert_series_equal(
+        merged["check_dst"], merged["original_dst"], check_names=False
+    )
 
 
 @pytest.mark.parametrize("graph_file", utils.DATASETS)
@@ -196,23 +198,22 @@ def test_renumber_files(graph_file):
     translate = 1000
 
     df = cudf.DataFrame()
-    df["src"] = cudf.Series([x + translate for x in sources.
-                            values_host])
-    df["dst"] = cudf.Series([x + translate for x in destinations.
-                            values_host])
+    df["src"] = cudf.Series([x + translate for x in sources.values_host])
+    df["dst"] = cudf.Series([x + translate for x in destinations.values_host])
 
-    exp_src = cudf.Series([x + translate for x in sources.
-                          values_host])
-    exp_dst = cudf.Series([x + translate for x in destinations.
-                          values_host])
+    exp_src = cudf.Series([x + translate for x in sources.values_host])
+    exp_dst = cudf.Series([x + translate for x in destinations.values_host])
 
-    renumbered_df, renumber_map = NumberMap.renumber(df, "src", "dst",
-                                                     preserve_order=True)
+    renumbered_df, renumber_map = NumberMap.renumber(
+        df, "src", "dst", preserve_order=True
+    )
 
-    unrenumbered_df = renumber_map.unrenumber(renumbered_df, "src",
-                                              preserve_order=True)
-    unrenumbered_df = renumber_map.unrenumber(unrenumbered_df, "dst",
-                                              preserve_order=True)
+    unrenumbered_df = renumber_map.unrenumber(
+        renumbered_df, "src", preserve_order=True
+    )
+    unrenumbered_df = renumber_map.unrenumber(
+        unrenumbered_df, "dst", preserve_order=True
+    )
 
     assert_series_equal(exp_src, unrenumbered_df["src"], check_names=False)
     assert_series_equal(exp_dst, unrenumbered_df["dst"], check_names=False)
@@ -229,22 +230,22 @@ def test_renumber_files_col(graph_file):
     translate = 1000
 
     gdf = cudf.DataFrame()
-    gdf['src'] = cudf.Series([x + translate for x in sources.values_host])
-    gdf['dst'] = cudf.Series([x + translate for x in destinations.
-                             values_host])
+    gdf["src"] = cudf.Series([x + translate for x in sources.values_host])
+    gdf["dst"] = cudf.Series([x + translate for x in destinations.values_host])
 
-    exp_src = cudf.Series([x + translate for x in sources.
-                          values_host])
-    exp_dst = cudf.Series([x + translate for x in destinations.
-                          values_host])
+    exp_src = cudf.Series([x + translate for x in sources.values_host])
+    exp_dst = cudf.Series([x + translate for x in destinations.values_host])
 
-    renumbered_df, renumber_map = NumberMap.renumber(gdf, ["src"], ["dst"],
-                                                     preserve_order=True)
+    renumbered_df, renumber_map = NumberMap.renumber(
+        gdf, ["src"], ["dst"], preserve_order=True
+    )
 
-    unrenumbered_df = renumber_map.unrenumber(renumbered_df, "src",
-                                              preserve_order=True)
-    unrenumbered_df = renumber_map.unrenumber(unrenumbered_df, "dst",
-                                              preserve_order=True)
+    unrenumbered_df = renumber_map.unrenumber(
+        renumbered_df, "src", preserve_order=True
+    )
+    unrenumbered_df = renumber_map.unrenumber(
+        unrenumbered_df, "dst", preserve_order=True
+    )
 
     assert_series_equal(exp_src, unrenumbered_df["src"], check_names=False)
     assert_series_equal(exp_dst, unrenumbered_df["dst"], check_names=False)
@@ -266,21 +267,26 @@ def test_renumber_files_multi_col(graph_file):
     gdf["src"] = sources + translate
     gdf["dst"] = destinations + translate
 
-    renumbered_df, renumber_map = NumberMap.renumber(gdf,
-                                                     ["src", "src_old"],
-                                                     ["dst", "dst_old"],
-                                                     preserve_order=True)
+    renumbered_df, renumber_map = NumberMap.renumber(
+        gdf, ["src", "src_old"], ["dst", "dst_old"], preserve_order=True
+    )
 
-    unrenumbered_df = renumber_map.unrenumber(renumbered_df, "src",
-                                              preserve_order=True)
-    unrenumbered_df = renumber_map.unrenumber(unrenumbered_df, "dst",
-                                              preserve_order=True)
+    unrenumbered_df = renumber_map.unrenumber(
+        renumbered_df, "src", preserve_order=True
+    )
+    unrenumbered_df = renumber_map.unrenumber(
+        unrenumbered_df, "dst", preserve_order=True
+    )
 
-    assert_series_equal(gdf["src"], unrenumbered_df["0_src"],
-                        check_names=False)
-    assert_series_equal(gdf["src_old"], unrenumbered_df["1_src"],
-                        check_names=False)
-    assert_series_equal(gdf["dst"], unrenumbered_df["0_dst"],
-                        check_names=False)
-    assert_series_equal(gdf["dst_old"], unrenumbered_df["1_dst"],
-                        check_names=False)
+    assert_series_equal(
+        gdf["src"], unrenumbered_df["0_src"], check_names=False
+    )
+    assert_series_equal(
+        gdf["src_old"], unrenumbered_df["1_src"], check_names=False
+    )
+    assert_series_equal(
+        gdf["dst"], unrenumbered_df["0_dst"], check_names=False
+    )
+    assert_series_equal(
+        gdf["dst_old"], unrenumbered_df["1_dst"], check_names=False
+    )

--- a/python/cugraph/cugraph/tests/test_renumber.py
+++ b/python/cugraph/cugraph/tests/test_renumber.py
@@ -50,10 +50,10 @@ def test_renumber_ips():
                                                       "dest_as_int",
                                                       preserve_order=True)
 
-    check_src = renumber_map.from_internal_vertex_id(renumbered_gdf['src']
-                                                     )["0"]
-    check_dst = renumber_map.from_internal_vertex_id(renumbered_gdf['dst']
-                                                     )["0"]
+    check_src = renumber_map.add_internal_vertex_id(renumbered_gdf['src'],
+                                                    preserve_order=True)["0"]
+    check_dst = renumber_map.add_internal_vertex_id(renumbered_gdf['dst'],
+                                                    preserve_order=True)["0"]
 
     assert_series_equal(check_src, gdf["source_as_int"], check_names=False)
     assert_series_equal(check_dst, gdf["dest_as_int"], check_names=False)
@@ -86,10 +86,10 @@ def test_renumber_ips_cols():
                                                       ["dest_as_int"],
                                                       preserve_order=True)
 
-    check_src = renumber_map.from_internal_vertex_id(renumbered_gdf['src']
-                                                     )["0"]
-    check_dst = renumber_map.from_internal_vertex_id(renumbered_gdf['dst']
-                                                     )["0"]
+    check_src = renumber_map.add_internal_vertex_id(renumbered_gdf['src'],
+                                                    preserve_order=True)["0"]
+    check_dst = renumber_map.add_internal_vertex_id(renumbered_gdf['dst'],
+                                                    preserve_order=True)["0"]
 
     assert_series_equal(check_src, gdf["source_as_int"], check_names=False)
     assert_series_equal(check_dst, gdf["dest_as_int"], check_names=False)
@@ -120,10 +120,10 @@ def test_renumber_ips_str_cols():
                                                       ["dest_as_int"],
                                                       preserve_order=True)
 
-    check_src = renumber_map.from_internal_vertex_id(renumbered_gdf['src']
-                                                     )["0"]
-    check_dst = renumber_map.from_internal_vertex_id(renumbered_gdf['dst']
-                                                     )["0"]
+    check_src = renumber_map.add_internal_vertex_id(renumbered_gdf['src'],
+                                                    preserve_order=True)["0"]
+    check_dst = renumber_map.add_internal_vertex_id(renumbered_gdf['dst'],
+                                                    preserve_order=True)["0"]
 
     assert_series_equal(check_src, gdf["source_list"], check_names=False)
     assert_series_equal(check_dst, gdf["dest_list"], check_names=False)
@@ -142,10 +142,10 @@ def test_renumber_negative():
                                                       "dest_list",
                                                       preserve_order=True)
 
-    check_src = renumber_map.from_internal_vertex_id(renumbered_gdf['src']
-                                                     )["0"]
-    check_dst = renumber_map.from_internal_vertex_id(renumbered_gdf['dst']
-                                                     )["0"]
+    check_src = renumber_map.add_internal_vertex_id(renumbered_gdf['src'],
+                                                    preserve_order=True)["0"]
+    check_dst = renumber_map.add_internal_vertex_id(renumbered_gdf['dst'],
+                                                    preserve_order=True)["0"]
 
     assert_series_equal(check_src, gdf["source_list"], check_names=False)
     assert_series_equal(check_dst, gdf["dest_list"], check_names=False)
@@ -164,10 +164,10 @@ def test_renumber_negative_col():
                                                       "dest_list",
                                                       preserve_order=True)
 
-    check_src = renumber_map.from_internal_vertex_id(renumbered_gdf['src']
-                                                     )["0"]
-    check_dst = renumber_map.from_internal_vertex_id(renumbered_gdf['dst']
-                                                     )["0"]
+    check_src = renumber_map.add_internal_vertex_id(renumbered_gdf['src'],
+                                                    preserve_order=True)["0"]
+    check_dst = renumber_map.add_internal_vertex_id(renumbered_gdf['dst'],
+                                                    preserve_order=True)["0"]
 
     assert_series_equal(check_src, gdf["source_list"], check_names=False)
     assert_series_equal(check_dst, gdf["dest_list"], check_names=False)
@@ -201,10 +201,12 @@ def test_renumber_series(graph_file):
     renumbered_dst = numbering_series_2.add_internal_vertex_id(
         df["dst"], "dst_id")
 
-    check_src = numbering_series_1.from_internal_vertex_id(renumbered_src,
-                                                           "src_id")
-    check_dst = numbering_series_2.from_internal_vertex_id(renumbered_dst,
-                                                           "dst_id")
+    check_src = numbering_series_1.add_internal_vertex_id(renumbered_src,
+                                                          "src_id",
+                                                          preserve_order=True)
+    check_dst = numbering_series_2.add_internal_vertex_id(renumbered_dst,
+                                                          "dst_id",
+                                                          preserve_order=True)
 
     assert_series_equal(check_src["0_y"], check_src["0_x"], check_names=False)
     assert_series_equal(check_dst["0_y"], check_dst["0_x"], check_names=False)

--- a/python/cugraph/cugraph/tests/test_renumber.py
+++ b/python/cugraph/cugraph/tests/test_renumber.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, NVIDIA CORPORATION.
+# Copyright (c) 2019-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
Replaces #1975

Update all references to CHECK_CUDA, CUDA_CHECK and CUDA_TRY to use the new raft names

Also updated calls to `cudaStreamSynchronize` to use the `handle.sync_stream()` method.