### PR TITLE
Remove major/minor from renumber_edgelist public functions.

### DIFF
--- a/cpp/include/cugraph/graph_functions.hpp
+++ b/cpp/include/cugraph/graph_functions.hpp
@@ -78,7 +78,7 @@ struct renumber_meta_t<vertex_t, edge_t, multi_gpu, std::enable_if_t<!multi_gpu>
  * graph adjacency matrix partition; a local partition can be further segmented by applying the
  * compute_gpu_id_from_vertex_t function to edge minor vertex IDs. This optinoal information is used
  * for further memory footprint optimization if provided.
- * @param store_transposed Should be true if renumbered edges will be used to create a graph if
+ * @param store_transposed Should be true if renumbered edges will be used to create a graph with
  * store_transposed = true. Should be false if the edges will be used to create a graph with
  * store_transposed = false.
  * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
@@ -115,11 +115,12 @@ renumber_edgelist(
  * handles to various CUDA libraries) to run graph algorithms.
  * @param vertices If valid, vertices in the graph to be renumbered. This parameter can be used to
  * include isolated vertices.
- * @param edgelist_srcs Edge source vertex IDs. Source IDs are updated in-place ([INOUT] parameter).
- * @param edgelist_dsts Edge destination vertex IDs. Destination IDs are updated in-place ([INOUT]
- * parameter).
+ * @param edgelist_srcs A pointer to edge source vertex IDs. Source IDs are updated in-place
+ * ([INOUT] parameter).
+ * @param edgelist_dsts A pointer to edge destination vertex IDs. Destination IDs are updated
+ * in-place ([INOUT] parameter).
  * @param num_edgelist_edges Number of edges in the edgelist.
- * @param store_transposed Should be true if renumbered edges will be used to create a graph if
+ * @param store_transposed Should be true if renumbered edges will be used to create a graph with
  * store_transposed = true. Should be false if the edges will be used to create a graph with
  * store_transposed = false.
  * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).

