### PR TITLE
Updates to enable NumberMap to generate unique src/dst column names

### DIFF
--- a/notebooks/structure/Renumber-2.ipynb
+++ b/notebooks/structure/Renumber-2.ipynb
@@ -155,9 +155,11 @@
     "gdf['order'] = gdf.index\n",
     "\n",
     "tmp_df, numbering = NumberMap.renumber(gdf, ['src_ip'], ['dst_ip'])\n",
+    "new_src_col_name = numbering.renumbered_src_col_name\n",
+    "new_dst_col_name = numbering.renumbered_dst_col_name\n",
     "\n",
     "gdf = gdf.merge(tmp_df, on='order').sort_values('order').set_index(keys='order', drop=True)\n",
-    "gdf = gdf.rename(columns={'src': 'src_r', 'dst': 'dst_r'})"
+    "gdf = gdf.rename(columns={new_src_col_name: 'src_r', new_dst_col_name: 'dst_r'})"
    ]
   },
   {

--- a/notebooks/structure/Renumber.ipynb
+++ b/notebooks/structure/Renumber.ipynb
@@ -126,7 +126,7 @@
    "source": [
     "# Run renumbering\n",
     "\n",
-    "Output from renumbering is a data frame and a NumberMap object.  The data frame contains the renumbered sources and destinations.  The NumberMap will allow you to translate from external to internal vertex identifiers.  The renumbering call will rename the specified source and destination columns to indicate they were renumbered and no longer contain the original data, and the new names will be guaranteed to be unique and not collide with other column names.\n",
+    "Output from renumbering is a data frame and a NumberMap object.  The data frame contains the renumbered sources and destinations.  The NumberMap will allow you to translate from external to internal vertex identifiers.  The renumbering call will rename the specified source and destination columns to indicate they were renumbered and no longer contain the original data, and the new names are guaranteed to be unique and not collide with other column names.\n",
     "\n",
     "Note that renumbering does not guarantee that the output data frame is in the same order as the input data frame (although in our simple example it will match).  To address this we will add the index as a column of gdf before renumbering.\n"
    ]

--- a/notebooks/structure/Renumber.ipynb
+++ b/notebooks/structure/Renumber.ipynb
@@ -126,7 +126,7 @@
    "source": [
     "# Run renumbering\n",
     "\n",
-    "Output from renumbering is a data frame and a NumberMap object.  The data frame contains the renumbered sources and destinations.  The NumberMap will allow you to translate from external to internal vertex identifiers.\n",
+    "Output from renumbering is a data frame and a NumberMap object.  The data frame contains the renumbered sources and destinations.  The NumberMap will allow you to translate from external to internal vertex identifiers.  The renumbering call will rename the specified source and destination columns to indicate they were renumbered and no longer contain the original data, and the new names will be guaranteed to be unique and not collide with other column names.\n",
     "\n",
     "Note that renumbering does not guarantee that the output data frame is in the same order as the input data frame (although in our simple example it will match).  To address this we will add the index as a column of gdf before renumbering.\n"
    ]
@@ -140,6 +140,8 @@
     "gdf['order'] = gdf.index\n",
     "\n",
     "renumbered_df, numbering = NumberMap.renumber(gdf, ['source_as_int'], ['dest_as_int'])\n",
+    "new_src_col_name = numbering.renumbered_src_col_name\n",
+    "new_dst_col_name = numbering.renumbered_dst_col_name\n",
     "\n",
     "renumbered_df"
    ]
@@ -204,10 +206,10 @@
     "for i in range(len(renumbered_df)):\n",
     "    print(\" \", i,\n",
     "          \": (\",  source_as_int[i], \",\", dest_as_int[i],\n",
-    "          \"), renumbered: (\", renumbered_df['src'][i], \",\", renumbered_df['dst'][i], \n",
+    "          \"), renumbered: (\", renumbered_df[new_src_col_name][i], \",\", renumbered_df[new_dst_col_name][i], \n",
     "          \"), translate back: (\",\n",
-    "          numbering.from_internal_vertex_id(cudf.Series([renumbered_df['src'][i]]))['0'][0], \",\",\n",
-    "          numbering.from_internal_vertex_id(cudf.Series([renumbered_df['dst'][i]]))['0'][0], \")\"\n",
+    "          numbering.from_internal_vertex_id(cudf.Series([renumbered_df[new_src_col_name][i]]))['0'][0], \",\",\n",
+    "          numbering.from_internal_vertex_id(cudf.Series([renumbered_df[new_dst_col_name][i]]))['0'][0], \")\"\n",
     "         )\n"
    ]
   },
