### PR TITLE
Make diagram and caption consistent in Pagerank.ipynb

### DIFF
--- a/notebooks/link_analysis/Pagerank.ipynb
+++ b/notebooks/link_analysis/Pagerank.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# PageRank\n",
     "\n",
@@ -11,13 +13,13 @@
     "Notebook Credits\n",
     "* Original Authors: Bradley Rees and James Wyles\n",
     "* Created:   08/13/2019\n",
-    "* Updated:   01/17/2021\n",
+    "* Updated:   04/06/2022\n",
     "\n",
-    "RAPIDS Versions: 0.14    \n",
+    "RAPIDS Versions: 22.04  \n",
     "\n",
     "Test Hardware\n",
     "\n",
-    "* GV100 32G, CUDA 10.0\n",
+    "* GV100 32G, CUDA 11.5\n",
     "\n",
     "\n",
     "## Introduction\n",
@@ -75,9 +77,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: networkx in /home/brad/anaconda3/envs/cugraph_dev/lib/python3.8/site-packages (2.6.2)\n",
-      "Requirement already satisfied: scipy in /home/brad/anaconda3/envs/cugraph_dev/lib/python3.8/site-packages (1.7.0)\n",
-      "Requirement already satisfied: numpy<1.23.0,>=1.16.5 in /home/brad/anaconda3/envs/cugraph_dev/lib/python3.8/site-packages (from scipy) (1.21.1)\n"
+      "Requirement already satisfied: networkx in /opt/conda/envs/rapids/lib/python3.9/site-packages (2.6.3)\n",
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\u001b[33m\n",
+      "\u001b[0mRequirement already satisfied: scipy in /opt/conda/envs/rapids/lib/python3.9/site-packages (1.6.0)\n",
+      "Requirement already satisfied: numpy>=1.16.5 in /opt/conda/envs/rapids/lib/python3.9/site-packages (from scipy) (1.21.5)\n",
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\u001b[33m\n",
+      "\u001b[0m"
      ]
     }
    ],
@@ -270,7 +275,16 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/envs/rapids/lib/python3.9/site-packages/cudf/core/indexed_frame.py:2271: FutureWarning: append is deprecated and will be removed in a future version. Use concat instead.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "# create a Graph using the source (src) and destination (dst) vertex pairs from the Dataframe \n",
     "G = cugraph.from_edgelist(gdf, source='src', destination='dst')"
@@ -315,7 +329,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Best vertex is 34 with score of 0.10091734\n"
+      "Best vertex is 34 with score of 0.100917324\n"
      ]
     }
    ],
@@ -373,7 +387,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Best vertex is 34 with score of 0.10091734\n"
+      "Best vertex is 34 with score of 0.100917324\n"
      ]
     }
    ],
@@ -433,17 +447,17 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>16</th>\n",
        "      <td>0.100917</td>\n",
        "      <td>34</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>17</th>\n",
        "      <td>0.096999</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>18</th>\n",
        "      <td>0.071692</td>\n",
        "      <td>33</td>\n",
        "    </tr>\n",
@@ -452,10 +466,10 @@
        "</div>"
       ],
       "text/plain": [
-       "   pagerank  vertex\n",
-       "2  0.100917      34\n",
-       "3  0.096999       1\n",
-       "4  0.071692      33"
+       "    pagerank  vertex\n",
+       "16  0.100917      34\n",
+       "17  0.096999       1\n",
+       "18  0.071692      33"
       ]
      },
      "execution_count": 17,
@@ -517,39 +531,32 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>16</th>\n",
        "      <td>17</td>\n",
        "      <td>17</td>\n",
        "      <td>34</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>17</th>\n",
        "      <td>16</td>\n",
        "      <td>16</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>18</th>\n",
        "      <td>12</td>\n",
        "      <td>12</td>\n",
        "      <td>33</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>10</td>\n",
-       "      <td>10</td>\n",
-       "      <td>3</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   in_degree  out_degree  vertex\n",
-       "2         17          17      34\n",
-       "3         16          16       1\n",
-       "4         12          12      33\n",
-       "5         10          10       3"
+       "    in_degree  out_degree  vertex\n",
+       "16         17          17      34\n",
+       "17         16          16       1\n",
+       "18         12          12      33"
       ]
      },
      "execution_count": 19,
@@ -558,7 +565,7 @@
     }
    ],
    "source": [
-    "d.sort_values('out_degree', ascending=False).head(4)"
+    "d.sort_values('out_degree', ascending=False).head(3)"
    ]
   },
   {
@@ -585,7 +592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -597,7 +604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -606,7 +613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -636,17 +643,17 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>22</th>\n",
+       "      <th>4</th>\n",
        "      <td>0.121756</td>\n",
        "      <td>26</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>28</th>\n",
+       "      <th>10</th>\n",
        "      <td>0.085409</td>\n",
        "      <td>17</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>17</th>\n",
        "      <td>0.077714</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
@@ -656,12 +663,12 @@
       ],
       "text/plain": [
        "    pagerank  vertex\n",
-       "22  0.121756      26\n",
-       "28  0.085409      17\n",
-       "3   0.077714       1"
+       "4   0.121756      26\n",
+       "10  0.085409      17\n",
+       "17  0.077714       1"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -672,7 +679,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -702,12 +709,12 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>22</th>\n",
+       "      <th>4</th>\n",
        "      <td>0.021006</td>\n",
        "      <td>26</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>28</th>\n",
+       "      <th>10</th>\n",
        "      <td>0.016785</td>\n",
        "      <td>17</td>\n",
        "    </tr>\n",
@@ -717,11 +724,11 @@
       ],
       "text/plain": [
        "    pagerank  vertex\n",
-       "22  0.021006      26\n",
-       "28  0.016785      17"
+       "4   0.021006      26\n",
+       "10  0.016785      17"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -747,9 +754,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cugraph_dev",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "cugraph_dev"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -761,7 +768,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/link_analysis/Pagerank.ipynb
+++ b/notebooks/link_analysis/Pagerank.ipynb
@@ -718,6 +718,11 @@
        "      <td>0.016785</td>\n",
        "      <td>17</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>0.096999</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
@@ -725,7 +730,8 @@
       "text/plain": [
        "    pagerank  vertex\n",
        "4   0.021006      26\n",
-       "10  0.016785      17"
+       "10  0.016785      17\n",
+       "17  0.096999       1"
       ]
      },
      "execution_count": 23,
@@ -735,7 +741,7 @@
    ],
    "source": [
     "# looking at the initial PageRank values\n",
-    "gdf_page[gdf_page['vertex'].isin([17,26])]"
+    "gdf_page[gdf_page['vertex'].isin([26,17,1])]"
    ]
   },
   {


### PR DESCRIPTION
Fixes some small inconsistencies between code blocks / diagrams and their associated captions in the Pagerank notebook. We might want to resolve the FutureWarning raised in `from_cudf_edgelist` first, as it crops up in the outputs (xref https://github.com/rapidsai/cugraph/issues/2174).

Closes #2182