### PR TITLE
HITS C API implementation

### DIFF
--- a/cpp/include/cugraph/detail/shuffle_wrappers.hpp
+++ b/cpp/include/cugraph/detail/shuffle_wrappers.hpp
@@ -93,5 +93,29 @@ rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   std::optional<rmm::device_uvector<weight_t>>& d_edgelist_weights,
   bool groupby_and_count_local_partition_by_minor = false);
 
+/**
+ * @brief Collect vertex values (represented as k/v pairs across cluster) and update the
+ *        local value arrays on the GPU responsible for each vertex.
+ *
+ * Data will be shuffled and d_local_values[d_vertices[i]] = d_values[i]
+ *
+ * @tparam vertex_t Type of vertex identifiers. Needs to be an integral type.
+ * @tparam value_t  Type of value associated with the vertex.
+ * @tparam bool     multi_gpu flag
+ *
+ * @param[in] handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator,
+ * and handles to various CUDA libraries) to run graph algorithms.
+ * @param[in/out] d_vertices Vertex IDs for the k/v pair
+ * @param[in/out] d_values Values for the k/v pair
+ * @param[out] d_local_values The device vector on each GPU that should be updated
+ * @param[in] local_vertex_first The first vertex id assigned to the local GPU
+ */
+template <typename vertex_t, typename value_t, bool multi_gpu>
+void collect_vertex_values_to_local(raft::handle_t const& handle,
+                                    rmm::device_uvector<vertex_t>& d_vertices,
+                                    rmm::device_uvector<value_t>& d_values,
+                                    rmm::device_uvector<value_t>& d_local_values,
+                                    vertex_t local_vertex_first);
+
 }  // namespace detail
 }  // namespace cugraph

--- a/cpp/include/cugraph/detail/shuffle_wrappers.hpp
+++ b/cpp/include/cugraph/detail/shuffle_wrappers.hpp
@@ -117,7 +117,7 @@ rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
  *         vertex (i + local_vertex_first)
  */
 template <typename vertex_t, typename value_t, bool multi_gpu>
