### PR TITLE
[REVIEW] Upgrade `dask` and `distributed`

### DIFF
--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -14,8 +14,8 @@ dependencies:
 - libraft-headers=22.04.*
 - pyraft=22.04.*
 - cuda-python>=11.5,<12.0
-- dask>=2021.11.1
-- distributed>=2021.11.1
+- dask>=2022.02.1
+- distributed>=2022.02.1
 - dask-cuda=22.04.*
 - dask-cudf=22.04.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -14,8 +14,8 @@ dependencies:
 - libraft-headers=22.04.*
 - pyraft=22.04.*
 - cuda-python>=11.5,<12.0
-- dask>=2021.11.1
-- distributed>=2021.11.1
+- dask>=2022.02.1
+- distributed>=2022.02.1
 - dask-cuda=22.04.*
 - dask-cudf=22.04.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -14,8 +14,8 @@ dependencies:
 - libraft-headers=22.04.*
 - pyraft=22.04.*
 - cuda-python>=11.5,<12.0
-- dask>=2021.11.1
-- distributed>=2021.11.1
+- dask>=2022.02.1
+- distributed>=2022.02.1
 - dask-cuda=22.04.*
 - dask-cudf=22.04.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.5.yml
+++ b/conda/environments/cugraph_dev_cuda11.5.yml
@@ -14,8 +14,8 @@ dependencies:
 - libraft-headers=22.04.*
 - pyraft=22.04.*
 - cuda-python>=11.5,<12.0
-- dask>=2021.11.1
-- distributed>=2021.11.1
+- dask>=2022.02.1
+- distributed>=2022.02.1
 - dask-cuda=22.04.*
 - dask-cudf=22.04.*
 - nccl>=2.9.9

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -44,8 +44,8 @@ requirements:
     - cudf={{ minor_version }}
     - dask-cudf {{ minor_version }}
     - dask-cuda {{ minor_version }}
-    - dask>=2021.11.1
-    - distributed>=2021.11.1
+    - dask>=2022.02.1
+    - distributed>=2022.02.1
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}


### PR DESCRIPTION
This PR upgrades `dask` & `distributed` min versions to be inline with: https://github.com/rapidsai/cudf/pull/10182/