### PR TITLE
Update `libcugraph` recipe to output `libcugraph_tests` package

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -36,10 +36,6 @@ export CONDA_BLD_DIR="${WORKSPACE}/.conda-bld"
 # ucx-py version
 export UCX_PY_VERSION='0.25.*'
 
-export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"
-export CMAKE_CXX_COMPILER_LAUNCHER="sccache"
-export CMAKE_C_COMPILER_LAUNCHER="sccache"
-
 ################################################################################
 # SETUP - Check environment
 ################################################################################

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -42,10 +42,6 @@ export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 # ucx-py version
 export UCX_PY_VERSION='0.25.*'
 
-export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"
-export CMAKE_CXX_COMPILER_LAUNCHER="sccache"
-export CMAKE_C_COMPILER_LAUNCHER="sccache"
-
 ################################################################################
 # SETUP - Check environment
 ################################################################################


### PR DESCRIPTION
This PR updates the `libcugraph` recipe to include a new output, `libcugraph_tests`. `libcugraph_tests` is a `conda` package that includes all of the binaries for `libcugraph`'s tests and benchmarks. This PR is a prerequisite for deprecating Project Flash.

This also updates the CI scripts to use the new package for tests.