### PR TITLE
Fix call to `getDeviceAttribute` following API change in RMM.

### DIFF
--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -10,6 +10,7 @@ dependencies:
 - libcudf=22.02.*
 - rmm=22.02.*
 - librmm=22.02.*
+- cuda-python>=11.5,<12.0
 - dask>=2021.09.1
 - distributed>=2021.09.1
 - dask-cuda=22.02.*

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -10,6 +10,7 @@ dependencies:
 - libcudf=22.02.*
 - rmm=22.02.*
 - librmm=22.02.*
+- cuda-python>=11.5,<12.0
 - dask>=2021.09.1
 - distributed>=2021.09.1
 - dask-cuda=22.02.*

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -10,6 +10,7 @@ dependencies:
 - libcudf=22.02.*
 - rmm=22.02.*
 - librmm=22.02.*
+- cuda-python>=11.5,<12.0
 - dask>=2021.09.1
 - distributed>=2021.09.1
 - dask-cuda=22.02.*

--- a/conda/environments/cugraph_dev_cuda11.5.yml
+++ b/conda/environments/cugraph_dev_cuda11.5.yml
@@ -10,6 +10,7 @@ dependencies:
 - libcudf=22.02.*
 - rmm=22.02.*
 - librmm=22.02.*
+- cuda-python>=11.5,<12.0
 - dask>=2021.09.1
 - distributed>=2021.09.1
 - dask-cuda=22.02.*

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
 # Usage:
 #   conda build -c nvidia -c rapidsai -c conda-forge  .

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -44,6 +44,7 @@ requirements:
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
+    - cuda-python >=11.5,<12.0
 
 tests:                                 # [linux64]
   requirements:                        # [linux64]

--- a/python/cugraph/cugraph/utilities/utils.py
+++ b/python/cugraph/cugraph/utilities/utils.py
@@ -217,12 +217,8 @@ def is_device_version_less_than(min_version=(7, 0)):
     """
     Returns True if the version of CUDA being used is less than min_version
     """
-    major_version = getDeviceAttribute(
-        cudaDeviceAttr.cudaDevAttrComputeCapabilityMajor, 0
-    )
-    minor_version = getDeviceAttribute(
-        cudaDeviceAttr.cudaDevAttrComputeCapabilityMinor, 0
-    )
+    major_version = getDeviceAttribute("ComputeCapabilityMajor", 0)
+    minor_version = getDeviceAttribute("ComputeCapabilityMinor", 0)
     if major_version > min_version[0]:
         return False
     if major_version < min_version[0]:

--- a/python/cugraph/cugraph/utilities/utils.py
+++ b/python/cugraph/cugraph/utilities/utils.py
@@ -16,10 +16,7 @@ import importlib
 from numba import cuda
 
 import cudf
-from rmm._cuda.gpu import (
-    getDeviceAttribute,
-    cudaDeviceAttr,
-)
+from rmm._cuda.gpu import getDeviceAttribute
 
 
 # optional dependencies

--- a/python/cugraph/cugraph/utilities/utils.py
+++ b/python/cugraph/cugraph/utilities/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/utilities/utils.py
+++ b/python/cugraph/cugraph/utilities/utils.py
@@ -16,6 +16,8 @@ import importlib
 from numba import cuda
 
 import cudf
+
+from cuda.cudart import cudaDeviceAttr
 from rmm._cuda.gpu import getDeviceAttribute
 
 
@@ -214,8 +216,12 @@ def is_device_version_less_than(min_version=(7, 0)):
     """
     Returns True if the version of CUDA being used is less than min_version
     """
-    major_version = getDeviceAttribute("ComputeCapabilityMajor", 0)
-    minor_version = getDeviceAttribute("ComputeCapabilityMinor", 0)
+    major_version = getDeviceAttribute(
+        cudaDeviceAttr.cudaDevAttrComputeCapabilityMajor, 0
+    )
+    minor_version = getDeviceAttribute(
+        cudaDeviceAttr.cudaDevAttrComputeCapabilityMinor, 0
+    )
     if major_version > min_version[0]:
         return False
     if major_version < min_version[0]:


### PR DESCRIPTION
Please do not merge until https://github.com/rapidsai/rmm/pull/930 is merged.

For the reasons described in that PR, this API has changed to accept a `cuda.cudart.cudaDeviceAttr` object, `cuda` being the official CUDA Python bindings package.