### PR TITLE
Allow class types to be properly represented in the `experimental_warning_wrapper()` return value

### DIFF
--- a/python/cugraph/cugraph/utilities/api_tools.py
+++ b/python/cugraph/cugraph/utilities/api_tools.py
@@ -14,27 +14,34 @@
 import functools
 import warnings
 import inspect
+import types
 
 experimental_prefix = "EXPERIMENTAL"
 
+# FIXME: this utility is copied from pylibcugraph. Remove this copy and have
+# cugraph code call the version in pylibcugraph.
 
-def experimental_warning_wrapper(obj, make_public_name=True):
+def experimental_warning_wrapper(obj):
     """
-    Return a callable obj wrapped in a callable the prints a warning about it
-    being "experimental" (an object that is in the public API but subject to
-    change or removal) prior to calling it and returning its value.
+    Return a callable obj wrapped in a callable the prints a warning about
+    it being "experimental" (an object that is in the public API but subject
+    to change or removal) prior to calling it and returning its value.
 
-    If make_public_name is False, the object's name used in the warning message
-    is left unmodified. If True (default), any leading __ and/or EXPERIMENTAL
-    string are removed from the name used in warning messages. This allows an
-    object to be named with a "private" name in the public API so it can remain
-    hidden while it is still experimental, but have a public name within the
-    experimental namespace so it can be easily discovered and used.
+    The object's name used in the warning message also has any leading __
+    and/or EXPERIMENTAL string are removed from the name used in warning
+    messages. This allows an object to be named with a "private" name in the
+    public API so it can remain hidden while it is still experimental, but
+    have a public name within the experimental namespace so it can be easily
+    discovered and used.
     """
-    obj_name = obj.__qualname__
-    if make_public_name:
-        obj_name = obj_name.lstrip(experimental_prefix)
-        obj_name = obj_name.lstrip("__")
+    obj_type = type(obj)
+    if obj_type not in [type, types.FunctionType, types.BuiltinFunctionType]:
+        raise TypeError("obj must be a class or a function type, got "
+                        f"{obj_type}")
+
+    obj_name = obj.__name__
+    obj_name = obj_name.lstrip(experimental_prefix)
+    obj_name = obj_name.lstrip("__")
 
     # Assume the caller of this function is the module containing the
     # experimental obj and try to get its namespace name. Default to no
@@ -42,17 +49,41 @@ def experimental_warning_wrapper(obj, make_public_name=True):
     call_stack = inspect.stack()
     calling_frame = call_stack[1].frame
     ns_name = calling_frame.f_locals.get("__name__")
-    if ns_name is not None:
-        ns_name += "."
-    else:
-        ns_name = ""
+    dot = "." if ns_name is not None else ""
 
-    warning_msg = (f"{ns_name}{obj_name} is experimental and will change "
-                   "or be removed in a future release.")
+    warning_msg = (f"{ns_name}{dot}{obj_name} is experimental and will "
+                   "change or be removed in a future release.")
 
+    # If obj is a class, create a wrapper class which 1) inherits from the
+    # incoming class, and 2) has a ctor that simply prints the warning and
+    # assigns self to an instance of the incoming class. Ideally a wrapper
+    # around __init__ would be created and assigned to the class as the new
+    # __init__, but #2 is necessary since assigning attributes cannot be done to
+    # a builtin type (such as what a class defined in cython produces).
+    if obj_type is type:
+        class WarningWrapperClass(obj):
+            def __init__(self, *args, **kwargs):
+                warnings.warn(warning_msg, PendingDeprecationWarning)
+                # cython classes do not have a standard __init__, but assigning
+                # to self works instead.
+                if type(obj.__init__) is types.FunctionType:
+                    super(WarningWrapperClass, self).__init__(*args, **kwargs)
+                else:
+                    self = obj(*args, **kwargs)
+        WarningWrapperClass.__module__ = ns_name
+        WarningWrapperClass.__qualname__ = obj_name
+        WarningWrapperClass.__name__ = obj_name
+
+        return WarningWrapperClass
+
+    # If this point is reached, the incoming obj is a function so wrap it and
+    # return the wrapper (which is also a function type).
     @functools.wraps(obj)
-    def callable_warning_wrapper(*args, **kwargs):
+    def warning_wrapper_function(*args, **kwargs):
         warnings.warn(warning_msg, PendingDeprecationWarning)
         return obj(*args, **kwargs)
