### PR TITLE
Fix bug Random Walk in array sizes

### DIFF
--- a/cpp/src/sampling/random_walks.cuh
+++ b/cpp/src/sampling/random_walks.cuh
@@ -776,10 +776,10 @@ random_walks_impl(raft::handle_t const& handle,
 
   // pre-allocate num_paths * max_depth;
   //
-  auto coalesced_sz = num_paths * max_depth;
-  device_vec_t<vertex_t> d_coalesced_v(coalesced_sz, stream);  // coalesced vertex set
-  device_vec_t<weight_t> d_coalesced_w(coalesced_sz, stream);  // coalesced weight set
-  device_vec_t<index_t> d_paths_sz(num_paths, stream);         // paths sizes
+  device_vec_t<vertex_t> d_coalesced_v(num_paths * max_depth, stream);  // coalesced vertex set
+  device_vec_t<weight_t> d_coalesced_w(num_paths * (max_depth - 1),
+                                       stream);         // coalesced weight set
+  device_vec_t<index_t> d_paths_sz(num_paths, stream);  // paths sizes
 
   // traversal policy:
   //

--- a/cpp/tests/c_api/node2vec_test.c
+++ b/cpp/tests/c_api/node2vec_test.c
@@ -92,6 +92,11 @@ int generic_node2vec_test(vertex_t* h_src,
     p_handle, (byte_t*)h_weights, weights, &ret_error);
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
 
+  TEST_ASSERT(test_ret_value,
+              cugraph_type_erased_device_array_view_size(paths) ==
+                (cugraph_type_erased_device_array_view_size(weights) + num_seeds),
+              "paths and weights sizes are not consistent");
+
   //  We can easily validate that the results of node2vec
   //  are feasible by converting the sparse (h_src,h_dst,h_wgt)
   //  into a dense host matrix and check each path.
@@ -113,6 +118,14 @@ int generic_node2vec_test(vertex_t* h_src,
     ret_code = cugraph_type_erased_device_array_view_copy_to_host(
       p_handle, (byte_t*)h_path_sizes, path_sizes, &ret_error);
     TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+    edge_t path_size = 0;
+    for (int i = 0; i < num_seeds; ++i)
+      path_size += h_path_sizes[i];
+
+    TEST_ASSERT(test_ret_value,
+                cugraph_type_erased_device_array_view_size(paths) == path_size,
+                "compressed paths size does not match expected size");
 
     h_path_offsets[0] = 0;
     for (int i = 0; i < num_seeds; ++i)


### PR DESCRIPTION
Random walk implementation returns a list of paths (vertex ids) and a list of edge weights for the edges on those paths.

@betochimas discovered that the size of the returned arrays is the same, even though the contents are different sizes.  In his example, if the return path contains one path:  `[ 0, 1, 3, 5 ]` it returns a weights array with 4 elements `[0.1, 2.1, 7.2, ???]` even though only the first three elements are valid.  The weights are edge weights, the path `[0,1,3,5]` only has 3 edges.  The first 3 elements in the returned array are correct.  Interpreting the results as intended will never reference that value.  However the sizes should be correct.

This PR fixes the initialization of the arrays to the correct size, which seems to correct the bug.