### PR TITLE
Skips ktruss docstring example for CUDA version 11.2, 11.4

### DIFF
--- a/python/cugraph/cugraph/tests/test_doctests.py
+++ b/python/cugraph/cugraph/tests/test_doctests.py
@@ -25,6 +25,7 @@ import pytest
 
 import cugraph
 import cudf
+from numba import cuda
 
 
 modules_to_skip = ["dask", "proto", "raft"]
@@ -122,6 +123,14 @@ class TestDoctests:
         globs = dict(cudf=cudf, np=np, cugraph=cugraph, datasets_path=datasets,
                      scipy=scipy, pd=pd)
         docstring.globs = globs
+
+        # FIXME: An 11.2 and 11.4 bug causes ktruss to crash in that
+        # environment. Skip docstring test if the cuda version is either
+        # 11.2 or 11.4. See ktruss_subgraph.py
+        if docstring.name == 'ktruss_subgraph':
+            if cuda.runtime.get_version() == (11, 4) or (11, 2):
+                return
+
         # Capture stdout and include failing outputs in the traceback.
         doctest_stdout = io.StringIO()
         with contextlib.redirect_stdout(doctest_stdout):


### PR DESCRIPTION
Addresses unit test failures affecting CUDA 11.2 and 11.4 builds, skips ktruss doctest and avoids assertion error