+    warning_wrapper_function.__module__ = ns_name
+    warning_wrapper_function.__qualname__ = obj_name
+    warning_wrapper_function.__name__ = obj_name
 
-    return callable_warning_wrapper
+    return warning_wrapper_function

--- a/python/pylibcugraph/pylibcugraph/graphs.pxd
+++ b/python/pylibcugraph/pylibcugraph/graphs.pxd
@@ -19,11 +19,14 @@ from pylibcugraph._cugraph_c.graph cimport (
 )
 
 
-cdef class EXPERIMENTAL__Graph:
+# Base class allowing functions to accept either SGGraph or MGGraph
+# This is not visible in python
+cdef class _GPUGraph:
     cdef cugraph_graph_t* c_graph_ptr
 
-cdef class EXPERIMENTAL__SGGraph(EXPERIMENTAL__Graph):
+cdef class EXPERIMENTAL__SGGraph(_GPUGraph):
     pass
 
-# cdef class EXPERIMENTAL__MGGraph(EXPERIMENTAL__Graph):
+# Not yet supported
+# cdef class EXPERIMENTAL__MGGraph(_GPUGraph):
 #     pass

--- a/python/pylibcugraph/pylibcugraph/graphs.pyx
+++ b/python/pylibcugraph/pylibcugraph/graphs.pyx
@@ -48,7 +48,7 @@ from pylibcugraph.utils cimport (
 )
 
 
-cdef class EXPERIMENTAL__SGGraph(EXPERIMENTAL__Graph):
+cdef class EXPERIMENTAL__SGGraph(_GPUGraph):
     """
     RAII-stye Graph class for use with single-GPU APIs that manages the
     individual create/free calls and the corresponding cugraph_graph_t pointer.

--- a/python/pylibcugraph/pylibcugraph/pagerank.pyx
+++ b/python/pylibcugraph/pylibcugraph/pagerank.pyx
@@ -48,7 +48,7 @@ from pylibcugraph.resource_handle cimport (
     EXPERIMENTAL__ResourceHandle,
 )
 from pylibcugraph.graphs cimport (
-    EXPERIMENTAL__Graph,
+    _GPUGraph,
 )
 from pylibcugraph.utils cimport (
     assert_success,
@@ -58,7 +58,7 @@ from pylibcugraph.utils cimport (
 
 
 def EXPERIMENTAL__pagerank(EXPERIMENTAL__ResourceHandle resource_handle,
-                           EXPERIMENTAL__Graph graph,
+                           _GPUGraph graph,
                            precomputed_vertex_out_weight_sums,
                            double alpha,
                            double epsilon,

--- a/python/pylibcugraph/pylibcugraph/sssp.pyx
+++ b/python/pylibcugraph/pylibcugraph/sssp.pyx
@@ -49,7 +49,7 @@ from pylibcugraph.resource_handle cimport (
     EXPERIMENTAL__ResourceHandle,
 )
 from pylibcugraph.graphs cimport (
-    EXPERIMENTAL__Graph,
+    _GPUGraph,
 )
 from pylibcugraph.utils cimport (
     assert_success,
@@ -58,7 +58,7 @@ from pylibcugraph.utils cimport (
 
 
 def EXPERIMENTAL__sssp(EXPERIMENTAL__ResourceHandle resource_handle,
-                       EXPERIMENTAL__Graph graph,
+                       _GPUGraph graph,
                        size_t source,
                        double cutoff,
                        bool_t compute_predecessors,

--- a/python/pylibcugraph/pylibcugraph/tests/test_utils.py
+++ b/python/pylibcugraph/pylibcugraph/tests/test_utils.py
@@ -50,4 +50,4 @@ def test_experimental_warning_wrapper_for_unsupported_type():
     # A module type should not be allowed to be wrapped
     mod = types.ModuleType("modname")
     with pytest.raises(TypeError):
-        exp_mod = experimental_warning_wrapper(mod)
+        experimental_warning_wrapper(mod)

--- a/python/pylibcugraph/pylibcugraph/tests/test_utils.py
+++ b/python/pylibcugraph/pylibcugraph/tests/test_utils.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import types
+
+import pytest
+
+
+def test_experimental_warning_wrapper_for_funcs():
+    from pylibcugraph.utilities.api_tools import experimental_warning_wrapper
+
+    def EXPERIMENTAL__func(a, b):
+        return a - b
+
+    exp_func = experimental_warning_wrapper(EXPERIMENTAL__func)
+
+    with pytest.warns(PendingDeprecationWarning):
+        assert 1 == exp_func(3, 2)
+
+
+def test_experimental_warning_wrapper_for_classes():
+    from pylibcugraph.utilities.api_tools import experimental_warning_wrapper
+
+    class EXPERIMENTAL__klass:
+        def __init__(self, a, b):
+            self.r = a - b
+
+    exp_klass = experimental_warning_wrapper(EXPERIMENTAL__klass)
+
+    with pytest.warns(PendingDeprecationWarning):
+        k = exp_klass(3, 2)
+        assert 1 == k.r
+        assert isinstance(k, exp_klass)
+        assert k.__class__.__name__ == "klass"
+
+
+def test_experimental_warning_wrapper_for_unsupported_type():
+    from pylibcugraph.utilities.api_tools import experimental_warning_wrapper
+
+    # A module type should not be allowed to be wrapped
+    mod = types.ModuleType("modname")
+    with pytest.raises(TypeError):
+        exp_mod = experimental_warning_wrapper(mod)

--- a/python/pylibcugraph/pylibcugraph/utilities/api_tools.py
+++ b/python/pylibcugraph/pylibcugraph/utilities/api_tools.py
@@ -14,27 +14,31 @@
 import functools
 import warnings
 import inspect
+import types
 
 experimental_prefix = "EXPERIMENTAL"
 
-
-def experimental_warning_wrapper(obj, make_public_name=True):
+def experimental_warning_wrapper(obj):
     """
