### PR TITLE
renaming detail space functions

### DIFF
--- a/cpp/include/cugraph/prims/copy_v_transform_reduce_in_out_nbr.cuh
+++ b/cpp/include/cugraph/prims/copy_v_transform_reduce_in_out_nbr.cuh
@@ -44,7 +44,7 @@ namespace cugraph {
 
 namespace detail {
 
-int32_t constexpr copy_v_transform_reduce_nbr_for_all_block_size = 512;
+int32_t constexpr copy_v_transform_reduce_nbr_kernel_block_size = 512;
 
 template <bool update_major,
           typename GraphViewType,
@@ -56,7 +56,7 @@ template <bool update_major,
           ,
           typename EdgeOp,
           typename T>
-__global__ void for_all_major_for_all_nbr_hypersparse(
+__global__ void copy_v_transform_reduce_nbr_hypersparse(
   edge_partition_device_view_t<typename GraphViewType::vertex_type,
                                typename GraphViewType::edge_type,
                                typename GraphViewType::weight_type,
@@ -169,7 +169,7 @@ template <bool update_major,
           ,
           typename EdgeOp,
           typename T>
-__global__ void for_all_major_for_all_nbr_low_degree(
+__global__ void copy_v_transform_reduce_nbr_low_degree(
   edge_partition_device_view_t<typename GraphViewType::vertex_type,
                                typename GraphViewType::edge_type,
                                typename GraphViewType::weight_type,
@@ -281,7 +281,7 @@ template <bool update_major,
           ,
           typename EdgeOp,
           typename T>
-__global__ void for_all_major_for_all_nbr_mid_degree(
+__global__ void copy_v_transform_reduce_nbr_mid_degree(
   edge_partition_device_view_t<typename GraphViewType::vertex_type,
                                typename GraphViewType::edge_type,
                                typename GraphViewType::weight_type,
@@ -300,7 +300,7 @@ __global__ void for_all_major_for_all_nbr_mid_degree(
   using e_op_result_t = T;
 
   auto const tid = threadIdx.x + blockIdx.x * blockDim.x;
-  static_assert(copy_v_transform_reduce_nbr_for_all_block_size % raft::warp_size() == 0);
+  static_assert(copy_v_transform_reduce_nbr_kernel_block_size % raft::warp_size() == 0);
   auto const lane_id = tid % raft::warp_size();
   auto major_start_offset =
     static_cast<size_t>(major_range_first - edge_partition.major_range_first());
@@ -308,7 +308,7 @@ __global__ void for_all_major_for_all_nbr_mid_degree(
 
   using WarpReduce = cub::WarpReduce<e_op_result_t>;
   [[maybe_unused]] __shared__ typename WarpReduce::TempStorage
-    temp_storage[copy_v_transform_reduce_nbr_for_all_block_size /
+    temp_storage[copy_v_transform_reduce_nbr_kernel_block_size /
                  raft::warp_size()];  // relevant only if update_major == true
 
   [[maybe_unused]] property_op<e_op_result_t, thrust::plus>
@@ -376,7 +376,7 @@ template <bool update_major,
           ,
           typename EdgeOp,
           typename T>
-__global__ void for_all_major_for_all_nbr_high_degree(
+__global__ void copy_v_transform_reduce_nbr_high_degree(
   edge_partition_device_view_t<typename GraphViewType::vertex_type,
                                typename GraphViewType::edge_type,
                                typename GraphViewType::weight_type,
@@ -399,7 +399,7 @@ __global__ void for_all_major_for_all_nbr_high_degree(
   auto idx = static_cast<size_t>(blockIdx.x);
 
   using BlockReduce =
-    cub::BlockReduce<e_op_result_t, copy_v_transform_reduce_nbr_for_all_block_size>;
+    cub::BlockReduce<e_op_result_t, copy_v_transform_reduce_nbr_kernel_block_size>;
   [[maybe_unused]] __shared__
     typename BlockReduce::TempStorage temp_storage;  // relevant only if update_major == true
 
@@ -650,7 +650,7 @@ void copy_v_transform_reduce_nbr(raft::handle_t const& handle,
             : handle.get_stream();
         if constexpr (update_major) {  // this is necessary as we don't visit every vertex in the
                                        // hypersparse segment in
-                                       // for_all_major_for_all_nbr_hypersparse
+                                       // copy_v_transform_reduce_nbr_hypersparse
           thrust::fill(rmm::exec_policy(exec_stream),
                        output_buffer + (*segment_offsets)[3],
                        output_buffer + (*segment_offsets)[4],
@@ -658,11 +658,11 @@ void copy_v_transform_reduce_nbr(raft::handle_t const& handle,
         }
         if (*(edge_partition.dcs_nzd_vertex_count()) > 0) {
           raft::grid_1d_thread_t update_grid(*(edge_partition.dcs_nzd_vertex_count()),
-                                             detail::copy_v_transform_reduce_nbr_for_all_block_size,
+                                             detail::copy_v_transform_reduce_nbr_kernel_block_size,
                                              handle.get_device_properties().maxGridSize[0]);
           auto segment_output_buffer = output_buffer;
           if constexpr (update_major) { segment_output_buffer += (*segment_offsets)[3]; }
-          detail::for_all_major_for_all_nbr_hypersparse<update_major, GraphViewType>
+          detail::copy_v_transform_reduce_nbr_hypersparse<update_major, GraphViewType>
             <<<update_grid.num_blocks, update_grid.block_size, 0, exec_stream>>>(
               edge_partition,
               edge_partition.major_range_first() + (*segment_offsets)[3],
@@ -679,11 +679,11 @@ void copy_v_transform_reduce_nbr(raft::handle_t const& handle,
                                                                   (*stream_pool_indices).size())
                              : handle.get_stream();
         raft::grid_1d_thread_t update_grid((*segment_offsets)[3] - (*segment_offsets)[2],
-                                           detail::copy_v_transform_reduce_nbr_for_all_block_size,
+                                           detail::copy_v_transform_reduce_nbr_kernel_block_size,
                                            handle.get_device_properties().maxGridSize[0]);
         auto segment_output_buffer = output_buffer;
         if constexpr (update_major) { segment_output_buffer += (*segment_offsets)[2]; }
-        detail::for_all_major_for_all_nbr_low_degree<update_major, GraphViewType>
+        detail::copy_v_transform_reduce_nbr_low_degree<update_major, GraphViewType>
           <<<update_grid.num_blocks, update_grid.block_size, 0, exec_stream>>>(
             edge_partition,
             edge_partition.major_range_first() + (*segment_offsets)[2],
@@ -700,11 +700,11 @@ void copy_v_transform_reduce_nbr(raft::handle_t const& handle,
                                                                   (*stream_pool_indices).size())
                              : handle.get_stream();
         raft::grid_1d_warp_t update_grid((*segment_offsets)[2] - (*segment_offsets)[1],
-                                         detail::copy_v_transform_reduce_nbr_for_all_block_size,
+                                         detail::copy_v_transform_reduce_nbr_kernel_block_size,
                                          handle.get_device_properties().maxGridSize[0]);
         auto segment_output_buffer = output_buffer;
         if constexpr (update_major) { segment_output_buffer += (*segment_offsets)[1]; }
-        detail::for_all_major_for_all_nbr_mid_degree<update_major, GraphViewType>
+        detail::copy_v_transform_reduce_nbr_mid_degree<update_major, GraphViewType>
           <<<update_grid.num_blocks, update_grid.block_size, 0, exec_stream>>>(
             edge_partition,
             edge_partition.major_range_first() + (*segment_offsets)[1],
@@ -721,9 +721,9 @@ void copy_v_transform_reduce_nbr(raft::handle_t const& handle,
                                                                   (*stream_pool_indices).size())
                              : handle.get_stream();
         raft::grid_1d_block_t update_grid((*segment_offsets)[1],
-                                          detail::copy_v_transform_reduce_nbr_for_all_block_size,
+                                          detail::copy_v_transform_reduce_nbr_kernel_block_size,
                                           handle.get_device_properties().maxGridSize[0]);
-        detail::for_all_major_for_all_nbr_high_degree<update_major, GraphViewType>
+        detail::copy_v_transform_reduce_nbr_high_degree<update_major, GraphViewType>
           <<<update_grid.num_blocks, update_grid.block_size, 0, exec_stream>>>(
             edge_partition,
             edge_partition.major_range_first(),
@@ -737,9 +737,9 @@ void copy_v_transform_reduce_nbr(raft::handle_t const& handle,
     } else {
       if (edge_partition.major_range_size() > 0) {
         raft::grid_1d_thread_t update_grid(edge_partition.major_range_size(),
-                                           detail::copy_v_transform_reduce_nbr_for_all_block_size,
+                                           detail::copy_v_transform_reduce_nbr_kernel_block_size,
                                            handle.get_device_properties().maxGridSize[0]);
-        detail::for_all_major_for_all_nbr_low_degree<update_major, GraphViewType>
+        detail::copy_v_transform_reduce_nbr_low_degree<update_major, GraphViewType>
           <<<update_grid.num_blocks, update_grid.block_size, 0, handle.get_stream()>>>(
             edge_partition,
             edge_partition.major_range_first(),

--- a/cpp/include/cugraph/prims/update_frontier_v_push_if_out_nbr.cuh
+++ b/cpp/include/cugraph/prims/update_frontier_v_push_if_out_nbr.cuh
@@ -55,7 +55,7 @@ namespace cugraph {
 
 namespace detail {
 
-int32_t constexpr update_frontier_v_push_if_out_nbr_for_all_block_size = 512;
+int32_t constexpr update_frontier_v_push_if_out_nbr_kernel_block_size = 512;
 
 // we cannot use std::iterator_traits<Iterator>::value_type if Iterator is void* (reference to void
 // is not allowed)
@@ -216,7 +216,7 @@ template <typename GraphViewType,
           typename BufferKeyOutputIterator,
           typename BufferPayloadOutputIterator,
           typename EdgeOp>
-__global__ void for_all_frontier_src_for_all_nbr_hypersparse(
+__global__ void update_frontier_v_push_if_out_nbr_hypersparse(
   edge_partition_device_view_t<typename GraphViewType::vertex_type,
                                typename GraphViewType::edge_type,
                                typename GraphViewType::weight_type,
@@ -256,14 +256,14 @@ __global__ void for_all_frontier_src_for_all_nbr_hypersparse(
   auto idx = static_cast<size_t>(tid);
 
   __shared__ edge_t
-    warp_local_degree_inclusive_sums[update_frontier_v_push_if_out_nbr_for_all_block_size];
+    warp_local_degree_inclusive_sums[update_frontier_v_push_if_out_nbr_kernel_block_size];
   __shared__ edge_t
-    warp_key_local_edge_offsets[update_frontier_v_push_if_out_nbr_for_all_block_size];
+    warp_key_local_edge_offsets[update_frontier_v_push_if_out_nbr_kernel_block_size];
 
   using WarpScan = cub::WarpScan<edge_t, raft::warp_size()>;
   __shared__ typename WarpScan::TempStorage temp_storage;
 
-  __shared__ size_t buffer_warp_start_indices[update_frontier_v_push_if_out_nbr_for_all_block_size /
+  __shared__ size_t buffer_warp_start_indices[update_frontier_v_push_if_out_nbr_kernel_block_size /
                                               raft::warp_size()];
 
   auto indices = edge_partition.indices();
@@ -386,7 +386,7 @@ template <typename GraphViewType,
           typename BufferKeyOutputIterator,
           typename BufferPayloadOutputIterator,
           typename EdgeOp>
-__global__ void for_all_frontier_src_for_all_nbr_low_degree(
+__global__ void update_frontier_v_push_if_out_nbr_low_degree(
   edge_partition_device_view_t<typename GraphViewType::vertex_type,
                                typename GraphViewType::edge_type,
                                typename GraphViewType::weight_type,
@@ -423,14 +423,14 @@ __global__ void for_all_frontier_src_for_all_nbr_low_degree(
   auto idx           = static_cast<size_t>(tid);
 
   __shared__ edge_t
-    warp_local_degree_inclusive_sums[update_frontier_v_push_if_out_nbr_for_all_block_size];
+    warp_local_degree_inclusive_sums[update_frontier_v_push_if_out_nbr_kernel_block_size];
   __shared__ edge_t
-    warp_key_local_edge_offsets[update_frontier_v_push_if_out_nbr_for_all_block_size];
+    warp_key_local_edge_offsets[update_frontier_v_push_if_out_nbr_kernel_block_size];
 
   using WarpScan = cub::WarpScan<edge_t, raft::warp_size()>;
   __shared__ typename WarpScan::TempStorage temp_storage;
 
-  __shared__ size_t buffer_warp_start_indices[update_frontier_v_push_if_out_nbr_for_all_block_size /
+  __shared__ size_t buffer_warp_start_indices[update_frontier_v_push_if_out_nbr_kernel_block_size /
                                               raft::warp_size()];
 
   auto indices = edge_partition.indices();
@@ -546,7 +546,7 @@ template <typename GraphViewType,
           typename BufferKeyOutputIterator,
           typename BufferPayloadOutputIterator,
           typename EdgeOp>
-__global__ void for_all_frontier_src_for_all_nbr_mid_degree(
+__global__ void update_frontier_v_push_if_out_nbr_mid_degree(
   edge_partition_device_view_t<typename GraphViewType::vertex_type,
                                typename GraphViewType::edge_type,
                                typename GraphViewType::weight_type,
@@ -578,12 +578,12 @@ __global__ void for_all_frontier_src_for_all_nbr_mid_degree(
                 "GraphViewType should support the push model.");
 
   auto const tid = threadIdx.x + blockIdx.x * blockDim.x;
-  static_assert(update_frontier_v_push_if_out_nbr_for_all_block_size % raft::warp_size() == 0);
+  static_assert(update_frontier_v_push_if_out_nbr_kernel_block_size % raft::warp_size() == 0);
   auto const warp_id = threadIdx.x / raft::warp_size();
   auto const lane_id = tid % raft::warp_size();
   auto idx           = static_cast<size_t>(tid / raft::warp_size());
 
-  __shared__ size_t buffer_warp_start_indices[update_frontier_v_push_if_out_nbr_for_all_block_size /
+  __shared__ size_t buffer_warp_start_indices[update_frontier_v_push_if_out_nbr_kernel_block_size /
                                               raft::warp_size()];
   while (idx < static_cast<size_t>(thrust::distance(key_first, key_last))) {
     auto key = *(key_first + idx);
@@ -653,7 +653,7 @@ template <typename GraphViewType,
           typename BufferKeyOutputIterator,
           typename BufferPayloadOutputIterator,
           typename EdgeOp>
-__global__ void for_all_frontier_src_for_all_nbr_high_degree(
+__global__ void update_frontier_v_push_if_out_nbr_high_degree(
   edge_partition_device_view_t<typename GraphViewType::vertex_type,
                                typename GraphViewType::edge_type,
                                typename GraphViewType::weight_type,
@@ -686,7 +686,7 @@ __global__ void for_all_frontier_src_for_all_nbr_high_degree(
 
   auto idx = static_cast<size_t>(blockIdx.x);
 
-  using BlockScan = cub::BlockScan<edge_t, update_frontier_v_push_if_out_nbr_for_all_block_size>;
+  using BlockScan = cub::BlockScan<edge_t, update_frontier_v_push_if_out_nbr_kernel_block_size>;
   __shared__ typename BlockScan::TempStorage temp_storage;
   __shared__ size_t buffer_block_start_idx;
 
@@ -705,9 +705,9 @@ __global__ void for_all_frontier_src_for_all_nbr_high_degree(
     thrust::tie(indices, weights, local_out_degree) = edge_partition.local_edges(src_offset);
     auto rounded_up_local_out_degree =
       ((static_cast<size_t>(local_out_degree) +
-        (update_frontier_v_push_if_out_nbr_for_all_block_size - 1)) /
-       update_frontier_v_push_if_out_nbr_for_all_block_size) *
-      update_frontier_v_push_if_out_nbr_for_all_block_size;
+        (update_frontier_v_push_if_out_nbr_kernel_block_size - 1)) /
+       update_frontier_v_push_if_out_nbr_kernel_block_size) *
+      update_frontier_v_push_if_out_nbr_kernel_block_size;
     for (size_t i = threadIdx.x; i < rounded_up_local_out_degree; i += blockDim.x) {
       e_op_result_t e_op_result{};
       vertex_t dst{};
@@ -1175,9 +1175,9 @@ void update_frontier_v_push_if_out_nbr(
       if (h_offsets[0] > 0) {
         raft::grid_1d_block_t update_grid(
           h_offsets[0],
-          detail::update_frontier_v_push_if_out_nbr_for_all_block_size,
+          detail::update_frontier_v_push_if_out_nbr_kernel_block_size,
           handle.get_device_properties().maxGridSize[0]);
-        detail::for_all_frontier_src_for_all_nbr_high_degree<GraphViewType>
+        detail::update_frontier_v_push_if_out_nbr_high_degree<GraphViewType>
           <<<update_grid.num_blocks, update_grid.block_size, 0, handle.get_stream()>>>(
             edge_partition,
             get_dataframe_buffer_begin(edge_partition_frontier_key_buffer),
@@ -1192,9 +1192,9 @@ void update_frontier_v_push_if_out_nbr(
       if (h_offsets[1] - h_offsets[0] > 0) {
         raft::grid_1d_warp_t update_grid(
           h_offsets[1] - h_offsets[0],
-          detail::update_frontier_v_push_if_out_nbr_for_all_block_size,
+          detail::update_frontier_v_push_if_out_nbr_kernel_block_size,
           handle.get_device_properties().maxGridSize[0]);
-        detail::for_all_frontier_src_for_all_nbr_mid_degree<GraphViewType>
+        detail::update_frontier_v_push_if_out_nbr_mid_degree<GraphViewType>
           <<<update_grid.num_blocks, update_grid.block_size, 0, handle.get_stream()>>>(
             edge_partition,
             get_dataframe_buffer_begin(edge_partition_frontier_key_buffer) + h_offsets[0],
@@ -1209,9 +1209,9 @@ void update_frontier_v_push_if_out_nbr(
       if (h_offsets[2] - h_offsets[1] > 0) {
         raft::grid_1d_thread_t update_grid(
           h_offsets[2] - h_offsets[1],
-          detail::update_frontier_v_push_if_out_nbr_for_all_block_size,
+          detail::update_frontier_v_push_if_out_nbr_kernel_block_size,
           handle.get_device_properties().maxGridSize[0]);
-        detail::for_all_frontier_src_for_all_nbr_low_degree<GraphViewType>
+        detail::update_frontier_v_push_if_out_nbr_low_degree<GraphViewType>
           <<<update_grid.num_blocks, update_grid.block_size, 0, handle.get_stream()>>>(
             edge_partition,
             get_dataframe_buffer_begin(edge_partition_frontier_key_buffer) + h_offsets[1],
@@ -1226,9 +1226,9 @@ void update_frontier_v_push_if_out_nbr(
       if (edge_partition.dcs_nzd_vertex_count() && (h_offsets[3] - h_offsets[2] > 0)) {
         raft::grid_1d_thread_t update_grid(
           h_offsets[3] - h_offsets[2],
-          detail::update_frontier_v_push_if_out_nbr_for_all_block_size,
+          detail::update_frontier_v_push_if_out_nbr_kernel_block_size,
           handle.get_device_properties().maxGridSize[0]);
-        detail::for_all_frontier_src_for_all_nbr_hypersparse<GraphViewType>
+        detail::update_frontier_v_push_if_out_nbr_hypersparse<GraphViewType>
           <<<update_grid.num_blocks, update_grid.block_size, 0, handle.get_stream()>>>(
             edge_partition,
             edge_partition.major_range_first() + (*segment_offsets)[3],
@@ -1245,10 +1245,10 @@ void update_frontier_v_push_if_out_nbr(
       if (edge_partition_frontier_size > 0) {
         raft::grid_1d_thread_t update_grid(
           edge_partition_frontier_size,
-          detail::update_frontier_v_push_if_out_nbr_for_all_block_size,
+          detail::update_frontier_v_push_if_out_nbr_kernel_block_size,
           handle.get_device_properties().maxGridSize[0]);
 
-        detail::for_all_frontier_src_for_all_nbr_low_degree<GraphViewType>
+        detail::update_frontier_v_push_if_out_nbr_low_degree<GraphViewType>
           <<<update_grid.num_blocks, update_grid.block_size, 0, handle.get_stream()>>>(
             edge_partition,
             get_dataframe_buffer_begin(edge_partition_frontier_key_buffer),


### PR DESCRIPTION
To address the comment in https://github.com/rapidsai/cugraph/pull/2117#discussion_r828304519

Device kernels for graph primitives for different vertex degree ranges had been named `for_all_major_for_all_nbr_...`. This is subject to naming conflicts and @kaatish established a better naming convention to avoid this. This PR applies the same naming conventions to other graph primitives.