### PR TITLE
Reduce peak memory requirement in graph creation (part 1/2)

### DIFF
--- a/cpp/include/cugraph/detail/shuffle_wrappers.hpp
+++ b/cpp/include/cugraph/detail/shuffle_wrappers.hpp
@@ -76,8 +76,8 @@ rmm::device_uvector<vertex_t> shuffle_vertices_by_gpu_id(
  * @param[in/out] d_edgelist_minors Vertex IDs for columns (if the graph adjacency matrix is stored
  * as is) or rows (if the graph adjacency matrix is stored transposed)
  * @param[in/out] d_edgelist_weights Optional edge weights
- * @param[in] groupby_and_count_local_partition If set to true, groupby and count edges based on
- * (local partition ID, GPU ID) pairs (where GPU IDs are computed by applying the
+ * @param[in] groupby_and_count_local_partition_by_minor If set to true, groupby and count edges
+ * based on (local partition ID, GPU ID) pairs (where GPU IDs are computed by applying the
  * compute_gpu_id_from_vertex_t function to the minor vertex ID). If set to false, groupby and count
  * edges by just local partition ID.
  *
@@ -91,7 +91,7 @@ rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   rmm::device_uvector<vertex_t>& d_edgelist_majors,
   rmm::device_uvector<vertex_t>& d_edgelist_minors,
   std::optional<rmm::device_uvector<weight_t>>& d_edgelist_weights,
-  bool groupby_and_count_local_partition = false);
+  bool groupby_and_count_local_partition_by_minor = false);
 
 }  // namespace detail
 }  // namespace cugraph

--- a/cpp/include/cugraph/graph_functions.hpp
+++ b/cpp/include/cugraph/graph_functions.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cugraph/graph_functions.hpp
+++ b/cpp/include/cugraph/graph_functions.hpp
@@ -37,9 +37,6 @@ struct renumber_meta_t<vertex_t, edge_t, multi_gpu, std::enable_if_t<multi_gpu>>
   edge_t number_of_edges{};
   partition_t<vertex_t> partition{};
   std::vector<vertex_t> segment_offsets{};
-
-  vertex_t num_local_unique_edge_majors{};
-  vertex_t num_local_unique_edge_minors{};
 };
 
 template <typename vertex_t, typename edge_t, bool multi_gpu>

