### PR TITLE
Coarsening symmetric graphs leads to slightly asymmetric edge weights

### DIFF
--- a/cpp/include/cugraph/detail/decompress_matrix_partition.cuh
+++ b/cpp/include/cugraph/detail/decompress_matrix_partition.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cugraph/detail/decompress_matrix_partition.cuh
+++ b/cpp/include/cugraph/detail/decompress_matrix_partition.cuh
@@ -184,9 +184,9 @@ template <typename vertex_t, typename edge_t, typename weight_t, bool multi_gpu>
 void decompress_matrix_partition_to_edgelist(
   raft::handle_t const& handle,
   matrix_partition_device_view_t<vertex_t, edge_t, weight_t, multi_gpu> const matrix_partition,
-  vertex_t* edgelist_majors /* [INOUT] */,
-  vertex_t* edgelist_minors /* [INOUT] */,
-  std::optional<weight_t*> edgelist_weights /* [INOUT] */,
+  vertex_t* edgelist_majors /* [OUT] */,
+  vertex_t* edgelist_minors /* [OUT] */,
+  std::optional<weight_t*> edgelist_weights /* [OUT] */,
   std::optional<std::vector<vertex_t>> const& segment_offsets)
 {
   auto number_of_edges = matrix_partition.get_number_of_edges();

--- a/cpp/include/cugraph/detail/graph_utils.cuh
+++ b/cpp/include/cugraph/detail/graph_utils.cuh
@@ -86,12 +86,13 @@ struct is_first_in_run_t {
   }
 };
 
-template <typename PairIterator>
+template <typename vertex_t>
 struct is_first_in_run_pair_t {
-  PairIterator pair_first{};
+  vertex_t const* vertices0{nullptr};
+  vertex_t const* vertices1{nullptr};
   __device__ bool operator()(size_t i) const
   {
-    return (i == 0) || (*(pair_first + (i - 1)) != *(pair_first + i));
+    return (i == 0) || ((vertices0[i - 1] != vertices0[i]) || (vertices1[i - 1] != vertices1[i]));
   }
 };
 

--- a/cpp/include/cugraph/detail/graph_utils.cuh
+++ b/cpp/include/cugraph/detail/graph_utils.cuh
@@ -86,5 +86,14 @@ struct is_first_in_run_t {
   }
 };
 
+template <typename PairIterator>
+struct is_first_in_run_pair_t {
+  PairIterator pair_first{};
+  __device__ bool operator()(size_t i) const
+  {
+    return (i == 0) || (*(pair_first + (i - 1)) != *(pair_first + i));
+  }
+};
+
 }  // namespace detail
 }  // namespace cugraph

--- a/cpp/src/structure/coarsen_graph_impl.cuh
+++ b/cpp/src/structure/coarsen_graph_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/coarsen_graph_impl.cuh
+++ b/cpp/src/structure/coarsen_graph_impl.cuh
@@ -78,7 +78,7 @@ edge_t groupby_e_and_coarsen_edgelist(vertex_t* edgelist_majors /* [INOUT] */,
       thrust::count_if(rmm::exec_policy(stream_view),
                        thrust::make_counting_iterator(size_t{0}),
                        thrust::make_counting_iterator(static_cast<size_t>(number_of_edges)),
-                       detail::is_first_in_run_pair_t<decltype(pair_first)>{pair_first});
+                       detail::is_first_in_run_pair_t<vertex_t>{edgelist_majors, edgelist_minors});
 
     rmm::device_uvector<vertex_t> tmp_edgelist_majors(num_uniques, stream_view);
     rmm::device_uvector<vertex_t> tmp_edgelist_minors(tmp_edgelist_majors.size(), stream_view);

--- a/cpp/src/structure/coarsen_graph_impl.cuh
+++ b/cpp/src/structure/coarsen_graph_impl.cuh
@@ -116,24 +116,13 @@ template <typename vertex_t,
 std::tuple<rmm::device_uvector<vertex_t>,
            rmm::device_uvector<vertex_t>,
            std::optional<rmm::device_uvector<weight_t>>>
