### PR TITLE
[FEA] Enable building static libs

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -247,6 +247,7 @@ set_target_properties(cugraph
                CXX_STANDARD_REQUIRED               ON
                CUDA_STANDARD                       17
                CUDA_STANDARD_REQUIRED              ON
+               POSITION_INDEPENDENT_CODE           ON
                INTERFACE_POSITION_INDEPENDENT_CODE ON
 )
 


### PR DESCRIPTION
This PR allows building libcugraph static libs via CMake option `-DBUILD_SHARED_LIBS=ON|OFF`.

I was seeing a linker error due to not having `-fPIC` enabled, but I wouldn't have expected this to affect static libs. I'll investigate some more and turn it off if possible, but for now `-fPIC` is enabled.