### PR TITLE
Add SSSP API, test and implementation

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -359,6 +359,7 @@ add_library(cugraph_c SHARED
         src/c_api/graph_mg.cpp
         src/c_api/pagerank.cpp
         src/c_api/bfs.cpp
+        src/c_api/sssp.cpp
         src/c_api/extract_paths.cpp
         )
 add_library(cugraph::cugraph_c ALIAS cugraph_c)

--- a/cpp/include/cugraph_c/algorithms.h
+++ b/cpp/include/cugraph_c/algorithms.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,7 +201,10 @@ void cugraph_paths_result_free(cugraph_paths_result_t* result);
  * input graphs.
  * @param depth_limit Sets the maximum number of breadth-first search iterations. Any vertices
  * farther than @p depth_limit hops from @p source_vertex will be marked as unreachable.
- * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
+ * @param [in] do_expensive_check A flag to run expensive checks for input arguments (if set to
+ * `true`).
+ * @param [in] compute_predecessors A flag to indicate whether to compute the predecessors in the
+ * result
  * @param [out] result       Opaque pointer to paths results
  * @param [out] error        Pointer to an error object storing details of any error.  Will
  *                           be populated if error code is not CUGRAPH_SUCCESS
@@ -220,6 +223,36 @@ cugraph_error_code_t cugraph_bfs(
   cugraph_error_t** error);
 
 /**
+ * @brief     Perform single-source shortest-path to compute the minimum distances
+ *            (and predecessors) from the source vertex.
+ *
+ * This function computes the distances (minimum edge weight sums) from the source
+ * vertex. If @p predecessors is not NULL, this function calculates the predecessor of each
+ * vertex (parent vertex in the breadth-first search tree) as well.
+ *
+ * @param [in]  handle       Handle for accessing resources
+ * @param [in]  graph        Pointer to graph
+ * @param [in]  source       Source vertex id 
+ * @param [in]  cutoff       Maximum edge weight sum to consider
+ * @param [in]  do_expensive_check A flag to run expensive checks for input arguments (if set to
+ * `true`).
+ * @param [in]  compute_predecessors A flag to indicate whether to compute the predecessors in the
+ * result
+ * @param [out] result       Opaque pointer to paths results
+ * @param [out] error        Pointer to an error object storing details of any error.  Will
+ *                           be populated if error code is not CUGRAPH_SUCCESS
+ * @return error code
+ */
+cugraph_error_code_t cugraph_sssp(const cugraph_resource_handle_t* handle,
+                                  cugraph_graph_t* graph,
+                                  size_t source,
+                                  double cutoff,
+                                  bool_t do_expensive_check,
+                                  bool_t compute_predecessors,
+                                  cugraph_paths_result_t** result,
+                                  cugraph_error_t** error);
+
+/**
  * @brief     Opaque extract_paths result type
  */
 typedef struct {
@@ -227,12 +260,12 @@ typedef struct {
 } cugraph_extract_paths_result_t;
 
 /**
- * @brief     Extract BFS paths from a BFS result
+ * @brief     Extract BFS or SSSP paths from a cugraph_paths_result_t
  *
- * This function extracts paths from the BFS output.  BFS outputs distances
- * and predecessors.  The path from a vertex v back to the original source vertex
- * can be extracted by recursively looking up the predecessor vertex until you arrive
- * back at the original source vertex.
+ * This function extracts paths from the BFS or SSSP output.  BFS and SSSP output
+ * distances and predecessors.  The path from a vertex v back to the original
+ * source vertex can be extracted by recursively looking up the predecessor
+ * vertex until you arrive back at the original source vertex.
  *
  * @param [in]  handle       Handle for accessing resources
  * @param [in]  graph        Pointer to graph.  NOTE: Graph might be modified if the storage

--- a/cpp/include/cugraph_c/algorithms.h
+++ b/cpp/include/cugraph_c/algorithms.h
@@ -232,7 +232,7 @@ cugraph_error_code_t cugraph_bfs(
  *
  * @param [in]  handle       Handle for accessing resources
  * @param [in]  graph        Pointer to graph
- * @param [in]  source       Source vertex id 
+ * @param [in]  source       Source vertex id
  * @param [in]  cutoff       Maximum edge weight sum to consider
  * @param [in]  do_expensive_check A flag to run expensive checks for input arguments (if set to
  * `true`).

--- a/cpp/include/cugraph_c/algorithms.h
+++ b/cpp/include/cugraph_c/algorithms.h
@@ -74,7 +74,8 @@ void cugraph_pagerank_result_free(cugraph_pagerank_result_t* result);
  * @param [in]  has_initial_guess If set to `true`, values in the PageRank output array (pointed by
  * @p pageranks) is used as initial PageRank values. If false, initial PageRank values are set
  * to 1.0 divided by the number of vertices in the graph.
- * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
+ * @param [in]  do_expensive_check A flag to run expensive checks for input arguments (if set to
+ * `true`).
  * @param [out] result      Opaque pointer to pagerank results
  * @param [out] error       Pointer to an error object storing details of any error.  Will
  *                          be populated if error code is not CUGRAPH_SUCCESS
@@ -116,7 +117,8 @@ cugraph_error_code_t cugraph_pagerank(
  * @param [in]  has_initial_guess If set to `true`, values in the PageRank output array (pointed by
  * @p pageranks) is used as initial PageRank values. If false, initial PageRank values are set
  * to 1.0 divided by the number of vertices in the graph.
- * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
+ * @param [in]  do_expensive_check A flag to run expensive checks for input arguments (if set to
+ * `true`).
  * @param [out] result      Opaque pointer to pagerank results
  * @param [out] error       Pointer to an error object storing details of any error.  Will
  *                          be populated if error code is not CUGRAPH_SUCCESS
@@ -201,10 +203,10 @@ void cugraph_paths_result_free(cugraph_paths_result_t* result);
  * input graphs.
  * @param depth_limit Sets the maximum number of breadth-first search iterations. Any vertices
  * farther than @p depth_limit hops from @p source_vertex will be marked as unreachable.
- * @param [in] do_expensive_check A flag to run expensive checks for input arguments (if set to
- * `true`).
  * @param [in] compute_predecessors A flag to indicate whether to compute the predecessors in the
  * result
+ * @param [in] do_expensive_check A flag to run expensive checks for input arguments (if set to
+ * `true`).
  * @param [out] result       Opaque pointer to paths results
  * @param [out] error        Pointer to an error object storing details of any error.  Will
  *                           be populated if error code is not CUGRAPH_SUCCESS
@@ -217,8 +219,8 @@ cugraph_error_code_t cugraph_bfs(
   cugraph_type_erased_device_array_t* sources,
   bool_t direction_optimizing,
   size_t depth_limit,
-  bool_t do_expensive_check,
   bool_t compute_predecessors,
+  bool_t do_expensive_check,
   cugraph_paths_result_t** result,
   cugraph_error_t** error);
 
@@ -234,10 +236,10 @@ cugraph_error_code_t cugraph_bfs(
  * @param [in]  graph        Pointer to graph
  * @param [in]  source       Source vertex id
  * @param [in]  cutoff       Maximum edge weight sum to consider
- * @param [in]  do_expensive_check A flag to run expensive checks for input arguments (if set to
- * `true`).
  * @param [in]  compute_predecessors A flag to indicate whether to compute the predecessors in the
  * result
+ * @param [in]  do_expensive_check A flag to run expensive checks for input arguments (if set to
+ * `true`).
  * @param [out] result       Opaque pointer to paths results
  * @param [out] error        Pointer to an error object storing details of any error.  Will
  *                           be populated if error code is not CUGRAPH_SUCCESS
@@ -247,8 +249,8 @@ cugraph_error_code_t cugraph_sssp(const cugraph_resource_handle_t* handle,
                                   cugraph_graph_t* graph,
                                   size_t source,
                                   double cutoff,
-                                  bool_t do_expensive_check,
                                   bool_t compute_predecessors,
+                                  bool_t do_expensive_check,
                                   cugraph_paths_result_t** result,
                                   cugraph_error_t** error);
 

--- a/cpp/src/c_api/bfs.cpp
+++ b/cpp/src/c_api/bfs.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/c_api/bfs.cpp
+++ b/cpp/src/c_api/bfs.cpp
@@ -36,8 +36,8 @@ struct bfs_functor : public abstract_functor {
   cugraph_type_erased_device_array_t* sources_;
   bool direction_optimizing_;
   size_t depth_limit_;
-  bool do_expensive_check_;
   bool compute_predecessors_;
+  bool do_expensive_check_;
   cugraph_paths_result_t* result_{};
 
   bfs_functor(raft::handle_t const& handle,
@@ -45,16 +45,16 @@ struct bfs_functor : public abstract_functor {
               cugraph_type_erased_device_array_t* sources,
               bool direction_optimizing,
               size_t depth_limit,
-              bool do_expensive_check,
-              bool compute_predecessors)
+              bool compute_predecessors,
+              bool do_expensive_check)
     : abstract_functor(),
       handle_(handle),
       graph_(graph),
       sources_(sources),
       direction_optimizing_(direction_optimizing),
       depth_limit_(depth_limit),
-      do_expensive_check_(do_expensive_check),
-      compute_predecessors_(compute_predecessors)
+      compute_predecessors_(compute_predecessors),
+      do_expensive_check_(do_expensive_check)
   {
   }
 
@@ -176,8 +176,8 @@ extern "C" cugraph_error_code_t cugraph_bfs(const cugraph_resource_handle_t* han
                                             cugraph_type_erased_device_array_t* sources,
                                             bool_t direction_optimizing,
                                             size_t depth_limit,
-                                            bool_t do_expensive_check,
                                             bool_t compute_predecessors,
+                                            bool_t do_expensive_check,
                                             cugraph_paths_result_t** result,
                                             cugraph_error_t** error)
 {
@@ -194,8 +194,8 @@ extern "C" cugraph_error_code_t cugraph_bfs(const cugraph_resource_handle_t* han
                                         p_sources,
                                         direction_optimizing,
                                         depth_limit,
-                                        do_expensive_check,
-                                        compute_predecessors);
+                                        compute_predecessors,
+                                        do_expensive_check);
 
     // FIXME:  This seems like a recurring pattern.  Can I encapsulate
     //    The vertex_dispatcher and error handling calls into a reusable function?

--- a/cpp/src/c_api/sssp.cpp
+++ b/cpp/src/c_api/sssp.cpp
@@ -35,23 +35,23 @@ struct sssp_functor : public abstract_functor {
   cugraph_graph_t* graph_;
   size_t source_;
   double cutoff_;
-  bool do_expensive_check_;
   bool compute_predecessors_;
+  bool do_expensive_check_;
   cugraph_paths_result_t* result_{};
 
   sssp_functor(raft::handle_t const& handle,
                cugraph_graph_t* graph,
                size_t source,
                double cutoff,
-               bool do_expensive_check,
-               bool compute_predecessors)
+               bool compute_predecessors,
+               bool do_expensive_check)
     : abstract_functor(),
       handle_(handle),
       graph_(graph),
       source_(source),
       cutoff_(cutoff),
-      do_expensive_check_(do_expensive_check),
-      compute_predecessors_(compute_predecessors)
+      compute_predecessors_(compute_predecessors),
+      do_expensive_check_(do_expensive_check)
   {
   }
 
@@ -146,8 +146,8 @@ extern "C" cugraph_error_code_t cugraph_sssp(const cugraph_resource_handle_t* ha
                                              cugraph_graph_t* graph,
                                              size_t source,
                                              double cutoff,
-                                             bool_t do_expensive_check,
                                              bool_t compute_predecessors,
+                                             bool_t do_expensive_check,
                                              cugraph_paths_result_t** result,
                                              cugraph_error_t** error)
 {
@@ -159,7 +159,7 @@ extern "C" cugraph_error_code_t cugraph_sssp(const cugraph_resource_handle_t* ha
     auto p_graph  = reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(graph);
 
     cugraph::c_api::sssp_functor functor(
-      *p_handle, p_graph, source, cutoff, do_expensive_check, compute_predecessors);
+      *p_handle, p_graph, source, cutoff, compute_predecessors, do_expensive_check);
 
     // FIXME:  This seems like a recurring pattern.  Can I encapsulate
     //    The vertex_dispatcher and error handling calls into a reusable function?

--- a/cpp/src/c_api/sssp.cpp
+++ b/cpp/src/c_api/sssp.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cugraph_c/algorithms.h>
+
+#include <c_api/abstract_functor.hpp>
+#include <c_api/graph.hpp>
+#include <c_api/paths_result.hpp>
+
+#include <cugraph/algorithms.hpp>
+#include <cugraph/detail/utility_wrappers.hpp>
+#include <cugraph/graph_functions.hpp>
+#include <cugraph/visitors/generic_cascaded_dispatch.hpp>
+
+#include <raft/handle.hpp>
+
+namespace cugraph {
+namespace c_api {
+
+struct sssp_functor : public abstract_functor {
+  raft::handle_t const& handle_;
+  cugraph_graph_t* graph_;
+  size_t source_;
+  double cutoff_;
+  bool do_expensive_check_;
+  bool compute_predecessors_;
+  cugraph_paths_result_t* result_{};
+
+  sssp_functor(raft::handle_t const& handle,
+               cugraph_graph_t* graph,
+               size_t source,
+               double cutoff,
+               bool do_expensive_check,
+               bool compute_predecessors)
+    : abstract_functor(),
+      handle_(handle),
+      graph_(graph),
+      source_(source),
+      cutoff_(cutoff),
+      do_expensive_check_(do_expensive_check),
+      compute_predecessors_(compute_predecessors)
+  {
+  }
+
+  template <typename vertex_t,
+            typename edge_t,
+            typename weight_t,
+            bool store_transposed,
+            bool multi_gpu>
+  void operator()()
+  {
+    // FIXME: Think about how to handle SG vice MG
+    if constexpr (!cugraph::is_candidate<vertex_t, edge_t, weight_t>::value) {
+      unsupported();
+    } else {
+      // SSSP expects store_transposed == false
+      if constexpr (store_transposed) {
+        error_code_ = cugraph::c_api::
+          transpose_storage<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>(
+            handle_, graph_, error_.get());
+        if (error_code_ != CUGRAPH_SUCCESS) return;
+      }
+
+      auto graph =
+        reinterpret_cast<cugraph::graph_t<vertex_t, edge_t, weight_t, false, multi_gpu>*>(
+          graph_->graph_);
+
+      auto graph_view = graph->view();
+
+      auto number_map = reinterpret_cast<rmm::device_uvector<vertex_t>*>(graph_->number_map_);
+
+      rmm::device_uvector<vertex_t> source_ids(1, handle_.get_stream());
+      rmm::device_uvector<vertex_t> vertex_ids(graph->get_number_of_vertices(),
+                                               handle_.get_stream());
+      rmm::device_uvector<weight_t> distances(graph->get_number_of_vertices(),
+                                              handle_.get_stream());
+      rmm::device_uvector<vertex_t> predecessors(0, handle_.get_stream());
+
+      if (compute_predecessors_) {
+        predecessors.resize(graph->get_number_of_vertices(), handle_.get_stream());
+      }
+
+      vertex_t src = static_cast<vertex_t>(source_);
+      raft::update_device(source_ids.data(), &src, 1, handle_.get_stream());
+
+      //
+      // Need to renumber sources
+      //
+      renumber_ext_vertices<vertex_t, multi_gpu>(handle_,
+                                                 source_ids.data(),
+                                                 1,
+                                                 number_map->data(),
+                                                 graph_view.get_local_vertex_first(),
+                                                 graph_view.get_local_vertex_last(),
+                                                 do_expensive_check_);
+
+      raft::update_host(&src, source_ids.data(), 1, handle_.get_stream());
+
+      cugraph::sssp<vertex_t, edge_t, weight_t, multi_gpu>(
+        handle_,
+        graph_view,
+        distances.data(),
+        compute_predecessors_ ? predecessors.data() : nullptr,
+        src,
+        static_cast<weight_t>(cutoff_),
+        do_expensive_check_);
+
+      raft::copy(vertex_ids.data(), number_map->data(), vertex_ids.size(), handle_.get_stream());
+
+      if (compute_predecessors_) {
+        std::vector<vertex_t> vertex_partition_lasts = graph_view.get_vertex_partition_lasts();
+
+        unrenumber_int_vertices<vertex_t, multi_gpu>(handle_,
+                                                     predecessors.data(),
+                                                     predecessors.size(),
+                                                     number_map->data(),
+                                                     vertex_partition_lasts,
+                                                     do_expensive_check_);
+      }
+
+      result_ = new cugraph_paths_result_t{
+        new cugraph_type_erased_device_array_t(vertex_ids, graph_->vertex_type_),
+        new cugraph_type_erased_device_array_t(distances, graph_->weight_type_),
+        new cugraph_type_erased_device_array_t(predecessors, graph_->vertex_type_)};
+    }
+  }
+};
+
+}  // namespace c_api
+}  // namespace cugraph
+
+extern "C" cugraph_error_code_t cugraph_sssp(const cugraph_resource_handle_t* handle,
+                                             cugraph_graph_t* graph,
+                                             size_t source,
+                                             double cutoff,
+                                             bool_t do_expensive_check,
+                                             bool_t compute_predecessors,
+                                             cugraph_paths_result_t** result,
+                                             cugraph_error_t** error)
+{
+  *result = nullptr;
+  *error  = nullptr;
+
+  try {
+    auto p_handle = reinterpret_cast<raft::handle_t const*>(handle);
+    auto p_graph  = reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(graph);
+
+    cugraph::c_api::sssp_functor functor(
+      *p_handle, p_graph, source, cutoff, do_expensive_check, compute_predecessors);
+
+    // FIXME:  This seems like a recurring pattern.  Can I encapsulate
+    //    The vertex_dispatcher and error handling calls into a reusable function?
+    //    After all, we're in C++ here.
+    cugraph::dispatch::vertex_dispatcher(cugraph::c_api::dtypes_mapping[p_graph->vertex_type_],
+                                         cugraph::c_api::dtypes_mapping[p_graph->edge_type_],
+                                         cugraph::c_api::dtypes_mapping[p_graph->weight_type_],
+                                         p_graph->store_transposed_,
+                                         p_graph->multi_gpu_,
+                                         functor);
+
+    if (functor.error_code_ != CUGRAPH_SUCCESS) {
+      *error = reinterpret_cast<cugraph_error_t*>(functor.error_.release());
+      return functor.error_code_;
+    }
+
+    *result = reinterpret_cast<cugraph_paths_result_t*>(functor.result_);
+  } catch (std::exception const& ex) {
+    *error = reinterpret_cast<cugraph_error_t*>(new cugraph::c_api::cugraph_error_t{ex.what()});
+    return CUGRAPH_UNKNOWN_ERROR;
+  }
+
+  return CUGRAPH_SUCCESS;
+}

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 ﻿#
-# Copyright (c) 2019-2021, NVIDIA CORPORATION.
+# Copyright (c) 2019-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -593,6 +593,7 @@ ConfigureCTest(CAPI_CREATE_GRAPH_TEST c_api/create_graph_test.c)
 ConfigureCTest(CAPI_RANDOM_WALKS_TEST c_api/random_walks_test.c)
 ConfigureCTest(CAPI_PAGERANK_TEST c_api/pagerank_test.c)
 ConfigureCTest(CAPI_BFS_TEST c_api/bfs_test.c)
+ConfigureCTest(CAPI_SSSP_TEST c_api/sssp_test.c)
 ConfigureCTest(CAPI_EXTRACT_PATHS_TEST c_api/extract_paths_test.c)
 
 ###################################################################################################

--- a/cpp/tests/c_api/bfs_test.c
+++ b/cpp/tests/c_api/bfs_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/c_api/bfs_test.c
+++ b/cpp/tests/c_api/bfs_test.c
@@ -62,7 +62,7 @@ int generic_bfs_test(vertex_t* h_src,
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src copy_from_host failed.");
 
   ret_code = cugraph_bfs(
-    p_handle, p_graph, p_sources, FALSE, depth_limit, FALSE, TRUE, &p_result, &ret_error);
+    p_handle, p_graph, p_sources, FALSE, depth_limit, TRUE, FALSE, &p_result, &ret_error);
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "cugraph_bfs failed.");
 
   cugraph_type_erased_device_array_t* vertices;

--- a/cpp/tests/c_api/c_test_utils.h
+++ b/cpp/tests/c_api/c_test_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/c_api/c_test_utils.h
+++ b/cpp/tests/c_api/c_test_utils.h
@@ -20,10 +20,12 @@
 #include <stdio.h>
 #include <time.h>
 
-#define TEST_ASSERT(RETURN_VALUE, STATEMENT, MESSAGE)                    \
-  {                                                                      \
-    (RETURN_VALUE) = !(STATEMENT);                                       \
-    if ((RETURN_VALUE)) { printf("ASSERTION FAILED: %s\n", (MESSAGE)); } \
+#define TEST_ASSERT(RETURN_VALUE, STATEMENT, MESSAGE)                      \
+  {                                                                        \
+    if (!(RETURN_VALUE)) {                                                 \
+      (RETURN_VALUE) = !(STATEMENT);                                       \
+      if ((RETURN_VALUE)) { printf("ASSERTION FAILED: %s\n", (MESSAGE)); } \
+    }                                                                      \
   }
 
 /*

--- a/cpp/tests/c_api/extract_paths_test.c
+++ b/cpp/tests/c_api/extract_paths_test.c
@@ -74,7 +74,7 @@ int generic_bfs_test_with_extract_paths(vertex_t* h_src,
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src copy_from_host failed.");
 
   ret_code = cugraph_bfs(
-    p_handle, p_graph, p_sources, FALSE, depth_limit, FALSE, TRUE, &p_paths_result, &ret_error);
+    p_handle, p_graph, p_sources, FALSE, depth_limit, TRUE, FALSE, &p_paths_result, &ret_error);
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "cugraph_bfs failed.");
 
   ret_code = cugraph_extract_paths(p_handle,

--- a/cpp/tests/c_api/sssp_test.c
+++ b/cpp/tests/c_api/sssp_test.c
@@ -55,7 +55,7 @@ int generic_sssp_test(vertex_t* h_src,
     p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, &p_graph, &ret_error);
 
   ret_code = cugraph_sssp(
-    p_handle, p_graph, source, cutoff, FALSE, TRUE, &p_result, &ret_error);
+    p_handle, p_graph, source, cutoff, TRUE, FALSE, &p_result, &ret_error);
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "cugraph_sssp failed.");
 
   cugraph_type_erased_device_array_t* vertices;
@@ -84,8 +84,7 @@ int generic_sssp_test(vertex_t* h_src,
 
   for (int i = 0; (i < num_vertices) && (test_ret_value == 0); ++i) {
     TEST_ASSERT(test_ret_value,
-                //nearlyEqual(expected_distances[h_vertices[i]], h_distances[i], EPSILON),
-                expected_distances[h_vertices[i]] == h_distances[i],
+                nearlyEqual(expected_distances[h_vertices[i]], h_distances[i], EPSILON),
                 "sssp distances don't match");
 
     TEST_ASSERT(test_ret_value,

--- a/cpp/tests/c_api/sssp_test.c
+++ b/cpp/tests/c_api/sssp_test.c
@@ -84,11 +84,12 @@ int generic_sssp_test(vertex_t* h_src,
 
   for (int i = 0; (i < num_vertices) && (test_ret_value == 0); ++i) {
     TEST_ASSERT(test_ret_value,
-                nearlyEqual(expected_distances[h_vertices[i]], h_distances[i], EPSILON),
+                //nearlyEqual(expected_distances[h_vertices[i]], h_distances[i], EPSILON),
+                expected_distances[h_vertices[i]] == h_distances[i],
                 "sssp distances don't match");
 
     TEST_ASSERT(test_ret_value,
-                nearlyEqual(expected_predecessors[h_vertices[i]], h_predecessors[i], EPSILON),
+                expected_predecessors[h_vertices[i]] == h_predecessors[i],
                 "sssp predecessors don't match");
   }
 

--- a/cpp/tests/c_api/sssp_test.c
+++ b/cpp/tests/c_api/sssp_test.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "c_test_utils.h" /* RUN_TEST */
+
+#include <cugraph_c/algorithms.h>
+#include <cugraph_c/graph.h>
+
+#include <math.h>
+#include <float.h>
+
+typedef int32_t vertex_t;
+typedef int32_t edge_t;
+typedef float weight_t;
+
+int generic_sssp_test(vertex_t* h_src,
+                      vertex_t* h_dst,
+                      weight_t* h_wgt,
+                      vertex_t source,
+                      weight_t const* expected_distances,
+                      vertex_t const* expected_predecessors,
+                      size_t num_vertices,
+                      size_t num_edges,
+                      weight_t cutoff,
+                      bool_t store_transposed)
+{
+  int test_ret_value = 0;
+
+  cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
+  cugraph_error_t* ret_error;
+
+  cugraph_resource_handle_t* p_handle           = NULL;
+  cugraph_graph_t* p_graph                      = NULL;
+  cugraph_paths_result_t* p_result              = NULL;
+
+  p_handle = cugraph_create_resource_handle();
+  TEST_ASSERT(test_ret_value, p_handle != NULL, "resource handle creation failed.");
+
+  ret_code = create_test_graph(
+    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, &p_graph, &ret_error);
+
+  ret_code = cugraph_sssp(
+    p_handle, p_graph, source, cutoff, FALSE, TRUE, &p_result, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "cugraph_sssp failed.");
+
+  cugraph_type_erased_device_array_t* vertices;
+  cugraph_type_erased_device_array_t* distances;
+  cugraph_type_erased_device_array_t* predecessors;
+
+  vertices     = cugraph_paths_result_get_vertices(p_result);
+  distances    = cugraph_paths_result_get_distances(p_result);
+  predecessors = cugraph_paths_result_get_predecessors(p_result);
+
+  vertex_t h_vertices[num_vertices];
+  weight_t h_distances[num_vertices];
+  vertex_t h_predecessors[num_vertices];
+
+  ret_code = cugraph_type_erased_device_array_copy_to_host(
+    p_handle, (byte_t*)h_vertices, vertices, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+  ret_code = cugraph_type_erased_device_array_copy_to_host(
+    p_handle, (byte_t*)h_distances, distances, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+  ret_code = cugraph_type_erased_device_array_copy_to_host(
+    p_handle, (byte_t*)h_predecessors, predecessors, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+  for (int i = 0; (i < num_vertices) && (test_ret_value == 0); ++i) {
+    TEST_ASSERT(test_ret_value,
+                expected_distances[h_vertices[i]] == h_distances[i],
+                "sssp distances don't match");
+
+    TEST_ASSERT(test_ret_value,
+                expected_predecessors[h_vertices[i]] == h_predecessors[i],
+                "sssp predecessors don't match");
+  }
+
+  cugraph_paths_result_free(p_result);
+  cugraph_sg_graph_free(p_graph);
+  cugraph_free_resource_handle(p_handle);
+  cugraph_error_free(ret_error);
+
+  return test_ret_value;
+}
+
+int test_sssp()
+{
+  size_t num_edges    = 8;
+  size_t num_vertices = 6;
+
+  vertex_t src[]                   = {0, 1, 1, 2, 2, 2, 3, 4};
+  vertex_t dst[]                   = {1, 3, 4, 0, 1, 3, 5, 5};
+  weight_t wgt[]                   = {0.1f, 2.1f, 1.1f, 5.1f, 3.1f, 4.1f, 7.2f, 3.2f};
+  weight_t expected_distances[]    = {0.0f, 0.1f, FLT_MAX, 2.2f, 1.2f, 4.4f};
+  vertex_t expected_predecessors[] = {-1, 0, -1, 1, 1, 4};
+
+  // Bfs wants store_transposed = FALSE
+  return generic_sssp_test(src,
+                           dst,
+                           wgt,
+                           0,
+                           expected_distances,
+                           expected_predecessors,
+                           num_vertices,
+                           num_edges,
+                           10,
+                           FALSE);
+}
+
+int test_sssp_with_transpose()
+{
+  size_t num_edges    = 8;
+  size_t num_vertices = 6;
+
+  vertex_t src[]                   = {0, 1, 1, 2, 2, 2, 3, 4};
+  vertex_t dst[]                   = {1, 3, 4, 0, 1, 3, 5, 5};
+  weight_t wgt[]                   = {0.1f, 2.1f, 1.1f, 5.1f, 3.1f, 4.1f, 7.2f, 3.2f};
+  weight_t expected_distances[]    = {4.4, 4.3, 7.4, 7.2f, 3.2f, 0.0f};
+  vertex_t expected_predecessors[] = {1, 4, 1, 5, 5, -1};
+
+  // Bfs wants store_transposed = FALSE
+  //    This call will force cugraph_sssp to transpose the graph
+  return generic_sssp_test(src,
+                           dst,
+                           wgt,
+                           5,
+                           expected_distances,
+                           expected_predecessors,
+                           num_vertices,
+                           num_edges,
+                           10,
+                           TRUE);
+}
+
+/******************************************************************************/
+
+int main(int argc, char** argv)
+{
+  int result = 0;
+  result |= RUN_TEST(test_sssp);
+  result |= RUN_TEST(test_sssp_with_transpose);
+  return result;
+}

--- a/cpp/tests/c_api/sssp_test.c
+++ b/cpp/tests/c_api/sssp_test.c
@@ -26,6 +26,8 @@ typedef int32_t vertex_t;
 typedef int32_t edge_t;
 typedef float weight_t;
 
+const weight_t EPSILON = 0.001;
+
 int generic_sssp_test(vertex_t* h_src,
                       vertex_t* h_dst,
                       weight_t* h_wgt,
@@ -82,11 +84,11 @@ int generic_sssp_test(vertex_t* h_src,
 
   for (int i = 0; (i < num_vertices) && (test_ret_value == 0); ++i) {
     TEST_ASSERT(test_ret_value,
-                expected_distances[h_vertices[i]] == h_distances[i],
+                nearlyEqual(expected_distances[h_vertices[i]], h_distances[i], EPSILON),
                 "sssp distances don't match");
 
     TEST_ASSERT(test_ret_value,
-                expected_predecessors[h_vertices[i]] == h_predecessors[i],
+                nearlyEqual(expected_predecessors[h_vertices[i]], h_predecessors[i], EPSILON),
                 "sssp predecessors don't match");
   }
 

--- a/cpp/tests/c_api/test_utils.c
+++ b/cpp/tests/c_api/test_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/c_api/test_utils.c
+++ b/cpp/tests/c_api/test_utils.c
@@ -23,8 +23,7 @@ int nearlyEqual(float a, float b, float epsilon)
   // FIXME:  There is a better test than this,
   //   perhaps use the gtest comparison for consistency
   //   with C++ and wrap it in a C wrapper.
-  int x = (fabsf(a - b) < (fabsf(a) * epsilon));
-  return (fabsf(a - b) < (fabsf(a) * epsilon));
+  return (fabsf(a - b) <= (((fabsf(a) < fabsf(b)) ? fabs(b) : fabs(a)) * epsilon));
 }
 
 /*


### PR DESCRIPTION
@rlratzel needed the SSSP C API squeezed into version 22.02.  Skipped the usual API PR and implementation PR to squeeze these together in the interest of time.  Note that SSSP is nearly identical (semantically) to BFS which is already in the C API using a similar API.

This PR provides:
* C API definition of SSSP
* C unit test for SSSP
* Implementation of the C API of SSSP (calling the underlying C++ implementation)