-rmm::device_uvector<value_t> collect_renumber_ext_vertex_values_to_local(
+rmm::device_uvector<value_t> collect_local_vertex_values_from_ext_vertex_value_pairs(
   raft::handle_t const& handle,
   rmm::device_uvector<vertex_t>&& d_vertices,
   rmm::device_uvector<value_t>&& d_values,

--- a/cpp/include/cugraph/graph_functions.hpp
+++ b/cpp/include/cugraph/graph_functions.hpp
@@ -143,7 +143,7 @@ renumber_edgelist(raft::handle_t const& handle,
                   bool do_expensive_check = false);
 
 /**
- * @brief Renumber external vertices to internal vertices based on the provoided @p
+ * @brief Renumber external vertices to internal vertices based on the provided @p
  * renumber_map_labels.
  *
  * Note cugraph::invalid_id<vertex_t>::value remains unchanged.
@@ -301,6 +301,37 @@ std::enable_if_t<!multi_gpu, void> unrenumber_local_int_edges(raft::handle_t con
                                                               vertex_t const* renumber_map_labels,
                                                               vertex_t num_vertices,
                                                               bool do_expensive_check = false);
+
+/**
+ * @brief Renumber local external vertices to internal vertices based on the provided @p
+ * renumber_map_labels.
+ *
+ * Note cugraph::invalid_id<vertex_t>::value remains unchanged.
+ *
+ * @tparam vertex_t Type of vertex identifiers. Needs to be an integral type.
+ * @tparam multi_gpu Flag indicating whether template instantiation should target single-GPU (false)
+ * or multi-GPU (true).
+ * @param handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator, and
+ * handles to various CUDA libraries) to run graph algorithms.
+ * @param vertices Pointer to the vertices to be renumbered. The input external vertices are
+ * renumbered to internal vertices in-place.
+ * @param num_vertices Number of vertices to be renumbered.
+ * @param renumber_map_labels Pointer to the external vertices corresponding to the internal
+ * vertices in the range [@p local_int_vertex_first, @p local_int_vertex_last).
+ * @param local_int_vertex_first The first local internal vertex (inclusive, assigned to this
+ * process in multi-GPU).
+ * @param local_int_vertex_last The last local internal vertex (exclusive, assigned to this process
+ * in multi-GPU).
+ * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
+ */
+template <typename vertex_t, bool multi_gpu>
+void renumber_local_ext_vertices(raft::handle_t const& handle,
+                                 vertex_t* vertices /* [INOUT] */,
+                                 size_t num_vertices,
+                                 vertex_t const* renumber_map_labels,
+                                 vertex_t local_int_vertex_first,
+                                 vertex_t local_int_vertex_last,
+                                 bool do_expensive_check = false);
 
 /**
  * @brief Symmetrize edgelist.

--- a/cpp/include/cugraph_c/graph.h
+++ b/cpp/include/cugraph_c/graph.h
@@ -32,7 +32,7 @@ typedef struct {
   bool_t is_multigraph;
 } cugraph_graph_properties_t;
 
-// FIXME: Add support for specifying isloated vertices
+// FIXME: Add support for specifying isolated vertices
 /**
  * @brief     Construct an SG graph
  *
@@ -74,7 +74,7 @@ cugraph_error_code_t cugraph_sg_graph_create(const cugraph_resource_handle_t* ha
 //         but didn't want to confuse with original cugraph_free_graph
 void cugraph_sg_graph_free(cugraph_graph_t* graph);
 
-// FIXME: Add support for specifying isloated vertices
+// FIXME: Add support for specifying isolated vertices
 /**
  * @brief     Construct an MG graph
  *

--- a/cpp/src/c_api/bfs.cpp
+++ b/cpp/src/c_api/bfs.cpp
@@ -84,8 +84,6 @@ struct bfs_functor : public abstract_functor {
 
       auto number_map = reinterpret_cast<rmm::device_uvector<vertex_t>*>(graph_->number_map_);
 
-      rmm::device_uvector<vertex_t> vertex_ids(graph->get_number_of_vertices(),
-                                               handle_.get_stream());
       rmm::device_uvector<vertex_t> distances(graph->get_number_of_vertices(),
                                               handle_.get_stream());
       rmm::device_uvector<vertex_t> predecessors(0, handle_.get_stream());
@@ -116,6 +114,8 @@ struct bfs_functor : public abstract_functor {
         static_cast<vertex_t>(depth_limit_),
         do_expensive_check_);
 
+      rmm::device_uvector<vertex_t> vertex_ids(graph->get_number_of_vertices(),
+                                               handle_.get_stream());
       raft::copy(vertex_ids.data(), number_map->data(), vertex_ids.size(), handle_.get_stream());
 
       if (compute_predecessors_) {

--- a/cpp/src/c_api/hits.cpp
+++ b/cpp/src/c_api/hits.cpp
@@ -128,7 +128,7 @@ struct hits_functor : public cugraph::c_api::abstract_functor {
                    handle_.get_stream());
 
         hubs = cugraph::detail::
-          collect_renumber_ext_vertex_values_to_local<vertex_t, weight_t, multi_gpu>(
+          collect_local_vertex_values_from_ext_vertex_value_pairs<vertex_t, weight_t, multi_gpu>(
             handle_,
             std::move(guess_vertices),
             std::move(guess_values),

--- a/cpp/src/c_api/hits.cpp
+++ b/cpp/src/c_api/hits.cpp
@@ -22,6 +22,7 @@
 #include <c_api/utils.hpp>
 
 #include <cugraph/algorithms.hpp>
+#include <cugraph/detail/shuffle_wrappers.hpp>
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/graph_functions.hpp>
 
@@ -113,40 +114,46 @@ struct hits_functor : public cugraph::c_api::abstract_functor {
       weight_t hub_score_differences{0};
       size_t number_of_iterations{0};
 
-#if 0
-      // FIXME:  Implementation will look something like this.
-      
-      if (initial_hubs_guess_ != nullptr) {
-        //
-        // Need to renumber initial_hubs_guess_vertices
-        // Need to shuffle and populate hubs
-        //
-        //  This is the original pagerank code, it will be sort of like this
-        renumber_ext_vertices<vertex_t, multi_gpu>(handle_,
-                                                   personalization_vertices_->as_type<vertex_t>(),
-                                                   personalization_vertices_->size_,
-                                                   number_map->data(),
-                                                   graph_view.get_local_vertex_first(),
-                                                   graph_view.get_local_vertex_last(),
-                                                   do_expensive_check_);
+      if (initial_hubs_guess_vertices_ != nullptr) {
+        rmm::device_uvector<vertex_t> guess_vertices(initial_hubs_guess_vertices_->size_,
+                                                     handle_.get_stream());
+        rmm::device_uvector<weight_t> guess_values(initial_hubs_guess_values_->size_,
+                                                   handle_.get_stream());
+
+        raft::copy(guess_vertices.data(),
+                   initial_hubs_guess_vertices_->as_type<vertex_t>(),
+                   guess_vertices.size(),
+                   handle_.get_stream());
+        raft::copy(guess_values.data(),
+                   initial_hubs_guess_values_->as_type<weight_t>(),
+                   guess_values.size(),
+                   handle_.get_stream());
+
+        cugraph::renumber_ext_vertices<vertex_t, multi_gpu>(handle_,
+                                                            guess_vertices.data(),
+                                                            guess_vertices.size(),
+                                                            number_map->data(),
+                                                            graph_view.get_local_vertex_first(),
+                                                            graph_view.get_local_vertex_last(),
+                                                            do_expensive_check_);
+
+        cugraph::detail::collect_vertex_values_to_local<vertex_t, weight_t, multi_gpu>(
+          handle_, guess_vertices, guess_values, hubs, graph_view.get_local_vertex_first());
       }
 
-      // TODO:  Add these to the result
       std::tie(hub_score_differences, number_of_iterations) =
-        cugraph::hits<vertex_t, edge_t, weight_t, multi_gpu>(handle_,
-                                                             graph_view,
-                                                             hubs.data(),
-                                                             authorities.data(),
-                                                             epsilon_,
-                                                             max_iterations_,
-                                                             has_initial_hubs_guess,
-                                                             normalize_,
-                                                             do_expensive_check_);
+        cugraph::hits<vertex_t, edge_t, weight_t, multi_gpu>(
+          handle_,
+          graph_view,
+          hubs.data(),
+          authorities.data(),
+          epsilon_,
+          max_iterations_,
+          (initial_hubs_guess_vertices_ != nullptr),
+          normalize_,
+          do_expensive_check_);
 
       raft::copy(vertex_ids.data(), number_map->data(), vertex_ids.size(), handle_.get_stream());
-#else
-      unsupported();
-#endif
 
       result_ = new cugraph::c_api::cugraph_hits_result_t{
         new cugraph::c_api::cugraph_type_erased_device_array_t(vertex_ids, graph_->vertex_type_),

--- a/cpp/src/c_api/pagerank.cpp
+++ b/cpp/src/c_api/pagerank.cpp
@@ -105,8 +105,6 @@ struct pagerank_functor : public abstract_functor {
 
       auto number_map = reinterpret_cast<rmm::device_uvector<vertex_t>*>(graph_->number_map_);
 
-      rmm::device_uvector<vertex_t> vertex_ids(graph_view.get_number_of_local_vertices(),
-                                               handle_.get_stream());
       rmm::device_uvector<weight_t> pageranks(graph_view.get_number_of_local_vertices(),
                                               handle_.get_stream());
 
@@ -145,6 +143,8 @@ struct pagerank_functor : public abstract_functor {
         has_initial_guess_,
         do_expensive_check_);
 
+      rmm::device_uvector<vertex_t> vertex_ids(graph_view.get_number_of_local_vertices(),
+                                               handle_.get_stream());
       raft::copy(vertex_ids.data(), number_map->data(), vertex_ids.size(), handle_.get_stream());
 
       result_ = new cugraph_pagerank_result_t{

--- a/cpp/src/c_api/sssp.cpp
+++ b/cpp/src/c_api/sssp.cpp
@@ -82,8 +82,6 @@ struct sssp_functor : public abstract_functor {
       auto number_map = reinterpret_cast<rmm::device_uvector<vertex_t>*>(graph_->number_map_);
 
       rmm::device_uvector<vertex_t> source_ids(1, handle_.get_stream());
-      rmm::device_uvector<vertex_t> vertex_ids(graph->get_number_of_vertices(),
-                                               handle_.get_stream());
       rmm::device_uvector<weight_t> distances(graph->get_number_of_vertices(),
                                               handle_.get_stream());
       rmm::device_uvector<vertex_t> predecessors(0, handle_.get_stream());
@@ -117,6 +115,8 @@ struct sssp_functor : public abstract_functor {
         static_cast<weight_t>(cutoff_),
         do_expensive_check_);
 
+      rmm::device_uvector<vertex_t> vertex_ids(graph->get_number_of_vertices(),
+                                               handle_.get_stream());
       raft::copy(vertex_ids.data(), number_map->data(), vertex_ids.size(), handle_.get_stream());
 
       if (compute_predecessors_) {

--- a/cpp/src/detail/shuffle_wrappers.cu
+++ b/cpp/src/detail/shuffle_wrappers.cu
@@ -337,7 +337,7 @@ template rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partiti
   bool groupby_and_counts_local_partition);
 
 template <typename vertex_t, typename value_t, bool multi_gpu>
-rmm::device_uvector<value_t> collect_renumber_ext_vertex_values_to_local(
+rmm::device_uvector<value_t> collect_local_vertex_values_from_ext_vertex_value_pairs(
   raft::handle_t const& handle,
   rmm::device_uvector<vertex_t>&& d_vertices,
   rmm::device_uvector<value_t>&& d_values,
@@ -389,7 +389,7 @@ rmm::device_uvector<value_t> collect_renumber_ext_vertex_values_to_local(
 }
 
 template rmm::device_uvector<float>
-collect_renumber_ext_vertex_values_to_local<int32_t, float, false>(
+collect_local_vertex_values_from_ext_vertex_value_pairs<int32_t, float, false>(
   raft::handle_t const& handle,
   rmm::device_uvector<int32_t>&& d_vertices,
   rmm::device_uvector<float>&& d_values,
@@ -400,7 +400,7 @@ collect_renumber_ext_vertex_values_to_local<int32_t, float, false>(
   bool do_expensive_check);
 
 template rmm::device_uvector<float>
-collect_renumber_ext_vertex_values_to_local<int64_t, float, false>(
+collect_local_vertex_values_from_ext_vertex_value_pairs<int64_t, float, false>(
   raft::handle_t const& handle,
   rmm::device_uvector<int64_t>&& d_vertices,
   rmm::device_uvector<float>&& d_values,
@@ -411,7 +411,7 @@ collect_renumber_ext_vertex_values_to_local<int64_t, float, false>(
   bool do_expensive_check);
 
 template rmm::device_uvector<double>
-collect_renumber_ext_vertex_values_to_local<int32_t, double, false>(
+collect_local_vertex_values_from_ext_vertex_value_pairs<int32_t, double, false>(
   raft::handle_t const& handle,
   rmm::device_uvector<int32_t>&& d_vertices,
   rmm::device_uvector<double>&& d_values,
@@ -422,7 +422,7 @@ collect_renumber_ext_vertex_values_to_local<int32_t, double, false>(
   bool do_expensive_check);
 
 template rmm::device_uvector<double>
-collect_renumber_ext_vertex_values_to_local<int64_t, double, false>(
+collect_local_vertex_values_from_ext_vertex_value_pairs<int64_t, double, false>(
   raft::handle_t const& handle,
   rmm::device_uvector<int64_t>&& d_vertices,
   rmm::device_uvector<double>&& d_values,
@@ -433,7 +433,7 @@ collect_renumber_ext_vertex_values_to_local<int64_t, double, false>(
   bool do_expensive_check);
 
 template rmm::device_uvector<float>
-collect_renumber_ext_vertex_values_to_local<int32_t, float, true>(
+collect_local_vertex_values_from_ext_vertex_value_pairs<int32_t, float, true>(
   raft::handle_t const& handle,
   rmm::device_uvector<int32_t>&& d_vertices,
   rmm::device_uvector<float>&& d_values,
@@ -444,7 +444,7 @@ collect_renumber_ext_vertex_values_to_local<int32_t, float, true>(
   bool do_expensive_check);
 
 template rmm::device_uvector<float>
-collect_renumber_ext_vertex_values_to_local<int64_t, float, true>(
+collect_local_vertex_values_from_ext_vertex_value_pairs<int64_t, float, true>(
   raft::handle_t const& handle,
   rmm::device_uvector<int64_t>&& d_vertices,
   rmm::device_uvector<float>&& d_values,
@@ -455,7 +455,7 @@ collect_renumber_ext_vertex_values_to_local<int64_t, float, true>(
   bool do_expensive_check);
 
 template rmm::device_uvector<double>
-collect_renumber_ext_vertex_values_to_local<int32_t, double, true>(
+collect_local_vertex_values_from_ext_vertex_value_pairs<int32_t, double, true>(
   raft::handle_t const& handle,
   rmm::device_uvector<int32_t>&& d_vertices,
   rmm::device_uvector<double>&& d_values,
@@ -466,7 +466,7 @@ collect_renumber_ext_vertex_values_to_local<int32_t, double, true>(
   bool do_expensive_check);
 
 template rmm::device_uvector<double>
-collect_renumber_ext_vertex_values_to_local<int64_t, double, true>(
+collect_local_vertex_values_from_ext_vertex_value_pairs<int64_t, double, true>(
   raft::handle_t const& handle,
   rmm::device_uvector<int64_t>&& d_vertices,
   rmm::device_uvector<double>&& d_values,

--- a/cpp/src/detail/shuffle_wrappers.cu
+++ b/cpp/src/detail/shuffle_wrappers.cu
@@ -377,53 +377,61 @@ void collect_vertex_values_to_local(raft::handle_t const& handle,
   }
 }
 
-template void collect_vertex_values_to_local<int32_t, float, false>(raft::handle_t const& handle,
-                                             rmm::device_uvector<int32_t>& d_vertices,
-                                             rmm::device_uvector<float>& d_values,
-                                             rmm::device_uvector<float>& d_local_values,
-                                             int32_t local_vertex_first);
+template void collect_vertex_values_to_local<int32_t, float, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>& d_vertices,
+  rmm::device_uvector<float>& d_values,
+  rmm::device_uvector<float>& d_local_values,
+  int32_t local_vertex_first);
 
-template void collect_vertex_values_to_local<int64_t, float, false>(raft::handle_t const& handle,
-                                             rmm::device_uvector<int64_t>& d_vertices,
-                                             rmm::device_uvector<float>& d_values,
-                                             rmm::device_uvector<float>& d_local_values,
-                                             int64_t local_vertex_first);
+template void collect_vertex_values_to_local<int64_t, float, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t>& d_vertices,
+  rmm::device_uvector<float>& d_values,
+  rmm::device_uvector<float>& d_local_values,
+  int64_t local_vertex_first);
 
-template void collect_vertex_values_to_local<int32_t, double, false>(raft::handle_t const& handle,
-                                             rmm::device_uvector<int32_t>& d_vertices,
-                                             rmm::device_uvector<double>& d_values,
-                                             rmm::device_uvector<double>& d_local_values,
-                                             int32_t local_vertex_first);
+template void collect_vertex_values_to_local<int32_t, double, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>& d_vertices,
+  rmm::device_uvector<double>& d_values,
+  rmm::device_uvector<double>& d_local_values,
+  int32_t local_vertex_first);
 
-template void collect_vertex_values_to_local<int64_t, double, false>(raft::handle_t const& handle,
-                                             rmm::device_uvector<int64_t>& d_vertices,
-                                             rmm::device_uvector<double>& d_values,
-                                             rmm::device_uvector<double>& d_local_values,
-                                             int64_t local_vertex_first);
+template void collect_vertex_values_to_local<int64_t, double, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t>& d_vertices,
+  rmm::device_uvector<double>& d_values,
+  rmm::device_uvector<double>& d_local_values,
+  int64_t local_vertex_first);
 
-template void collect_vertex_values_to_local<int32_t, float, true>(raft::handle_t const& handle,
-                                             rmm::device_uvector<int32_t>& d_vertices,
-                                             rmm::device_uvector<float>& d_values,
-                                             rmm::device_uvector<float>& d_local_values,
-                                             int32_t local_vertex_first);
+template void collect_vertex_values_to_local<int32_t, float, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>& d_vertices,
+  rmm::device_uvector<float>& d_values,
+  rmm::device_uvector<float>& d_local_values,
+  int32_t local_vertex_first);
 
-template void collect_vertex_values_to_local<int64_t, float, true>(raft::handle_t const& handle,
-                                             rmm::device_uvector<int64_t>& d_vertices,
-                                             rmm::device_uvector<float>& d_values,
-                                             rmm::device_uvector<float>& d_local_values,
-                                             int64_t local_vertex_first);
+template void collect_vertex_values_to_local<int64_t, float, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t>& d_vertices,
+  rmm::device_uvector<float>& d_values,
+  rmm::device_uvector<float>& d_local_values,
+  int64_t local_vertex_first);
 
-template void collect_vertex_values_to_local<int32_t, double, true>(raft::handle_t const& handle,
-                                             rmm::device_uvector<int32_t>& d_vertices,
-                                             rmm::device_uvector<double>& d_values,
-                                             rmm::device_uvector<double>& d_local_values,
-                                             int32_t local_vertex_first);
+template void collect_vertex_values_to_local<int32_t, double, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>& d_vertices,
+  rmm::device_uvector<double>& d_values,
+  rmm::device_uvector<double>& d_local_values,
+  int32_t local_vertex_first);
 
-template void collect_vertex_values_to_local<int64_t, double, true>(raft::handle_t const& handle,
-                                             rmm::device_uvector<int64_t>& d_vertices,
-                                             rmm::device_uvector<double>& d_values,
-                                             rmm::device_uvector<double>& d_local_values,
-                                             int64_t local_vertex_first);
+template void collect_vertex_values_to_local<int64_t, double, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t>& d_vertices,
+  rmm::device_uvector<double>& d_values,
+  rmm::device_uvector<double>& d_local_values,
+  int64_t local_vertex_first);
 
 }  // namespace detail
 }  // namespace cugraph

--- a/cpp/src/structure/renumber_utils_impl.cuh
+++ b/cpp/src/structure/renumber_utils_impl.cuh
@@ -507,8 +507,8 @@ void renumber_local_ext_vertices(raft::handle_t const& handle,
     stream_adapter,
     handle.get_stream());
 
-  auto pair_first = thrust::make_zip_iterator(
-    thrust::make_tuple(renumber_map_labels, thrust::make_counting_iterator(local_int_vertex_first)));
+  auto pair_first = thrust::make_zip_iterator(thrust::make_tuple(
+    renumber_map_labels, thrust::make_counting_iterator(local_int_vertex_first)));
   renumber_map_ptr->insert(pair_first,
                            pair_first + (local_int_vertex_last - local_int_vertex_first),
                            cuco::detail::MurmurHash3_32<vertex_t>{},

--- a/cpp/src/structure/renumber_utils_impl.cuh
+++ b/cpp/src/structure/renumber_utils_impl.cuh
@@ -471,6 +471,71 @@ void renumber_ext_vertices(raft::handle_t const& handle,
   renumber_map_ptr->find(vertices, vertices + num_vertices, vertices);
 }
 
+template <typename vertex_t, bool multi_gpu>
+void renumber_local_ext_vertices(raft::handle_t const& handle,
+                                 vertex_t* vertices /* [INOUT] */,
+                                 size_t num_vertices,
+                                 vertex_t const* renumber_map_labels,
+                                 vertex_t local_int_vertex_first,
+                                 vertex_t local_int_vertex_last,
+                                 bool do_expensive_check)
+{
+  double constexpr load_factor = 0.7;
+
+  if (do_expensive_check) {
+    rmm::device_uvector<vertex_t> labels(local_int_vertex_last - local_int_vertex_first,
+                                         handle.get_stream());
+    thrust::copy(handle.get_thrust_policy(),
+                 renumber_map_labels,
+                 renumber_map_labels + labels.size(),
+                 labels.begin());
+    thrust::sort(handle.get_thrust_policy(), labels.begin(), labels.end());
+    CUGRAPH_EXPECTS(
+      thrust::unique(handle.get_thrust_policy(), labels.begin(), labels.end()) == labels.end(),
+      "Invalid input arguments: renumber_map_labels have duplicate elements.");
+  }
+
+  auto poly_alloc = rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());
+  auto stream_adapter   = rmm::mr::make_stream_allocator_adaptor(poly_alloc, handle.get_stream());
+  auto renumber_map_ptr = std::make_unique<
+    cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>>(
+    std::max(static_cast<size_t>(
+               static_cast<double>(local_int_vertex_last - local_int_vertex_first) / load_factor),
+             static_cast<size_t>(local_int_vertex_last - local_int_vertex_first) + 1),
+    invalid_vertex_id<vertex_t>::value,
+    invalid_vertex_id<vertex_t>::value,
+    stream_adapter,
+    handle.get_stream());
+
+  auto pair_first = thrust::make_zip_iterator(
+    thrust::make_tuple(renumber_map_labels, thrust::make_counting_iterator(local_int_vertex_last)));
+  renumber_map_ptr->insert(pair_first,
+                           pair_first + (local_int_vertex_last - local_int_vertex_first),
+                           cuco::detail::MurmurHash3_32<vertex_t>{},
+                           thrust::equal_to<vertex_t>{},
+                           handle.get_stream());
+
+  if (do_expensive_check) {
+    rmm::device_uvector<bool> contains(num_vertices, handle.get_stream());
+    renumber_map_ptr->contains(vertices, vertices + num_vertices, contains.begin());
+    auto vc_pair_first = thrust::make_zip_iterator(thrust::make_tuple(vertices, contains.begin()));
+    CUGRAPH_EXPECTS(thrust::count_if(handle.get_thrust_policy(),
+                                     vc_pair_first,
+                                     vc_pair_first + num_vertices,
+                                     [] __device__(auto pair) {
+                                       auto v = thrust::get<0>(pair);
+                                       auto c = thrust::get<1>(pair);
+                                       return v == invalid_vertex_id<vertex_t>::value
+                                                ? (c == true)
+                                                : (c == false);
+                                     }) == 0,
+                    "Invalid input arguments: vertices have elements that are missing in "
+                    "(aggregate) renumber_map_labels.");
+  }
+
+  renumber_map_ptr->find(vertices, vertices + num_vertices, vertices);
+}
+
 template <typename vertex_t>
 void unrenumber_local_int_vertices(
   raft::handle_t const& handle,

--- a/cpp/src/structure/renumber_utils_impl.cuh
+++ b/cpp/src/structure/renumber_utils_impl.cuh
@@ -508,7 +508,7 @@ void renumber_local_ext_vertices(raft::handle_t const& handle,
     handle.get_stream());
 
   auto pair_first = thrust::make_zip_iterator(
-    thrust::make_tuple(renumber_map_labels, thrust::make_counting_iterator(local_int_vertex_last)));
+    thrust::make_tuple(renumber_map_labels, thrust::make_counting_iterator(local_int_vertex_first)));
   renumber_map_ptr->insert(pair_first,
                            pair_first + (local_int_vertex_last - local_int_vertex_first),
                            cuco::detail::MurmurHash3_32<vertex_t>{},

--- a/cpp/src/structure/renumber_utils_mg.cu
+++ b/cpp/src/structure/renumber_utils_mg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/renumber_utils_mg.cu
+++ b/cpp/src/structure/renumber_utils_mg.cu
@@ -36,6 +36,22 @@ template void renumber_ext_vertices<int64_t, true>(raft::handle_t const& handle,
                                                    int64_t local_int_vertex_last,
                                                    bool do_expensive_check);
 
+template void renumber_local_ext_vertices<int32_t, true>(raft::handle_t const& handle,
+                                                         int32_t* vertices,
+                                                         size_t num_vertices,
+                                                         int32_t const* renumber_map_labels,
+                                                         int32_t local_int_vertex_first,
+                                                         int32_t local_int_vertex_last,
+                                                         bool do_expensive_check);
+
+template void renumber_local_ext_vertices<int64_t, true>(raft::handle_t const& handle,
+                                                         int64_t* vertices,
+                                                         size_t num_vertices,
+                                                         int64_t const* renumber_map_labels,
+                                                         int64_t local_int_vertex_first,
+                                                         int64_t local_int_vertex_last,
+                                                         bool do_expensive_check);
+
 template void unrenumber_int_vertices<int32_t, true>(
   raft::handle_t const& handle,
   int32_t* vertices,

--- a/cpp/src/structure/renumber_utils_sg.cu
+++ b/cpp/src/structure/renumber_utils_sg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/renumber_utils_sg.cu
+++ b/cpp/src/structure/renumber_utils_sg.cu
@@ -37,20 +37,20 @@ template void renumber_ext_vertices<int64_t, false>(raft::handle_t const& handle
                                                     bool do_expensive_check);
 
 template void renumber_local_ext_vertices<int32_t, false>(raft::handle_t const& handle,
-                                                           int32_t* vertices,
-                                                           size_t num_vertices,
-                                                           int32_t const* renumber_map_labels,
-                                                           int32_t local_int_vertex_first,
-                                                           int32_t local_int_vertex_last,
-                                                           bool do_expensive_check);
+                                                          int32_t* vertices,
+                                                          size_t num_vertices,
+                                                          int32_t const* renumber_map_labels,
+                                                          int32_t local_int_vertex_first,
+                                                          int32_t local_int_vertex_last,
+                                                          bool do_expensive_check);
 
 template void renumber_local_ext_vertices<int64_t, false>(raft::handle_t const& handle,
-                                                           int64_t* vertices,
-                                                           size_t num_vertices,
-                                                           int64_t const* renumber_map_labels,
-                                                           int64_t local_int_vertex_first,
-                                                           int64_t local_int_vertex_last,
-                                                           bool do_expensive_check);
+                                                          int64_t* vertices,
+                                                          size_t num_vertices,
+                                                          int64_t const* renumber_map_labels,
+                                                          int64_t local_int_vertex_first,
+                                                          int64_t local_int_vertex_last,
+                                                          bool do_expensive_check);
 
 template void unrenumber_local_int_vertices<int32_t>(raft::handle_t const& handle,
                                                      int32_t* vertices,

--- a/cpp/src/structure/renumber_utils_sg.cu
+++ b/cpp/src/structure/renumber_utils_sg.cu
@@ -36,6 +36,22 @@ template void renumber_ext_vertices<int64_t, false>(raft::handle_t const& handle
                                                     int64_t local_int_vertex_last,
                                                     bool do_expensive_check);
 
+template void renumber_local_ext_vertices<int32_t, false>(raft::handle_t const& handle,
+                                                           int32_t* vertices,
+                                                           size_t num_vertices,
+                                                           int32_t const* renumber_map_labels,
+                                                           int32_t local_int_vertex_first,
+                                                           int32_t local_int_vertex_last,
+                                                           bool do_expensive_check);
+
+template void renumber_local_ext_vertices<int64_t, false>(raft::handle_t const& handle,
+                                                           int64_t* vertices,
+                                                           size_t num_vertices,
+                                                           int64_t const* renumber_map_labels,
+                                                           int64_t local_int_vertex_first,
+                                                           int64_t local_int_vertex_last,
+                                                           bool do_expensive_check);
+
 template void unrenumber_local_int_vertices<int32_t>(raft::handle_t const& handle,
                                                      int32_t* vertices,
                                                      size_t num_vertices,

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -620,6 +620,7 @@ if(BUILD_CUGRAPH_MG_TESTS)
         # - MG C API tests ------------------------------------------------------------------------
         ConfigureCTestMG(MG_CAPI_CREATE_GRAPH c_api/mg_create_graph_test.c c_api/mg_test_utils.cpp)
         ConfigureCTestMG(MG_CAPI_PAGERANK c_api/mg_pagerank_test.c c_api/mg_test_utils.cpp)
+        ConfigureCTestMG(MG_CAPI_HITS c_api/mg_hits_test.c c_api/mg_test_utils.cpp)
     else()
        message(FATAL_ERROR "OpenMPI NOT found, cannot build MG tests.")
     endif()

--- a/cpp/tests/c_api/bfs_test.c
+++ b/cpp/tests/c_api/bfs_test.c
@@ -52,7 +52,7 @@ int generic_bfs_test(vertex_t* h_src,
   TEST_ASSERT(test_ret_value, p_handle != NULL, "resource handle creation failed.");
 
   ret_code = create_test_graph(
-    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, &p_graph, &ret_error);
+                               p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, FALSE, &p_graph, &ret_error);
 
   /*
    * FIXME: in create_graph_test.c, variables are defined but then hard-coded to

--- a/cpp/tests/c_api/c_test_utils.h
+++ b/cpp/tests/c_api/c_test_utils.h
@@ -49,6 +49,7 @@ int create_test_graph(const cugraph_resource_handle_t* p_handle,
                       float* h_wgt,
                       size_t num_edges,
                       bool_t store_transposed,
+                      bool_t renumber,
                       cugraph_graph_t** p_graph,
                       cugraph_error_t** ret_error);
 

--- a/cpp/tests/c_api/extract_paths_test.c
+++ b/cpp/tests/c_api/extract_paths_test.c
@@ -57,7 +57,7 @@ int generic_bfs_test_with_extract_paths(vertex_t* h_src,
   TEST_ASSERT(test_ret_value, p_handle != NULL, "resource handle creation failed.");
 
   ret_code = create_test_graph(
-    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, &p_graph, &ret_error);
+    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, FALSE, &p_graph, &ret_error);
 
   ret_code =
     cugraph_type_erased_device_array_create(p_handle, num_seeds, INT32, &p_sources, &ret_error);

--- a/cpp/tests/c_api/hits_test.c
+++ b/cpp/tests/c_api/hits_test.c
@@ -28,11 +28,16 @@ typedef float weight_t;
 int generic_hits_test(vertex_t* h_src,
                       vertex_t* h_dst,
                       weight_t* h_wgt,
-                      weight_t* h_result_hubs,
-                      weight_t* h_result_authorities,
                       size_t num_vertices,
                       size_t num_edges,
+                      vertex_t* h_initial_vertices,
+                      weight_t* h_initial_hubs,
+                      size_t num_initial_vertices,
+                      weight_t* h_result_hubs,
+                      weight_t* h_result_authorities,
                       bool_t store_transposed,
+                      bool_t renumber,
+                      bool_t normalize,
                       double epsilon,
                       size_t max_iterations)
 {
@@ -49,13 +54,58 @@ int generic_hits_test(vertex_t* h_src,
   TEST_ASSERT(test_ret_value, p_handle != NULL, "resource handle creation failed.");
 
   ret_code = create_test_graph(
-    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, &p_graph, &ret_error);
+    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, renumber, &p_graph, &ret_error);
 
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "create_test_graph failed.");
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
 
-  ret_code = cugraph_hits(
-    p_handle, p_graph, epsilon, max_iterations, NULL, NULL, FALSE, FALSE, &p_result, &ret_error);
+  if (h_initial_vertices == NULL) {
+    ret_code = cugraph_hits(p_handle,
+                            p_graph,
+                            epsilon,
+                            max_iterations,
+                            NULL,
+                            NULL,
+                            normalize,
+                            FALSE,
+                            &p_result,
+                            &ret_error);
+  } else {
+    cugraph_type_erased_device_array_t* initial_vertices;
+    cugraph_type_erased_device_array_t* initial_hubs;
+    cugraph_type_erased_device_array_view_t* initial_vertices_view;
+    cugraph_type_erased_device_array_view_t* initial_hubs_view;
+
+    ret_code = cugraph_type_erased_device_array_create(
+      p_handle, num_initial_vertices, INT32, &initial_vertices, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "initial_vertices create failed.");
+
+    ret_code = cugraph_type_erased_device_array_create(
+      p_handle, num_initial_vertices, FLOAT32, &initial_hubs, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "initial_hubs create failed.");
+
+    initial_vertices_view = cugraph_type_erased_device_array_view(initial_vertices);
+    initial_hubs_view     = cugraph_type_erased_device_array_view(initial_hubs);
+
+    ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+      p_handle, initial_vertices_view, (byte_t*)h_initial_vertices, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src copy_from_host failed.");
+
+    ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+      p_handle, initial_hubs_view, (byte_t*)h_initial_hubs, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src copy_from_host failed.");
+
+    ret_code = cugraph_hits(p_handle,
+                            p_graph,
+                            epsilon,
+                            max_iterations,
+                            initial_vertices_view,
+                            initial_hubs_view,
+                            normalize,
+                            FALSE,
+                            &p_result,
+                            &ret_error);
+  }
 
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "cugraph_hits failed.");
 
@@ -120,11 +170,16 @@ int test_hits()
   return generic_hits_test(h_src,
                            h_dst,
                            h_wgt,
-                           h_hubs,
-                           h_authorities,
                            num_vertices,
                            num_edges,
+                           NULL,
+                           NULL,
+                           0,
+                           h_hubs,
+                           h_authorities,
                            TRUE,
+                           FALSE,
+                           FALSE,
                            epsilon,
                            max_iterations);
 }
@@ -149,19 +204,203 @@ int test_hits_with_transpose()
   return generic_hits_test(h_src,
                            h_dst,
                            h_wgt,
-                           h_hubs,
-                           h_authorities,
                            num_vertices,
                            num_edges,
+                           NULL,
+                           NULL,
+                           0,
+                           h_hubs,
+                           h_authorities,
+                           FALSE,
+                           FALSE,
                            FALSE,
                            epsilon,
                            max_iterations);
 }
 
+int test_hits_with_initial()
+{
+  size_t num_edges        = 8;
+  size_t num_vertices     = 6;
+  size_t num_initial_hubs = 5;
+
+  vertex_t h_src[]              = {0, 1, 1, 2, 2, 2, 3, 4};
+  vertex_t h_dst[]              = {1, 3, 4, 0, 1, 3, 5, 5};
+  weight_t h_wgt[]              = {0.1f, 2.1f, 1.1f, 5.1f, 3.1f, 4.1f, 7.2f, 3.2f};
+  weight_t h_hubs[]             = {0.347296, 0.532089, 1, 0.00000959, 0.00000959, 0};
+  weight_t h_authorities[]      = {0.652704, 0.879385, 0, 1, 0.347296, 0.00002428};
+  vertex_t h_initial_vertices[] = {0, 1, 2, 3, 4};
+  weight_t h_initial_hubs[]     = {0.347296, 0.532089, 1, 0.00003608, 0.00003608};
+
+  double epsilon        = 0.0001;
+  size_t max_iterations = 20;
+
+  return generic_hits_test(h_src,
+                           h_dst,
+                           h_wgt,
+                           num_vertices,
+                           num_edges,
+                           h_initial_vertices,
+                           h_initial_hubs,
+                           num_initial_hubs,
+                           h_hubs,
+                           h_authorities,
+                           FALSE,
+                           FALSE,
+                           FALSE,
+                           epsilon,
+                           max_iterations);
+}
+
+int test_hits_bigger()
+{
+  size_t num_edges    = 48;
+  size_t num_vertices = 54;
+
+  vertex_t h_src[] = {29, 45, 6,  8,  16, 45, 8,  16, 6,  38, 45, 45, 48, 45, 45, 45,
+                      45, 48, 53, 45, 6,  45, 38, 45, 38, 45, 16, 45, 38, 16, 45, 45,
+                      38, 6,  38, 45, 45, 45, 16, 38, 6,  45, 29, 45, 29, 6,  38, 6};
+  vertex_t h_dst[] = {45, 45, 16, 45, 6,  45, 45, 16, 45, 38, 45, 6,  45, 38, 16, 45,
+                      45, 45, 45, 53, 29, 16, 45, 8,  8,  16, 45, 38, 45, 6,  45, 45,
+                      6,  6,  16, 38, 16, 45, 45, 6,  16, 6,  53, 16, 38, 45, 45, 16};
+  weight_t h_wgt[] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+  weight_t h_hubs[] = {0, 0, 0, 0, 0,        0,        0.323569, 0,        0.156401, 0,        0,
+                       0, 0, 0, 0, 0,        0.253312, 0,        0,        0,        0,        0,
+                       0, 0, 0, 0, 0,        0,        0,        0.110617, 0,        0,        0,
+                       0, 0, 0, 0, 0,        0.365733, 0,        0,        0,        0,        0,
+                       0, 1, 0, 0, 0.156401, 0,        0,        0,        0,        0.0782005};
+  weight_t h_authorities[] = {0, 0, 0, 0, 0, 0,        0.321874, 0,         0.123424, 0,       0,
+                              0, 0, 0, 0, 0, 0.595522, 0,        0,         0,        0,       0,
+                              0, 0, 0, 0, 0, 0,        0,        0.0292397, 0,        0,       0,
+                              0, 0, 0, 0, 0, 0.314164, 0,        0,         0,        0,       0,
+                              0, 1, 0, 0, 0, 0,        0,        0,         0,        0.100368};
+
+  double epsilon        = 0.000001;
+  size_t max_iterations = 100;
+
+  return generic_hits_test(h_src,
+                           h_dst,
+                           h_wgt,
+                           num_vertices,
+                           num_edges,
+                           NULL,
+                           NULL,
+                           0,
+                           h_hubs,
+                           h_authorities,
+                           FALSE,
+                           FALSE,
+                           FALSE,
+                           epsilon,
+                           max_iterations);
+}
+
+int test_hits_bigger_unnormalized()
+{
+  size_t num_edges    = 48;
+  size_t num_vertices = 54;
+
+  vertex_t h_src[] = {29, 45, 6,  8,  16, 45, 8,  16, 6,  38, 45, 45, 48, 45, 45, 45,
+                      45, 48, 53, 45, 6,  45, 38, 45, 38, 45, 16, 45, 38, 16, 45, 45,
+                      38, 6,  38, 45, 45, 45, 16, 38, 6,  45, 29, 45, 29, 6,  38, 6};
+  vertex_t h_dst[] = {45, 45, 16, 45, 6,  45, 45, 16, 45, 38, 45, 6,  45, 38, 16, 45,
+                      45, 45, 45, 53, 29, 16, 45, 8,  8,  16, 45, 38, 45, 6,  45, 45,
+                      6,  6,  16, 38, 16, 45, 45, 6,  16, 6,  53, 16, 38, 45, 45, 16};
+  weight_t h_wgt[] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+  weight_t h_hubs[] = {0, 0, 0, 0, 0,        0,        0.323569, 0,        0.156401, 0,        0,
+                       0, 0, 0, 0, 0,        0.253312, 0,        0,        0,        0,        0,
+                       0, 0, 0, 0, 0,        0,        0,        0.110617, 0,        0,        0,
+                       0, 0, 0, 0, 0,        0.365733, 0,        0,        0,        0,        0,
+                       0, 1, 0, 0, 0.156401, 0,        0,        0,        0,        0.0782005};
+  weight_t h_authorities[] = {0, 0, 0, 0, 0, 0,        0.321874, 0,         0.123424, 0,       0,
+                              0, 0, 0, 0, 0, 0.595522, 0,        0,         0,        0,       0,
+                              0, 0, 0, 0, 0, 0,        0,        0.0292397, 0,        0,       0,
+                              0, 0, 0, 0, 0, 0.314164, 0,        0,         0,        0,       0,
+                              0, 1, 0, 0, 0, 0,        0,        0,         0,        0.100368};
+
+  double epsilon        = 0.000001;
+  size_t max_iterations = 100;
+
+  return generic_hits_test(h_src,
+                           h_dst,
+                           h_wgt,
+                           num_vertices,
+                           num_edges,
+                           NULL,
+                           NULL,
+                           0,
+                           h_hubs,
+                           h_authorities,
+                           FALSE,
+                           FALSE,
+                           FALSE,
+                           epsilon,
+                           max_iterations);
+}
+
+int test_hits_bigger_normalized()
+{
+  size_t num_edges    = 48;
+  size_t num_vertices = 54;
+
+  vertex_t h_src[] = {29, 45, 6,  8,  16, 45, 8,  16, 6,  38, 45, 45, 48, 45, 45, 45,
+                      45, 48, 53, 45, 6,  45, 38, 45, 38, 45, 16, 45, 38, 16, 45, 45,
+                      38, 6,  38, 45, 45, 45, 16, 38, 6,  45, 29, 45, 29, 6,  38, 6};
+  vertex_t h_dst[] = {45, 45, 16, 45, 6,  45, 45, 16, 45, 38, 45, 6,  45, 38, 16, 45,
+                      45, 45, 45, 53, 29, 16, 45, 8,  8,  16, 45, 38, 45, 6,  45, 45,
+                      6,  6,  16, 38, 16, 45, 45, 6,  16, 6,  53, 16, 38, 45, 45, 16};
+  weight_t h_wgt[] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+  weight_t h_hubs[] = {
+    0, 0,         0,        0,        0, 0, 0.132381,  0, 0.0639876, 0, 0,        0,        0, 0,
+    0, 0,         0.103637, 0,        0, 0, 0,         0, 0,         0, 0,        0,        0, 0,
+    0, 0.0452563, 0,        0,        0, 0, 0,         0, 0,         0, 0.149631, 0,        0, 0,
+    0, 0,         0,        0.409126, 0, 0, 0.0639876, 0, 0,         0, 0,        0.0319938};
+
+  weight_t h_authorities[] = {
+    0, 0,         0,        0,        0, 0, 0.129548, 0, 0.0496755, 0, 0,        0,        0, 0,
+    0, 0,         0.239688, 0,        0, 0, 0,        0, 0,         0, 0,        0,        0, 0,
+    0, 0.0117691, 0,        0,        0, 0, 0,        0, 0,         0, 0.126445, 0,        0, 0,
+    0, 0,         0,        0.402479, 0, 0, 0,        0, 0,         0, 0,        0.0403963};
+
+  double epsilon        = 0.000001;
+  size_t max_iterations = 100;
+
+  return generic_hits_test(h_src,
+                           h_dst,
+                           h_wgt,
+                           num_vertices,
+                           num_edges,
+                           NULL,
+                           NULL,
+                           0,
+                           h_hubs,
+                           h_authorities,
+                           FALSE,
+                           FALSE,
+                           TRUE,
+                           epsilon,
+                           max_iterations);
+}
 int main(int argc, char** argv)
 {
   int result = 0;
   result |= RUN_TEST(test_hits);
   result |= RUN_TEST(test_hits_with_transpose);
+  result |= RUN_TEST(test_hits_with_initial);
+  result |= RUN_TEST(test_hits_bigger);
+  result |= RUN_TEST(test_hits_bigger_normalized);
+  result |= RUN_TEST(test_hits_bigger_unnormalized);
   return result;
 }

--- a/cpp/tests/c_api/mg_hits_test.c
+++ b/cpp/tests/c_api/mg_hits_test.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "c_test_utils.h" /* RUN_TEST */
+#include "mg_test_utils.h" /* RUN_TEST */
 
 #include <cugraph_c/algorithms.h>
 #include <cugraph_c/graph.h>
@@ -25,7 +25,8 @@ typedef int32_t vertex_t;
 typedef int32_t edge_t;
 typedef float weight_t;
 
-int generic_hits_test(vertex_t* h_src,
+int generic_hits_test(const cugraph_resource_handle_t *p_handle,
+                      vertex_t* h_src,
                       vertex_t* h_dst,
                       weight_t* h_wgt,
                       weight_t* h_result_hubs,
@@ -41,17 +42,13 @@ int generic_hits_test(vertex_t* h_src,
   cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
   cugraph_error_t* ret_error;
 
-  cugraph_resource_handle_t* p_handle = NULL;
   cugraph_graph_t* p_graph            = NULL;
   cugraph_hits_result_t* p_result     = NULL;
 
-  p_handle = cugraph_create_resource_handle(NULL);
-  TEST_ASSERT(test_ret_value, p_handle != NULL, "resource handle creation failed.");
-
-  ret_code = create_test_graph(
+  ret_code = create_mg_test_graph(
     p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, &p_graph, &ret_error);
 
-  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "create_test_graph failed.");
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "create_mg_test_graph failed.");
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
 
   ret_code = cugraph_hits(
@@ -59,6 +56,10 @@ int generic_hits_test(vertex_t* h_src,
 
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "cugraph_hits failed.");
 
+  // NOTE: Because we get back vertex ids, hubs and authorities, we can
+  //       simply compare the returned values with the expected results
+  //       for the entire graph.  Each GPU will have a subset of the
+  //       total vertices, so they will do a subset of the comparisons.
   cugraph_type_erased_device_array_view_t* vertices;
   cugraph_type_erased_device_array_view_t* hubs;
   cugraph_type_erased_device_array_view_t* authorities;
@@ -85,7 +86,9 @@ int generic_hits_test(vertex_t* h_src,
     p_handle, (byte_t*)h_authorities, authorities, &ret_error);
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
 
-  for (int i = 0; (i < num_vertices) && (test_ret_value == 0); ++i) {
+  size_t num_local_vertices = cugraph_type_erased_device_array_view_size(vertices);
+
+  for (int i = 0; (i < num_local_vertices) && (test_ret_value == 0); ++i) {
     TEST_ASSERT(test_ret_value,
                 nearlyEqual(h_result_hubs[h_vertices[i]], h_hubs[i], 0.001),
                 "hubs results don't match");
@@ -95,14 +98,13 @@ int generic_hits_test(vertex_t* h_src,
   }
 
   cugraph_hits_result_free(p_result);
-  cugraph_sg_graph_free(p_graph);
-  cugraph_free_resource_handle(p_handle);
+  cugraph_mg_graph_free(p_graph);
   cugraph_error_free(ret_error);
 
   return test_ret_value;
 }
 
-int test_hits()
+int test_hits(const cugraph_resource_handle_t* handle)
 {
   size_t num_edges    = 8;
   size_t num_vertices = 6;
@@ -117,7 +119,8 @@ int test_hits()
   size_t max_iterations = 20;
 
   // hits wants store_transposed = TRUE
-  return generic_hits_test(h_src,
+  return generic_hits_test(handle,
+                           h_src,
                            h_dst,
                            h_wgt,
                            h_hubs,
@@ -129,7 +132,7 @@ int test_hits()
                            max_iterations);
 }
 
-int test_hits_with_transpose()
+int test_hits_with_transpose(const cugraph_resource_handle_t* handle)
 {
   size_t num_edges    = 8;
   size_t num_vertices = 6;
@@ -146,7 +149,8 @@ int test_hits_with_transpose()
   // Hits wants store_transposed = TRUE
   //    This call will force cugraph_hits to transpose the graph
   //    But we're passing src/dst backwards so the results will be the same
-  return generic_hits_test(h_src,
+  return generic_hits_test(handle,
+                           h_src,
                            h_dst,
                            h_wgt,
                            h_hubs,
@@ -158,10 +162,41 @@ int test_hits_with_transpose()
                            max_iterations);
 }
 
+/******************************************************************************/
+
 int main(int argc, char** argv)
 {
-  int result = 0;
-  result |= RUN_TEST(test_hits);
-  result |= RUN_TEST(test_hits_with_transpose);
+  // Set up MPI:
+  int comm_rank;
+  int comm_size;
+  int num_gpus_per_node;
+  cudaError_t status;
+  int mpi_status;
+  int result                        = 0;
+  cugraph_resource_handle_t* handle = NULL;
+  cugraph_error_t* ret_error;
+  cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
+  int prows                     = 1;
+
+  C_MPI_TRY(MPI_Init(&argc, &argv));
+  C_MPI_TRY(MPI_Comm_rank(MPI_COMM_WORLD, &comm_rank));
+  C_MPI_TRY(MPI_Comm_size(MPI_COMM_WORLD, &comm_size));
+  C_CUDA_TRY(cudaGetDeviceCount(&num_gpus_per_node));
+  C_CUDA_TRY(cudaSetDevice(comm_rank % num_gpus_per_node));
+
+  void* raft_handle = create_raft_handle(prows);
+  handle            = cugraph_create_resource_handle(raft_handle);
+
+  if (result == 0) {
+    result |= RUN_MG_TEST(test_hits, handle);
+    result |= RUN_MG_TEST(test_hits_with_transpose, handle);
+
+    cugraph_free_resource_handle(handle);
+  }
+
+  free_raft_handle(raft_handle);
+
+  C_MPI_TRY(MPI_Finalize());
+
   return result;
 }

--- a/cpp/tests/c_api/mg_hits_test.c
+++ b/cpp/tests/c_api/mg_hits_test.c
@@ -25,15 +25,19 @@ typedef int32_t vertex_t;
 typedef int32_t edge_t;
 typedef float weight_t;
 
-int generic_hits_test(const cugraph_resource_handle_t *p_handle,
+int generic_hits_test(const cugraph_resource_handle_t* p_handle,
                       vertex_t* h_src,
                       vertex_t* h_dst,
                       weight_t* h_wgt,
-                      weight_t* h_result_hubs,
-                      weight_t* h_result_authorities,
                       size_t num_vertices,
                       size_t num_edges,
+                      vertex_t* h_initial_vertices,
+                      weight_t* h_initial_hubs,
+                      size_t num_initial_vertices,
+                      weight_t* h_result_hubs,
+                      weight_t* h_result_authorities,
                       bool_t store_transposed,
+                      bool_t normalize,
                       double epsilon,
                       size_t max_iterations)
 {
@@ -42,8 +46,8 @@ int generic_hits_test(const cugraph_resource_handle_t *p_handle,
   cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
   cugraph_error_t* ret_error;
 
-  cugraph_graph_t* p_graph            = NULL;
-  cugraph_hits_result_t* p_result     = NULL;
+  cugraph_graph_t* p_graph        = NULL;
+  cugraph_hits_result_t* p_result = NULL;
 
   ret_code = create_mg_test_graph(
     p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, &p_graph, &ret_error);
@@ -51,8 +55,44 @@ int generic_hits_test(const cugraph_resource_handle_t *p_handle,
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "create_mg_test_graph failed.");
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
 
-  ret_code = cugraph_hits(
-    p_handle, p_graph, epsilon, max_iterations, NULL, NULL, FALSE, FALSE, &p_result, &ret_error);
+  if (h_initial_vertices == NULL) {
+    ret_code = cugraph_hits(
+      p_handle, p_graph, epsilon, max_iterations, NULL, NULL, normalize, FALSE, &p_result, &ret_error);
+  } else {
+    int rank = cugraph_resource_handle_get_rank(p_handle);
+
+    if (rank != 0) {
+      // Only initialize the vertices on rank 0
+      num_initial_vertices = 0;
+    }
+
+    cugraph_type_erased_device_array_t* initial_vertices;
+    cugraph_type_erased_device_array_t* initial_hubs;
+    cugraph_type_erased_device_array_view_t* initial_vertices_view;
+    cugraph_type_erased_device_array_view_t* initial_hubs_view;
+
+    ret_code = cugraph_type_erased_device_array_create(
+      p_handle, num_initial_vertices, INT32, &initial_vertices, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "initial_vertices create failed.");
+
+    ret_code = cugraph_type_erased_device_array_create(
+      p_handle, num_initial_vertices, FLOAT32, &initial_hubs, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "initial_hubs create failed.");
+
+    initial_vertices_view = cugraph_type_erased_device_array_view(initial_vertices);
+    initial_hubs_view     = cugraph_type_erased_device_array_view(initial_hubs);
+
+    ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+      p_handle, initial_vertices_view, (byte_t*)h_initial_vertices, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src copy_from_host failed.");
+
+    ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+      p_handle, initial_hubs_view, (byte_t*)h_initial_hubs, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src copy_from_host failed.");
+
+    ret_code = cugraph_hits(
+      p_handle, p_graph, epsilon, max_iterations, initial_vertices_view, initial_hubs_view, normalize, FALSE, &p_result, &ret_error);
+  }
 
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "cugraph_hits failed.");
 
@@ -123,11 +163,15 @@ int test_hits(const cugraph_resource_handle_t* handle)
                            h_src,
                            h_dst,
                            h_wgt,
-                           h_hubs,
-                           h_authorities,
                            num_vertices,
                            num_edges,
+                           NULL,
+                           NULL,
+                           0,
+                           h_hubs,
+                           h_authorities,
                            TRUE,
+                           FALSE,
                            epsilon,
                            max_iterations);
 }
@@ -153,10 +197,196 @@ int test_hits_with_transpose(const cugraph_resource_handle_t* handle)
                            h_src,
                            h_dst,
                            h_wgt,
-                           h_hubs,
-                           h_authorities,
                            num_vertices,
                            num_edges,
+                           NULL,
+                           NULL,
+                           0,
+                           h_hubs,
+                           h_authorities,
+                           FALSE,
+                           FALSE,
+                           epsilon,
+                           max_iterations);
+}
+
+int test_hits_with_initial(const cugraph_resource_handle_t* handle)
+{
+  size_t num_edges    = 8;
+  size_t num_vertices = 6;
+  size_t num_initial_hubs = 5;
+
+  vertex_t h_src[]         = {0, 1, 1, 2, 2, 2, 3, 4};
+  vertex_t h_dst[]         = {1, 3, 4, 0, 1, 3, 5, 5};
+  weight_t h_wgt[]         = {0.1f, 2.1f, 1.1f, 5.1f, 3.1f, 4.1f, 7.2f, 3.2f};
+  weight_t h_hubs[]        = {0.347296, 0.532089, 1, 0.00000959, 0.00000959, 0};
+  weight_t h_authorities[] = {0.652704, 0.879385, 0, 1, 0.347296, 0.00002428};
+  vertex_t h_initial_vertices[] = { 0, 1, 2, 3, 4 };
+  weight_t h_initial_hubs[]        = {0.347296, 0.532089, 1, 0.00003608, 0.00003608};
+
+  double epsilon        = 0.0001;
+  size_t max_iterations = 20;
+
+  // Hits wants store_transposed = TRUE
+  //    This call will force cugraph_hits to transpose the graph
+  //    But we're passing src/dst backwards so the results will be the same
+  return generic_hits_test(handle,
+                           h_src,
+                           h_dst,
+                           h_wgt,
+                           num_vertices,
+                           num_edges,
+                           h_initial_vertices,
+                           h_initial_hubs,
+                           num_initial_hubs,
+                           h_hubs,
+                           h_authorities,
+                           FALSE,
+                           FALSE,
+                           epsilon,
+                           max_iterations);
+}
+
+int test_hits_bigger(const cugraph_resource_handle_t* handle)
+{
+  size_t num_edges    = 48;
+  size_t num_vertices = 54;
+
+  vertex_t h_src[] = {29, 45, 6,  8,  16, 45, 8,  16, 6,  38, 45, 45, 48, 45, 45, 45,
+                      45, 48, 53, 45, 6,  45, 38, 45, 38, 45, 16, 45, 38, 16, 45, 45,
+                      38, 6,  38, 45, 45, 45, 16, 38, 6,  45, 29, 45, 29, 6,  38, 6};
+  vertex_t h_dst[] = {45, 45, 16, 45, 6,  45, 45, 16, 45, 38, 45, 6,  45, 38, 16, 45,
+                      45, 45, 45, 53, 29, 16, 45, 8,  8,  16, 45, 38, 45, 6,  45, 45,
+                      6,  6,  16, 38, 16, 45, 45, 6,  16, 6,  53, 16, 38, 45, 45, 16};
+  weight_t h_wgt[] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+  weight_t h_hubs[] = {0, 0, 0, 0, 0,        0,        0.323569, 0,        0.156401, 0,        0,
+                       0, 0, 0, 0, 0,        0.253312, 0,        0,        0,        0,        0,
+                       0, 0, 0, 0, 0,        0,        0,        0.110617, 0,        0,        0,
+                       0, 0, 0, 0, 0,        0.365733, 0,        0,        0,        0,        0,
+                       0, 1, 0, 0, 0.156401, 0,        0,        0,        0,        0.0782005};
+  weight_t h_authorities[] = {0, 0, 0, 0, 0, 0,        0.321874, 0,         0.123424, 0,       0,
+                              0, 0, 0, 0, 0, 0.595522, 0,        0,         0,        0,       0,
+                              0, 0, 0, 0, 0, 0,        0,        0.0292397, 0,        0,       0,
+                              0, 0, 0, 0, 0, 0.314164, 0,        0,         0,        0,       0,
+                              0, 1, 0, 0, 0, 0,        0,        0,         0,        0.100368};
+
+  double epsilon        = 0.0001;
+  size_t max_iterations = 20;
+
+  // Hits wants store_transposed = TRUE
+  //    This call will force cugraph_hits to transpose the graph
+  //    But we're passing src/dst backwards so the results will be the same
+  return generic_hits_test(handle,
+                           h_src,
+                           h_dst,
+                           h_wgt,
+                           num_vertices,
+                           num_edges,
+                           NULL,
+                           NULL,
+                           0,
+                           h_hubs,
+                           h_authorities,
+                           FALSE,
+                           FALSE,
+                           epsilon,
+                           max_iterations);
+}
+
+int test_hits_bigger_normalized(const cugraph_resource_handle_t* handle)
+{
+  size_t num_edges    = 48;
+  size_t num_vertices = 54;
+
+  vertex_t h_src[] = {29, 45, 6,  8,  16, 45, 8,  16, 6,  38, 45, 45, 48, 45, 45, 45,
+                      45, 48, 53, 45, 6,  45, 38, 45, 38, 45, 16, 45, 38, 16, 45, 45,
+                      38, 6,  38, 45, 45, 45, 16, 38, 6,  45, 29, 45, 29, 6,  38, 6};
+  vertex_t h_dst[] = {45, 45, 16, 45, 6,  45, 45, 16, 45, 38, 45, 6,  45, 38, 16, 45,
+                      45, 45, 45, 53, 29, 16, 45, 8,  8,  16, 45, 38, 45, 6,  45, 45,
+                      6,  6,  16, 38, 16, 45, 45, 6,  16, 6,  53, 16, 38, 45, 45, 16};
+  weight_t h_wgt[] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+  weight_t h_hubs[] = {
+    0, 0,         0,        0,        0, 0, 0.132381,  0, 0.0639876, 0, 0,        0,        0, 0,
+    0, 0,         0.103637, 0,        0, 0, 0,         0, 0,         0, 0,        0,        0, 0,
+    0, 0.0452563, 0,        0,        0, 0, 0,         0, 0,         0, 0.149631, 0,        0, 0,
+    0, 0,         0,        0.409126, 0, 0, 0.0639876, 0, 0,         0, 0,        0.0319938};
+
+  weight_t h_authorities[] = {
+    0, 0,         0,        0,        0, 0, 0.129548, 0, 0.0496755, 0, 0,        0,        0, 0,
+    0, 0,         0.239688, 0,        0, 0, 0,        0, 0,         0, 0,        0,        0, 0,
+    0, 0.0117691, 0,        0,        0, 0, 0,        0, 0,         0, 0.126445, 0,        0, 0,
+    0, 0,         0,        0.402479, 0, 0, 0,        0, 0,         0, 0,        0.0403963};
+
+  double epsilon        = 0.000001;
+  size_t max_iterations = 100;
+
+  return generic_hits_test(handle,
+                           h_src,
+                           h_dst,
+                           h_wgt,
+                           num_vertices,
+                           num_edges,
+                           NULL,
+                           NULL,
+                           0,
+                           h_hubs,
+                           h_authorities,
+                           FALSE,
+                           TRUE,
+                           epsilon,
+                           max_iterations);
+}
+
+int test_hits_bigger_unnormalized(const cugraph_resource_handle_t* handle)
+{
+  size_t num_edges    = 48;
+  size_t num_vertices = 54;
+
+  vertex_t h_src[] = {29, 45, 6,  8,  16, 45, 8,  16, 6,  38, 45, 45, 48, 45, 45, 45,
+                      45, 48, 53, 45, 6,  45, 38, 45, 38, 45, 16, 45, 38, 16, 45, 45,
+                      38, 6,  38, 45, 45, 45, 16, 38, 6,  45, 29, 45, 29, 6,  38, 6};
+  vertex_t h_dst[] = {45, 45, 16, 45, 6,  45, 45, 16, 45, 38, 45, 6,  45, 38, 16, 45,
+                      45, 45, 45, 53, 29, 16, 45, 8,  8,  16, 45, 38, 45, 6,  45, 45,
+                      6,  6,  16, 38, 16, 45, 45, 6,  16, 6,  53, 16, 38, 45, 45, 16};
+  weight_t h_wgt[] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+  weight_t h_hubs[] = {0, 0, 0, 0, 0,        0,        0.323569, 0,        0.156401, 0,        0,
+                       0, 0, 0, 0, 0,        0.253312, 0,        0,        0,        0,        0,
+                       0, 0, 0, 0, 0,        0,        0,        0.110617, 0,        0,        0,
+                       0, 0, 0, 0, 0,        0.365733, 0,        0,        0,        0,        0,
+                       0, 1, 0, 0, 0.156401, 0,        0,        0,        0,        0.0782005};
+  weight_t h_authorities[] = {0, 0, 0, 0, 0, 0,        0.321874, 0,         0.123424, 0,       0,
+                              0, 0, 0, 0, 0, 0.595522, 0,        0,         0,        0,       0,
+                              0, 0, 0, 0, 0, 0,        0,        0.0292397, 0,        0,       0,
+                              0, 0, 0, 0, 0, 0.314164, 0,        0,         0,        0,       0,
+                              0, 1, 0, 0, 0, 0,        0,        0,         0,        0.100368};
+
+  double epsilon        = 0.000001;
+  size_t max_iterations = 100;
+
+  return generic_hits_test(handle,
+                           h_src,
+                           h_dst,
+                           h_wgt,
+                           num_vertices,
+                           num_edges,
+                           NULL,
+                           NULL,
+                           0,
+                           h_hubs,
+                           h_authorities,
+                           FALSE,
                            FALSE,
                            epsilon,
                            max_iterations);
@@ -190,6 +420,9 @@ int main(int argc, char** argv)
   if (result == 0) {
     result |= RUN_MG_TEST(test_hits, handle);
     result |= RUN_MG_TEST(test_hits_with_transpose, handle);
+    result |= RUN_MG_TEST(test_hits_with_initial, handle);
+    result |= RUN_MG_TEST(test_hits_bigger_normalized, handle);
+    result |= RUN_MG_TEST(test_hits_bigger_unnormalized, handle);
 
     cugraph_free_resource_handle(handle);
   }

--- a/cpp/tests/c_api/mg_pagerank_test.c
+++ b/cpp/tests/c_api/mg_pagerank_test.c
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include "c_test_utils.h"  /* RUN_TEST */
 #include "mg_test_utils.h" /* RUN_TEST */
 
 #include <cugraph_c/algorithms.h>
@@ -49,12 +48,16 @@ int generic_pagerank_test(const cugraph_resource_handle_t* handle,
   ret_code = create_mg_test_graph(
     handle, h_src, h_dst, h_wgt, num_edges, store_transposed, &p_graph, &ret_error);
 
-  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "create_test_graph failed.");
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "create_mg_test_graph failed.");
 
   ret_code = cugraph_pagerank(
     handle, p_graph, NULL, alpha, epsilon, max_iterations, FALSE, FALSE, &p_result, &ret_error);
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "cugraph_pagerank failed.");
 
+  // NOTE: Because we get back vertex ids and pageranks, we can simply compare
+  //       the returned values with the expected results for the entire
+  //       graph.  Each GPU will have a subset of the total vertices, so
+  //       they will do a subset of the comparisons.
   cugraph_type_erased_device_array_view_t* vertices;
   cugraph_type_erased_device_array_view_t* pageranks;
 
@@ -83,7 +86,7 @@ int generic_pagerank_test(const cugraph_resource_handle_t* handle,
   cugraph_type_erased_device_array_view_free(pageranks);
   cugraph_type_erased_device_array_view_free(vertices);
   cugraph_pagerank_result_free(p_result);
-  cugraph_sg_graph_free(p_graph);
+  cugraph_mg_graph_free(p_graph);
   cugraph_error_free(ret_error);
 
   return test_ret_value;

--- a/cpp/tests/c_api/mg_test_utils.cpp
+++ b/cpp/tests/c_api/mg_test_utils.cpp
@@ -18,8 +18,11 @@
 #include <c_api/resource_handle.hpp>
 
 #include <cugraph/partition_manager.hpp>
+#include <cugraph/utilities/error.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
+
+#include <rmm/device_uvector.hpp>
 
 extern "C" int run_mg_test(int (*test)(const cugraph_resource_handle_t*),
                            const char* test_name,
@@ -28,6 +31,10 @@ extern "C" int run_mg_test(int (*test)(const cugraph_resource_handle_t*),
   int ret_val = 0;
   time_t start_time, end_time;
   int rank = 0;
+
+  auto raft_handle =
+    reinterpret_cast<cugraph::c_api::cugraph_resource_handle_t const*>(handle)->handle_;
+  auto &comm = raft_handle->get_comms();
 
   rank = cugraph_resource_handle_get_rank(handle);
 
@@ -39,6 +46,18 @@ extern "C" int run_mg_test(int (*test)(const cugraph_resource_handle_t*),
   }
 
   ret_val = test(handle);
+
+  // FIXME:  This is copied from host_scalar_allreduce
+  //         which is in a file of thrust enabled code which can't
+  //         be inclined in a cpp file.  Either make this file a .cu
+  //         or refactor host_scalar_comm.cuh to separate the thrust
+  //         code from the non-thrust code
+  rmm::device_uvector<int> d_input(1, raft_handle->get_stream());
+  raft::update_device(d_input.data(), &ret_val, 1, raft_handle->get_stream());
+  comm.allreduce(d_input.data(), d_input.data(), 1, raft::comms::op_t::SUM, raft_handle->get_stream());
+  raft::update_host(&ret_val, d_input.data(), 1, raft_handle->get_stream());
+  auto status = comm.sync_stream(raft_handle->get_stream());
+  CUGRAPH_EXPECTS(status == raft::comms::status_t::SUCCESS, "sync_stream() failure.");
 
   if (rank == 0) {
     time(&end_time);

--- a/cpp/tests/c_api/mg_test_utils.cpp
+++ b/cpp/tests/c_api/mg_test_utils.cpp
@@ -34,7 +34,7 @@ extern "C" int run_mg_test(int (*test)(const cugraph_resource_handle_t*),
 
   auto raft_handle =
     reinterpret_cast<cugraph::c_api::cugraph_resource_handle_t const*>(handle)->handle_;
-  auto &comm = raft_handle->get_comms();
+  auto& comm = raft_handle->get_comms();
 
   rank = cugraph_resource_handle_get_rank(handle);
 
@@ -54,7 +54,8 @@ extern "C" int run_mg_test(int (*test)(const cugraph_resource_handle_t*),
   //         code from the non-thrust code
   rmm::device_uvector<int> d_input(1, raft_handle->get_stream());
   raft::update_device(d_input.data(), &ret_val, 1, raft_handle->get_stream());
-  comm.allreduce(d_input.data(), d_input.data(), 1, raft::comms::op_t::SUM, raft_handle->get_stream());
+  comm.allreduce(
+    d_input.data(), d_input.data(), 1, raft::comms::op_t::SUM, raft_handle->get_stream());
   raft::update_host(&ret_val, d_input.data(), 1, raft_handle->get_stream());
   auto status = comm.sync_stream(raft_handle->get_stream());
   CUGRAPH_EXPECTS(status == raft::comms::status_t::SUCCESS, "sync_stream() failure.");

--- a/cpp/tests/c_api/mg_test_utils.h
+++ b/cpp/tests/c_api/mg_test_utils.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include "c_test_utils.h"
+
 #include <mpi.h>
 #include <stdlib.h>
 

--- a/cpp/tests/c_api/node2vec_test.c
+++ b/cpp/tests/c_api/node2vec_test.c
@@ -55,7 +55,7 @@ int generic_node2vec_test(vertex_t* h_src,
   TEST_ASSERT(test_ret_value, p_handle != NULL, "resource handle creation failed.");
 
   ret_code = create_test_graph(
-    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, &p_graph, &ret_error);
+    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, FALSE, &p_graph, &ret_error);
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "graph creation failed.");
 
   ret_code =

--- a/cpp/tests/c_api/pagerank_test.c
+++ b/cpp/tests/c_api/pagerank_test.c
@@ -49,7 +49,7 @@ int generic_pagerank_test(vertex_t* h_src,
   TEST_ASSERT(test_ret_value, p_handle != NULL, "resource handle creation failed.");
 
   ret_code = create_test_graph(
-    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, &p_graph, &ret_error);
+    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, FALSE, &p_graph, &ret_error);
 
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "create_test_graph failed.");
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));

--- a/cpp/tests/c_api/sssp_test.c
+++ b/cpp/tests/c_api/sssp_test.c
@@ -52,7 +52,7 @@ int generic_sssp_test(vertex_t* h_src,
   TEST_ASSERT(test_ret_value, p_handle != NULL, "resource handle creation failed.");
 
   ret_code = create_test_graph(
-    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, &p_graph, &ret_error);
+    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, FALSE, &p_graph, &ret_error);
 
   ret_code = cugraph_sssp(
     p_handle, p_graph, source, cutoff, TRUE, FALSE, &p_result, &ret_error);

--- a/cpp/tests/c_api/test_utils.cpp
+++ b/cpp/tests/c_api/test_utils.cpp
@@ -35,6 +35,7 @@ extern "C" int create_test_graph(const cugraph_resource_handle_t* p_handle,
                                  float* h_wgt,
                                  size_t num_edges,
                                  bool_t store_transposed,
+                                 bool_t renumber,
                                  cugraph_graph_t** p_graph,
                                  cugraph_error_t** ret_error)
 {
@@ -91,7 +92,7 @@ extern "C" int create_test_graph(const cugraph_resource_handle_t* p_handle,
                                      dst_view,
                                      wgt_view,
                                      store_transposed,
-                                     FALSE,
+                                     renumber,
                                      FALSE,
                                      p_graph,
                                      ret_error);


### PR DESCRIPTION
Closes #2092 

Provide the C API implementation for HITS.  Adds a unit tester for MG, updates the unit tests for both SG and MG.