-    Return a callable obj wrapped in a callable the prints a warning about it
-    being "experimental" (an object that is in the public API but subject to
-    change or removal) prior to calling it and returning its value.
+    Return a callable obj wrapped in a callable the prints a warning about
+    it being "experimental" (an object that is in the public API but subject
+    to change or removal) prior to calling it and returning its value.
 
-    If make_public_name is False, the object's name used in the warning message
-    is left unmodified. If True (default), any leading __ and/or EXPERIMENTAL
-    string are removed from the name used in warning messages. This allows an
-    object to be named with a "private" name in the public API so it can remain
-    hidden while it is still experimental, but have a public name within the
-    experimental namespace so it can be easily discovered and used.
+    The object's name used in the warning message also has any leading __
+    and/or EXPERIMENTAL string are removed from the name used in warning
+    messages. This allows an object to be named with a "private" name in the
+    public API so it can remain hidden while it is still experimental, but
+    have a public name within the experimental namespace so it can be easily
+    discovered and used.
     """
-    obj_name = obj.__qualname__
-    if make_public_name:
-        obj_name = obj_name.lstrip(experimental_prefix)
-        obj_name = obj_name.lstrip("__")
+    obj_type = type(obj)
+    if obj_type not in [type, types.FunctionType, types.BuiltinFunctionType]:
+        raise TypeError("obj must be a class or a function type, got "
+                        f"{obj_type}")
+
+    obj_name = obj.__name__
+    obj_name = obj_name.lstrip(experimental_prefix)
+    obj_name = obj_name.lstrip("__")
 
     # Assume the caller of this function is the module containing the
     # experimental obj and try to get its namespace name. Default to no
@@ -42,17 +46,41 @@ def experimental_warning_wrapper(obj, make_public_name=True):
     call_stack = inspect.stack()
     calling_frame = call_stack[1].frame
     ns_name = calling_frame.f_locals.get("__name__")
-    if ns_name is not None:
-        ns_name += "."
-    else:
-        ns_name = ""
+    dot = "." if ns_name is not None else ""
 
-    warning_msg = (f"{ns_name}{obj_name} is experimental and will change "
-                   "or be removed in a future release.")
+    warning_msg = (f"{ns_name}{dot}{obj_name} is experimental and will "
+                   "change or be removed in a future release.")
 
+    # If obj is a class, create a wrapper class which 1) inherits from the
+    # incoming class, and 2) has a ctor that simply prints the warning and
+    # assigns self to an instance of the incoming class. Ideally a wrapper
+    # around __init__ would be created and assigned to the class as the new
+    # __init__, but #2 is necessary since assigning attributes cannot be done to
+    # a builtin type (such as what a class defined in cython produces).
+    if obj_type is type:
+        class WarningWrapperClass(obj):
+            def __init__(self, *args, **kwargs):
+                warnings.warn(warning_msg, PendingDeprecationWarning)
+                # cython classes do not have a standard __init__, but assigning
+                # to self works instead.
+                if type(obj.__init__) is types.FunctionType:
+                    super(WarningWrapperClass, self).__init__(*args, **kwargs)
+                else:
+                    self = obj(*args, **kwargs)
+        WarningWrapperClass.__module__ = ns_name
+        WarningWrapperClass.__qualname__ = obj_name
+        WarningWrapperClass.__name__ = obj_name
+
+        return WarningWrapperClass
+
+    # If this point is reached, the incoming obj is a function so wrap it and
+    # return the wrapper (which is also a function type).
     @functools.wraps(obj)
-    def callable_warning_wrapper(*args, **kwargs):
+    def warning_wrapper_function(*args, **kwargs):
         warnings.warn(warning_msg, PendingDeprecationWarning)
         return obj(*args, **kwargs)
+    warning_wrapper_function.__module__ = ns_name
+    warning_wrapper_function.__qualname__ = obj_name
+    warning_wrapper_function.__name__ = obj_name
 
-    return callable_warning_wrapper
+    return warning_wrapper_function

--- a/python/pylibcugraph/pylibcugraph/utilities/api_tools.py
+++ b/python/pylibcugraph/pylibcugraph/utilities/api_tools.py
@@ -18,6 +18,7 @@ import types
 
 experimental_prefix = "EXPERIMENTAL"
 
+
 def experimental_warning_wrapper(obj):
     """
     Return a callable obj wrapped in a callable the prints a warning about
