### PR TITLE
Add `node2vec` wrappers to pylibcugraph

### DIFF
--- a/python/pylibcugraph/pylibcugraph/_cugraph_c/algorithms.pxd
+++ b/python/pylibcugraph/pylibcugraph/_cugraph_c/algorithms.pxd
@@ -164,3 +164,42 @@ cdef extern from "cugraph_c/algorithms.h":
             cugraph_paths_result_t** result,
             cugraph_error_t** error
         )
+
+    ###########################################################################
+    # random_walks
+    ctypedef struct cugraph_random_walk_result_t:
+        pass
+
+    cdef cugraph_type_erased_device_array_view_t* \
+        cugraph_random_walk_result_get_paths(
+            cugraph_random_walk_result_t* result
+        )
+
+    cdef cugraph_type_erased_device_array_view_t* \
+        cugraph_random_walk_result_get_weights(
+            cugraph_random_walk_result_t* result
+        )
+
+    cdef cugraph_type_erased_device_array_view_t* \
+        cugraph_random_walk_result_get_path_sizes(
+            cugraph_random_walk_result_t* result
+        )
+
+    cdef void \
+        cugraph_random_walk_result_free(
+            cugraph_random_walk_result_t* result
+        )
+
+    # node2vec
+    cdef cugraph_error_code_t \
+        cugraph_node2vec(
+            const cugraph_resource_handle_t* handle,
+            cugraph_graph_t* graph,
+            const cugraph_type_erased_device_array_view_t* sources,
+            size_t max_depth,
+            bool_t compress_result,
+            double p,
+            double q,
+            cugraph_random_walk_result_t** result,
+            cugraph_error_t** error
+        )

--- a/python/pylibcugraph/pylibcugraph/experimental/__init__.py
+++ b/python/pylibcugraph/pylibcugraph/experimental/__init__.py
@@ -52,3 +52,6 @@ pagerank = experimental_warning_wrapper(EXPERIMENTAL__pagerank)
 
 from pylibcugraph.sssp import EXPERIMENTAL__sssp
 sssp = experimental_warning_wrapper(EXPERIMENTAL__sssp)
+
+from pylibcugraph.node2vec import EXPERIMENTAL__node2vec
+node2vec = experimental_warning_wrapper(EXPERIMENTAL__node2vec)

--- a/python/pylibcugraph/pylibcugraph/graphs.pyx
+++ b/python/pylibcugraph/pylibcugraph/graphs.pyx
@@ -45,6 +45,7 @@ from pylibcugraph.graph_properties cimport (
 from pylibcugraph.utils cimport (
     assert_success,
     assert_CAI_type,
+    get_c_type_from_numpy_type,
 )
 
 
@@ -122,32 +123,29 @@ cdef class EXPERIMENTAL__SGGraph(_GPUGraph):
         cdef cugraph_error_t* error_ptr
         cdef cugraph_error_code_t error_code
 
-        # FIXME: set dtype properly
         cdef uintptr_t cai_srcs_ptr = \
             src_array.__cuda_array_interface__["data"][0]
         cdef cugraph_type_erased_device_array_view_t* srcs_view_ptr = \
             cugraph_type_erased_device_array_view_create(
                 <void*>cai_srcs_ptr,
                 len(src_array),
-                data_type_id_t.INT32)
+                get_c_type_from_numpy_type(src_array.dtype))
 
-        # FIXME: set dtype properly
         cdef uintptr_t cai_dsts_ptr = \
             dst_array.__cuda_array_interface__["data"][0]
         cdef cugraph_type_erased_device_array_view_t* dsts_view_ptr = \
             cugraph_type_erased_device_array_view_create(
                 <void*>cai_dsts_ptr,
                 len(dst_array),
-                data_type_id_t.INT32)
+                get_c_type_from_numpy_type(dst_array.dtype))
 
