### PR TITLE
Prepare upload scripts for Python 3.7 removal

### DIFF
--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -18,7 +18,7 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     export BUILD_LIBCUGRAPH=1
 fi
 
-if [[ "$PYTHON" == "3.7" ]]; then
+if [[ "$PYTHON" == "3.8" ]]; then
     export UPLOAD_LIBCUGRAPH=1
 else
     export UPLOAD_LIBCUGRAPH=0


### PR DESCRIPTION
As we will remove Python 3.7, we need to update the Python version in the upload scripts