### PR TITLE
[FIX] Use `rapids_find_package` to get `cugraph-ops`

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -79,7 +79,6 @@ rapids_cmake_build_type(Release)
 option(BUILD_CUGRAPH_MG_TESTS "Build cuGraph multigpu algorithm tests" OFF)
 option(CMAKE_CUDA_LINEINFO "Enable the -lineinfo option for nvcc (useful for cuda-memcheck / profiler" OFF)
 option(BUILD_TESTS "Configure CMake to build tests" ON)
-option(BUILD_CUGRAPH_OPS_PYTHON_LIBRARY "Build cugraph-ops python library." OFF)
 
 ################################################################################
 # - compiler options -----------------------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -79,6 +79,7 @@ rapids_cmake_build_type(Release)
 option(BUILD_CUGRAPH_MG_TESTS "Build cuGraph multigpu algorithm tests" OFF)
 option(CMAKE_CUDA_LINEINFO "Enable the -lineinfo option for nvcc (useful for cuda-memcheck / profiler" OFF)
 option(BUILD_TESTS "Configure CMake to build tests" ON)
+option(BUILD_CUGRAPH_OPS_PYTHON_LIBRARY "Build cugraph-ops python library." OFF)
 
 ################################################################################
 # - compiler options -----------------------------------------------------------