--- a/cpp/include/cugraph/graph_functions.hpp
+++ b/cpp/include/cugraph/graph_functions.hpp
@@ -47,8 +47,9 @@ struct renumber_meta_t<vertex_t, edge_t, multi_gpu, std::enable_if_t<!multi_gpu>
 /**
  * @brief renumber edgelist (multi-GPU)
  *
- * This function assumes that vertices and edges are pre-shuffled to their target processes using
- * the compute_gpu_id_from_vertex_t & compute_gpu_id_from_edge_t functors, respectively.
+ * This function assumes that vertices are pre-shuffled to their target processes and edges are
+ * pre-shuffled to their target processess and edge partitions using compute_gpu_id_from_vertex_t
+ * and compute_gpu_id_from_edge_t & compute_partition_id_from_edge_t functors, respectively.
  *
  * @tparam vertex_t Type of vertex identifiers. Needs to be an integral type.
  * @tparam edge_t Type of edge identifiers. Needs to be an integral type.
@@ -60,28 +61,26 @@ struct renumber_meta_t<vertex_t, edge_t, multi_gpu, std::enable_if_t<!multi_gpu>
  * This parameter can be used to include isolated vertices. Applying the
  * compute_gpu_id_from_vertex_t to every vertex should return the local GPU ID for this function to
  * work (vertices should be pre-shuffled).
- * @param edgelist_majors Pointers (one pointer per local graph adjacency matrix partition assigned
- * to this process) to edge source vertex IDs (if the graph adjacency matrix is stored as is) or
- * edge destination vertex IDs (if the transposed graph adjacency matrix is stored). Vertex IDs are
- * updated in-place ([INOUT] parameter). Edges should be pre-shuffled to their final target process
- * & matrix partition; i.e. applying the compute_gpu_id_from_edge_t functor to every (major, minor)
- * pair should return the GPU ID of this process and applying the compute_partition_id_from_edge_t
- * fuctor to every (major, minor) pair for a local matrix partition should return the partition ID
- * of the corresponding matrix partition.
- * @param edgelist_minors Pointers (one pointer per local graph adjacency matrix partition assigned
- * to this process) to edge destination vertex IDs (if the graph adjacency matrix is stored as is)
- * or edge source vertex IDs (if the transposed graph adjacency matrix is stored). Vertex IDs are
- * updated in-place ([INOUT] parameter). Edges should be pre-shuffled to their final target process
- * & matrix partition; i.e. applying the compute_gpu_id_from_edge_t functor to every (major, minor)
- * pair should return the GPU ID of this process and applying the compute_partition_id_from_edge_t
- * fuctor to every (major, minor) pair for a local matrix partition should return the partition ID
- * of the corresponding matrix partition.
- * @param edgelist_edge_counts Edge counts (one count per local graph adjacency matrix partition
- * assigned to this process).
+ * @param edgelist_srcs Pointers (one pointer per local edge partition assigned to this process) to
+ * edge source vertex IDs. Source IDs are updated in-place ([INOUT] parameter). Applying the
+ * compute_gpu_id_from_edge_t functor to every (destination ID, source ID) pair (if store_transposed
+ * = true) or (source ID, destination ID) pair (if store_transposed = false) should return the local
+ * GPU ID for this function to work (edges should be pre-shuffled). Applying the
+ * compute_partition_id_from_edge_t to every (destination ID, source ID) pair (if store_transposed =
+ * true) or (source ID, destination ID) pair (if store_transposed = false) should also return the
+ * corresponding edge partition ID. The best way to enforce this is to use
+ * shuffle_edgelist_by_gpu_id & groupby_and_count_edgelist_by_local_partition_id.
+ * @param edgelist_dsts Pointers (one pointer per local edge partition assigned to this process) to
+ * edge destination vertex IDs. Destination IDs are updated in-place ([INOUT] parameter).
+ * @param edgelist_edge_counts Edge counts (one count per local edge partition assigned to this
+ * process).
  * @param edgelist_intra_partition_segment_offsets If valid, store segment offsets within a local
  * graph adjacency matrix partition; a local partition can be further segmented by applying the
  * compute_gpu_id_from_vertex_t function to edge minor vertex IDs. This optinoal information is used
  * for further memory footprint optimization if provided.
+ * @param store_transposed Should be true if renumbered edges will be used to create a graph if
+ * store_transposed = true. Should be false if the edges will be used to create a graph with
+ * store_transposed = false.
  * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
  * @return std::tuple<rmm::device_uvector<vertex_t>, renumber_meta_t<vertex_t, edge_t, multi_gpu>>
  * Tuple of labels (vertex IDs before renumbering) for the entire set of vertices (assigned to this
@@ -98,10 +97,11 @@ std::enable_if_t<
 renumber_edgelist(
   raft::handle_t const& handle,
   std::optional<rmm::device_uvector<vertex_t>>&& local_vertices,
-  std::vector<vertex_t*> const& edgelist_majors /* [INOUT] */,
-  std::vector<vertex_t*> const& edgelist_minors /* [INOUT] */,
+  std::vector<vertex_t*> const& edgelist_srcs /* [INOUT] */,
+  std::vector<vertex_t*> const& edgelist_dsts /* [INOUT] */,
   std::vector<edge_t> const& edgelist_edge_counts,
   std::optional<std::vector<std::vector<edge_t>>> const& edgelist_intra_partition_segment_offsets,
+  bool store_transposed,
   bool do_expensive_check = false);
 
 /**
@@ -115,13 +115,13 @@ renumber_edgelist(
  * handles to various CUDA libraries) to run graph algorithms.
  * @param vertices If valid, vertices in the graph to be renumbered. This parameter can be used to
  * include isolated vertices.
- * @param edgelist_majors Edge source vertex IDs (if the graph adjacency matrix is stored as is) or
- * edge destination vertex IDs (if the transposed graph adjacency matrix is stored). Vertex IDs are
- * updated in-place ([INOUT] parameter).
- * @param edgelist_minors Edge destination vertex IDs (if the graph adjacency matrix is stored as
- * is) or edge source vertex IDs (if the transposed graph adjacency matrix is stored). Vertex IDs
- * are updated in-place ([INOUT] parameter).
+ * @param edgelist_srcs Edge source vertex IDs. Source IDs are updated in-place ([INOUT] parameter).
+ * @param edgelist_dsts Edge destination vertex IDs. Destination IDs are updated in-place ([INOUT]
+ * parameter).
  * @param num_edgelist_edges Number of edges in the edgelist.
+ * @param store_transposed Should be true if renumbered edges will be used to create a graph if
+ * store_transposed = true. Should be false if the edges will be used to create a graph with
+ * store_transposed = false.
  * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
  * @return std::tuple<rmm::device_uvector<vertex_t>, renumber_meta_t<vertex_t, edge_t, multi_gpu>>
  * Tuple of labels (vertex IDs before renumbering) for the entire set of vertices and meta-data
@@ -135,9 +135,10 @@ std::enable_if_t<
   std::tuple<rmm::device_uvector<vertex_t>, renumber_meta_t<vertex_t, edge_t, multi_gpu>>>
 renumber_edgelist(raft::handle_t const& handle,
                   std::optional<rmm::device_uvector<vertex_t>>&& vertices,
-                  vertex_t* edgelist_majors /* [INOUT] */,
-                  vertex_t* edgelist_minors /* [INOUT] */,
+                  vertex_t* edgelist_srcs /* [INOUT] */,
+                  vertex_t* edgelist_dsts /* [INOUT] */,
                   edge_t num_edgelist_edges,
