### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -45,5 +45,5 @@ dependencies:
 - rapids-pytest-benchmark
 - doxygen
 - pytest-cov
-- gtest
-- gmock
+- gtest=1.10.0
+- gmock=1.10.0

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -45,5 +45,5 @@ dependencies:
 - rapids-pytest-benchmark
 - doxygen
 - pytest-cov
-- gtest
-- gmock
+- gtest=1.10.0
+- gmock=1.10.0

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -45,5 +45,5 @@ dependencies:
 - rapids-pytest-benchmark
 - doxygen
 - pytest-cov
-- gtest
-- gmock
+- gtest=1.10.0
+- gmock=1.10.0

--- a/conda/environments/cugraph_dev_cuda11.5.yml
+++ b/conda/environments/cugraph_dev_cuda11.5.yml
@@ -45,5 +45,5 @@ dependencies:
 - rapids-pytest-benchmark
 - doxygen
 - pytest-cov
-- gtest
-- gmock
+- gtest=1.10.0
+- gmock=1.10.0


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.