@@ -53,17 +54,19 @@ def experimental_warning_wrapper(obj):
 
     # If obj is a class, create a wrapper class which 1) inherits from the
     # incoming class, and 2) has a ctor that simply prints the warning and
-    # assigns self to an instance of the incoming class. Ideally a wrapper
-    # around __init__ would be created and assigned to the class as the new
-    # __init__, but #2 is necessary since assigning attributes cannot be done to
-    # a builtin type (such as what a class defined in cython produces).
+    # calls the base class ctor. A wrapper class is needed so the new type
+    # matches the incoming type.
+    # Ideally a wrapper function would be created and assigned to the class as
+    # the new __init__, but #2 is necessary since assigning attributes cannot
+    # be done to a builtin type (such as a class defined in cython).
     if obj_type is type:
         class WarningWrapperClass(obj):
             def __init__(self, *args, **kwargs):
                 warnings.warn(warning_msg, PendingDeprecationWarning)
-                # cython classes do not have a standard __init__, but assigning
-                # to self works instead.
-                if type(obj.__init__) is types.FunctionType:
+                # call base class __init__ for python, but cython classes do
+                # not have a standard callable __init__ and assigning to self
+                # works instead.
+                if isinstance(obj.__init__, types.FunctionType):
                     super(WarningWrapperClass, self).__init__(*args, **kwargs)
                 else:
                     self = obj(*args, **kwargs)
@@ -73,8 +76,9 @@ def experimental_warning_wrapper(obj):
 
         return WarningWrapperClass
 
-    # If this point is reached, the incoming obj is a function so wrap it and
-    # return the wrapper (which is also a function type).
+    # If this point is reached, the incoming obj is a function so simply wrap
+    # it and return the wrapper. Since the wrapper is a function type, it will
+    # match the incoming obj type.
     @functools.wraps(obj)
     def warning_wrapper_function(*args, **kwargs):
         warnings.warn(warning_msg, PendingDeprecationWarning)


### PR DESCRIPTION
`experimental_warning_wrapper()` returned a wrapper function that prints a `PendingDeprecationWarning` when an `experimental` API is used. It can be used for experimental functions and classes, however for classes, the wrapper it returns was a `function` type instead of a `type` type.  This caused the following problem:
```
>>> from cugraph.experimental import PropertyGraph
>>> pG = PropertyGraph()
>>> isinstance(pG, PropertyGraph)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: isinstance() arg 2 must be a type or tuple of types
```

This fix identifies the object to be wrapped and either creates a standard function wrapper for `function` types, or a class wrapper for `type` types:
```
>>> from cugraph.experimental import PropertyGraph
>>> pG = PropertyGraph()
>>> isinstance(pG, PropertyGraph)
True
```

NOTE: the `api_tools.py` module is copied in both cugraph and pylibcugraph. When cugraph starts using pylibcugraph, the copy in cugraph can be removed (see FIXME).