### PR TITLE
Fix build script

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -84,9 +84,8 @@ if [ "$BUILD_LIBCUGRAPH" == '1' ]; then
   else
     gpuci_conda_retry build --no-build-id --croot ${CONDA_BLD_DIR} --dirty --no-remove-work-dir conda/recipes/libcugraph
     gpuci_conda_retry build --no-build-id --croot ${CONDA_BLD_DIR} --dirty --no-remove-work-dir conda/recipes/libcugraph_etl
-    mkdir -p ${CONDA_BLD_DIR}/libcugraph/work
-    cp -r ${CONDA_BLD_DIR}/work/* ${CONDA_BLD_DIR}/libcugraph/work
-    rm -rf ${CONDA_BLD_DIR}/work
+    mkdir -p ${CONDA_BLD_DIR}/libcugraph
+    mv ${CONDA_BLD_DIR}/work ${CONDA_BLD_DIR}/libcugraph/work
   fi
 else
   gpuci_logger "SKIPPING build of conda package for libcugraph and libcugraph_etl"
@@ -100,9 +99,8 @@ if [ "$BUILD_CUGRAPH" == "1" ]; then
   else
     gpuci_conda_retry build --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/pylibcugraph -c $CONDA_BLD_DIR --dirty --no-remove-work-dir --python=$PYTHON
     gpuci_conda_retry build --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/cugraph -c $CONDA_BLD_DIR --dirty --no-remove-work-dir --python=$PYTHON
-    mkdir -p ${CONDA_BLD_DIR}/cugraph/work
-    cp -r ${CONDA_BLD_DIR}/work/ ${CONDA_BLD_DIR}/cugraph/work
-    rm -rf ${CONDA_BLD_DIR}/work
+    mkdir -p ${CONDA_BLD_DIR}/cugraph
+    mv ${CONDA_BLD_DIR}/work ${CONDA_BLD_DIR}/cugraph/work
   fi
 else
   gpuci_logger "SKIPPING build of conda packages for pylibcugraph and cugraph"

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 #########################################
 # cuGraph CPU conda build script for CI #
 #########################################


### PR DESCRIPTION
The directory moving for `cugraph` was missing a `*` in the `cp` command which was creating the wrong directory hierarchy. Fixing this by using `mv` instead