-        # FIXME: set dtype properly
         cdef uintptr_t cai_weights_ptr = \
             weight_array.__cuda_array_interface__["data"][0]
         cdef cugraph_type_erased_device_array_view_t* weights_view_ptr = \
             cugraph_type_erased_device_array_view_create(
                 <void*>cai_weights_ptr,
                 len(weight_array),
-                data_type_id_t.FLOAT32)
+                get_c_type_from_numpy_type(weight_array.dtype))
 
         error_code = cugraph_sg_graph_create(
             resource_handle.c_resource_handle_ptr,

--- a/python/pylibcugraph/pylibcugraph/node2vec.pyx
+++ b/python/pylibcugraph/pylibcugraph/node2vec.pyx
@@ -1,0 +1,184 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Have cython use python 3 syntax
+# cython: language_level = 3
+
+from libc.stdint cimport uintptr_t
+
+from pylibcugraph._cugraph_c.cugraph_api cimport (
+    bool_t,
+    data_type_id_t,
+    cugraph_resource_handle_t,
+)
+from pylibcugraph._cugraph_c.error cimport (
+    cugraph_error_code_t,
+    cugraph_error_t,
+)
+from pylibcugraph._cugraph_c.array cimport (
+    cugraph_type_erased_device_array_view_t,
+    cugraph_type_erased_device_array_view_create,
+    cugraph_type_erased_device_array_free,
+)
+from pylibcugraph._cugraph_c.graph cimport (
+    cugraph_graph_t,
+)
+from pylibcugraph._cugraph_c.algorithms cimport (
+    cugraph_node2vec,
+    cugraph_random_walk_result_t,
+    cugraph_random_walk_result_get_paths,
+    cugraph_random_walk_result_get_weights,
+    cugraph_random_walk_result_get_path_sizes,
+    cugraph_random_walk_result_free,
+)
+from pylibcugraph.resource_handle cimport (
+    EXPERIMENTAL__ResourceHandle,
+)
+from pylibcugraph.graphs cimport (
+    _GPUGraph,
+)
+from pylibcugraph.utils cimport (
+    assert_success,
+    copy_to_cupy_array,
+    assert_CAI_type,
+    get_c_type_from_numpy_type,
+)
+
+
+def EXPERIMENTAL__node2vec(EXPERIMENTAL__ResourceHandle resource_handle,
+                           _GPUGraph graph,
+                           src_array,
+                           size_t max_depth,
+                           bool_t compress_result,
+                           double p,
+                           double q):
+    """
+    Computes random walks under node2vec sampling procedure.
+
+    Parameters
+    ----------
+    resource_handle : ResourceHandle
+        Handle to the underlying device resources needed for referencing data
+        and running algorithms.
+
+    graph : SGGraph
+        The input graph.
+
+    src_array: device array type
+        Device array containing the
+        The pointer to the array of source vertices.
+
+    max_depth : size_t
+        Maximum length of generated path
+
+    compress_result : bool_t
+        If true, the third return device array contains the sizes for each path,
+        otherwise outputs empty device array.
+
+    p : double
+        The return factor p represents the likelihood of backtracking to a node
+        in the walk. A higher value (> max(q, 1)) makes it less likely to sample
+        a previously visited node, while a lower value (< min(q, 1)) would make it
+        more likely to backtrack, making the walk more "local".
+
+    q : double
+        The in-out factor q represents the likelihood of visiting nodes closer or
+        further from the outgoing node. If q > 1, the random walk is likelier to
+        visit nodes closer to the outgoing node. If q < 1, the random walk is
+        likelier to visit nodes further from the outgoing node.
+
+    Returns
+    -------
+    A tuple of device arrays, where the first item in the tuple is a device
+    array containing the compressed paths, the second item is a device
+    array containing the corresponding weights for each edge traversed in
+    each path, and the third item is a device array containing the sizes
+    for each of the compressed paths, if compress_result is True.
+
+    Examples
+    --------
+    >>> import pylibcugraph, cupy, numpy
+    >>> srcs = cupy.asarray([0, 1, 2], dtype=numpy.int32)
+    >>> dsts = cupy.asarray([1, 2, 3], dtype=numpy.int32)
+    >>> weights = cupy.asarray([1.0, 1.0, 1.0], dtype=numpy.float32)
+    >>> resource_handle = pylibcugraph.experimental.ResourceHandle()
+    >>> graph_props = pylibcugraph.experimental.GraphProperties(
+    ...     is_symmetric=False, is_multigraph=False)
+    >>> G = pylibcugraph.experimental.SGGraph(
+    ...     resource_handle, graph_props, srcs, dsts, weights,
+    ...     store_transposed=False, renumber=False, do_expensive_check=False)
+    >>> (paths, weights, sizes) = pylibcugraph.experimental.node2vec(
+    ...                             resource_handle, G, srcs, 3, True, p=1.0, q=1.0)
+
+    """
+
+    # FIXME: import these modules here for now until a better pattern can be
+    # used for optional imports (perhaps 'import_optional()' from cugraph), or
+    # these are made hard dependencies.
+    try:
+        import cupy
+    except ModuleNotFoundError:
+        raise RuntimeError("node2vec requires the cupy package, which could not "
+                           "be imported")
+    try:
+        import numpy
+    except ModuleNotFoundError:
+        raise RuntimeError("node2vec requires the numpy package, which could not "
+                           "be imported")
+    assert_CAI_type(src_array, "src_array")
+
+    cdef cugraph_resource_handle_t* c_resource_handle_ptr = \
+        resource_handle.c_resource_handle_ptr
+    cdef cugraph_graph_t* c_graph_ptr = graph.c_graph_ptr
+
+    cdef cugraph_random_walk_result_t* result_ptr
+    cdef cugraph_error_code_t error_code
+    cdef cugraph_error_t* error_ptr
+
+    cdef uintptr_t cai_srcs_ptr = \
+        src_array.__cuda_array_interface__["data"][0]
+    cdef cugraph_type_erased_device_array_view_t* srcs_view_ptr = \
+        cugraph_type_erased_device_array_view_create(
+            <void*>cai_srcs_ptr,
+            len(src_array),
+            get_c_type_from_numpy_type(src_array.dtype))
+
+
+    error_code = cugraph_node2vec(c_resource_handle_ptr,
+                                  c_graph_ptr,
+                                  srcs_view_ptr,
+                                  max_depth,
+                                  compress_result,
+                                  p,
+                                  q,
+                                  &result_ptr,
+                                  &error_ptr)
+    assert_success(error_code, error_ptr, "cugraph_node2vec")
+
+    # Extract individual device array pointers from result and copy to cupy
+    # arrays for returning.
+    cdef cugraph_type_erased_device_array_view_t* paths_ptr = \
+        cugraph_random_walk_result_get_paths(result_ptr)
+    cdef cugraph_type_erased_device_array_view_t* weights_ptr = \
+        cugraph_random_walk_result_get_weights(result_ptr)
+    cdef cugraph_type_erased_device_array_view_t* path_sizes_ptr = \
+        cugraph_random_walk_result_get_path_sizes(result_ptr)
+
+    cupy_paths = copy_to_cupy_array(c_resource_handle_ptr, paths_ptr)
+    cupy_weights = copy_to_cupy_array(c_resource_handle_ptr, weights_ptr)
+    cupy_path_sizes = copy_to_cupy_array(c_resource_handle_ptr,
+                                           path_sizes_ptr)
+
+    cugraph_random_walk_result_free(result_ptr)
+
+    return (cupy_paths, cupy_weights, cupy_path_sizes)

--- a/python/pylibcugraph/pylibcugraph/tests/test_node2vec.py
+++ b/python/pylibcugraph/pylibcugraph/tests/test_node2vec.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest as pyt
+import cupy as cp
+import numpy as np
+
+
+# =============================================================================
+# Test data
+# =============================================================================
+# The result names correspond to the datasets defined in conftest.py
+
+_test_data = {"karate.csv": {
+                  "seeds": cp.asarray([0, 0], dtype=np.int32),
+                  "paths": cp.asarray([0, 8, 33, 29, 26, 0, 1, 3, 13, 33],
+                                      dtype=np.int32),
+                  "weights": cp.asarray([1., 1., 1., 1., 1., 1., 1., 1.,
+                                         0., 0.],
+                                        dtype=np.float32),
+                  "path_sizes": cp.asarray([5, 5], dtype=np.int32),
+                  "max_depth": 5
+                  },
+              "dolphins.csv": {
+                  "seeds": cp.asarray([11], dtype=np.int32),
+                  "paths": cp.asarray([11, 51, 11, 51],
+                                      dtype=np.int32),
+                  "weights": cp.asarray([1., 1., 1.],
+                                        dtype=np.float32),
+                  "path_sizes": cp.asarray([4], dtype=np.int32),
+                  "max_depth": 4
+                  },
+              "Simple_1": {
+                  "seeds": cp.asarray([0, 3], dtype=np.int32),
+                  "paths": cp.asarray([0, 1, 2, 3],
+                                      dtype=np.int32),
+                  "weights": cp.asarray([1., 1., 0.],
+                                        dtype=np.float32),
+                  "path_sizes": cp.asarray([3, 1], dtype=np.int32),
+                  "max_depth": 3
+                  },
+              "Simple_2": {
+                  "seeds": cp.asarray([0, 3], dtype=np.int32),
+                  "paths": cp.asarray([0, 1, 3, 5, 3, 5],
+                                      dtype=np.int32),
+                  "weights": cp.asarray([0.1, 2.1, 7.2, 7.2, 7.2, 3.2],
+                                        dtype=np.float32),
+                  "path_sizes": cp.asarray([4, 2], dtype=np.int32),
+                  "max_depth": 4
+                  },
+              }
+
+# =============================================================================
+# Pytest fixtures
+# =============================================================================
+# fixtures used in this test module are defined in conftest.py
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+def test_node2vec(sg_graph_objs):
+    from pylibcugraph.experimental import node2vec
+
+    (g, resource_handle, ds_name) = sg_graph_objs
+
+    (seeds, expected_paths, expected_weights, expected_path_sizes, max_depth) \
+        = _test_data[ds_name].values()
+
+    compress_result = True
+    p = 0.8
+    q = 0.5
+
+    result = node2vec(resource_handle, g, seeds, max_depth,
+                      compress_result, p, q)
+
+    (actual_paths, actual_weights, actual_path_sizes) = result
+    num_paths = len(seeds)
+
+    # Do a simple check using the vertices as array indices.
+    assert len(actual_path_sizes) == num_paths
+
+    assert actual_paths.dtype == expected_paths.dtype
+    assert actual_weights.dtype == expected_weights.dtype
+    assert actual_path_sizes.dtype == expected_path_sizes.dtype
+
+    actual_paths = actual_paths.tolist()
+    actual_weights = actual_weights.tolist()
+    actual_path_sizes = actual_path_sizes.tolist()
+    expected_paths = expected_paths.tolist()
+    expected_weights = expected_weights.tolist()
+    expected_path_sizes = expected_path_sizes.tolist()
+
+    if ds_name not in ["karate.csv", "dolphins.csv", "Simple_2"]:
+        for i in range(len(expected_paths)):
+            assert pyt.approx(actual_paths[i], 1e-4) == expected_paths[i]
+        for i in range(len(expected_weights)):
+            assert pyt.approx(actual_weights[i], 1e-4) == expected_weights[i]
+
+    # Starting vertex of each path should be the seed
+    path_start = 0
+    for i in range(num_paths):
+        assert actual_path_sizes[i] == expected_path_sizes[i]
+        assert actual_paths[path_start] == seeds[i]
+        path_start += actual_path_sizes[i]

--- a/python/pylibcugraph/pylibcugraph/utils.pxd
+++ b/python/pylibcugraph/pylibcugraph/utils.pxd
@@ -35,6 +35,8 @@ cdef assert_CAI_type(obj, var_name, allow_None=*)
 
 cdef get_numpy_type_from_c_type(data_type_id_t c_type)
 
+cdef get_c_type_from_numpy_type(numpy_type)
+
 cdef copy_to_cupy_array(
    cugraph_resource_handle_t* c_resource_handle_ptr,
    cugraph_type_erased_device_array_view_t* device_array_view_ptr)

--- a/python/pylibcugraph/pylibcugraph/utils.pyx
+++ b/python/pylibcugraph/pylibcugraph/utils.pyx
@@ -77,6 +77,20 @@ cdef get_numpy_type_from_c_type(data_type_id_t c_type):
                            f"from C: {c_type}")
 
 
+cdef get_c_type_from_numpy_type(numpy_type):
+    if numpy_type == numpy.int32:
+        return data_type_id_t.INT32
+    elif numpy_type == numpy.int64:
+        return data_type_id_t.INT64
+    elif numpy_type == numpy.float32:
+        return data_type_id_t.FLOAT32
+    elif numpy_type == numpy.float64:
+        return data_type_id_t.FLOAT64
+    else:
+        raise RuntimeError("Internal error: got invalid data type enum value "
+                          f"from Numpy: {numpy_type}")
+
+
 cdef copy_to_cupy_array(
    cugraph_resource_handle_t* c_resource_handle_ptr,
    cugraph_type_erased_device_array_view_t* device_array_view_ptr):


### PR DESCRIPTION
Helps close #2058, when combined with a future PR for the cugraph layer implementation of node2vec, which depends on this PR. Ready for review