### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -5,4 +5,4 @@ auto_merger: true
 branch_checker: true
 label_checker: true
 release_drafter: true
-external_contributors: true
+external_contributors: false

--- a/conda/environments/cugraph_dev_cuda11.0.yml
+++ b/conda/environments/cugraph_dev_cuda11.0.yml
@@ -14,8 +14,8 @@ dependencies:
 - libraft-headers=22.04.*
 - pyraft=22.04.*
 - cuda-python>=11.5,<12.0
-- dask>=2022.02.1
-- distributed>=2022.02.1
+- dask==2022.03.0
+- distributed==2022.03.0
 - dask-cuda=22.04.*
 - dask-cudf=22.04.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -14,8 +14,8 @@ dependencies:
 - libraft-headers=22.04.*
 - pyraft=22.04.*
 - cuda-python>=11.5,<12.0
-- dask>=2022.02.1
-- distributed>=2022.02.1
+- dask==2022.03.0
+- distributed==2022.03.0
 - dask-cuda=22.04.*
 - dask-cudf=22.04.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -14,8 +14,8 @@ dependencies:
 - libraft-headers=22.04.*
 - pyraft=22.04.*
 - cuda-python>=11.5,<12.0
-- dask>=2022.02.1
-- distributed>=2022.02.1
+- dask==2022.03.0
+- distributed==2022.03.0
 - dask-cuda=22.04.*
 - dask-cudf=22.04.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.5.yml
+++ b/conda/environments/cugraph_dev_cuda11.5.yml
@@ -14,8 +14,8 @@ dependencies:
 - libraft-headers=22.04.*
 - pyraft=22.04.*
 - cuda-python>=11.5,<12.0
-- dask>=2022.02.1
-- distributed>=2022.02.1
+- dask==2022.03.0
+- distributed==2022.03.0
 - dask-cuda=22.04.*
 - dask-cudf=22.04.*
 - nccl>=2.9.9

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -45,8 +45,8 @@ requirements:
     - cudf={{ minor_version }}
     - dask-cudf {{ minor_version }}
     - dask-cuda {{ minor_version }}
-    - dask>=2022.02.1
-    - distributed>=2022.02.1
+    - dask==2022.03.0
+    - distributed==2022.03.0
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.