@@ -230,8 +232,8 @@
    "source": [
     "G = cugraph.Graph()\n",
     "gdf_r = cudf.DataFrame()\n",
-    "gdf_r[\"src\"] = renumbered_df[\"src\"]\n",
-    "gdf_r[\"dst\"] = renumbered_df[\"dst\"]\n",
+    "gdf_r[\"src\"] = renumbered_df[new_src_col_name]\n",
+    "gdf_r[\"dst\"] = renumbered_df[new_dst_col_name]\n",
     "\n",
     "G.from_cudf_edgelist(gdf_r, source='src', destination='dst', renumber=False)\n",
     "\n",

--- a/python/cugraph/cugraph/dask/centrality/katz_centrality.py
+++ b/python/cugraph/cugraph/dask/centrality/katz_centrality.py
@@ -24,6 +24,8 @@ import dask_cudf
 
 def call_katz_centrality(sID,
                          data,
+                         src_col_name,
+                         dst_col_name,
                          num_verts,
                          num_edges,
                          vertex_partition_offsets,
@@ -40,6 +42,8 @@ def call_katz_centrality(sID,
     segment_offsets = \
         aggregate_segment_offsets[local_size * wid: local_size * (wid + 1)]
     return mg_katz_centrality.mg_katz_centrality(data[0],
+                                                 src_col_name,
+                                                 dst_col_name,
                                                  num_verts,
                                                  num_edges,
                                                  vertex_partition_offsets,
@@ -153,9 +157,14 @@ def katz_centrality(input_graph,
     num_edges = len(ddf)
     data = get_distributed_data(ddf)
 
+    src_col_name = input_graph.renumber_map.renumbered_src_col_name
+    dst_col_name = input_graph.renumber_map.renumbered_dst_col_name
+
     result = [client.submit(call_katz_centrality,
                             Comms.get_session_id(),
                             wf[1],
+                            src_col_name,
+                            dst_col_name,
                             num_verts,
                             num_edges,
                             vertex_partition_offsets,

--- a/python/cugraph/cugraph/dask/centrality/mg_katz_centrality_wrapper.pyx
+++ b/python/cugraph/cugraph/dask/centrality/mg_katz_centrality_wrapper.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ import numpy as np
 
 
 def mg_katz_centrality(input_df,
+                       src_col_name,
+                       dst_col_name,
                        num_global_verts,
                        num_global_edges,
                        vertex_partition_offsets,
@@ -43,8 +45,8 @@ def mg_katz_centrality(input_df,
     cdef size_t handle_size_t = <size_t>handle.getHandle()
     handle_ = <c_katz_centrality.handle_t*>handle_size_t
 
-    src = input_df['src']
-    dst = input_df['dst']
+    src = input_df[src_col_name]
+    dst = input_df[dst_col_name]
     vertex_t = src.dtype
     if num_global_edges > (2**31 - 1):
         edge_t = np.dtype("int64")
@@ -79,7 +81,7 @@ def mg_katz_centrality(input_df,
     cdef uintptr_t c_edge_weights = <uintptr_t>NULL
     if weights is not None:
       c_edge_weights = weights.__cuda_array_interface__['data'][0]
-    
+
     # FIXME: data is on device, move to host (to_pandas()), convert to np array and access pointer to pass to C
     vertex_partition_offsets_host = vertex_partition_offsets.values_host
     cdef uintptr_t c_vertex_partition_offsets = vertex_partition_offsets_host.__array_interface__['data'][0]
@@ -109,7 +111,7 @@ def mg_katz_centrality(input_df,
                              num_global_verts, num_global_edges,
                              is_weighted,
                              False,
-                             True, True) 
+                             True, True)
 
     df = cudf.DataFrame()
     df['vertex'] = cudf.Series(np.arange(vertex_partition_offsets.iloc[rank], vertex_partition_offsets.iloc[rank+1]), dtype=vertex_t)

--- a/python/cugraph/cugraph/dask/common/input_utils.py
+++ b/python/cugraph/cugraph/dask/common/input_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -229,7 +229,9 @@ def get_vertex_partition_offsets(input_graph):
     renumber_vertex_count = input_graph.renumber_map.implementation.ddf.\
         map_partitions(len).compute()
     renumber_vertex_cumsum = renumber_vertex_count.cumsum()
-    vertex_dtype = input_graph.edgelist.edgelist_df['src'].dtype
+    # Assume the input_graph edgelist was renumbered
+    src_col_name = input_graph.renumber_map.renumbered_src_col_name
+    vertex_dtype = input_graph.edgelist.edgelist_df[src_col_name].dtype
     vertex_partition_offsets = cudf.Series([0], dtype=vertex_dtype)
     vertex_partition_offsets = vertex_partition_offsets.append(cudf.Series(
         renumber_vertex_cumsum, dtype=vertex_dtype))

--- a/python/cugraph/cugraph/dask/community/louvain.py
+++ b/python/cugraph/cugraph/dask/community/louvain.py
@@ -26,6 +26,8 @@ import dask_cudf
 
 def call_louvain(sID,
                  data,
+                 src_col_name,
+                 dst_col_name,
                  num_verts,
                  num_edges,
                  vertex_partition_offsets,
@@ -38,6 +40,8 @@ def call_louvain(sID,
     segment_offsets = \
         aggregate_segment_offsets[local_size * wid: local_size * (wid + 1)]
     return c_mg_louvain.louvain(data[0],
+                                src_col_name,
+                                dst_col_name,
                                 num_verts,
                                 num_edges,
                                 vertex_partition_offsets,
@@ -130,9 +134,14 @@ def louvain(input_graph, max_iter=100, resolution=1.0):
     num_edges = len(ddf)
     data = get_distributed_data(ddf)
 
+    src_col_name = input_graph.renumber_map.renumbered_src_col_name
+    dst_col_name = input_graph.renumber_map.renumbered_dst_col_name
+
     futures = [client.submit(call_louvain,
                              Comms.get_session_id(),
                              wf[1],
+                             src_col_name,
+                             dst_col_name,
                              num_verts,
                              num_edges,
                              vertex_partition_offsets,

--- a/python/cugraph/cugraph/dask/community/louvain_wrapper.pyx
+++ b/python/cugraph/cugraph/dask/community/louvain_wrapper.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -33,6 +33,8 @@ numberTypeMap = {np.dtype("int32") : <int>numberTypeEnum.int32Type,
 
 
 def louvain(input_df,
+            src_col_name,
+            dst_col_name,
             num_global_verts,
             num_global_edges,
             vertex_partition_offsets,
@@ -55,8 +57,8 @@ def louvain(input_df,
     # FIXME: much of this code is common to other algo wrappers, consider adding
     #        this to a shared utility as well
 
-    src = input_df['src']
-    dst = input_df['dst']
+    src = input_df[src_col_name]
+    dst = input_df[dst_col_name]
     num_local_edges = len(src)
 
     if "value" in input_df.columns:

--- a/python/cugraph/cugraph/dask/components/connectivity.py
+++ b/python/cugraph/cugraph/dask/components/connectivity.py
@@ -21,6 +21,8 @@ import dask_cudf
 
 def call_wcc(sID,
              data,
+             src_col_name,
+             dst_col_name,
              num_verts,
              num_edges,
              vertex_partition_offsets,
@@ -31,6 +33,8 @@ def call_wcc(sID,
     segment_offsets = \
         aggregate_segment_offsets[local_size * wid: local_size * (wid + 1)]
     return mg_connectivity.mg_wcc(data[0],
+                                  src_col_name,
+                                  dst_col_name,
                                   num_verts,
                                   num_edges,
                                   vertex_partition_offsets,
@@ -62,9 +66,14 @@ def weakly_connected_components(input_graph):
     num_edges = len(ddf)
     data = get_distributed_data(ddf)
 
+    src_col_name = input_graph.renumber_map.renumbered_src_col_name
+    dst_col_name = input_graph.renumber_map.renumbered_dst_col_name
+
     result = [client.submit(call_wcc,
                             Comms.get_session_id(),
                             wf[1],
+                            src_col_name,
+                            dst_col_name,
                             num_verts,
                             num_edges,
                             vertex_partition_offsets,

--- a/python/cugraph/cugraph/dask/components/mg_connectivity_wrapper.pyx
+++ b/python/cugraph/cugraph/dask/components/mg_connectivity_wrapper.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ import numpy as np
 
 
 def mg_wcc(input_df,
+           src_col_name,
+           dst_col_name,
            num_global_verts,
            num_global_edges,
            vertex_partition_offsets,
@@ -35,8 +37,8 @@ def mg_wcc(input_df,
     cdef size_t handle_size_t = <size_t>handle.getHandle()
     handle_ = <c_connectivity.handle_t*>handle_size_t
 
-    src = input_df['src']
-    dst = input_df['dst']
+    src = input_df[src_col_name]
+    dst = input_df[dst_col_name]
     vertex_t = src.dtype
     if num_global_edges > (2**31 - 1):
         edge_t = np.dtype("int64")
@@ -91,7 +93,7 @@ def mg_wcc(input_df,
                              is_weighted,
                              True,
                              False,
-                             True) 
+                             True)
 
     df = cudf.DataFrame()
     df['vertex'] = cudf.Series(np.arange(vertex_partition_offsets.iloc[rank], vertex_partition_offsets.iloc[rank+1]), dtype=vertex_t)
@@ -99,7 +101,7 @@ def mg_wcc(input_df,
 
     cdef uintptr_t c_labels_val = df['labels'].__cuda_array_interface__['data'][0];
 
-    if vertex_t == np.int32:    
+    if vertex_t == np.int32:
         c_connectivity.call_wcc[int, float](handle_[0],
                                             graph_container,
                                             <int*>c_labels_val)

--- a/python/cugraph/cugraph/dask/link_analysis/pagerank.py
+++ b/python/cugraph/cugraph/dask/link_analysis/pagerank.py
@@ -24,6 +24,8 @@ from dask.dataframe.shuffle import rearrange_by_column
 
 def call_pagerank(sID,
                   data,
+                  src_col_name,
+                  dst_col_name,
                   num_verts,
                   num_edges,
                   vertex_partition_offsets,
@@ -39,6 +41,8 @@ def call_pagerank(sID,
     segment_offsets = \
         aggregate_segment_offsets[local_size * wid: local_size * (wid + 1)]
     return mg_pagerank.mg_pagerank(data[0],
+                                   src_col_name,
+                                   dst_col_name,
                                    num_verts,
                                    num_edges,
                                    vertex_partition_offsets,
@@ -141,6 +145,9 @@ def pagerank(input_graph,
     num_edges = len(ddf)
     data = get_distributed_data(ddf)
 
+    src_col_name = input_graph.renumber_map.renumbered_src_col_name
+    dst_col_name = input_graph.renumber_map.renumbered_dst_col_name
+
     if personalization is not None:
         if input_graph.renumbered is True:
             personalization = input_graph.add_internal_vertex_id(
@@ -181,6 +188,8 @@ def pagerank(input_graph,
         result = [client.submit(call_pagerank,
                                 Comms.get_session_id(),
                                 wf[1],
+                                src_col_name,
+                                dst_col_name,
                                 num_verts,
                                 num_edges,
                                 vertex_partition_offsets,
@@ -196,6 +205,8 @@ def pagerank(input_graph,
         result = [client.submit(call_pagerank,
                                 Comms.get_session_id(),
                                 wf[1],
+                                src_col_name,
+                                dst_col_name,
                                 num_verts,
                                 num_edges,
                                 vertex_partition_offsets,

--- a/python/cugraph/cugraph/dask/traversal/bfs.py
+++ b/python/cugraph/cugraph/dask/traversal/bfs.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+from collections.abc import Iterable
+
 from dask.distributed import wait, default_client
 from cugraph.dask.common.input_utils import (get_distributed_data,
                                              get_vertex_partition_offsets)
@@ -24,6 +26,8 @@ import dask_cudf
 
 def call_bfs(sID,
              data,
+             src_col_name,
+             dst_col_name,
              num_verts,
              num_edges,
              vertex_partition_offsets,
@@ -37,6 +41,8 @@ def call_bfs(sID,
     segment_offsets = \
         aggregate_segment_offsets[local_size * wid: local_size * (wid + 1)]
     return mg_bfs.mg_bfs(data[0],
+                         src_col_name,
+                         dst_col_name,
                          num_verts,
                          num_edges,
                          vertex_partition_offsets,
@@ -48,7 +54,7 @@ def call_bfs(sID,
                          return_distances)
 
 
-def bfs(graph,
+def bfs(input_graph,
         start,
         depth_limit=None,
         return_distances=True):
@@ -60,8 +66,8 @@ def bfs(graph,
 
     Parameters
     ----------
-    graph : cugraph.DiGraph
-        cuGraph graph descriptor, should contain the connectivity information
+    input_graph : directed cugraph.Graph
+        cuGraph graph instance, should contain the connectivity information
         as dask cudf edge list dataframe(edge weights are not used for this
         algorithm). Undirected Graph not currently supported.
 
@@ -104,9 +110,9 @@ def bfs(graph,
 
     client = default_client()
 
-    graph.compute_renumber_edge_list(transposed=False)
-    ddf = graph.edgelist.edgelist_df
-    vertex_partition_offsets = get_vertex_partition_offsets(graph)
+    input_graph.compute_renumber_edge_list(transposed=False)
+    ddf = input_graph.edgelist.edgelist_df
+    vertex_partition_offsets = get_vertex_partition_offsets(input_graph)
     num_verts = vertex_partition_offsets.iloc[-1]
 
     num_edges = len(ddf)
@@ -116,9 +122,11 @@ def bfs(graph,
         x = df[0].merge(tmp_df, on=tmp_col_names, how='inner')
         return x['global_id']
 
-    if graph.renumbered:
-        renumber_ddf = graph.renumber_map.implementation.ddf
-        col_names = graph.renumber_map.implementation.col_names
+    if input_graph.renumbered:
+        src_col_name = input_graph.renumber_map.renumbered_src_col_name
+        dst_col_name = input_graph.renumber_map.renumbered_dst_col_name
+        renumber_ddf = input_graph.renumber_map.implementation.ddf
+        col_names = input_graph.renumber_map.implementation.col_names
         if isinstance(start,
                       dask_cudf.DataFrame) or isinstance(start,
                                                          cudf.DataFrame):
@@ -141,15 +149,39 @@ def bfs(graph,
                  for idx, wf in enumerate(renumber_data.worker_to_parts.items()
                                           )
                  ]
+    else:
+        # If the input graph was created with renumbering disabled (Graph(...,
+        # renumber=False), the above compute_renumber_edge_list() call will not
+        # perform a renumber step and the renumber_map will not have src/dst
+        # col names. In that case, the src/dst values specified when reading
+        # the edgelist dataframe are to be used, but only if they were single
+        # string values (ie. not a list representing multi-columns).
+        if isinstance(input_graph.source_columns, Iterable):
+            raise RuntimeError("input_graph was not renumbered but has a "
+                               "non-string source column name (got: "
+                               f"{input_graph.source_columns}). Re-create "
+                               "input_graph with either renumbering enabled "
+                               "or a source column specified as a string.")
+        if isinstance(input_graph.destination_columns, Iterable):
+            raise RuntimeError("input_graph was not renumbered but has a "
+                               "non-string destination column name (got: "
+                               f"{input_graph.destination_columns}). "
+                               "Re-create input_graph with either renumbering "
+                               "enabled or a destination column specified as "
+                               "a string.")
+        src_col_name = input_graph.source_columns
+        dst_col_name = input_graph.destination_columns
 
     result = [client.submit(
               call_bfs,
               Comms.get_session_id(),
               wf[1],
+              src_col_name,
+              dst_col_name,
               num_verts,
               num_edges,
               vertex_partition_offsets,
-              graph.aggregate_segment_offsets,
+              input_graph.aggregate_segment_offsets,
               start[idx],
               depth_limit,
               return_distances,
@@ -158,8 +190,8 @@ def bfs(graph,
     wait(result)
     ddf = dask_cudf.from_delayed(result)
 
-    if graph.renumbered:
-        ddf = graph.unrenumber(ddf, 'vertex')
-        ddf = graph.unrenumber(ddf, 'predecessor')
+    if input_graph.renumbered:
+        ddf = input_graph.unrenumber(ddf, 'vertex')
+        ddf = input_graph.unrenumber(ddf, 'predecessor')
         ddf = ddf.fillna(-1)
     return ddf

--- a/python/cugraph/cugraph/dask/traversal/mg_bfs_wrapper.pyx
+++ b/python/cugraph/cugraph/dask/traversal/mg_bfs_wrapper.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import cugraph.structure.graph_primtypes_wrapper as graph_primtypes_wrapper
 from libc.stdint cimport uintptr_t
 
 def mg_bfs(input_df,
+           src_col_name,
+           dst_col_name,
            num_global_verts,
            num_global_edges,
            vertex_partition_offsets,
@@ -38,8 +40,8 @@ def mg_bfs(input_df,
     handle_ = <c_bfs.handle_t*>handle_size_t
 
     # Local COO information
-    src = input_df['src']
-    dst = input_df['dst']
+    src = input_df[src_col_name]
+    dst = input_df[dst_col_name]
     vertex_t = src.dtype
     if num_global_edges > (2**31 - 1):
         edge_t = np.dtype("int64")
@@ -95,7 +97,7 @@ def mg_bfs(input_df,
                              num_global_verts, num_global_edges,
                              False, # BFS runs on unweighted graphs
                              False,
-                             False, True) 
+                             False, True)
 
     # Generate the cudf.DataFrame result
     df = cudf.DataFrame()
@@ -113,7 +115,7 @@ def mg_bfs(input_df,
 
     cdef bool direction_optimizing = <bool> 0
 
-    if vertex_t == np.int32:    
+    if vertex_t == np.int32:
         if depth_limit is None:
             depth_limit = c_bfs.INT_MAX
         c_bfs.call_bfs[int, float](handle_[0],

--- a/python/cugraph/cugraph/dask/traversal/mg_sssp_wrapper.pyx
+++ b/python/cugraph/cugraph/dask/traversal/mg_sssp_wrapper.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import cugraph.structure.graph_primtypes_wrapper as graph_primtypes_wrapper
 from libc.stdint cimport uintptr_t
 
 def mg_sssp(input_df,
+            src_col_name,
+            dst_col_name,
             num_global_verts,
             num_global_edges,
             vertex_partition_offsets,
@@ -37,8 +39,8 @@ def mg_sssp(input_df,
     handle_ = <c_sssp.handle_t*>handle_size_t
 
     # Local COO information
-    src = input_df['src']
-    dst = input_df['dst']
+    src = input_df[src_col_name]
+    dst = input_df[dst_col_name]
     vertex_t = src.dtype
     if num_global_edges > (2**31 - 1):
         edge_t = np.dtype("int64")
@@ -98,7 +100,7 @@ def mg_sssp(input_df,
                              num_global_verts, num_global_edges,
                              is_weighted,
                              False,
-                             False, True) 
+                             False, True)
 
     # Generate the cudf.DataFrame result
     df = cudf.DataFrame()

--- a/python/cugraph/cugraph/structure/graph_classes.py
+++ b/python/cugraph/cugraph/structure/graph_classes.py
@@ -46,7 +46,6 @@ class Graph:
     >>> G = cugraph.Graph()
     >>> # directed graph
     >>> G = cugraph.Graph(directed=True)
-
     """
 
     class Properties:
@@ -140,10 +139,10 @@ class Graph:
         if self._Impl is None:
             self._Impl = simpleGraphImpl(self.graph_properties)
         elif type(self._Impl) is not simpleGraphImpl:
-            raise Exception("Graph is already initialized")
+            raise RuntimeError("Graph is already initialized")
         elif (self._Impl.edgelist is not None or
               self._Impl.adjlist is not None):
-            raise Exception("Graph already has values")
+            raise RuntimeError("Graph already has values")
         self._Impl._simpleGraphImpl__from_edgelist(input_df,
                                                    source=source,
                                                    destination=destination,
@@ -197,10 +196,10 @@ class Graph:
         if self._Impl is None:
             self._Impl = simpleGraphImpl(self.graph_properties)
         elif type(self._Impl) is not simpleGraphImpl:
-            raise Exception("Graph is already initialized")
+            raise RuntimeError("Graph is already initialized")
         elif (self._Impl.edgelist is not None or
               self._Impl.adjlist is not None):
-            raise Exception("Graph already has values")
+            raise RuntimeError("Graph already has values")
         self._Impl._simpleGraphImpl__from_adjlist(offset_col,
                                                   index_col,
                                                   value_col)
@@ -247,9 +246,9 @@ class Graph:
         if self._Impl is None:
             self._Impl = simpleDistributedGraphImpl(self.graph_properties)
         elif type(self._Impl) is not simpleDistributedGraphImpl:
-            raise Exception("Graph is already initialized")
+            raise RuntimeError("Graph is already initialized")
         elif (self._Impl.edgelist is not None):
-            raise Exception("Graph already has values")
+            raise RuntimeError("Graph already has values")
         self._Impl._simpleDistributedGraphImpl__from_edgelist(input_ddf,
                                                               source,
                                                               destination,
@@ -770,7 +769,7 @@ class NPartiteGraph(Graph):
             If source and destination indices are not in range 0 to V where V
             is number of vertices, renumber argument should be True.
         """
-        raise Exception("Distributed N-partite graph not supported")
+        raise TypeError("Distributed N-partite graph not supported")
 
     def add_nodes_from(self, nodes, bipartite=None, multipartite=None):
         """

--- a/python/cugraph/cugraph/structure/graph_primtypes.pyx
+++ b/python/cugraph/cugraph/structure/graph_primtypes.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -57,6 +57,8 @@ cdef move_device_buffer_to_series(
 
 
 cdef coo_to_df(GraphCOOPtrType graph):
+    # FIXME: this function assumes columns named "src" and "dst" and can only
+    # be used for SG graphs due to that assumption.
     contents = move(graph.get()[0].release())
     src = move_device_buffer_to_column(move(contents.src_indices), "int32")
     dst = move_device_buffer_to_column(move(contents.dst_indices), "int32")
@@ -121,6 +123,8 @@ cdef GraphCSRViewType get_csr_graph_view(input_graph, bool weighted=True, GraphC
 
 
 cdef GraphCOOViewType get_coo_graph_view(input_graph, bool weighted=True, GraphCOOViewType* dummy=NULL):
+    # FIXME: this function assumes columns named "src" and "dst" and can only
+    # be used for SG graphs due to that assumption.
     if not input_graph.edgelist:
         input_graph.view_edge_list()
 

--- a/python/cugraph/cugraph/structure/number_map.py
+++ b/python/cugraph/cugraph/structure/number_map.py
@@ -295,6 +295,7 @@ class NumberMap:
         self.renumbered_src_col_name = "renumbered_src"
         self.renumbered_dst_col_name = "renumbered_dst"
 
+    @staticmethod
     def compute_vals_types(df, column_names):
         """
         Helper function to compute internal column names and types
@@ -315,6 +316,7 @@ class NumberMap:
             counter += 1
         return name
 
+    @staticmethod
     def compute_vals(column_names):
         """
         Helper function to compute internal column names based on external
@@ -483,6 +485,7 @@ class NumberMap:
 
         return output_df
 
+    @staticmethod
     def renumber_and_segment(
         df, src_col_names, dst_col_names, preserve_order=False,
         store_transposed=False
@@ -501,8 +504,8 @@ class NumberMap:
             dst_col_names = [dst_col_names]
 
         # Assign the new src and dst column names to be used in the renumbered
-        # dataframe to return (self.renumbered_src_col_name and
-        # self.renumbered_dst_col_name)
+        # dataframe to return (renumbered_src_col_name and
+        # renumbered_dst_col_name)
         renumber_map.set_renumbered_col_names(
             src_col_names, dst_col_names, df.columns)
 
@@ -635,6 +638,7 @@ class NumberMap:
             renumber_map.implementation.numbered = True
             return renumbered_df, renumber_map, segment_offsets
 
+    @staticmethod
     def renumber(df, src_col_names, dst_col_names, preserve_order=False,
                  store_transposed=False):
         return NumberMap.renumber_and_segment(

--- a/python/cugraph/cugraph/structure/number_map.py
+++ b/python/cugraph/cugraph/structure/number_map.py
@@ -13,23 +13,30 @@
 # limitations under the License.
 #
 
+from collections.abc import Iterable
+
 from dask.distributed import wait, default_client
-from cugraph.dask.common.input_utils import get_distributed_data
-from cugraph.structure import renumber_wrapper as c_renumber
-import cugraph.comms.comms as Comms
 import dask_cudf
 import numpy as np
 import cudf
 
+from cugraph.dask.common.input_utils import get_distributed_data
+from cugraph.structure import renumber_wrapper as c_renumber
+import cugraph.comms.comms as Comms
+
 
 def call_renumber(sID,
                   data,
+                  renumbered_src_col_name,
+                  renumbered_dst_col_name,
                   num_edges,
                   is_mnmg,
                   store_transposed):
     wid = Comms.get_worker_id(sID)
     handle = Comms.get_handle(sID)
     return c_renumber.renumber(data[0],
+                               renumbered_src_col_name,
+                               renumbered_dst_col_name,
                                num_edges,
                                wid,
                                handle,
@@ -282,6 +289,11 @@ class NumberMap:
     def __init__(self, id_type=np.int32):
         self.implementation = None
         self.id_type = id_type
+        # The default src/dst column names in the resulting renumbered
+        # dataframe. These may be updated by the renumbering methods if the
+        # input dataframe uses the default names.
+        self.renumbered_src_col_name = "renumbered_src"
+        self.renumbered_dst_col_name = "renumbered_dst"
 
     def compute_vals_types(df, column_names):
         """
@@ -291,14 +303,16 @@ class NumberMap:
             str(i): df[column_names[i]].dtype for i in range(len(column_names))
         }
 
-    def generate_unused_column_name(column_names):
+    @staticmethod
+    def generate_unused_column_name(column_names, start_with_name="col"):
         """
         Helper function to generate an unused column name
         """
-        name = 'x'
+        name = start_with_name
+        counter = 2
         while name in column_names:
-            name = name + "x"
-
+            name = f"{start_with_name}{counter}"
+            counter += 1
         return name
 
     def compute_vals(column_names):
@@ -486,6 +500,12 @@ class NumberMap:
             src_col_names = [src_col_names]
             dst_col_names = [dst_col_names]
 
+        # Assign the new src and dst column names to be used in the renumbered
+        # dataframe to return (self.renumbered_src_col_name and
+        # self.renumbered_dst_col_name)
+        renumber_map.set_renumbered_col_names(
+            src_col_names, dst_col_names, df.columns)
+
         id_type = df[src_col_names[0]].dtype
         if isinstance(df, cudf.DataFrame):
             renumber_map.implementation = NumberMap.SingleGPU(
@@ -498,7 +518,7 @@ class NumberMap:
                 store_transposed
             )
         else:
-            raise Exception("df must be cudf.DataFrame or dask_cudf.DataFrame")
+            raise TypeError("df must be cudf.DataFrame or dask_cudf.DataFrame")
 
         if renumber_type == 'legacy':
             indirection_map = renumber_map.implementation.\
@@ -506,17 +526,20 @@ class NumberMap:
                                               src_col_names,
                                               dst_col_names)
             df = renumber_map.add_internal_vertex_id(
-                df, "src", src_col_names, drop=True,
-                preserve_order=preserve_order
+                df, renumber_map.renumbered_src_col_name, src_col_names,
+                drop=True, preserve_order=preserve_order
             )
             df = renumber_map.add_internal_vertex_id(
-                df, "dst", dst_col_names, drop=True,
-                preserve_order=preserve_order
+                df, renumber_map.renumbered_dst_col_name, dst_col_names,
+                drop=True, preserve_order=preserve_order
             )
         else:
-            df = df.rename(columns={src_col_names[0]: "src",
-                                    dst_col_names[0]: "dst"})
-
+            df = df.rename(
+                columns={src_col_names[0]:
+                         renumber_map.renumbered_src_col_name,
+                         dst_col_names[0]:
+                         renumber_map.renumbered_dst_col_name}
+            )
         num_edges = len(df)
 
         if isinstance(df, dask_cudf.DataFrame):
@@ -530,6 +553,8 @@ class NumberMap:
             result = [(client.submit(call_renumber,
                                      Comms.get_session_id(),
                                      wf[1],
+                                     renumber_map.renumbered_src_col_name,
+                                     renumber_map.renumbered_dst_col_name,
                                      num_edges,
                                      is_mnmg,
                                      store_transposed,
@@ -544,10 +569,12 @@ class NumberMap:
                 return data[1]
 
             def get_renumbered_df(id_type, data):
-                # FIXME: This assume the column names are always 'src'
-                # and 'dst' which is the case now
-                data[2]['src'] = data[2]['src'].astype(id_type)
-                data[2]['dst'] = data[2]['dst'].astype(id_type)
+                data[2][renumber_map.renumbered_src_col_name] = \
+                    data[2][renumber_map.renumbered_src_col_name]\
+                    .astype(id_type)
+                data[2][renumber_map.renumbered_dst_col_name] = \
+                    data[2][renumber_map.renumbered_dst_col_name]\
+                    .astype(id_type)
                 return data[2]
 
             renumbering_map = dask_cudf.from_delayed(
@@ -588,6 +615,8 @@ class NumberMap:
         else:
             renumbering_map, segment_offsets, renumbered_df = \
                 c_renumber.renumber(df,
+                                    renumber_map.renumbered_src_col_name,
+                                    renumber_map.renumbered_dst_col_name,
                                     num_edges,
                                     0,
                                     Comms.get_default_handle(),
@@ -658,7 +687,9 @@ class NumberMap:
         ...                    header=None)
         >>> df, number_map = number_map.NumberMap.renumber(df, '0', '1')
         >>> G = cugraph.Graph()
-        >>> G.from_cudf_edgelist(df, 'src', 'dst')
+        >>> G.from_cudf_edgelist(df,
+        ...                      number_map.renumbered_src_col_name,
+        ...                      number_map.renumbered_dst_col_name)
         >>> pr = cugraph.pagerank(G, alpha = 0.85, max_iter = 500,
         ...                       tol = 1.0e-05)
         >>> pr = number_map.unrenumber(pr, 'vertex')
@@ -699,3 +730,34 @@ class NumberMap:
 
     def vertex_column_size(self):
         return len(self.implementation.col_names)
+
+    def set_renumbered_col_names(self,
+                                 src_col_names_to_replace,
+                                 dst_col_names_to_replace,
+                                 all_col_names):
+        """
+        Sets self.renumbered_src_col_name and self.renumbered_dst_col_name to
+        values that can be used to replace src_col_names_to_replace and
+        dst_col_names_to_replace to values that will not collide with any other
+        column names in all_col_names.
+
+        The new unique column names are generated using the existing
+        self.renumbered_src_col_name and self.renumbered_dst_col_name as
+        starting points.
+        """
+        assert isinstance(src_col_names_to_replace, Iterable)
+        assert isinstance(dst_col_names_to_replace, Iterable)
+        assert isinstance(all_col_names, Iterable)
+        # No need to consider the col_names_to_replace when picking new unique
+        # names, since those names will be replaced anyway, and replacing a
+        # name with the same value is allowed.
+        reserved_col_names = set(all_col_names) - \
+            set(src_col_names_to_replace + dst_col_names_to_replace)
+        self.renumbered_src_col_name = \
+            self.generate_unused_column_name(
+                reserved_col_names,
+                start_with_name=self.renumbered_src_col_name)
+        self.renumbered_dst_col_name = \
+            self.generate_unused_column_name(
+                reserved_col_names,
+                start_with_name=self.renumbered_dst_col_name)

--- a/python/cugraph/cugraph/structure/renumber_wrapper.pyx
+++ b/python/cugraph/cugraph/structure/renumber_wrapper.pyx
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -71,6 +71,8 @@ cdef renumber_helper(shuffled_vertices_t* ptr_maj_min_w, vertex_t, weights):
 
 
 def renumber(input_df,           # maybe use cpdef ?
+             renumbered_src_col_name,
+             renumbered_dst_col_name,
              num_global_edges,
              rank,
              handle,
@@ -84,11 +86,11 @@ def renumber(input_df,           # maybe use cpdef ?
     handle_ptr = <handle_t*>handle_size_t
 
     if not transposed:
-        major_vertices = input_df['src']
-        minor_vertices = input_df['dst']
+        major_vertices = input_df[renumbered_src_col_name]
+        minor_vertices = input_df[renumbered_dst_col_name]
     else:
-        major_vertices = input_df['dst']
-        minor_vertices = input_df['src']
+        major_vertices = input_df[renumbered_dst_col_name]
+        minor_vertices = input_df[renumbered_src_col_name]
 
     cdef uintptr_t c_edge_weights = <uintptr_t>NULL # set below...
 
@@ -175,9 +177,9 @@ def renumber(input_df,           # maybe use cpdef ?
                     minor_vertices = shuffled_df['minor_vertices']
                     num_local_edges = len(shuffled_df)
                     if not transposed:
-                        major = 'src'; minor = 'dst'
+                        major = renumbered_src_col_name; minor = renumbered_dst_col_name
                     else:
-                        major = 'dst'; minor = 'src'
+                        major = renumbered_dst_col_name; minor = renumbered_src_col_name
                     shuffled_df = shuffled_df.rename(columns={'major_vertices':major, 'minor_vertices':minor}, copy=False)
                     edge_counts_32 = move(ptr_shuffled_32_32_32.get().get_edge_counts_wrap())
                 else:
@@ -240,9 +242,9 @@ def renumber(input_df,           # maybe use cpdef ?
                     minor_vertices = shuffled_df['minor_vertices']
                     num_local_edges = len(shuffled_df)
                     if not transposed:
-                        major = 'src'; minor = 'dst'
+                        major = renumbered_src_col_name; minor = renumbered_dst_col_name
                     else:
-                        major = 'dst'; minor = 'src'
+                        major = renumbered_dst_col_name; minor = renumbered_src_col_name
                     shuffled_df = shuffled_df.rename(columns={'major_vertices':major, 'minor_vertices':minor}, copy=False)
                     edge_counts_32 = move(ptr_shuffled_32_32_64.get().get_edge_counts_wrap())
                 else:
@@ -307,9 +309,9 @@ def renumber(input_df,           # maybe use cpdef ?
                     minor_vertices = shuffled_df['minor_vertices']
                     num_local_edges = len(shuffled_df)
                     if not transposed:
-                        major = 'src'; minor = 'dst'
+                        major = renumbered_src_col_name; minor = renumbered_dst_col_name
                     else:
-                        major = 'dst'; minor = 'src'
+                        major = renumbered_dst_col_name; minor = renumbered_src_col_name
                     shuffled_df = shuffled_df.rename(columns={'major_vertices':major, 'minor_vertices':minor}, copy=False)
                     edge_counts_64 = move(ptr_shuffled_32_64_32.get().get_edge_counts_wrap())
                 else:
@@ -372,9 +374,9 @@ def renumber(input_df,           # maybe use cpdef ?
                     minor_vertices = shuffled_df['minor_vertices']
                     num_local_edges = len(shuffled_df)
                     if not transposed:
-                        major = 'src'; minor = 'dst'
+                        major = renumbered_src_col_name; minor = renumbered_dst_col_name
                     else:
-                        major = 'dst'; minor = 'src'
+                        major = renumbered_dst_col_name; minor = renumbered_src_col_name
                     shuffled_df = shuffled_df.rename(columns={'major_vertices':major, 'minor_vertices':minor}, copy=False)
                     edge_counts_64 = move(ptr_shuffled_32_64_64.get().get_edge_counts_wrap())
                 else:
@@ -439,9 +441,9 @@ def renumber(input_df,           # maybe use cpdef ?
                     minor_vertices = shuffled_df['minor_vertices']
                     num_local_edges = len(shuffled_df)
                     if not transposed:
-                        major = 'src'; minor = 'dst'
+                        major = renumbered_src_col_name; minor = renumbered_dst_col_name
                     else:
-                        major = 'dst'; minor = 'src'
+                        major = renumbered_dst_col_name; minor = renumbered_src_col_name
                     shuffled_df = shuffled_df.rename(columns={'major_vertices':major, 'minor_vertices':minor}, copy=False)
                     edge_counts_64 = move(ptr_shuffled_64_64_32.get().get_edge_counts_wrap())
                 else:
@@ -505,9 +507,9 @@ def renumber(input_df,           # maybe use cpdef ?
                     minor_vertices = shuffled_df['minor_vertices']
                     num_local_edges = len(shuffled_df)
                     if not transposed:
-                        major = 'src'; minor = 'dst'
+                        major = renumbered_src_col_name; minor = renumbered_dst_col_name
                     else:
-                        major = 'dst'; minor = 'src'
+                        major = renumbered_dst_col_name; minor = renumbered_src_col_name
                     shuffled_df = shuffled_df.rename(columns={'major_vertices':major, 'minor_vertices':minor}, copy=False)
                     edge_counts_64 = move(ptr_shuffled_64_64_64.get().get_edge_counts_wrap())
                 else:

--- a/python/cugraph/cugraph/tests/dask/test_mg_katz_centrality.py
+++ b/python/cugraph/cugraph/tests/dask/test_mg_katz_centrality.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -41,7 +41,7 @@ def test_dask_katz_centrality(dask_client):
         dtype=["int32", "int32", "float32"],
     )
 
-    dg = cugraph.DiGraph()
+    dg = cugraph.Graph(directed=True)
     dg.from_dask_cudf_edgelist(ddf, "src", "dst")
 
     largest_out_degree = dg.out_degree().compute().\

--- a/python/cugraph/cugraph/tests/test_renumber.py
+++ b/python/cugraph/cugraph/tests/test_renumber.py
@@ -52,10 +52,12 @@ def test_renumber_ips():
     input_check = renumbered_gdf.merge(gdf, on=["source_list", "dest_list"])
 
     output_check = renumber_map.from_internal_vertex_id(
-        renumbered_gdf, "src", external_column_names=["check_src"]
+        renumbered_gdf, renumber_map.renumbered_src_col_name,
+        external_column_names=["check_src"]
     )
     output_check = renumber_map.from_internal_vertex_id(
-        output_check, "dst", external_column_names=["check_dst"]
+        output_check, renumber_map.renumbered_dst_col_name,
+        external_column_names=["check_dst"]
     )
 
     merged = output_check.merge(input_check, on=["source_list", "dest_list"])
@@ -97,10 +99,12 @@ def test_renumber_ips_cols():
     input_check = renumbered_gdf.merge(gdf, on=["source_list", "dest_list"])
 
     output_check = renumber_map.from_internal_vertex_id(
-        renumbered_gdf, "src", external_column_names=["check_src"]
+        renumbered_gdf, renumber_map.renumbered_src_col_name,
+        external_column_names=["check_src"]
     )
     output_check = renumber_map.from_internal_vertex_id(
-        output_check, "dst", external_column_names=["check_dst"]
+        output_check, renumber_map.renumbered_dst_col_name,
+        external_column_names=["check_dst"]
     )
 
     merged = output_check.merge(input_check, on=["source_list", "dest_list"])
@@ -132,10 +136,12 @@ def test_renumber_negative():
     )
 
     output_check = renumber_map.from_internal_vertex_id(
-        renumbered_gdf, "src", external_column_names=["check_src"]
+        renumbered_gdf, renumber_map.renumbered_src_col_name,
+        external_column_names=["check_src"]
     )
     output_check = renumber_map.from_internal_vertex_id(
-        output_check, "dst", external_column_names=["check_dst"]
+        output_check, renumber_map.renumbered_dst_col_name,
+        external_column_names=["check_dst"]
     )
 
     merged = output_check.merge(
@@ -169,10 +175,12 @@ def test_renumber_negative_col():
     )
 
     output_check = renumber_map.from_internal_vertex_id(
-        renumbered_gdf, "src", external_column_names=["check_src"]
+        renumbered_gdf, renumber_map.renumbered_src_col_name,
+        external_column_names=["check_src"]
     )
     output_check = renumber_map.from_internal_vertex_id(
-        output_check, "dst", external_column_names=["check_dst"]
+        output_check, renumber_map.renumbered_dst_col_name,
+        external_column_names=["check_dst"]
     )
 
     merged = output_check.merge(
@@ -209,14 +217,20 @@ def test_renumber_files(graph_file):
     )
 
     unrenumbered_df = renumber_map.unrenumber(
-        renumbered_df, "src", preserve_order=True
+        renumbered_df, renumber_map.renumbered_src_col_name,
+        preserve_order=True
     )
     unrenumbered_df = renumber_map.unrenumber(
-        unrenumbered_df, "dst", preserve_order=True
+        unrenumbered_df, renumber_map.renumbered_dst_col_name,
+        preserve_order=True
     )
 
-    assert_series_equal(exp_src, unrenumbered_df["src"], check_names=False)
-    assert_series_equal(exp_dst, unrenumbered_df["dst"], check_names=False)
+    assert_series_equal(exp_src,
+                        unrenumbered_df[renumber_map.renumbered_src_col_name],
+                        check_names=False)
+    assert_series_equal(exp_dst,
+                        unrenumbered_df[renumber_map.renumbered_dst_col_name],
+                        check_names=False)
 
 
 @pytest.mark.parametrize("graph_file", utils.DATASETS)
@@ -241,14 +255,20 @@ def test_renumber_files_col(graph_file):
     )
 
     unrenumbered_df = renumber_map.unrenumber(
-        renumbered_df, "src", preserve_order=True
+        renumbered_df, renumber_map.renumbered_src_col_name,
+        preserve_order=True
     )
     unrenumbered_df = renumber_map.unrenumber(
-        unrenumbered_df, "dst", preserve_order=True
+        unrenumbered_df, renumber_map.renumbered_dst_col_name,
+        preserve_order=True
     )
 
-    assert_series_equal(exp_src, unrenumbered_df["src"], check_names=False)
-    assert_series_equal(exp_dst, unrenumbered_df["dst"], check_names=False)
+    assert_series_equal(exp_src,
+                        unrenumbered_df[renumber_map.renumbered_src_col_name],
+                        check_names=False)
+    assert_series_equal(exp_dst,
+                        unrenumbered_df[renumber_map.renumbered_dst_col_name],
+                        check_names=False)
 
 
 @pytest.mark.parametrize("graph_file", utils.DATASETS)
@@ -272,21 +292,83 @@ def test_renumber_files_multi_col(graph_file):
     )
 
     unrenumbered_df = renumber_map.unrenumber(
-        renumbered_df, "src", preserve_order=True
+        renumbered_df, renumber_map.renumbered_src_col_name,
+        preserve_order=True
     )
     unrenumbered_df = renumber_map.unrenumber(
-        unrenumbered_df, "dst", preserve_order=True
+        unrenumbered_df, renumber_map.renumbered_dst_col_name,
+        preserve_order=True
     )
 
+    src = renumber_map.renumbered_src_col_name
+    dst = renumber_map.renumbered_dst_col_name
     assert_series_equal(
-        gdf["src"], unrenumbered_df["0_src"], check_names=False
+        gdf["src"], unrenumbered_df[f"0_{src}"], check_names=False
     )
     assert_series_equal(
-        gdf["src_old"], unrenumbered_df["1_src"], check_names=False
+        gdf["src_old"], unrenumbered_df[f"1_{src}"], check_names=False
     )
     assert_series_equal(
-        gdf["dst"], unrenumbered_df["0_dst"], check_names=False
+        gdf["dst"], unrenumbered_df[f"0_{dst}"], check_names=False
     )
     assert_series_equal(
-        gdf["dst_old"], unrenumbered_df["1_dst"], check_names=False
+        gdf["dst_old"], unrenumbered_df[f"1_{dst}"], check_names=False
     )
+
+
+def test_renumber_common_col_names():
+    """
+    Ensure that commonly-used column names in the input do not conflict with
+    names used internally by NumberMap.
+    """
+    # test multi-column ("legacy" renumbering code path)
+    gdf = cudf.DataFrame({"src": [0, 1, 2],
+                          "dst": [1, 2, 3],
+                          "weights": [0.1, 0.2, 0.3],
+                          "col_a": [8, 1, 82],
+                          "col_b": [1, 82, 3],
+                          "col_c": [9, 7, 2],
+                          "col_d": [1, 2, 3]})
+
+    renumbered_df, renumber_map = NumberMap.renumber(
+        gdf, ["col_a", "col_b"], ["col_c", "col_d"])
+
+    assert renumber_map.renumbered_src_col_name != "src"
+    assert renumber_map.renumbered_dst_col_name != "dst"
+    assert renumber_map.renumbered_src_col_name in renumbered_df.columns
+    assert renumber_map.renumbered_dst_col_name in renumbered_df.columns
+
+    # test experimental renumbering code path
+    gdf = cudf.DataFrame({"src": [0, 1, 2],
+                          "dst": [1, 2, 3],
+                          "weights": [0.1, 0.2, 0.3],
+                          "col_a": [0, 1, 2],
+                          "col_b": [1, 2, 3]})
+
+    renumbered_df, renumber_map = NumberMap.renumber(gdf, "col_a", "col_b")
+
+    assert renumber_map.renumbered_src_col_name != "src"
+    assert renumber_map.renumbered_dst_col_name != "dst"
+    assert renumber_map.renumbered_src_col_name in renumbered_df.columns
+    assert renumber_map.renumbered_dst_col_name in renumbered_df.columns
+
+
+def test_renumber_unrenumber_non_default_vert_names():
+    """
+    Test that renumbering a dataframe with generated src/dst column names can
+    be used for unrenumbering results.
+    """
+    input_gdf = cudf.DataFrame({"dst": [1, 2, 3],
+                                "weights": [0.1, 0.2, 0.3],
+                                "col_a": [99, 199, 2],
+                                "col_b": [199, 2, 32]})
+
+    renumbered_df, number_map = NumberMap.renumber(input_gdf, "col_a", "col_b")
+
+    some_result_gdf = cudf.DataFrame({"vertex": [0, 1, 2, 3]})
+    expected_values = [99, 199, 2, 32]
+
+    some_result_gdf = number_map.unrenumber(some_result_gdf, "vertex")
+
+    assert sorted(expected_values) == \
+           sorted(some_result_gdf["vertex"].to_arrow().to_pylist())


### PR DESCRIPTION
* Updates to enable `NumberMap` to generate unique src/dst column names instead of assuming the names `src` and `dst`. This is needed since cudf no longer allows for duplicate column names, and some user input may contain "src" and "dst" as pre-existing column names intended for other purposes.
* This commit also cleans up various tech debt items (exception types, docstrings, etc.).

Tested by ensuring the existing python unit tests for SG and MG (2 GPUs) passed, and also ran all notebooks as tests. New tests to emphasize support for specific column names that previously failed with the latest cudf were also added.