### PR TITLE
Add CMake `install` rules for tests

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -136,11 +136,12 @@ function(ConfigureTest CMAKE_TEST_NAME)
 
     set_target_properties(
         ${CMAKE_TEST_NAME}
-            PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
+            PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib")
 
     install(
         TARGETS ${CMAKE_TEST_NAME}
         COMPONENT testing
+        DESTINATION bin/gtests/libcugraph
         EXCLUDE_FROM_ALL)
 endfunction()
 
@@ -222,11 +223,12 @@ function(ConfigureTestMG CMAKE_TEST_NAME)
 
     set_target_properties(
         ${CMAKE_TEST_NAME}
-            PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
+            PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib")
 
         install(
             TARGETS ${CMAKE_TEST_NAME}
             COMPONENT testing
+            DESTINATION bin/gtests/libcugraph_mg
             EXCLUDE_FROM_ALL)
 endfunction()
 
@@ -247,11 +249,12 @@ function(ConfigureCTest CMAKE_TEST_NAME)
 
     set_target_properties(
         ${CMAKE_TEST_NAME}
-            PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
+            PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib")
 
         install(
             TARGETS ${CMAKE_TEST_NAME}
             COMPONENT testing
+            DESTINATION bin/gtests/libcugraph_c
             EXCLUDE_FROM_ALL)
 endfunction()
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -133,6 +133,15 @@ function(ConfigureTest CMAKE_TEST_NAME)
     endif(OpenMP_CXX_FOUND)
 
     add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
+
+    set_target_properties(
+        ${CMAKE_TEST_NAME}
+            PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
+
+    install(
+        TARGETS ${CMAKE_TEST_NAME}
+        COMPONENT testing
+        EXCLUDE_FROM_ALL)
 endfunction()
 
 function(ConfigureTestMG CMAKE_TEST_NAME)
@@ -211,6 +220,14 @@ function(ConfigureTestMG CMAKE_TEST_NAME)
              ${CMAKE_TEST_NAME}
              ${MPIEXEC_POSTFLAGS})
 
+    set_target_properties(
+        ${CMAKE_TEST_NAME}
+            PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
+
+        install(
+            TARGETS ${CMAKE_TEST_NAME}
+            COMPONENT testing
+            EXCLUDE_FROM_ALL)
 endfunction()
 
 function(ConfigureCTest CMAKE_TEST_NAME)
@@ -227,6 +244,15 @@ function(ConfigureCTest CMAKE_TEST_NAME)
     )
 
     add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
+
+    set_target_properties(
+        ${CMAKE_TEST_NAME}
+            PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
+
+        install(
+            TARGETS ${CMAKE_TEST_NAME}
+            COMPONENT testing
+            EXCLUDE_FROM_ALL)
 endfunction()
 
 ###################################################################################################


### PR DESCRIPTION
This PR adds a CMake `install` rule for test targets. This step is a prerequisite to being able to package tests in their own `conda` package, which will enable us to deprecate _Project Flash_.