### PR TITLE
Added `pylibcugraph` utility for setting up return array values

### DIFF
--- a/python/pylibcugraph/pylibcugraph/graphs.pyx
+++ b/python/pylibcugraph/pylibcugraph/graphs.pyx
@@ -28,7 +28,7 @@ from pylibcugraph._cugraph_c.error cimport (
 from pylibcugraph._cugraph_c.array cimport (
     cugraph_type_erased_device_array_view_t,
     cugraph_type_erased_device_array_view_create,
-    cugraph_type_erased_device_array_free,
+    cugraph_type_erased_device_array_view_free,
 )
 from pylibcugraph._cugraph_c.graph cimport (
     cugraph_graph_t,
@@ -164,7 +164,9 @@ cdef class EXPERIMENTAL__SGGraph(_GPUGraph):
         assert_success(error_code, error_ptr,
                        "cugraph_sg_graph_create()")
 
-        # FIXME: free the views
+        cugraph_type_erased_device_array_view_free(srcs_view_ptr)
+        cugraph_type_erased_device_array_view_free(dsts_view_ptr)
+        cugraph_type_erased_device_array_view_free(weights_view_ptr)
 
     def __dealloc__(self):
         if self.c_graph_ptr is not NULL:

--- a/python/pylibcugraph/pylibcugraph/graphs.pyx
+++ b/python/pylibcugraph/pylibcugraph/graphs.pyx
@@ -69,10 +69,10 @@ cdef class EXPERIMENTAL__SGGraph(_GPUGraph):
         define the ith edge of the graph.
 
     dst_array : device array type
-        Device array containing the vertex identifiers of the destination of each
-        directed edge. The order of the array corresponds to the ordering of the
-        src_array, where the ith item in src_array and the ith item in dst_array
-        define the ith edge of the graph.
+        Device array containing the vertex identifiers of the destination of
+        each directed edge. The order of the array corresponds to the ordering
+        of the src_array, where the ith item in src_array and the ith item in
+        dst_array define the ith edge of the graph.
 
     weight_array : device array type
         Device array containing the weight values of each directed edge. The

--- a/python/pylibcugraph/pylibcugraph/pagerank.pyx
+++ b/python/pylibcugraph/pylibcugraph/pagerank.pyx
@@ -14,8 +14,6 @@
 # Have cython use python 3 syntax
 # cython: language_level = 3
 
-from libc.stdint cimport uintptr_t
-
 from pylibcugraph._cugraph_c.cugraph_api cimport (
     bool_t,
     data_type_id_t,
@@ -27,11 +25,6 @@ from pylibcugraph._cugraph_c.error cimport (
 )
 from pylibcugraph._cugraph_c.array cimport (
     cugraph_type_erased_device_array_view_t,
-    cugraph_type_erased_device_array_view_size,
-    cugraph_type_erased_device_array_view_type,
-    cugraph_type_erased_device_array_view_create,
-    cugraph_type_erased_device_array_view_free,
-    cugraph_type_erased_device_array_view_copy,
 )
 from pylibcugraph._cugraph_c.graph cimport (
     cugraph_graph_t,
@@ -43,7 +36,6 @@ from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_pagerank_result_get_pageranks,
     cugraph_pagerank_result_free,
 )
-
 from pylibcugraph.resource_handle cimport (
     EXPERIMENTAL__ResourceHandle,
 )
@@ -53,7 +45,7 @@ from pylibcugraph.graphs cimport (
 from pylibcugraph.utils cimport (
     assert_success,
     assert_CAI_type,
-    get_numpy_type_from_c_type,
+    copy_to_cupy_array,
 )
 
 
@@ -193,64 +185,16 @@ def EXPERIMENTAL__pagerank(EXPERIMENTAL__ResourceHandle resource_handle,
                                   &error_ptr)
     assert_success(error_code, error_ptr, "cugraph_pagerank")
 
-    # Extract individual device array pointers from result
-    cdef cugraph_type_erased_device_array_view_t* vertices_ptr
-    cdef cugraph_type_erased_device_array_view_t* pageranks_ptr
-    vertices_ptr = cugraph_pagerank_result_get_vertices(result_ptr)
-    pageranks_ptr = cugraph_pagerank_result_get_pageranks(result_ptr)
+    # Extract individual device array pointers from result and copy to cupy
+    # arrays for returning.
+    cdef cugraph_type_erased_device_array_view_t* vertices_ptr = \
+        cugraph_pagerank_result_get_vertices(result_ptr)
+    cdef cugraph_type_erased_device_array_view_t* pageranks_ptr = \
+        cugraph_pagerank_result_get_pageranks(result_ptr)
 
-    # Extract meta-data needed to copy results
-    cdef data_type_id_t vertex_type = \
-        cugraph_type_erased_device_array_view_type(vertices_ptr)
-    cdef data_type_id_t pagerank_type = \
-        cugraph_type_erased_device_array_view_type(pageranks_ptr)
-    vertex_numpy_type = get_numpy_type_from_c_type(vertex_type)
-    pagerank_numpy_type = get_numpy_type_from_c_type(pagerank_type)
+    cupy_vertices = copy_to_cupy_array(c_resource_handle_ptr, vertices_ptr)
+    cupy_pageranks = copy_to_cupy_array(c_resource_handle_ptr, pageranks_ptr)
 
-    num_vertices = cugraph_type_erased_device_array_view_size(vertices_ptr)
-
-    # Set up cupy arrays to return and copy results to:
-    # * create cupy array object (these will be what the caller uses).
-    # * access the underlying device pointers.
-    # * create device array views which can be used with the copy APIs.
-    # * call copy APIs. This will copy data to the array pointed to the pointer
-    #   in the cupy array objects that will be returned.
-    # * free view objects.
-    cupy_vertices = cupy.array(numpy.zeros(num_vertices),
-                               dtype=vertex_numpy_type)
-    cupy_pageranks = cupy.array(numpy.zeros(num_vertices),
-                                dtype=pagerank_numpy_type)
-
-    cdef uintptr_t cupy_vertices_ptr = \
-        cupy_vertices.__cuda_array_interface__["data"][0]
-    cdef uintptr_t cupy_pageranks_ptr = \
-        cupy_pageranks.__cuda_array_interface__["data"][0]
-
-    cdef cugraph_type_erased_device_array_view_t* cupy_vertices_view_ptr = \
-        cugraph_type_erased_device_array_view_create(
-            <void*>cupy_vertices_ptr, num_vertices, vertex_type)
-
-    cdef cugraph_type_erased_device_array_view_t* cupy_pageranks_view_ptr = \
-        cugraph_type_erased_device_array_view_create(
-            <void*>cupy_pageranks_ptr, num_vertices, vertex_type)
-
-    error_code = cugraph_type_erased_device_array_view_copy(
-        c_resource_handle_ptr,
-        cupy_vertices_view_ptr,
-        vertices_ptr,
-        &error_ptr)
-    assert_success(error_code, error_ptr,
-                   "cugraph_type_erased_device_array_view_copy")
-    error_code = cugraph_type_erased_device_array_view_copy(
-        c_resource_handle_ptr,
-        cupy_pageranks_view_ptr,
-        pageranks_ptr,
-        &error_ptr)
-    assert_success(error_code, error_ptr,
-                   "cugraph_type_erased_device_array_view_copy")
-
-    cugraph_type_erased_device_array_view_free(cupy_pageranks_view_ptr)
-    cugraph_type_erased_device_array_view_free(cupy_vertices_view_ptr)
     cugraph_pagerank_result_free(result_ptr)
 
     return (cupy_vertices, cupy_pageranks)

--- a/python/pylibcugraph/pylibcugraph/sssp.pyx
+++ b/python/pylibcugraph/pylibcugraph/sssp.pyx
@@ -14,8 +14,6 @@
 # Have cython use python 3 syntax
 # cython: language_level = 3
 
-from libc.stdint cimport uintptr_t
-
 from pylibcugraph._cugraph_c.cugraph_api cimport (
     bool_t,
     data_type_id_t,
@@ -27,11 +25,6 @@ from pylibcugraph._cugraph_c.error cimport (
 )
 from pylibcugraph._cugraph_c.array cimport (
     cugraph_type_erased_device_array_view_t,
-    cugraph_type_erased_device_array_view_size,
-    cugraph_type_erased_device_array_view_type,
-    cugraph_type_erased_device_array_view_create,
-    cugraph_type_erased_device_array_view_free,
-    cugraph_type_erased_device_array_view_copy,
 )
 from pylibcugraph._cugraph_c.graph cimport (
     cugraph_graph_t,
@@ -44,7 +37,6 @@ from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_paths_result_get_predecessors,
     cugraph_paths_result_free,
 )
-
 from pylibcugraph.resource_handle cimport (
     EXPERIMENTAL__ResourceHandle,
 )
@@ -53,7 +45,7 @@ from pylibcugraph.graphs cimport (
 )
 from pylibcugraph.utils cimport (
     assert_success,
-    get_numpy_type_from_c_type,
+    copy_to_cupy_array,
 )
 
 
@@ -167,83 +159,20 @@ def EXPERIMENTAL__sssp(EXPERIMENTAL__ResourceHandle resource_handle,
                               &error_ptr)
     assert_success(error_code, error_ptr, "cugraph_sssp")
 
-    # Extract individual device array pointers from result
-    cdef cugraph_type_erased_device_array_view_t* vertices_ptr
-    cdef cugraph_type_erased_device_array_view_t* distances_ptr
-    cdef cugraph_type_erased_device_array_view_t* predecessors_ptr
-    vertices_ptr = cugraph_paths_result_get_vertices(result_ptr)
-    distances_ptr = cugraph_paths_result_get_distances(result_ptr)
-    predecessors_ptr = cugraph_paths_result_get_predecessors(result_ptr)
+    # Extract individual device array pointers from result and copy to cupy
+    # arrays for returning.
+    cdef cugraph_type_erased_device_array_view_t* vertices_ptr = \
+        cugraph_paths_result_get_vertices(result_ptr)
+    cdef cugraph_type_erased_device_array_view_t* distances_ptr = \
+        cugraph_paths_result_get_distances(result_ptr)
+    cdef cugraph_type_erased_device_array_view_t* predecessors_ptr = \
+        cugraph_paths_result_get_predecessors(result_ptr)
 
-    # Extract meta-data needed to copy results
-    cdef data_type_id_t vertex_type = \
-        cugraph_type_erased_device_array_view_type(vertices_ptr)
-    cdef data_type_id_t distance_type = \
-        cugraph_type_erased_device_array_view_type(distances_ptr)
-    cdef data_type_id_t predecessor_type = \
-        cugraph_type_erased_device_array_view_type(predecessors_ptr)
-    vertex_numpy_type = get_numpy_type_from_c_type(vertex_type)
-    distance_numpy_type = get_numpy_type_from_c_type(distance_type)
-    predecessor_numpy_type = get_numpy_type_from_c_type(predecessor_type)
+    cupy_vertices = copy_to_cupy_array(c_resource_handle_ptr, vertices_ptr)
+    cupy_distances = copy_to_cupy_array(c_resource_handle_ptr, distances_ptr)
+    cupy_predecessors = copy_to_cupy_array(c_resource_handle_ptr,
+                                           predecessors_ptr)
 
-    num_vertices = cugraph_type_erased_device_array_view_size(vertices_ptr)
-
-    # Set up cupy arrays to return and copy results to:
-    # * create cupy array object (these will be what the caller uses).
-    # * access the underlying device pointers.
-    # * create device array views which can be used with the copy APIs.
-    # * call copy APIs. This will copy data to the array pointed to the pointer
-    #   in the cupy array objects that will be returned.
-    # * free view objects.
-    cupy_vertices = cupy.array(numpy.zeros(num_vertices),
-                               dtype=vertex_numpy_type)
-    cupy_distances = cupy.array(numpy.zeros(num_vertices),
-                                dtype=distance_numpy_type)
-    cupy_predecessors = cupy.array(numpy.zeros(num_vertices),
-                                   dtype=predecessor_numpy_type)
-
-    cdef uintptr_t cupy_vertices_ptr = \
-        cupy_vertices.__cuda_array_interface__["data"][0]
-    cdef uintptr_t cupy_distances_ptr = \
-        cupy_distances.__cuda_array_interface__["data"][0]
-    cdef uintptr_t cupy_predecessors_ptr = \
-        cupy_predecessors.__cuda_array_interface__["data"][0]
-
-    cdef cugraph_type_erased_device_array_view_t* cupy_vertices_view_ptr = \
-        cugraph_type_erased_device_array_view_create(
-            <void*>cupy_vertices_ptr, num_vertices, vertex_type)
-    cdef cugraph_type_erased_device_array_view_t* cupy_distances_view_ptr = \
-        cugraph_type_erased_device_array_view_create(
-            <void*>cupy_distances_ptr, num_vertices, vertex_type)
-    cdef cugraph_type_erased_device_array_view_t* cupy_predecessors_view_ptr =\
-        cugraph_type_erased_device_array_view_create(
-            <void*>cupy_predecessors_ptr, num_vertices, vertex_type)
-
-    error_code = cugraph_type_erased_device_array_view_copy(
-        c_resource_handle_ptr,
-        cupy_vertices_view_ptr,
-        vertices_ptr,
-        &error_ptr)
-    assert_success(error_code, error_ptr,
-                   "cugraph_type_erased_device_array_view_copy")
-    error_code = cugraph_type_erased_device_array_view_copy(
-        c_resource_handle_ptr,
-        cupy_distances_view_ptr,
-        distances_ptr,
-        &error_ptr)
-    assert_success(error_code, error_ptr,
-                   "cugraph_type_erased_device_array_view_copy")
-    error_code = cugraph_type_erased_device_array_view_copy(
-        c_resource_handle_ptr,
-        cupy_predecessors_view_ptr,
-        predecessors_ptr,
-        &error_ptr)
-    assert_success(error_code, error_ptr,
-                   "cugraph_type_erased_device_array_view_copy")
-
-    cugraph_type_erased_device_array_view_free(cupy_distances_view_ptr)
-    cugraph_type_erased_device_array_view_free(cupy_predecessors_view_ptr)
-    cugraph_type_erased_device_array_view_free(cupy_vertices_view_ptr)
     cugraph_paths_result_free(result_ptr)
 
     return (cupy_vertices, cupy_distances, cupy_predecessors)

--- a/python/pylibcugraph/pylibcugraph/tests/test_connected_components.py
+++ b/python/pylibcugraph/pylibcugraph/tests/test_connected_components.py
@@ -139,7 +139,7 @@ def input_and_expected_output(request):
 
     offsets = cp.asarray(csr.indptr, dtype=np.int32)
     indices = cp.asarray(csr.indices, dtype=np.int32)
-    labels_to_populate = cp.asarray(np.zeros(num_verts, dtype=np.int32))
+    labels_to_populate = cp.zeros(num_verts, dtype=np.int32)
 
     return ((offsets, indices, labels_to_populate, num_verts, num_edges),
             expected_output_dict)
@@ -301,8 +301,7 @@ def test_bad_dtypes(api_name):
 
     cp_offsets = cp.asarray(scipy_csr.indptr)
     cp_indices = cp.asarray(scipy_csr.indices)
-    cp_labels = cp.asarray(np.zeros(num_verts,
-                                    dtype=np.int64))  # unsupported
+    cp_labels = cp.zeros(num_verts, dtype=np.int64)  # unsupported
     with pytest.raises(TypeError):
         api(offsets=cp_offsets,
             indices=cp_indices,
@@ -314,8 +313,7 @@ def test_bad_dtypes(api_name):
     cp_offsets = cp.asarray(scipy_csr.indptr,
                             dtype=np.int64)  # unsupported
     cp_indices = cp.asarray(scipy_csr.indices)
-    cp_labels = cp.asarray(np.zeros(num_verts),
-                           dtype=np.int32)
+    cp_labels = cp.zeros(num_verts, dtype=np.int32)
     with pytest.raises(TypeError):
         api(offsets=cp_offsets,
             indices=cp_indices,
@@ -327,8 +325,7 @@ def test_bad_dtypes(api_name):
     cp_offsets = cp.asarray(scipy_csr.indptr)
     cp_indices = cp.asarray(scipy_csr.indices,
                             dtype=np.float32)  # unsupported
-    cp_labels = cp.asarray(np.zeros(num_verts),
-                           dtype=np.int32)
+    cp_labels = cp.zeros(num_verts, dtype=np.int32)
     with pytest.raises(TypeError):
         api(offsets=cp_offsets,
             indices=cp_indices,

--- a/python/pylibcugraph/pylibcugraph/utils.pxd
+++ b/python/pylibcugraph/pylibcugraph/utils.pxd
@@ -16,6 +16,10 @@
 
 from pylibcugraph._cugraph_c.cugraph_api cimport (
     data_type_id_t,
+    cugraph_resource_handle_t,
+)
+from pylibcugraph._cugraph_c.array cimport (
+    cugraph_type_erased_device_array_view_t,
 )
 from pylibcugraph._cugraph_c.error cimport (
     cugraph_error_code_t,
@@ -30,3 +34,7 @@ cdef assert_success(cugraph_error_code_t code,
 cdef assert_CAI_type(obj, var_name, allow_None=*)
 
 cdef get_numpy_type_from_c_type(data_type_id_t c_type)
+
+cdef copy_to_cupy_array(
+   cugraph_resource_handle_t* c_resource_handle_ptr,
+   cugraph_type_erased_device_array_view_t* device_array_view_ptr)


### PR DESCRIPTION
Refactored common code that copies device arrays returned by `cugraph_*` C APIs to cupy arrays into a utility function.  This eliminates a significant amount of repeated code, and will be especially helpful as new `pylibcugraph` APIs are added that copy the existing patterns.

Tested by running existing `pylibcugraph` unit tests.