### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -286,7 +286,7 @@ target_include_directories(cugraph
 # - link libraries -------------------------------------------------------------
 target_link_libraries(cugraph
     PUBLIC
-        cugraphops::cugraphops
+        cugraph-ops::cugraph-ops++
         raft::raft
     PRIVATE
         cugraph::cuHornet

--- a/cpp/cmake/thirdparty/get_libcugraphops.cmake
+++ b/cpp/cmake/thirdparty/get_libcugraphops.cmake
@@ -14,26 +14,22 @@
 # limitations under the License.
 #=============================================================================
 
-function(find_and_configure_cugraphops)
+set(CUGRAPH_MIN_VERSION_cugraph_ops "${CUGRAPH_VERSION_MAJOR}.${CUGRAPH_VERSION_MINOR}.00")
 
-    if(TARGET cugraphops::cugraphops)
-        return()
-    endif()
+function(find_and_configure_cugraph_ops)
 
-    rapids_find_generate_module(cugraphops
-        HEADER_NAMES            graph/sampling.hpp
-        LIBRARY_NAMES           cugraph-ops++
-        INCLUDE_SUFFIXES        cugraph-ops
-        BUILD_EXPORT_SET    cugraph-exports
-        INSTALL_EXPORT_SET  cugraph-exports
+    set(oneValueArgs VERSION)
+    cmake_parse_arguments(PKG "" "${oneValueArgs}" "" ${ARGN})
+
+    rapids_find_package(cugraph-ops ${PKG_VERSION} REQUIRED
+      GLOBAL_TARGETS      cugraph-ops::cugraph-ops++
+      BUILD_EXPORT_SET    cugraph-exports
+      INSTALL_EXPORT_SET  cugraph-exports
     )
-
-    rapids_find_package(cugraphops
-        REQUIRED
-        BUILD_EXPORT_SET    cugraph-exports
-        INSTALL_EXPORT_SET  cugraph-exports
-    )
-
 endfunction()
 
-find_and_configure_cugraphops()
+###
+# To use a locally-built cugraph-ops package, set the CMake variable
+# `-D cugraph-ops_ROOT=/path/to/cugraph-ops/build`
+###
+find_and_configure_cugraph_ops(VERSION ${CUGRAPH_MIN_VERSION_cugraph_ops})

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -51,7 +51,7 @@ endfunction()
 
 # Change pinned tag and fork here to test a commit in CI
 # To use a different RAFT locally, set the CMake variable
-# RPM_raft_SOURCE=/path/to/local/raft
+# CPM_raft_SOURCE=/path/to/local/raft
 find_and_configure_raft(VERSION    ${CUGRAPH_MIN_VERSION_raft}
                         FORK       rapidsai
                         PINNED_TAG branch-${CUGRAPH_BRANCH_VERSION_raft}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.