--- a/cpp/include/cugraph/prims/copy_v_transform_reduce_key_aggregated_out_nbr.cuh
+++ b/cpp/include/cugraph/prims/copy_v_transform_reduce_key_aggregated_out_nbr.cuh
@@ -482,7 +482,7 @@ void copy_v_transform_reduce_key_aggregated_out_nbr(
       rmm::device_uvector<weight_t> rx_key_aggregated_edge_weights(0, handle.get_stream());
       std::forward_as_tuple(
         std::tie(rx_major_vertices, rx_minor_keys, rx_key_aggregated_edge_weights), std::ignore) =
-        groupby_gpuid_and_shuffle_values(
+        groupby_gpu_id_and_shuffle_values(
           col_comm,
           triplet_first,
           triplet_first + tmp_major_vertices.size(),

--- a/cpp/include/cugraph/prims/transform_reduce_by_adj_matrix_row_col_key_e.cuh
+++ b/cpp/include/cugraph/prims/transform_reduce_by_adj_matrix_row_col_key_e.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cugraph/prims/transform_reduce_by_adj_matrix_row_col_key_e.cuh
+++ b/cpp/include/cugraph/prims/transform_reduce_by_adj_matrix_row_col_key_e.cuh
@@ -505,7 +505,7 @@ transform_reduce_by_adj_matrix_row_col_key_e(
       rmm::device_uvector<vertex_t> rx_unique_keys(0, handle.get_stream());
       auto rx_value_for_unique_key_buffer = allocate_dataframe_buffer<T>(0, handle.get_stream());
       std::tie(rx_unique_keys, rx_value_for_unique_key_buffer, std::ignore) =
-        groupby_gpuid_and_shuffle_kv_pairs(
+        groupby_gpu_id_and_shuffle_kv_pairs(
           comm,
           tmp_keys.begin(),
           tmp_keys.end(),

--- a/cpp/include/cugraph/utilities/collect_comm.cuh
+++ b/cpp/include/cugraph/utilities/collect_comm.cuh
@@ -103,7 +103,7 @@ collect_values_for_keys(raft::comms::comms_t const& comm,
   {
     rmm::device_uvector<vertex_t> rx_unique_keys(0, stream_view);
     std::vector<size_t> rx_value_counts{};
-    std::tie(rx_unique_keys, rx_value_counts) = groupby_gpuid_and_shuffle_values(
+    std::tie(rx_unique_keys, rx_value_counts) = groupby_gpu_id_and_shuffle_values(
       comm,
       unique_keys.begin(),
       unique_keys.end(),
@@ -228,7 +228,7 @@ collect_values_for_unique_keys(raft::comms::comms_t const& comm,
   {
     rmm::device_uvector<vertex_t> rx_unique_keys(0, stream_view);
     std::vector<size_t> rx_value_counts{};
-    std::tie(rx_unique_keys, rx_value_counts) = groupby_gpuid_and_shuffle_values(
+    std::tie(rx_unique_keys, rx_value_counts) = groupby_gpu_id_and_shuffle_values(
       comm,
       unique_keys.begin(),
       unique_keys.end(),

--- a/cpp/include/cugraph/utilities/cython.hpp
+++ b/cpp/include/cugraph/utilities/cython.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cugraph/utilities/cython.hpp
+++ b/cpp/include/cugraph/utilities/cython.hpp
@@ -588,7 +588,7 @@ template <typename vertex_t, typename edge_t, typename weight_t>
 std::unique_ptr<major_minor_weights_t<vertex_t, edge_t, weight_t>> call_shuffle(
   raft::handle_t const& handle,
   vertex_t*
-    edgelist_major_vertices,  // [IN / OUT]: groupby_gpuid_and_shuffle_values() sorts in-place
+    edgelist_major_vertices,  // [IN / OUT]: groupby_gpu_id_and_shuffle_values() sorts in-place
   vertex_t* edgelist_minor_vertices,  // [IN / OUT]
   weight_t* edgelist_weights,         // [IN / OUT]
   edge_t num_edgelist_edges);

--- a/cpp/include/cugraph/utilities/shuffle_comm.cuh
+++ b/cpp/include/cugraph/utilities/shuffle_comm.cuh
@@ -125,6 +125,157 @@ compute_tx_rx_counts_offsets_ranks(raft::comms::comms_t const& comm,
   return std::make_tuple(tx_counts, tx_offsets, tx_dst_ranks, rx_counts, rx_offsets, rx_src_ranks);
 }
 
+template <typename value_type, typename ValueToGroupIdOp>
+struct value_group_id_less_t {
+  ValueToGroupIdOp value_to_group_id_op{};
+  int pivot{};
+  __device__ bool operator()(value_type v) const { return value_to_group_id_op(v) < pivot; }
+};
+
+template <typename key_type, typename value_type, typename KeyToGroupIdOp>
+struct kv_pair_group_id_less_t {
+  KeyToGroupIdOp key_to_group_id_op{};
+  int pivot{};
+  __device__ bool operator()(thrust::tuple<key_type, value_type> t) const
+  {
+    return key_to_group_id_op(thrust::get<0>(t)) < pivot;
+  }
+};
+
+template <typename value_type, typename ValueToGroupIdOp>
+struct value_group_id_greater_equal_t {
+  ValueToGroupIdOp value_to_group_id_op{};
+  int pivot{};
+  __device__ bool operator()(value_type v) const { return value_to_group_id_op(v) >= pivot; }
+};
+
+template <typename key_type, typename value_type, typename KeyToGroupIdOp>
+struct kv_pair_group_id_greater_equal_t {
+  KeyToGroupIdOp key_to_group_id_op{};
+  int pivot{};
+  __device__ bool operator()(thrust::tuple<key_type, value_type> t) const
+  {
+    return key_to_group_id_op(thrust::get<0>(t)) >= pivot;
+  }
+};
+
+// use roughly half temporary buffer than thrust::partition (if first & second partition sizes are
+// comparable)
+template <typename ValueIterator, typename ValueToGroupIdOp>
+ValueIterator mem_frugal_partition(
+  ValueIterator value_first,
+  ValueIterator value_last,
+  ValueToGroupIdOp value_to_group_id_op,
+  int pivot,  // group Id less than pivot goes to the first partition
+  rmm::cuda_stream_view stream_view)
+{
+  auto num_elements = static_cast<size_t>(thrust::distance(value_first, value_last));
+  auto first_size   = static_cast<size_t>(thrust::count_if(
+    rmm::exec_policy(stream_view),
+    value_first,
+    value_last,
+    value_group_id_less_t<typename thrust::iterator_traits<ValueIterator>::value_type,
+                          ValueToGroupIdOp>{value_to_group_id_op, pivot}));
+  auto second_size  = num_elements - first_size;
+
+  auto tmp_buffer =
+    allocate_dataframe_buffer<typename thrust::iterator_traits<ValueIterator>::value_type>(
+      second_size, stream_view);
+
+  // to limit memory footprint (16 * 1024 * 1024 is a tuning parameter)
+  // thrust::copy_if (1.15.0) also uses temporary buffer
+  auto constexpr max_elements_per_iteration = size_t{16} * 1024 * 1024;
+  auto num_chunks = (num_elements + max_elements_per_iteration - 1) / max_elements_per_iteration;
+  auto output_chunk_first = get_dataframe_buffer_begin(tmp_buffer);
+  for (size_t i = 0; i < num_chunks; ++i) {
+    output_chunk_first = thrust::copy_if(
+      rmm::exec_policy(stream_view),
+      value_first + max_elements_per_iteration * i,
+      value_first + std::min(max_elements_per_iteration * (i + 1), num_elements),
+      output_chunk_first,
+      value_group_id_greater_equal_t<typename thrust::iterator_traits<ValueIterator>::value_type,
+                                     ValueToGroupIdOp>{value_to_group_id_op, pivot});
+  }
+
+  thrust::remove_if(
+    rmm::exec_policy(stream_view),
+    value_first,
+    value_last,
+    value_group_id_greater_equal_t<typename thrust::iterator_traits<ValueIterator>::value_type,
+                                   ValueToGroupIdOp>{value_to_group_id_op, pivot});
+  thrust::copy(rmm::exec_policy(stream_view),
+               get_dataframe_buffer_cbegin(tmp_buffer),
+               get_dataframe_buffer_cend(tmp_buffer),
+               value_first + first_size);
+
+  return value_first + first_size;
+}
+
+// use roughly half temporary buffer than thrust::partition (if first & second partition sizes are
+// comparable)
+template <typename KeyIterator, typename ValueIterator, typename KeyToGroupIdOp>
+std::tuple<KeyIterator, ValueIterator> mem_frugal_partition(
+  KeyIterator key_first,
+  KeyIterator key_last,
+  ValueIterator value_first,
+  KeyToGroupIdOp key_to_group_id_op,
+  int pivot,  // group Id less than pivot goes to the first partition
+  rmm::cuda_stream_view stream_view)
+{
+  auto num_elements = static_cast<size_t>(thrust::distance(key_first, key_last));
+  auto first_size   = static_cast<size_t>(thrust::count_if(
+    rmm::exec_policy(stream_view),
+    key_first,
+    key_last,
+    kv_pair_group_id_less_t<typename thrust::iterator_traits<KeyIterator>::value_type,
+                            typename thrust::iterator_traits<ValueIterator>::value_type,
+                            KeyToGroupIdOp>{key_to_group_id_op, pivot}));
+  auto second_size  = num_elements - first_size;
+
+  auto tmp_key_buffer =
+    allocate_dataframe_buffer<typename thrust::iterator_traits<KeyIterator>::value_type>(
+      second_size, stream_view);
+  auto tmp_value_buffer =
+    allocate_dataframe_buffer<typename thrust::iterator_traits<ValueIterator>::value_type>(
+      second_size, stream_view);
+
+  // to limit memory footprint (16 * 1024 * 1024 is a tuning parameter)
+  // thrust::copy_if (1.15.0) also uses temporary buffer
+  auto max_elements_per_iteration = size_t{16} * 1024 * 1024;
+  auto num_chunks    = (num_elements + max_elements_per_iteration - 1) / max_elements_per_iteration;
+  auto kv_pair_first = thrust::make_zip_iterator(thrust::make_tuple(key_first, value_first));
+  auto output_chunk_first = thrust::make_zip_iterator(thrust::make_tuple(
+    get_dataframe_buffer_begin(tmp_key_buffer), get_dataframe_buffer_begin(tmp_value_buffer)));
+  for (size_t i = 0; i < num_chunks; ++i) {
+    output_chunk_first = thrust::copy_if(
+      rmm::exec_policy(stream_view),
+      kv_pair_first + max_elements_per_iteration * i,
+      kv_pair_first + std::min(max_elements_per_iteration * (i + 1), num_elements),
+      output_chunk_first,
+      kv_pair_group_id_greater_equal_t<typename thrust::iterator_traits<KeyIterator>::value_type,
+                                       typename thrust::iterator_traits<ValueIterator>::value_type,
+                                       KeyToGroupIdOp>{key_to_group_id_op, pivot});
+  }
+
+  thrust::remove_if(
+    rmm::exec_policy(stream_view),
+    kv_pair_first,
+    kv_pair_first + num_elements,
+    kv_pair_group_id_greater_equal_t<typename thrust::iterator_traits<KeyIterator>::value_type,
+                                     typename thrust::iterator_traits<ValueIterator>::value_type,
+                                     KeyToGroupIdOp>{key_to_group_id_op, pivot});
+  thrust::copy(rmm::exec_policy(stream_view),
+               get_dataframe_buffer_cbegin(tmp_key_buffer),
+               get_dataframe_buffer_cend(tmp_key_buffer),
+               key_first + first_size);
+  thrust::copy(rmm::exec_policy(stream_view),
+               get_dataframe_buffer_cbegin(tmp_value_buffer),
+               get_dataframe_buffer_cend(tmp_value_buffer),
+               value_first + first_size);
+
+  return std::make_tuple(key_first + first_size, value_first + first_size);
+}
+
 }  // namespace detail
 
 template <typename ValueIterator, typename ValueToGPUIdOp>
@@ -132,14 +283,33 @@ rmm::device_uvector<size_t> groupby_and_count(ValueIterator tx_value_first /* [I
                                               ValueIterator tx_value_last /* [INOUT */,
                                               ValueToGPUIdOp value_to_group_id_op,
                                               int num_groups,
+                                              bool mem_frugal,
                                               rmm::cuda_stream_view stream_view)
 {
-  thrust::sort(rmm::exec_policy(stream_view),
-               tx_value_first,
-               tx_value_last,
-               [value_to_group_id_op] __device__(auto lhs, auto rhs) {
-                 return value_to_group_id_op(lhs) < value_to_group_id_op(rhs);
-               });
+  if (mem_frugal) {
+    auto pivot        = num_groups / 2;
+    auto second_first = detail::mem_frugal_partition(
+      tx_value_first, tx_value_last, value_to_group_id_op, pivot, stream_view);
+    thrust::sort(rmm::exec_policy(stream_view),
+                 tx_value_first,
+                 second_first,
+                 [value_to_group_id_op] __device__(auto lhs, auto rhs) {
+                   return value_to_group_id_op(lhs) < value_to_group_id_op(rhs);
+                 });
+    thrust::sort(rmm::exec_policy(stream_view),
+                 second_first,
+                 tx_value_last,
+                 [value_to_group_id_op] __device__(auto lhs, auto rhs) {
+                   return value_to_group_id_op(lhs) < value_to_group_id_op(rhs);
+                 });
+  } else {
+    thrust::sort(rmm::exec_policy(stream_view),
+                 tx_value_first,
+                 tx_value_last,
+                 [value_to_group_id_op] __device__(auto lhs, auto rhs) {
+                   return value_to_group_id_op(lhs) < value_to_group_id_op(rhs);
+                 });
+  }
 
   auto group_id_first = thrust::make_transform_iterator(
     tx_value_first,
@@ -164,15 +334,36 @@ rmm::device_uvector<size_t> groupby_and_count(VertexIterator tx_key_first /* [IN
                                               ValueIterator tx_value_first /* [INOUT */,
                                               KeyToGPUIdOp key_to_group_id_op,
                                               int num_groups,
+                                              bool mem_frugal,
                                               rmm::cuda_stream_view stream_view)
 {
-  thrust::sort_by_key(rmm::exec_policy(stream_view),
-                      tx_key_first,
-                      tx_key_last,
-                      tx_value_first,
-                      [key_to_group_id_op] __device__(auto lhs, auto rhs) {
-                        return key_to_group_id_op(lhs) < key_to_group_id_op(rhs);
-                      });
+  if (mem_frugal) {
+    auto pivot        = num_groups / 2;
+    auto second_first = detail::mem_frugal_partition(
+      tx_key_first, tx_key_last, tx_value_first, key_to_group_id_op, pivot, stream_view);
+    thrust::sort_by_key(rmm::exec_policy(stream_view),
+                        tx_key_first,
+                        std::get<0>(second_first),
+                        tx_value_first,
+                        [key_to_group_id_op] __device__(auto lhs, auto rhs) {
+                          return key_to_group_id_op(lhs) < key_to_group_id_op(rhs);
+                        });
+    thrust::sort_by_key(rmm::exec_policy(stream_view),
+                        std::get<0>(second_first),
+                        tx_key_last,
+                        std::get<1>(second_first),
+                        [key_to_group_id_op] __device__(auto lhs, auto rhs) {
+                          return key_to_group_id_op(lhs) < key_to_group_id_op(rhs);
+                        });
+  } else {
+    thrust::sort_by_key(rmm::exec_policy(stream_view),
+                        tx_key_first,
+                        tx_key_last,
+                        tx_value_first,
+                        [key_to_group_id_op] __device__(auto lhs, auto rhs) {
+                          return key_to_group_id_op(lhs) < key_to_group_id_op(rhs);
+                        });
+  }
 
   auto group_id_first = thrust::make_transform_iterator(
     tx_key_first, [key_to_group_id_op] __device__(auto key) { return key_to_group_id_op(key); });
@@ -249,7 +440,7 @@ auto groupby_gpuid_and_shuffle_values(raft::comms::comms_t const& comm,
   auto const comm_size = comm.get_size();
 
   auto d_tx_value_counts = groupby_and_count(
-    tx_value_first, tx_value_last, value_to_gpu_id_op, comm.get_size(), stream_view);
+    tx_value_first, tx_value_last, value_to_gpu_id_op, comm.get_size(), false, stream_view);
 
   std::vector<size_t> tx_counts{};
   std::vector<size_t> tx_offsets{};
@@ -298,8 +489,13 @@ auto groupby_gpuid_and_shuffle_kv_pairs(raft::comms::comms_t const& comm,
 {
   auto const comm_size = comm.get_size();
 
-  auto d_tx_value_counts = groupby_and_count(
-    tx_key_first, tx_key_last, tx_value_first, key_to_gpu_id_op, comm.get_size(), stream_view);
+  auto d_tx_value_counts = groupby_and_count(tx_key_first,
+                                             tx_key_last,
+                                             tx_value_first,
+                                             key_to_gpu_id_op,
+                                             comm.get_size(),
+                                             false,
+                                             stream_view);
 
   std::vector<size_t> tx_counts{};
   std::vector<size_t> tx_offsets{};

--- a/cpp/src/community/louvain.cuh
+++ b/cpp/src/community/louvain.cuh
@@ -308,7 +308,7 @@ class Louvain {
         thrust::make_tuple(cluster_keys_v_.begin(), cluster_weights_v_.begin()));
 
       std::forward_as_tuple(std::tie(rx_keys_v, rx_weights_v), std::ignore) =
-        groupby_gpuid_and_shuffle_values(
+        groupby_gpu_id_and_shuffle_values(
           handle_.get_comms(),
           pair_first,
           pair_first + current_graph_view_.get_number_of_local_vertices(),

--- a/cpp/src/components/weakly_connected_components_impl.cuh
+++ b/cpp/src/components/weakly_connected_components_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/components/weakly_connected_components_impl.cuh
+++ b/cpp/src/components/weakly_connected_components_impl.cuh
@@ -371,17 +371,17 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
         // with fewer than one root per GPU
         if (std::reduce(first_candidate_degrees.begin(), first_candidate_degrees.end()) >
             degree_sum_threshold * comm_size) {
-          std::vector<std::tuple<edge_t, int>> degree_gpuid_pairs(comm_size);
+          std::vector<std::tuple<edge_t, int>> degree_gpu_id_pairs(comm_size);
           for (int i = 0; i < comm_size; ++i) {
-            degree_gpuid_pairs[i] = std::make_tuple(first_candidate_degrees[i], i);
+            degree_gpu_id_pairs[i] = std::make_tuple(first_candidate_degrees[i], i);
           }
-          std::sort(degree_gpuid_pairs.begin(), degree_gpuid_pairs.end(), [](auto lhs, auto rhs) {
+          std::sort(degree_gpu_id_pairs.begin(), degree_gpu_id_pairs.end(), [](auto lhs, auto rhs) {
             return std::get<0>(lhs) > std::get<0>(rhs);
           });
           edge_t sum{0};
-          for (size_t i = 0; i < degree_gpuid_pairs.size(); ++i) {
-            sum += std::get<0>(degree_gpuid_pairs[i]);
-            init_max_new_root_counts[std::get<1>(degree_gpuid_pairs[i])] = 1;
+          for (size_t i = 0; i < degree_gpu_id_pairs.size(); ++i) {
+            sum += std::get<0>(degree_gpu_id_pairs[i]);
+            init_max_new_root_counts[std::get<1>(degree_gpu_id_pairs[i])] = 1;
             if (sum > degree_sum_threshold * comm_size) { break; }
           }
         }
@@ -390,18 +390,18 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
         else if (level_graph_view.get_number_of_vertices() <=
                  static_cast<vertex_t>(handle.get_comms().get_size() *
                                        ceil(1.0 / max_new_roots_ratio))) {
-          std::vector<int> gpuids{};
-          gpuids.reserve(
+          std::vector<int> gpu_ids{};
+          gpu_ids.reserve(
             std::reduce(new_root_candidate_counts.begin(), new_root_candidate_counts.end()));
           for (size_t i = 0; i < new_root_candidate_counts.size(); ++i) {
-            gpuids.insert(gpuids.end(), new_root_candidate_counts[i], static_cast<int>(i));
+            gpu_ids.insert(gpu_ids.end(), new_root_candidate_counts[i], static_cast<int>(i));
           }
           std::random_device rd{};
-          std::shuffle(gpuids.begin(), gpuids.end(), std::mt19937(rd()));
-          gpuids.resize(
-            std::max(static_cast<vertex_t>(gpuids.size() * max_new_roots_ratio), vertex_t{1}));
-          for (size_t i = 0; i < gpuids.size(); ++i) {
-            ++init_max_new_root_counts[gpuids[i]];
+          std::shuffle(gpu_ids.begin(), gpu_ids.end(), std::mt19937(rd()));
+          gpu_ids.resize(
+            std::max(static_cast<vertex_t>(gpu_ids.size() * max_new_roots_ratio), vertex_t{1}));
+          for (size_t i = 0; i < gpu_ids.size(); ++i) {
+            ++init_max_new_root_counts[gpu_ids[i]];
           }
         } else {
           std::fill(init_max_new_root_counts.begin(),
@@ -678,7 +678,7 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
         auto& col_comm = handle.get_subcomm(cugraph::partition_2d::key_naming_t().col_name());
         auto const col_comm_size = col_comm.get_size();
 
-        std::tie(edge_buffer, std::ignore) = cugraph::groupby_gpuid_and_shuffle_values(
+        std::tie(edge_buffer, std::ignore) = cugraph::groupby_gpu_id_and_shuffle_values(
           comm,
           get_dataframe_buffer_begin(edge_buffer),
           get_dataframe_buffer_end(edge_buffer),

--- a/cpp/src/detail/shuffle_wrappers.cu
+++ b/cpp/src/detail/shuffle_wrappers.cu
@@ -147,7 +147,7 @@ rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   rmm::device_uvector<vertex_t>& d_edgelist_majors,
   rmm::device_uvector<vertex_t>& d_edgelist_minors,
   std::optional<rmm::device_uvector<weight_t>>& d_edgelist_weights,
-  bool groupby_and_count_local_partition)
+  bool groupby_and_count_local_partition_by_minor)
 {
   auto& comm               = handle.get_comms();
   auto const comm_size     = comm.get_size();
@@ -162,7 +162,7 @@ rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   auto pair_first = thrust::make_zip_iterator(
     thrust::make_tuple(d_edgelist_majors.begin(), d_edgelist_minors.begin()));
 
-  if (groupby_and_count_local_partition) {
+  if (groupby_and_count_local_partition_by_minor) {
     auto local_partition_id_gpu_id_pair_op =
       [comm_size,
        row_comm_size,

--- a/cpp/src/detail/shuffle_wrappers.cu
+++ b/cpp/src/detail/shuffle_wrappers.cu
@@ -41,6 +41,22 @@ shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
   auto& col_comm           = handle.get_subcomm(cugraph::partition_2d::key_naming_t().col_name());
   auto const col_comm_size = col_comm.get_size();
 
+  auto total_global_mem = handle.get_device_properties().totalGlobalMem;
+  auto element_size = sizeof(vertex_t) * 2 + (d_edgelist_weights ? sizeof(weight_t) : size_t{0});
+  auto mem_frugal =
+    d_edgelist_majors.size() * element_size >=
+    total_global_mem /
+      5;  // if the data size exceeds 1/5 of the device memory (1/5 is a tuning parameter),
+          // groupby_and_count requires temporary buffer comparable to the input data size, if
+          // mem_frugal is set to true, temporary buffer size can be reduced up to 50%
+
+  // invoke groupby_and_count and shuffle values to pass mem_frugal instead of directly calling
+  // groupby_gpu_id_and_shuffle_values there is no benefit in reducing peak memory as we need to
+  // allocate a receive buffer anyways) but this reduces the maximum memory allocation size by half
+  // (thrust::sort used inside the groupby_and_count allocates the entire temporary buffer in a
+  // single chunk, and the pool allocator  often cannot handle a large single allocation (due to
+  // fragmentation) even when the remaining free memory in aggregate is significantly larger than
+  // the requested size).
   rmm::device_uvector<vertex_t> d_rx_edgelist_majors(0, handle.get_stream());
   rmm::device_uvector<vertex_t> d_rx_edgelist_minors(0, handle.get_stream());
   std::optional<rmm::device_uvector<weight_t>> d_rx_edgelist_weights{std::nullopt};
@@ -48,35 +64,54 @@ shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
     auto edge_first = thrust::make_zip_iterator(thrust::make_tuple(
       d_edgelist_majors.begin(), d_edgelist_minors.begin(), (*d_edgelist_weights).begin()));
 
+    auto d_tx_value_counts = cugraph::groupby_and_count(
+      edge_first,
+      edge_first + d_edgelist_majors.size(),
+      [key_func =
+         cugraph::detail::compute_gpu_id_from_edge_t<vertex_t>{
+           comm_size, row_comm_size, col_comm_size}] __device__(auto val) {
+        return key_func(thrust::get<0>(val), thrust::get<1>(val));
+      },
+      comm_size,
+      mem_frugal,
+      handle.get_stream());
+
+    std::vector<size_t> h_tx_value_counts(d_tx_value_counts.size());
+    raft::update_host(h_tx_value_counts.data(),
+                      d_tx_value_counts.data(),
+                      d_tx_value_counts.size(),
+                      handle.get_stream());
+    handle.sync_stream();
+
     std::forward_as_tuple(
-      std::tie(d_rx_edgelist_majors, d_rx_edgelist_minors, d_rx_edgelist_weights),
-      std::ignore) =
-      cugraph::groupby_gpu_id_and_shuffle_values(
-        comm,  // handle.get_comms(),
-        edge_first,
-        edge_first + d_edgelist_majors.size(),
-        [key_func =
-           cugraph::detail::compute_gpu_id_from_edge_t<vertex_t>{
-             comm_size, row_comm_size, col_comm_size}] __device__(auto val) {
-          return key_func(thrust::get<0>(val), thrust::get<1>(val));
-        },
-        handle.get_stream());
+      std::tie(d_rx_edgelist_majors, d_rx_edgelist_minors, d_rx_edgelist_weights), std::ignore) =
+      shuffle_values(comm, edge_first, h_tx_value_counts, handle.get_stream());
   } else {
     auto edge_first = thrust::make_zip_iterator(
       thrust::make_tuple(d_edgelist_majors.begin(), d_edgelist_minors.begin()));
 
-    std::forward_as_tuple(std::tie(d_rx_edgelist_majors, d_rx_edgelist_minors),
-                          std::ignore) =
-      cugraph::groupby_gpu_id_and_shuffle_values(
-        comm,  // handle.get_comms(),
-        edge_first,
-        edge_first + d_edgelist_majors.size(),
-        [key_func =
-           cugraph::detail::compute_gpu_id_from_edge_t<vertex_t>{
-             comm_size, row_comm_size, col_comm_size}] __device__(auto val) {
-          return key_func(thrust::get<0>(val), thrust::get<1>(val));
-        },
-        handle.get_stream());
+    auto d_tx_value_counts = cugraph::groupby_and_count(
+      edge_first,
+      edge_first + d_edgelist_majors.size(),
+      [key_func =
+         cugraph::detail::compute_gpu_id_from_edge_t<vertex_t>{
+           comm_size, row_comm_size, col_comm_size}] __device__(auto val) {
+        return key_func(thrust::get<0>(val), thrust::get<1>(val));
+      },
+      comm_size,
+      mem_frugal,
+      handle.get_stream());
+
+    std::vector<size_t> h_tx_value_counts(d_tx_value_counts.size());
+    raft::update_host(h_tx_value_counts.data(),
+                      d_tx_value_counts.data(),
+                      d_tx_value_counts.size(),
+                      handle.get_stream());
+    handle.sync_stream();
+
+    std::forward_as_tuple(
+      std::tie(d_rx_edgelist_majors, d_rx_edgelist_minors), std::ignore) =
+      shuffle_values(comm, edge_first, h_tx_value_counts, handle.get_stream());
   }
 
   return std::make_tuple(std::move(d_rx_edgelist_majors),
@@ -164,7 +199,7 @@ rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   auto mem_frugal =
     d_edgelist_majors.size() * element_size >=
     total_global_mem /
-      4;  // if the data size exceeds 1/4 of the device memory (1/4 is a tuning parameter),
+      5;  // if the data size exceeds 1/5 of the device memory (1/5 is a tuning parameter),
           // groupby_and_count requires temporary buffer comparable to the input data size, if
           // mem_frugal is set to true, temporary buffer size can be reduced up to 50%
 

--- a/cpp/src/detail/shuffle_wrappers.cu
+++ b/cpp/src/detail/shuffle_wrappers.cu
@@ -51,7 +51,7 @@ shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
     std::forward_as_tuple(
       std::tie(d_rx_edgelist_majors, d_rx_edgelist_minors, d_rx_edgelist_weights),
       std::ignore) =
-      cugraph::groupby_gpuid_and_shuffle_values(
+      cugraph::groupby_gpu_id_and_shuffle_values(
         comm,  // handle.get_comms(),
         edge_first,
         edge_first + d_edgelist_majors.size(),
@@ -67,7 +67,7 @@ shuffle_edgelist_by_gpu_id(raft::handle_t const& handle,
 
     std::forward_as_tuple(std::tie(d_rx_edgelist_majors, d_rx_edgelist_minors),
                           std::ignore) =
-      cugraph::groupby_gpuid_and_shuffle_values(
+      cugraph::groupby_gpu_id_and_shuffle_values(
         comm,  // handle.get_comms(),
         edge_first,
         edge_first + d_edgelist_majors.size(),
@@ -124,7 +124,7 @@ rmm::device_uvector<vertex_t> shuffle_vertices_by_gpu_id(raft::handle_t const& h
   auto const comm_size = comm.get_size();
 
   rmm::device_uvector<vertex_t> d_rx_vertices(0, handle.get_stream());
-  std::tie(d_rx_vertices, std::ignore) = cugraph::groupby_gpuid_and_shuffle_values(
+  std::tie(d_rx_vertices, std::ignore) = cugraph::groupby_gpu_id_and_shuffle_values(
     comm,  // handle.get_comms(),
     d_vertices.begin(),
     d_vertices.end(),

--- a/cpp/src/structure/coarsen_graph_impl.cuh
+++ b/cpp/src/structure/coarsen_graph_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/coarsen_graph_impl.cuh
+++ b/cpp/src/structure/coarsen_graph_impl.cuh
@@ -421,9 +421,7 @@ coarsen_graph(
         meta.number_of_edges,
         graph_properties_t{graph_view.is_symmetric(), false},
         meta.partition,
-        meta.segment_offsets,
-        store_transposed ? meta.num_local_unique_edge_minors : meta.num_local_unique_edge_majors,
-        store_transposed ? meta.num_local_unique_edge_majors : meta.num_local_unique_edge_minors}),
+        meta.segment_offsets}),
     std::move(renumber_map_labels));
 }
 

--- a/cpp/src/structure/coarsen_graph_impl.cuh
+++ b/cpp/src/structure/coarsen_graph_impl.cuh
@@ -267,7 +267,7 @@ coarsen_graph(
 
     // 1-3. append data to local adjacency matrix partitions
 
-    // FIXME: we can skip this if groupby_gpuid_and_shuffle_values is updated to return sorted edge
+    // FIXME: we can skip this if groupby_gpu_id_and_shuffle_values is updated to return sorted edge
     // list based on the final matrix partition (maybe add
     // groupby_adj_matrix_partition_and_shuffle_values).
 

--- a/cpp/src/structure/create_graph_from_edgelist_impl.cuh
+++ b/cpp/src/structure/create_graph_from_edgelist_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/create_graph_from_edgelist_impl.cuh
+++ b/cpp/src/structure/create_graph_from_edgelist_impl.cuh
@@ -283,12 +283,11 @@ create_graph_from_edgelist_impl(raft::handle_t const& handle,
     cugraph::graph_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>(
       handle,
       edgelists,
-      cugraph::graph_meta_t<vertex_t, edge_t, multi_gpu>{
-        meta.number_of_vertices,
-        meta.number_of_edges,
-        graph_properties,
-        meta.partition,
-        meta.segment_offsets}),
+      cugraph::graph_meta_t<vertex_t, edge_t, multi_gpu>{meta.number_of_vertices,
+                                                         meta.number_of_edges,
+                                                         graph_properties,
+                                                         meta.partition,
+                                                         meta.segment_offsets}),
     std::optional<rmm::device_uvector<vertex_t>>{std::move(renumber_map_labels)});
 }
 

--- a/cpp/src/structure/create_graph_from_edgelist_impl.cuh
+++ b/cpp/src/structure/create_graph_from_edgelist_impl.cuh
@@ -288,9 +288,7 @@ create_graph_from_edgelist_impl(raft::handle_t const& handle,
         meta.number_of_edges,
         graph_properties,
         meta.partition,
-        meta.segment_offsets,
-        store_transposed ? meta.num_local_unique_edge_minors : meta.num_local_unique_edge_majors,
-        store_transposed ? meta.num_local_unique_edge_majors : meta.num_local_unique_edge_minors}),
+        meta.segment_offsets}),
     std::optional<rmm::device_uvector<vertex_t>>{std::move(renumber_map_labels)});
 }
 

--- a/cpp/src/structure/graph_impl.cuh
+++ b/cpp/src/structure/graph_impl.cuh
@@ -87,7 +87,8 @@ struct atomic_or_bitmap_t {
   uint32_t* bitmaps{nullptr};
   vertex_t minor_first{};
 
-  __device__ void operator()(vertex_t minor) const {
+  __device__ void operator()(vertex_t minor) const
+  {
     auto minor_offset = minor - minor_first;
     auto mask         = uint32_t{1} << (minor_offset % (sizeof(uint32_t) * 8));
     atomicOr(bitmaps + (minor_offset / (sizeof(uint32_t) * 8)), mask);
@@ -98,7 +99,8 @@ struct atomic_or_bitmap_t {
 // extended __device__ lambda must allow its address to be taken)
 template <typename vertex_t>
 struct popc_t {
-  __device__ vertex_t operator()(uint32_t bitmap) const {
+  __device__ vertex_t operator()(uint32_t bitmap) const
+  {
     return static_cast<vertex_t>(__popc(bitmap));
   }
 };
@@ -682,7 +684,6 @@ graph_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu, std::enable_if_
                         static_cast<edge_t>(adj_matrix_partition_indices_[i].size()));
   }
 
-
   // if # unique edge rows/cols << V / row_comm_size|col_comm_size, store unique edge rows/cols to
   // support storing edge row/column properties in (key, value) pairs.
 
@@ -691,7 +692,8 @@ graph_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu, std::enable_if_
     num_local_unique_edge_majors += thrust::count_if(
       handle.get_thrust_policy(),
       thrust::make_counting_iterator(vertex_t{0}),
-      thrust::make_counting_iterator(static_cast<vertex_t>(adj_matrix_partition_offsets_[i].size() - 1)),
+      thrust::make_counting_iterator(
+        static_cast<vertex_t>(adj_matrix_partition_offsets_[i].size() - 1)),
       has_nzd_t<vertex_t, edge_t>{adj_matrix_partition_offsets_[i].data(), vertex_t{0}});
   }
 
@@ -709,10 +711,7 @@ graph_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu, std::enable_if_
 
   auto count_first = thrust::make_transform_iterator(minor_bitmaps.begin(), popc_t<vertex_t>{});
   auto num_local_unique_edge_minors = thrust::reduce(
-    handle.get_thrust_policy(),
-    count_first,
-    count_first + minor_bitmaps.size(),
-    vertex_t{0});
+    handle.get_thrust_policy(), count_first, count_first + minor_bitmaps.size(), vertex_t{0});
 
   minor_bitmaps.resize(0, handle.get_stream());
   minor_bitmaps.shrink_to_fit(handle.get_stream());

--- a/cpp/src/structure/relabel_impl.cuh
+++ b/cpp/src/structure/relabel_impl.cuh
@@ -95,7 +95,7 @@ void relabel(raft::handle_t const& handle,
           thrust::make_tuple(label_pair_old_labels.begin(), label_pair_new_labels.begin()));
         std::forward_as_tuple(std::tie(rx_label_pair_old_labels, rx_label_pair_new_labels),
                               std::ignore) =
-          groupby_gpuid_and_shuffle_values(
+          groupby_gpu_id_and_shuffle_values(
             handle.get_comms(),
             pair_first,
             pair_first + num_label_pairs,
@@ -136,7 +136,7 @@ void relabel(raft::handle_t const& handle,
       {
         rmm::device_uvector<vertex_t> rx_unique_old_labels(0, handle.get_stream());
         std::vector<size_t> rx_value_counts{};
-        std::tie(rx_unique_old_labels, rx_value_counts) = groupby_gpuid_and_shuffle_values(
+        std::tie(rx_unique_old_labels, rx_value_counts) = groupby_gpu_id_and_shuffle_values(
           handle.get_comms(),
           unique_old_labels.begin(),
           unique_old_labels.end(),

--- a/cpp/src/utilities/cython.cu
+++ b/cpp/src/utilities/cython.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/utilities/cython.cu
+++ b/cpp/src/utilities/cython.cu
@@ -1248,11 +1248,13 @@ std::unique_ptr<major_minor_weights_t<vertex_t, edge_t, weight_t>> call_shuffle(
                                                     ptr_ret->get_weights().data(),
                                                     local_partition_id_op,
                                                     col_comm_size,
+                                                    false,
                                                     handle.get_stream())
                        : cugraph::groupby_and_count(pair_first,
                                                     pair_first + ptr_ret->get_major().size(),
                                                     local_partition_id_op,
                                                     col_comm_size,
+                                                    false,
                                                     handle.get_stream());
 
   std::vector<size_t> h_edge_counts(edge_counts.size());

--- a/cpp/src/utilities/cython.cu
+++ b/cpp/src/utilities/cython.cu
@@ -1182,7 +1182,7 @@ template <typename vertex_t, typename edge_t, typename weight_t>
 std::unique_ptr<major_minor_weights_t<vertex_t, edge_t, weight_t>> call_shuffle(
   raft::handle_t const& handle,
   vertex_t*
-    edgelist_major_vertices,  // [IN / OUT]: groupby_gpuid_and_shuffle_values() sorts in-place
+    edgelist_major_vertices,  // [IN / OUT]: groupby_gpu_id_and_shuffle_values() sorts in-place
   vertex_t* edgelist_minor_vertices,  // [IN / OUT]
   weight_t* edgelist_weights,         // [IN / OUT]
   edge_t num_edgelist_edges)
@@ -1204,7 +1204,7 @@ std::unique_ptr<major_minor_weights_t<vertex_t, edge_t, weight_t>> call_shuffle(
     std::forward_as_tuple(
       std::tie(ptr_ret->get_major(), ptr_ret->get_minor(), ptr_ret->get_weights()),
       std::ignore) =
-      cugraph::groupby_gpuid_and_shuffle_values(
+      cugraph::groupby_gpu_id_and_shuffle_values(
         comm,  // handle.get_comms(),
         zip_edge,
         zip_edge + num_edgelist_edges,
@@ -1220,7 +1220,7 @@ std::unique_ptr<major_minor_weights_t<vertex_t, edge_t, weight_t>> call_shuffle(
 
     std::forward_as_tuple(std::tie(ptr_ret->get_major(), ptr_ret->get_minor()),
                           std::ignore) =
-      cugraph::groupby_gpuid_and_shuffle_values(
+      cugraph::groupby_gpu_id_and_shuffle_values(
         comm,  // handle.get_comms(),
         zip_edge,
         zip_edge + num_edgelist_edges,

--- a/cpp/tests/utilities/test_graphs.hpp
+++ b/cpp/tests/utilities/test_graphs.hpp
@@ -29,6 +29,53 @@ namespace test {
 
 namespace detail {
 
+template <typename T>
+std::optional<rmm::device_uvector<T>> try_allocate(raft::handle_t const& handle, size_t size)
+{
+  try {
+    return std::make_optional<rmm::device_uvector<T>>(size, handle.get_stream());
+  } catch (std::exception const& e) {
+    return std::nullopt;
+  }
+}
+
+// use host memory as temporary buffer if memroy allocation on device fails
+template <typename T>
+rmm::device_uvector<T> concatenate(raft::handle_t const& handle,
+                                   std::vector<rmm::device_uvector<T>>&& inputs)
+{
+  size_t tot_count{0};
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    tot_count += inputs[i].size();
+  }
+
+  auto output = try_allocate<T>(handle, tot_count);
+  if (output) {
+    size_t offset{0};
+    for (size_t i = 0; i < inputs.size(); ++i) {
+      raft::copy(
+        (*output).data() + offset, inputs[i].data(), inputs[i].size(), handle.get_stream());
+      offset += inputs[i].size();
+    }
+    inputs.clear();
+    inputs.shrink_to_fit();
+  } else {
+    std::vector<T> h_buffer(tot_count);
+    size_t offset{0};
+    for (size_t i = 0; i < inputs.size(); ++i) {
+      raft::update_host(
+        h_buffer.data() + offset, inputs[i].data(), inputs[i].size(), handle.get_stream());
+      offset += inputs[i].size();
+    }
+    inputs.clear();
+    inputs.shrink_to_fit();
+    output = rmm::device_uvector<T>(tot_count, handle.get_stream());
+    raft::update_device((*output).data(), h_buffer.data(), h_buffer.size(), handle.get_stream());
+  }
+
+  return std::move(*output);
+}
+
 class TranslateGraph_Usecase {
  public:
   TranslateGraph_Usecase() = delete;
@@ -266,43 +313,17 @@ class Rmat_Usecase : public detail::TranslateGraph_Usecase {
       tot_edge_counts += src_partitions[i].size();
     }
 
-    rmm::device_uvector<vertex_t> src_v(tot_edge_counts, handle.get_stream());
-    size_t src_offset{0};
-    for (size_t i = 0; i < src_partitions.size(); ++i) {
-      thrust::copy(handle.get_thrust_policy(),
-                   src_partitions[i].begin(),
-                   src_partitions[i].end(),
-                   src_v.begin() + src_offset);
-      src_offset += src_partitions[i].size();
-    }
-    src_partitions.clear();
-    src_partitions.shrink_to_fit();
+    // detail::concatenate uses a host buffer to store input vectors if initial device memory
+    // allocation for the return vector fails. This does not improve peak memory usage and is not
+    // helpful with the rmm_mode = cuda. However, if rmm_mode = pool, memory allocation can fail
+    // even when the aggregate free memory size far exceeds the requested size. This heuristic is
+    // helpful in this case.
 
-    rmm::device_uvector<vertex_t> dst_v(tot_edge_counts, handle.get_stream());
-    size_t dst_offset{0};
-    for (size_t i = 0; i < dst_partitions.size(); ++i) {
-      thrust::copy(handle.get_thrust_policy(),
-                   dst_partitions[i].begin(),
-                   dst_partitions[i].end(),
-                   dst_v.begin() + dst_offset);
-      dst_offset += dst_partitions[i].size();
-    }
-    dst_partitions.clear();
-    dst_partitions.shrink_to_fit();
-
+    auto src_v = detail::concatenate(handle, std::move(src_partitions));
+    auto dst_v = detail::concatenate(handle, std::move(dst_partitions));
     std::optional<rmm::device_uvector<weight_t>> weight_v{std::nullopt};
     if (weight_partitions) {
-      weight_v = rmm::device_uvector<weight_t>(tot_edge_counts, handle.get_stream());
-      size_t weight_offset{0};
-      for (size_t i = 0; i < (*weight_partitions).size(); ++i) {
-        thrust::copy(handle.get_thrust_policy(),
-                     (*weight_partitions)[i].begin(),
-                     (*weight_partitions)[i].end(),
-                     (*weight_v).begin() + weight_offset);
-        weight_offset += (*weight_partitions)[i].size();
-      }
-      (*weight_partitions).clear();
-      (*weight_partitions).shrink_to_fit();
+      weight_v = detail::concatenate(handle, std::move(*weight_partitions));
     }
 
     // 3. generate vertices
@@ -314,11 +335,10 @@ class Rmat_Usecase : public detail::TranslateGraph_Usecase {
     rmm::device_uvector<vertex_t> vertex_v(tot_vertex_counts, handle.get_stream());
     size_t v_offset{0};
     for (size_t i = 0; i < partition_vertex_firsts.size(); ++i) {
-      cugraph::detail::sequence_fill(
-        handle.get_stream(),
-        vertex_v.begin() + v_offset,
-        partition_vertex_lasts[i] - partition_vertex_firsts[i],
-        partition_vertex_firsts[i]);
+      cugraph::detail::sequence_fill(handle.get_stream(),
+                                     vertex_v.begin() + v_offset,
+                                     partition_vertex_lasts[i] - partition_vertex_firsts[i],
+                                     partition_vertex_firsts[i]);
       v_offset += partition_vertex_lasts[i] - partition_vertex_firsts[i];
     }
 


### PR DESCRIPTION
Previously, graph creation requires roughly edge data size * 2 + alpha (if we can destroy the input edge data and reclaim the memory, * 3 if the input edge data cannot be destroyed). This PR cuts this to edge data size * 1.5 + alpha.

This is a breaking PR for projects using functions under https://github.com/rapidsai/cugraph/blob/branch-22.04/cpp/include/cugraph/utilities/shuffle_comm.cuh (@aschaffer You may be affected).

There will be a follow-up PR further optimizing memory footprint. Wrapping up this PR to avoid creating a giant PR.