+                  bool store_transposed,
                   bool do_expensive_check = false);
 
 /**

--- a/cpp/include/cugraph/utilities/cython.hpp
+++ b/cpp/include/cugraph/utilities/cython.hpp
@@ -598,9 +598,10 @@ std::unique_ptr<major_minor_weights_t<vertex_t, edge_t, weight_t>> call_shuffle(
 template <typename vertex_t, typename edge_t>
 std::unique_ptr<renum_tuple_t<vertex_t, edge_t>> call_renumber(
   raft::handle_t const& handle,
-  vertex_t* shuffled_edgelist_major_vertices /* [INOUT] */,
-  vertex_t* shuffled_edgelist_minor_vertices /* [INOUT] */,
+  vertex_t* shuffled_edgelist_src_vertices /* [INOUT] */,
+  vertex_t* shuffled_edgelist_dst_vertices /* [INOUT] */,
   std::vector<edge_t> const& edge_counts,
+  bool store_transposed,
   bool do_expensive_check,
   bool multi_gpu);
 

--- a/cpp/src/structure/renumber_edgelist_mg.cu
+++ b/cpp/src/structure/renumber_edgelist_mg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,30 +23,33 @@ template std::tuple<rmm::device_uvector<int32_t>, renumber_meta_t<int32_t, int32
 renumber_edgelist<int32_t, int32_t, true>(
   raft::handle_t const& handle,
   std::optional<rmm::device_uvector<int32_t>>&& local_vertices,
-  std::vector<int32_t*> const& edgelist_majors /* [INOUT] */,
-  std::vector<int32_t*> const& edgelist_minors /* [INOUT] */,
+  std::vector<int32_t*> const& edgelist_srcs /* [INOUT] */,
+  std::vector<int32_t*> const& edgelist_dsts /* [INOUT] */,
   std::vector<int32_t> const& edgelist_edge_counts,
   std::optional<std::vector<std::vector<int32_t>>> const& edgelist_intra_partition_segment_offsets,
+  bool store_transposed,
   bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int32_t>, renumber_meta_t<int32_t, int64_t, true>>
 renumber_edgelist<int32_t, int64_t, true>(
   raft::handle_t const& handle,
   std::optional<rmm::device_uvector<int32_t>>&& local_vertices,
-  std::vector<int32_t*> const& edgelist_majors /* [INOUT] */,
-  std::vector<int32_t*> const& edgelist_minors /* [INOUT] */,
+  std::vector<int32_t*> const& edgelist_srcs /* [INOUT] */,
+  std::vector<int32_t*> const& edgelist_dsts /* [INOUT] */,
   std::vector<int64_t> const& edgelist_edge_counts,
   std::optional<std::vector<std::vector<int64_t>>> const& edgelist_intra_partition_segment_offsets,
+  bool store_transposed,
   bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int64_t>, renumber_meta_t<int64_t, int64_t, true>>
 renumber_edgelist<int64_t, int64_t, true>(
   raft::handle_t const& handle,
   std::optional<rmm::device_uvector<int64_t>>&& local_vertices,
-  std::vector<int64_t*> const& edgelist_majors /* [INOUT] */,
-  std::vector<int64_t*> const& edgelist_minors /* [INOUT] */,
+  std::vector<int64_t*> const& edgelist_srcs /* [INOUT] */,
+  std::vector<int64_t*> const& edgelist_dsts /* [INOUT] */,
   std::vector<int64_t> const& edgelist_edge_counts,
   std::optional<std::vector<std::vector<int64_t>>> const& edgelist_intra_partition_segment_offsets,
+  bool store_transposed,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/renumber_edgelist_sg.cu
+++ b/cpp/src/structure/renumber_edgelist_sg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,25 +22,28 @@ namespace cugraph {
 template std::tuple<rmm::device_uvector<int32_t>, renumber_meta_t<int32_t, int32_t, false>>
 renumber_edgelist<int32_t, int32_t, false>(raft::handle_t const& handle,
                                            std::optional<rmm::device_uvector<int32_t>>&& vertices,
-                                           int32_t* edgelist_majors /* [INOUT] */,
-                                           int32_t* edgelist_minors /* [INOUT] */,
+                                           int32_t* edgelist_srcs /* [INOUT] */,
+                                           int32_t* edgelist_dsts /* [INOUT] */,
                                            int32_t num_edgelist_edges,
+                                           bool store_transposed,
                                            bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int32_t>, renumber_meta_t<int32_t, int64_t, false>>
 renumber_edgelist<int32_t, int64_t, false>(raft::handle_t const& handle,
                                            std::optional<rmm::device_uvector<int32_t>>&& vertices,
-                                           int32_t* edgelist_majors /* [INOUT] */,
-                                           int32_t* edgelist_minors /* [INOUT] */,
+                                           int32_t* edgelist_srcs /* [INOUT] */,
+                                           int32_t* edgelist_dsts /* [INOUT] */,
                                            int64_t num_edgelist_edges,
+                                           bool store_transposed,
                                            bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int64_t>, renumber_meta_t<int64_t, int64_t, false>>
 renumber_edgelist<int64_t, int64_t, false>(raft::handle_t const& handle,
                                            std::optional<rmm::device_uvector<int64_t>>&& vertices,
-                                           int64_t* edgelist_majors /* [INOUT] */,
-                                           int64_t* edgelist_minors /* [INOUT] */,
+                                           int64_t* edgelist_srcs /* [INOUT] */,
+                                           int64_t* edgelist_dsts /* [INOUT] */,
                                            int64_t num_edgelist_edges,
+                                           bool store_transposed,
                                            bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/tests/community/mg_louvain_helper.cu
+++ b/cpp/tests/community/mg_louvain_helper.cu
@@ -33,8 +33,8 @@ namespace test {
 
 template <typename T>
 void single_gpu_renumber_edgelist_given_number_map(raft::handle_t const& handle,
-                                                   rmm::device_uvector<T>& edgelist_rows_v,
-                                                   rmm::device_uvector<T>& edgelist_cols_v,
+                                                   rmm::device_uvector<T>& edgelist_srcs_v,
+                                                   rmm::device_uvector<T>& edgelist_dsts_v,
                                                    rmm::device_uvector<T>& renumber_map_gathered_v)
 {
   rmm::device_uvector<T> index_v(renumber_map_gathered_v.size(), handle.get_stream());
@@ -48,15 +48,15 @@ void single_gpu_renumber_edgelist_given_number_map(raft::handle_t const& handle,
       auto idx) { d_index[d_renumber_map_gathered[idx]] = idx; });
 
   thrust::transform(execution_policy,
-                    edgelist_rows_v.begin(),
-                    edgelist_rows_v.end(),
-                    edgelist_rows_v.begin(),
+                    edgelist_srcs_v.begin(),
+                    edgelist_srcs_v.end(),
+                    edgelist_srcs_v.begin(),
                     [d_index = index_v.data()] __device__(auto v) { return d_index[v]; });
 
   thrust::transform(execution_policy,
-                    edgelist_cols_v.begin(),
-                    edgelist_cols_v.end(),
-                    edgelist_cols_v.begin(),
+                    edgelist_dsts_v.begin(),
+                    edgelist_dsts_v.end(),
+                    edgelist_dsts_v.begin(),
                     [d_index = index_v.data()] __device__(auto v) { return d_index[v]; });
 }
 
@@ -264,14 +264,14 @@ coarsen_graph(
 
 template void single_gpu_renumber_edgelist_given_number_map(
   raft::handle_t const& handle,
-  rmm::device_uvector<int32_t>& d_edgelist_rows,
-  rmm::device_uvector<int32_t>& d_edgelist_cols,
+  rmm::device_uvector<int32_t>& d_edgelist_srcs,
+  rmm::device_uvector<int32_t>& d_edgelist_dsts,
   rmm::device_uvector<int32_t>& d_renumber_map_gathered_v);
 
 template void single_gpu_renumber_edgelist_given_number_map(
   raft::handle_t const& handle,
-  rmm::device_uvector<int64_t>& d_edgelist_rows,
-  rmm::device_uvector<int64_t>& d_edgelist_cols,
+  rmm::device_uvector<int64_t>& d_edgelist_srcs,
+  rmm::device_uvector<int64_t>& d_edgelist_dsts,
   rmm::device_uvector<int64_t>& d_renumber_map_gathered_v);
 
 template std::unique_ptr<cugraph::graph_t<int32_t, int32_t, float, false, false>> coarsen_graph(

--- a/cpp/tests/community/mg_louvain_helper.hpp
+++ b/cpp/tests/community/mg_louvain_helper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/community/mg_louvain_helper.hpp
+++ b/cpp/tests/community/mg_louvain_helper.hpp
@@ -37,8 +37,8 @@ bool compare_renumbered_vectors(raft::handle_t const& handle,
 template <typename T>
 void single_gpu_renumber_edgelist_given_number_map(
   raft::handle_t const& handle,
-  rmm::device_uvector<T>& d_edgelist_rows,
-  rmm::device_uvector<T>& d_edgelist_cols,
+  rmm::device_uvector<T>& d_edgelist_srcs,
+  rmm::device_uvector<T>& d_edgelist_dsts,
   rmm::device_uvector<T>& d_renumber_map_gathered_v);
 
 template <typename vertex_t, typename edge_t, typename weight_t, bool store_transposed>

--- a/cpp/tests/structure/renumbering_test.cpp
+++ b/cpp/tests/structure/renumbering_test.cpp
@@ -89,7 +89,7 @@ class Tests_Renumbering
 
     std::tie(renumber_map_labels_v, std::ignore) =
       cugraph::renumber_edgelist<vertex_t, edge_t, false>(
-        handle, std::nullopt, src_v.begin(), dst_v.begin(), src_v.size());
+        handle, std::nullopt, src_v.begin(), dst_v.begin(), src_v.size(), false);
 
     if (cugraph::test::g_perf) {
       RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement

--- a/python/cugraph/cugraph/structure/graph_utilities.pxd
+++ b/python/cugraph/cugraph/structure/graph_utilities.pxd
@@ -193,5 +193,6 @@ cdef extern from "cugraph/utilities/cython.hpp" namespace "cugraph::cython":
         vertex_t *edgelist_major_vertices,
         vertex_t *edgelist_minor_vertices,
         const vector[edge_t]& edge_counts,
+        bool store_transposed,
         bool do_check,
         bool multi_gpu) except +

--- a/python/cugraph/cugraph/structure/renumber_wrapper.pyx
+++ b/python/cugraph/cugraph/structure/renumber_wrapper.pyx
@@ -122,8 +122,8 @@ def renumber(input_df,           # maybe use cpdef ?
     cdef uintptr_t c_major_vertices = major_vertices.__cuda_array_interface__['data'][0]
     cdef uintptr_t c_minor_vertices = minor_vertices.__cuda_array_interface__['data'][0]
 
-    cdef uintptr_t shuffled_major = <uintptr_t>NULL
-    cdef uintptr_t shuffled_minor = <uintptr_t>NULL
+    cdef uintptr_t shuffled_src = <uintptr_t>NULL
+    cdef uintptr_t shuffled_dst = <uintptr_t>NULL
 
     # FIXME: Fix fails when do_check = True
     cdef bool do_check = False # ? for now...
@@ -186,13 +186,18 @@ def renumber(input_df,           # maybe use cpdef ?
                     shuffled_df = input_df
                     edge_counts_32 = make_unique[vector[int]](1, num_local_edges)
 
-                shuffled_major = major_vertices.__cuda_array_interface__['data'][0]
-                shuffled_minor = minor_vertices.__cuda_array_interface__['data'][0]
+                if not transposed:
+                    shuffled_src = major_vertices.__cuda_array_interface__['data'][0]
+                    shuffled_dst = minor_vertices.__cuda_array_interface__['data'][0]
+                else:
+                    shuffled_src = minor_vertices.__cuda_array_interface__['data'][0]
+                    shuffled_dst = major_vertices.__cuda_array_interface__['data'][0]
 
                 ptr_renum_tuple_32_32.reset(call_renumber[int, int](deref(handle_ptr),
-                                                                    <int*>shuffled_major,
-                                                                    <int*>shuffled_minor,
+                                                                    <int*>shuffled_src,
+                                                                    <int*>shuffled_dst,
                                                                     deref(edge_counts_32.get()),
+                                                                    transposed,
                                                                     do_check,
                                                                     mg_flag).release())
 
@@ -251,13 +256,18 @@ def renumber(input_df,           # maybe use cpdef ?
                     shuffled_df = input_df
                     edge_counts_32 = make_unique[vector[int]](1, num_local_edges)
 
-                shuffled_major = major_vertices.__cuda_array_interface__['data'][0]
-                shuffled_minor = minor_vertices.__cuda_array_interface__['data'][0]
+                if not transposed:
+                    shuffled_src = major_vertices.__cuda_array_interface__['data'][0]
+                    shuffled_dst = minor_vertices.__cuda_array_interface__['data'][0]
+                else:
+                    shuffled_src = minor_vertices.__cuda_array_interface__['data'][0]
+                    shuffled_dst = major_vertices.__cuda_array_interface__['data'][0]
 
                 ptr_renum_tuple_32_32.reset(call_renumber[int, int](deref(handle_ptr),
-                                                                    <int*>shuffled_major,
-                                                                    <int*>shuffled_minor,
+                                                                    <int*>shuffled_src,
+                                                                    <int*>shuffled_dst,
                                                                     deref(edge_counts_32.get()),
+                                                                    transposed,
                                                                     do_check,
                                                                     mg_flag).release())
 
@@ -318,13 +328,18 @@ def renumber(input_df,           # maybe use cpdef ?
                     shuffled_df = input_df
                     edge_counts_64 = make_unique[vector[long]](1, num_local_edges)
 
-                shuffled_major = major_vertices.__cuda_array_interface__['data'][0]
-                shuffled_minor = minor_vertices.__cuda_array_interface__['data'][0]
+                if not transposed:
+                    shuffled_src = major_vertices.__cuda_array_interface__['data'][0]
+                    shuffled_dst = minor_vertices.__cuda_array_interface__['data'][0]
+                else:
+                    shuffled_src = minor_vertices.__cuda_array_interface__['data'][0]
+                    shuffled_dst = major_vertices.__cuda_array_interface__['data'][0]
 
                 ptr_renum_tuple_32_64.reset(call_renumber[int, long](deref(handle_ptr),
-                                                                     <int*>shuffled_major,
-                                                                     <int*>shuffled_minor,
+                                                                     <int*>shuffled_src,
+                                                                     <int*>shuffled_dst,
                                                                      deref(edge_counts_64.get()),
+                                                                     transposed,
                                                                      do_check,
                                                                      mg_flag).release())
 
@@ -383,13 +398,18 @@ def renumber(input_df,           # maybe use cpdef ?
                     shuffled_df = input_df
                     edge_counts_64 = make_unique[vector[long]](1, num_local_edges)
 
-                shuffled_major = major_vertices.__cuda_array_interface__['data'][0]
-                shuffled_minor = minor_vertices.__cuda_array_interface__['data'][0]
+                if not transposed:
+                    shuffled_src = major_vertices.__cuda_array_interface__['data'][0]
+                    shuffled_dst = minor_vertices.__cuda_array_interface__['data'][0]
+                else:
+                    shuffled_src = minor_vertices.__cuda_array_interface__['data'][0]
+                    shuffled_dst = major_vertices.__cuda_array_interface__['data'][0]
 
                 ptr_renum_tuple_32_64.reset(call_renumber[int, long](deref(handle_ptr),
-                                                                     <int*>shuffled_major,
-                                                                     <int*>shuffled_minor,
+                                                                     <int*>shuffled_src,
+                                                                     <int*>shuffled_dst,
                                                                      deref(edge_counts_64.get()),
+                                                                     transposed,
                                                                      do_check,
                                                                      mg_flag).release())
 
@@ -450,13 +470,18 @@ def renumber(input_df,           # maybe use cpdef ?
                     shuffled_df = input_df
                     edge_counts_64 = make_unique[vector[long]](1, num_local_edges)
 
-                shuffled_major = major_vertices.__cuda_array_interface__['data'][0]
-                shuffled_minor = minor_vertices.__cuda_array_interface__['data'][0]
+                if not transposed:
+                    shuffled_src = major_vertices.__cuda_array_interface__['data'][0]
+                    shuffled_dst = minor_vertices.__cuda_array_interface__['data'][0]
+                else:
+                    shuffled_src = minor_vertices.__cuda_array_interface__['data'][0]
+                    shuffled_dst = major_vertices.__cuda_array_interface__['data'][0]
 
                 ptr_renum_tuple_64_64.reset(call_renumber[long, long](deref(handle_ptr),
-                                                                      <long*>shuffled_major,
-                                                                      <long*>shuffled_minor,
+                                                                      <long*>shuffled_src,
+                                                                      <long*>shuffled_dst,
                                                                       deref(edge_counts_64.get()),
+                                                                      transposed,
                                                                       do_check,
                                                                       mg_flag).release())
 
@@ -516,13 +541,18 @@ def renumber(input_df,           # maybe use cpdef ?
                     shuffled_df = input_df
                     edge_counts_64 = make_unique[vector[long]](1, num_local_edges)
 
-                shuffled_major = major_vertices.__cuda_array_interface__['data'][0]
-                shuffled_minor = minor_vertices.__cuda_array_interface__['data'][0]
+                if not transposed:
+                    shuffled_src = major_vertices.__cuda_array_interface__['data'][0]
+                    shuffled_dst = minor_vertices.__cuda_array_interface__['data'][0]
+                else:
+                    shuffled_src = minor_vertices.__cuda_array_interface__['data'][0]
+                    shuffled_dst = major_vertices.__cuda_array_interface__['data'][0]
 
                 ptr_renum_tuple_64_64.reset(call_renumber[long, long](deref(handle_ptr),
-                                                                      <long*>shuffled_major,
-                                                                      <long*>shuffled_minor,
+                                                                      <long*>shuffled_src,
+                                                                      <long*>shuffled_dst,
                                                                       deref(edge_counts_64.get()),
+                                                                      transposed,
                                                                       do_check,
                                                                       mg_flag).release())
 

--- a/python/cugraph/cugraph/structure/renumber_wrapper.pyx
+++ b/python/cugraph/cugraph/structure/renumber_wrapper.pyx
@@ -85,6 +85,11 @@ def renumber(input_df,           # maybe use cpdef ?
     # TODO: get handle_t out of handle...
     handle_ptr = <handle_t*>handle_size_t
 
+    # FIXME: call_shuffle currently works on major/minor while call_renumber is updated to work on
+    # source/destination. We'd better update call_shuffle to work on source/destination as well to
+    # avoid switching between major/minor & source/destination. Deferring this work at this moment
+    # expect this legacy code path will be replaced with the new pylibcugrpah & C API based path.
+
     if not transposed:
         major_vertices = input_df[renumbered_src_col_name]
         minor_vertices = input_df[renumbered_dst_col_name]

--- a/python/cugraph/cugraph/structure/renumber_wrapper.pyx
+++ b/python/cugraph/cugraph/structure/renumber_wrapper.pyx
@@ -88,7 +88,7 @@ def renumber(input_df,           # maybe use cpdef ?
     # FIXME: call_shuffle currently works on major/minor while call_renumber is updated to work on
     # source/destination. We'd better update call_shuffle to work on source/destination as well to
     # avoid switching between major/minor & source/destination. Deferring this work at this moment
-    # expect this legacy code path will be replaced with the new pylibcugrpah & C API based path.
+    # expecting this legacy code path will be replaced with the new pylibcugrpah & C API based path.
 
     if not transposed:
         major_vertices = input_df[renumbered_src_col_name]


### PR DESCRIPTION
Partially addresses #2003

We should not use major,minor (instead of src, dst) in the public non-detail API and should use major,minor in the detail space.

The public non-detail namespace renumber_edgelist currently uses major, minor and this PR fixes this.

This PR also replaces row/col to src/dst in `single_gpu_renumber_edgelist_given_number_map` as we're aiming to consistently use src/dst instead of row/col in our public C++ API.

This is possibly breaking as this PR changes the public API (but I am not aware of any non-cugraph libraries directly calling renumber_edgelist).