-decompress_matrix_partition_to_relabeled_and_grouped_and_coarsened_edgelist(raft::handle_t const&
-                                                                              handle,
-                                                                            matrix_partition_device_view_t<
-                                                                              vertex_t,
-                                                                              edge_t,
-                                                                              weight_t,
-                                                                              multi_gpu> const
-                                                                              matrix_partition,
-                                                                            vertex_t const*
-                                                                              major_label_first,
-                                                                            AdjMatrixMinorLabelInputWrapper const
-                                                                              minor_label_input,
-                                                                            std::optional<
-                                                                              std::vector<
-                                                                                vertex_t>> const&
-                                                                              segment_offsets,
-                                                                            bool
-                                                                              lower_triangular_only)
+decompress_matrix_partition_to_relabeled_and_grouped_and_coarsened_edgelist(
+  raft::handle_t const& handle,
+  matrix_partition_device_view_t<vertex_t, edge_t, weight_t, multi_gpu> const matrix_partition,
+  vertex_t const* major_label_first,
+  AdjMatrixMinorLabelInputWrapper const minor_label_input,
+  std::optional<std::vector<vertex_t>> const& segment_offsets,
+  bool lower_triangular_only)
 {
   static_assert(std::is_same_v<typename AdjMatrixMinorLabelInputWrapper::value_type, vertex_t>);
 

--- a/cpp/src/structure/coarsen_graph_impl.cuh
+++ b/cpp/src/structure/coarsen_graph_impl.cuh
@@ -248,8 +248,8 @@ coarsen_graph(
   }
 
   // 1. construct coarsened edge lists from each local partition (if the input graph is symmetric,
-  // start with only the lower triangular edges in the original graph, this is to prevent edge
-  // weights in the coarsened graph becoming asymmmetric due to limited floatping point resolution)
+  // start with only the lower triangular edges after relabeling, this is to prevent edge weights in
+  // the coarsened graph becoming asymmmetric due to limited floatping point resolution)
 
   bool lower_triangular_only = graph_view.is_symmetric();
 
@@ -647,7 +647,6 @@ coarsen_graph(
 
   if (lower_triangular_only) {
     if (coarsened_edgelist_weights) {
-      std::cout << "lower_triangular weighted" << std::endl;
       auto edge_first =
         thrust::make_zip_iterator(thrust::make_tuple(coarsened_edgelist_majors.begin(),
                                                      coarsened_edgelist_minors.begin(),

--- a/cpp/tests/structure/coarsen_graph_test.cpp
+++ b/cpp/tests/structure/coarsen_graph_test.cpp
@@ -433,7 +433,8 @@ INSTANTIATE_TEST_SUITE_P(
   ::testing::Combine(
     // enable correctness checks
     ::testing::Values(CoarsenGraph_Usecase{0.2, false}, CoarsenGraph_Usecase{0.2, true}),
-    ::testing::Values(cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false))));
+    ::testing::Values(cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false),
+                      cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, true, false))));
 
 INSTANTIATE_TEST_SUITE_P(
   file_benchmark_test, /* note that the test filename can be overridden in benchmarking (with
@@ -457,6 +458,7 @@ INSTANTIATE_TEST_SUITE_P(
     // disable correctness checks for large graphs
     ::testing::Values(CoarsenGraph_Usecase{0.2, false, false},
                       CoarsenGraph_Usecase{0.2, true, false}),
-    ::testing::Values(cugraph::test::Rmat_Usecase(20, 32, 0.57, 0.19, 0.19, 0, false, false))));
+    ::testing::Values(cugraph::test::Rmat_Usecase(20, 32, 0.57, 0.19, 0.19, 0, false, false),
+                      cugraph::test::Rmat_Usecase(20, 32, 0.57, 0.19, 0.19, 0, true, false))));
 
 CUGRAPH_TEST_PROGRAM_MAIN()


### PR DESCRIPTION
If you coarsen a symmetric (i.e. undirected) graph, the output graph should be symmetric as well.

However, due to limited floating point resolution, edge weights can be slightly asymmetric after coarsening (e.g. for a triplet of src, dst, weight, we may see (1, 2, 1.0) and its reverse edge (2, 1, 1.0 + 1e-7), this is only approximately symmetric and not strictly symmetric).

This PR fixes this by coarsening using only the lower triangular part (including the diagonal) after relabeling and reconstructing a symmetric graph from the lower triangular part (if the input graph is symmetric).