### PR TITLE
Renumbering causing inconsistent outputs in node2vec

### DIFF
--- a/python/pylibcugraph/pylibcugraph/tests/test_node2vec.py
+++ b/python/pylibcugraph/pylibcugraph/tests/test_node2vec.py
@@ -102,9 +102,6 @@ def test_node2vec(sg_graph_objs, compress_result):
         # up with weights array
         assert len(actual_path_sizes) == num_paths
         expected_walks = sum(exp_path_sizes) - num_paths
-        # FIXME: When using multiple seeds, paths are connected via the weights
-        # array, there should not be a weight connecting the end of a path with
-        # the beginning of another. PR #2089 will resolve this.
         # Verify the number of walks was equal to path sizes - num paths
         assert len(actual_weights) == expected_walks
     else:


### PR DESCRIPTION
Renumbering is done in two different layers when using the python package of cugraph, one in cugraph and one in libcugraph. Because of a renumbering bug, edges and vertices are not being renumbered correctly, causing multiple vertices and edges to be potentially identified as the same (i.e. take node ‘0’ and ‘6’ - they could both appear as node ‘0’). Testing was added to try to identify the exact source, although that is currently a WIP.