### PR TITLE
Use new raft-core conda package

### DIFF
--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -11,7 +11,7 @@ dependencies:
 - libcudf=22.04.*
 - rmm=22.04.*
 - librmm=22.04.*
-- libraft-headers=22.04.*
+- libraft-core=22.04.*
 - pyraft=22.04.*
 - cuda-python>=11.5,<12.0
 - dask>=2021.11.1

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -11,7 +11,7 @@ dependencies:
 - libcudf=22.04.*
 - rmm=22.04.*
 - librmm=22.04.*
-- libraft-headers=22.04.*
+- libraft-core=22.04.*
 - pyraft=22.04.*
 - cuda-python>=11.5,<12.0
 - dask>=2021.11.1

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -11,7 +11,7 @@ dependencies:
 - libcudf=22.04.*
 - rmm=22.04.*
 - librmm=22.04.*
-- libraft-headers=22.04.*
+- libraft-core=22.04.*
 - pyraft=22.04.*
 - cuda-python>=11.5,<12.0
 - dask>=2021.11.1

--- a/conda/environments/cugraph_dev_cuda11.5.yml
+++ b/conda/environments/cugraph_dev_cuda11.5.yml
@@ -11,7 +11,7 @@ dependencies:
 - libcudf=22.04.*
 - rmm=22.04.*
 - librmm=22.04.*
-- libraft-headers=22.04.*
+- libraft-core=22.04.*
 - pyraft=22.04.*
 - cuda-python>=11.5,<12.0
 - dask>=2021.11.1

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - python x.x
     - cython>=0.29,<0.30
     - libcugraph={{ version }}
-    - libraft-headers {{ minor_version }}
+    - libraft-core {{ minor_version }}
     - pyraft {{ minor_version }}
     - cudf={{ minor_version }}
     - ucx-py {{ ucx_py_version }}
@@ -39,7 +39,7 @@ requirements:
   run:
     - python x.x
     - libcugraph={{ version }}
-    - libraft-headers {{ minor_version }}
+    - libraft-core {{ minor_version }}
     - pyraft {{ minor_version }}
     - cudf={{ minor_version }}
     - dask-cudf {{ minor_version }}

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - cmake>=3.20.1
     - doxygen>=1.8.11
     - cudatoolkit {{ cuda_version }}.*
-    - libraft-headers {{ minor_version }}
+    - libraft-core {{ minor_version }}
     - libcugraphops {{ minor_version }}.*
     - librmm {{ minor_version }}.*
     - cudf {{ minor_version }}.*
@@ -48,7 +48,7 @@ requirements:
     - gmock=1.10.0  # FIXME: pinned to version in https://github.com/rapidsai/integration/blob/branch-22.04/conda/recipes/versions.yaml
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
-    - libraft-headers {{ minor_version }}
+    - libraft-core {{ minor_version }}
     - librmm {{ minor_version }}
     - nccl>=2.9.9
     - ucx-proc=*=gpu

--- a/conda/recipes/libcugraph_etl/meta.yaml
+++ b/conda/recipes/libcugraph_etl/meta.yaml
@@ -39,12 +39,12 @@ requirements:
     - cudatoolkit {{ cuda_version }}.*
     - libcudf {{ minor_version }}.*
     - libcugraph {{ minor_version }}.*
-    - libraft-headers {{ minor_version }}
+    - libraft-core {{ minor_version }}
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
     - libcudf {{ minor_version }}.*
     - libcugraph {{ minor_version }}.*
-    - libraft-headers {{ minor_version }}
+    - libraft-core {{ minor_version }}
     - librmm {{ minor_version }}
 
 about:

--- a/conda/recipes/pylibcugraph/meta.yaml
+++ b/conda/recipes/pylibcugraph/meta.yaml
@@ -33,10 +33,10 @@ requirements:
     - ucx-proc=*=gpu
     - cudatoolkit {{ cuda_version }}.*
     - rmm {{ minor_version }}.*
-    - libraft-headers {{ minor_version }}
+    - libraft-core {{ minor_version }}
   run:
     - python x.x
-    - libraft-headers {{ minor_version }}
+    - libraft-core {{ minor_version }}
     - libcugraph={{ version }}
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
 


### PR DESCRIPTION
This shouldn't be merged until https://github.com/rapidsai/raft/pull/540 is merged (and this is tested against the corresponding raft conda package's testing label).