### PR TITLE
Remove references to gmock

### DIFF
--- a/cpp/tests/centrality/legacy/betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/legacy/betweenness_centrality_test.cu
@@ -30,8 +30,6 @@
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
-#include <gmock/gmock.h>
-
 #include <fstream>
 #include <queue>
 #include <stack>

--- a/cpp/tests/centrality/legacy/edge_betweenness_centrality_test.cu
+++ b/cpp/tests/centrality/legacy/edge_betweenness_centrality_test.cu
@@ -27,8 +27,6 @@
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
-#include <gmock/gmock.h>
-
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>
 

--- a/cpp/tests/centrality/legacy/katz_centrality_test.cu
+++ b/cpp/tests/centrality/legacy/katz_centrality_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,6 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/legacy/graph.hpp>
 #include <rmm/device_vector.hpp>
-
-#include <gmock/gmock-generated-matchers.h>
-#include <gmock/gmock.h>
 
 #include <thrust/device_ptr.h>
 
@@ -152,10 +149,20 @@ class Tests_Katz : public ::testing::TestWithParam<Katz_Usecase> {
 
     cugraph::katz_centrality(G, d_katz, alpha, 100, 1e-6, false, true);
 
+    auto threshold_ratio     = 1e-3;
+    auto threshold_magnitude = (1.0 / static_cast<double>(m)) * threshold_ratio;
+
     std::vector<int> top10CUGraph = getTopKIds(d_katz, m);
     std::vector<int> top10Golden  = getGoldenTopKIds(fs_result);
 
-    EXPECT_THAT(top10CUGraph, ::testing::ContainerEq(top10Golden));
+    auto nearly_equal = [threshold_ratio, threshold_magnitude](auto lhs, auto rhs) {
+      return std::abs(lhs - rhs) <
+             std::max(std::max(lhs, rhs) * threshold_ratio, threshold_magnitude);
+    };
+
+    ASSERT_TRUE(
+      std::equal(top10CUGraph.begin(), top10CUGraph.end(), top10Golden.begin(), nearly_equal))
+      << "Katz centrality values do not match with the reference values.";
   }
 };
 


### PR DESCRIPTION
CI started failing due to some gmock references.  Upon review, these gmock references are unnecessary.