@@ -286,7 +287,7 @@ target_include_directories(cugraph
 # - link libraries -------------------------------------------------------------
 target_link_libraries(cugraph
     PUBLIC
-        cugraphops::cugraphops
+        cugraph-ops::cugraph-ops++
         raft::raft
     PRIVATE
         cugraph::cuHornet

--- a/cpp/cmake/thirdparty/get_libcugraphops.cmake
+++ b/cpp/cmake/thirdparty/get_libcugraphops.cmake
@@ -15,35 +15,20 @@
 #=============================================================================
 
 set(CUGRAPH_MIN_VERSION_cugraph_ops "${CUGRAPH_VERSION_MAJOR}.${CUGRAPH_VERSION_MINOR}.00")
-set(CUGRAPH_BRANCH_VERSION_cugraph_ops "${CUGRAPH_VERSION_MAJOR}.${CUGRAPH_VERSION_MINOR}")
 
 function(find_and_configure_cugraph_ops)
 
-    set(oneValueArgs VERSION FORK PINNED_TAG CLONE_ON_PIN)
-    cmake_parse_arguments(PKG "" "${oneValueArgs}" "" ${ARGN} )
+    set(oneValueArgs VERSION)
+    cmake_parse_arguments(PKG "" "${oneValueArgs}" "" ${ARGN})
 
-    if(PKG_CLONE_ON_PIN AND NOT PKG_PINNED_TAG STREQUAL "branch-${CUGRAPH_BRANCH_VERSION_cugraph_ops}")
-        message("Pinned tag found: ${PKG_PINNED_TAG}. Cloning cugraph-ops locally.")
-        set(CPM_DOWNLOAD_cugraph-ops ON)
-    endif()
-
-    rapids_cpm_find(cugraph-ops ${PKG_VERSION}
+    rapids_find_package(cugraph-ops ${PKG_VERSION} REQUIRED
       GLOBAL_TARGETS      cugraph-ops::cugraph-ops++
       BUILD_EXPORT_SET    cugraph-exports
       INSTALL_EXPORT_SET  cugraph-exports
-        CPM_ARGS
-            GIT_REPOSITORY https://github.com/${PKG_FORK}/cugraph-ops.git
-            GIT_TAG        ${PKG_PINNED_TAG}
-            OPTIONS
-                "BUILD_CUGRAPH_OPS_CPP_LIBRARY ON"
-                "BUILD_CUGRAPH_OPS_CPP_TESTS OFF"
-                "BUILD_CUGRAPH_OPS_PYTHON_LIBRARY ${PKG_BUILD_CUGRAPH_OPS_PYTHON_LIBRARY}"
     )
-
 endfunction()
 
 ###
-# Change pinned tag and fork here to test a commit in CI
 #
 # To use a locally-built cugraph-ops package, set the CMake variable
 # `-D cugraph-ops_ROOT=/path/to/cugraph-ops/build`
@@ -52,12 +37,4 @@ endfunction()
 # cugraph-ops as part of building cugraph itself, set the CMake variable
 # `-D CPM_cugraph-ops_SOURCE=/path/to/cugraph-ops`
 ###
-find_and_configure_cugraph_ops(VERSION    ${CUGRAPH_MIN_VERSION_cugraph_ops}
-                               FORK       rapidsai
-                               PINNED_TAG branch-${CUGRAPH_BRANCH_VERSION_cugraph_ops}
-                               # When PINNED_TAG above doesn't match cugraph,
-                               # force local cugraph-ops clone in build directory
-                               # even if it's already installed.
-                               CLONE_ON_PIN     ON
-                               BUILD_CUGRAPH_OPS_PYTHON_LIBRARY ${BUILD_CUGRAPH_OPS_PYTHON_LIBRARY}
-                               )
+find_and_configure_cugraph_ops(VERSION ${CUGRAPH_MIN_VERSION_cugraph_ops})

--- a/cpp/cmake/thirdparty/get_libcugraphops.cmake
+++ b/cpp/cmake/thirdparty/get_libcugraphops.cmake
@@ -29,12 +29,7 @@ function(find_and_configure_cugraph_ops)
 endfunction()
 
 ###
-#
 # To use a locally-built cugraph-ops package, set the CMake variable
 # `-D cugraph-ops_ROOT=/path/to/cugraph-ops/build`
-#
-# To use a local clone of cugraph-ops source and allow CMake to build
-# cugraph-ops as part of building cugraph itself, set the CMake variable
-# `-D CPM_cugraph-ops_SOURCE=/path/to/cugraph-ops`
 ###
 find_and_configure_cugraph_ops(VERSION ${CUGRAPH_MIN_VERSION_cugraph_ops})

--- a/cpp/cmake/thirdparty/get_libcugraphops.cmake
+++ b/cpp/cmake/thirdparty/get_libcugraphops.cmake
@@ -14,26 +14,50 @@
 # limitations under the License.
 #=============================================================================
 
-function(find_and_configure_cugraphops)
+set(CUGRAPH_MIN_VERSION_cugraph_ops "${CUGRAPH_VERSION_MAJOR}.${CUGRAPH_VERSION_MINOR}.00")
+set(CUGRAPH_BRANCH_VERSION_cugraph_ops "${CUGRAPH_VERSION_MAJOR}.${CUGRAPH_VERSION_MINOR}")
 
-    if(TARGET cugraphops::cugraphops)
-        return()
+function(find_and_configure_cugraph_ops)
+
+    set(oneValueArgs VERSION FORK PINNED_TAG CLONE_ON_PIN)
+    cmake_parse_arguments(PKG "" "${oneValueArgs}" "" ${ARGN} )
+
+    if(PKG_CLONE_ON_PIN AND NOT PKG_PINNED_TAG STREQUAL "branch-${CUGRAPH_BRANCH_VERSION_cugraph_ops}")
+        message("Pinned tag found: ${PKG_PINNED_TAG}. Cloning cugraph-ops locally.")
+        set(CPM_DOWNLOAD_cugraph-ops ON)
     endif()
 
-    rapids_find_generate_module(cugraphops
-        HEADER_NAMES            graph/sampling.hpp
-        LIBRARY_NAMES           cugraph-ops++
-        INCLUDE_SUFFIXES        cugraph-ops
-        BUILD_EXPORT_SET    cugraph-exports
-        INSTALL_EXPORT_SET  cugraph-exports
-    )
-
-    rapids_find_package(cugraphops
-        REQUIRED
-        BUILD_EXPORT_SET    cugraph-exports
-        INSTALL_EXPORT_SET  cugraph-exports
+    rapids_cpm_find(cugraph-ops ${PKG_VERSION}
+      GLOBAL_TARGETS      cugraph-ops::cugraph-ops++
+      BUILD_EXPORT_SET    cugraph-exports
+      INSTALL_EXPORT_SET  cugraph-exports
+        CPM_ARGS
+            GIT_REPOSITORY https://github.com/${PKG_FORK}/cugraph-ops.git
+            GIT_TAG        ${PKG_PINNED_TAG}
+            OPTIONS
+                "BUILD_CUGRAPH_OPS_CPP_LIBRARY ON"
+                "BUILD_CUGRAPH_OPS_CPP_TESTS OFF"
+                "BUILD_CUGRAPH_OPS_PYTHON_LIBRARY ${PKG_BUILD_CUGRAPH_OPS_PYTHON_LIBRARY}"
     )
 
 endfunction()
 
-find_and_configure_cugraphops()
+###
+# Change pinned tag and fork here to test a commit in CI
+#
+# To use a locally-built cugraph-ops package, set the CMake variable
+# `-D cugraph-ops_ROOT=/path/to/cugraph-ops/build`
+#
+# To use a local clone of cugraph-ops source and allow CMake to build
+# cugraph-ops as part of building cugraph itself, set the CMake variable
+# `-D CPM_cugraph-ops_SOURCE=/path/to/cugraph-ops`
+###
+find_and_configure_cugraph_ops(VERSION    ${CUGRAPH_MIN_VERSION_cugraph_ops}
+                               FORK       rapidsai
+                               PINNED_TAG branch-${CUGRAPH_BRANCH_VERSION_cugraph_ops}
+                               # When PINNED_TAG above doesn't match cugraph,
+                               # force local cugraph-ops clone in build directory
+                               # even if it's already installed.
+                               CLONE_ON_PIN     ON
+                               BUILD_CUGRAPH_OPS_PYTHON_LIBRARY ${BUILD_CUGRAPH_OPS_PYTHON_LIBRARY}
+                               )

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -51,7 +51,7 @@ endfunction()
 
 # Change pinned tag and fork here to test a commit in CI
 # To use a different RAFT locally, set the CMake variable
-# RPM_raft_SOURCE=/path/to/local/raft
+# CPM_raft_SOURCE=/path/to/local/raft
 find_and_configure_raft(VERSION    ${CUGRAPH_MIN_VERSION_raft}
                         FORK       rapidsai
                         PINNED_TAG branch-${CUGRAPH_BRANCH_VERSION_raft}


### PR DESCRIPTION
Depends on https://github.com/rapidsai/raft/pull/583 and https://github.com/rapidsai/cugraph-ops/pull/70

This PR uses `CPMFindPackage` to find (or build) `cugraph-ops`.

This enables building from source against a local `cugraph-ops` build via `-D cugraph-ops_ROOT=/cugraph-ops/build`.
