### PR TITLE
Address some MNMG issues in cython.cu

### DIFF
--- a/cpp/include/cugraph/utilities/cython.hpp
+++ b/cpp/include/cugraph/utilities/cython.hpp
@@ -594,9 +594,10 @@ std::unique_ptr<major_minor_weights_t<vertex_t, edge_t, weight_t>> call_shuffle(
     edgelist_major_vertices,  // [IN / OUT]: groupby_gpu_id_and_shuffle_values() sorts in-place
   vertex_t* edgelist_minor_vertices,  // [IN / OUT]
   weight_t* edgelist_weights,         // [IN / OUT]
-  edge_t num_edgelist_edges);
+  edge_t num_edgelist_edges,
+  bool is_weighted);
 
-// Wrapper for calling renumber_edeglist() inplace:
+// Wrapper for calling renumber_edgelist() inplace:
 //
 template <typename vertex_t, typename edge_t>
 std::unique_ptr<renum_tuple_t<vertex_t, edge_t>> call_renumber(

--- a/cpp/src/utilities/cython.cu
+++ b/cpp/src/utilities/cython.cu
@@ -1185,7 +1185,8 @@ std::unique_ptr<major_minor_weights_t<vertex_t, edge_t, weight_t>> call_shuffle(
     edgelist_major_vertices,  // [IN / OUT]: groupby_gpu_id_and_shuffle_values() sorts in-place
   vertex_t* edgelist_minor_vertices,  // [IN / OUT]
   weight_t* edgelist_weights,         // [IN / OUT]
-  edge_t num_edgelist_edges)
+  edge_t num_edgelist_edges,
+  bool is_weighted)
 {
   auto& comm               = handle.get_comms();
   auto const comm_size     = comm.get_size();
@@ -1197,7 +1198,7 @@ std::unique_ptr<major_minor_weights_t<vertex_t, edge_t, weight_t>> call_shuffle(
   std::unique_ptr<major_minor_weights_t<vertex_t, edge_t, weight_t>> ptr_ret =
     std::make_unique<major_minor_weights_t<vertex_t, edge_t, weight_t>>(handle);
 
-  if (edgelist_weights != nullptr) {
+  if (is_weighted) {
     auto zip_edge = thrust::make_zip_iterator(
       thrust::make_tuple(edgelist_major_vertices, edgelist_minor_vertices, edgelist_weights));
 
@@ -1242,7 +1243,7 @@ std::unique_ptr<major_minor_weights_t<vertex_t, edge_t, weight_t>> call_shuffle(
   auto pair_first = thrust::make_zip_iterator(
     thrust::make_tuple(ptr_ret->get_major().data(), ptr_ret->get_minor().data()));
 
-  auto edge_counts = (edgelist_weights != nullptr)
+  auto edge_counts = (is_weighted)
                        ? cugraph::groupby_and_count(pair_first,
                                                     pair_first + ptr_ret->get_major().size(),
                                                     ptr_ret->get_weights().data(),
@@ -1639,42 +1640,48 @@ template std::unique_ptr<major_minor_weights_t<int32_t, int32_t, float>> call_sh
   int32_t* edgelist_major_vertices,
   int32_t* edgelist_minor_vertices,
   float* edgelist_weights,
-  int32_t num_edgelist_edges);
+  int32_t num_edgelist_edges,
+  bool is_weighted);
 
 template std::unique_ptr<major_minor_weights_t<int32_t, int64_t, float>> call_shuffle(
   raft::handle_t const& handle,
   int32_t* edgelist_major_vertices,
   int32_t* edgelist_minor_vertices,
   float* edgelist_weights,
-  int64_t num_edgelist_edges);
+  int64_t num_edgelist_edges,
+  bool is_weighted);
 
 template std::unique_ptr<major_minor_weights_t<int32_t, int32_t, double>> call_shuffle(
   raft::handle_t const& handle,
   int32_t* edgelist_major_vertices,
   int32_t* edgelist_minor_vertices,
   double* edgelist_weights,
-  int32_t num_edgelist_edges);
+  int32_t num_edgelist_edges,
+  bool is_weighted);
 
 template std::unique_ptr<major_minor_weights_t<int32_t, int64_t, double>> call_shuffle(
   raft::handle_t const& handle,
   int32_t* edgelist_major_vertices,
   int32_t* edgelist_minor_vertices,
   double* edgelist_weights,
-  int64_t num_edgelist_edges);
+  int64_t num_edgelist_edges,
+  bool is_weighted);
 
 template std::unique_ptr<major_minor_weights_t<int64_t, int64_t, float>> call_shuffle(
   raft::handle_t const& handle,
   int64_t* edgelist_major_vertices,
   int64_t* edgelist_minor_vertices,
   float* edgelist_weights,
-  int64_t num_edgelist_edges);
+  int64_t num_edgelist_edges,
+  bool is_weighted);
 
 template std::unique_ptr<major_minor_weights_t<int64_t, int64_t, double>> call_shuffle(
   raft::handle_t const& handle,
   int64_t* edgelist_major_vertices,
   int64_t* edgelist_minor_vertices,
   double* edgelist_weights,
-  int64_t num_edgelist_edges);
+  int64_t num_edgelist_edges,
+  bool is_weighted);
 
 // TODO: add the remaining relevant EIDIr's:
 //

--- a/python/cugraph/cugraph/structure/graph_utilities.pxd
+++ b/python/cugraph/cugraph/structure/graph_utilities.pxd
@@ -182,7 +182,8 @@ cdef extern from "cugraph/utilities/cython.hpp" namespace "cugraph::cython":
         vertex_t *edgelist_major_vertices,
         vertex_t *edgelist_minor_vertices,
         weight_t* edgelist_weights,
-        edge_t num_edges) except +
+        edge_t num_edges,
+        bool is_weighted) except +
 
 # 5. `renumber_edgelist()` wrapper
 #

--- a/python/cugraph/cugraph/structure/renumber_wrapper.pyx
+++ b/python/cugraph/cugraph/structure/renumber_wrapper.pyx
@@ -54,10 +54,12 @@ cdef renumber_helper(shuffled_vertices_t* ptr_maj_min_w, vertex_t, weights):
     # which is not supported by '__cuda_array_interface__'
     if shuffled_major_series is None:
         shuffled_major_series = cudf.Series(dtype=vertex_t)
+    else:
+        shuffled_df['major_vertices']= shuffled_major_series
     if shuffled_minor_series is None:
         shuffled_minor_series = cudf.Series(dtype=vertex_t)
-    shuffled_df['major_vertices']= shuffled_major_series
-    shuffled_df['minor_vertices']= shuffled_minor_series
+    else:
+        shuffled_df['minor_vertices']= shuffled_minor_series
 
     if weights is not None:
         weight_t = weights.dtype

--- a/python/cugraph/cugraph/structure/renumber_wrapper.pyx
+++ b/python/cugraph/cugraph/structure/renumber_wrapper.pyx
@@ -65,7 +65,8 @@ cdef renumber_helper(shuffled_vertices_t* ptr_maj_min_w, vertex_t, weights):
             move(pair_s_weights.first), weight_t, "shuffled_weights")
         if shuffled_weights_series is None:
             shuffled_df['value']= cudf.Series(dtype=weight_t)
-        shuffled_df['value']= shuffled_weights_series
+        else:
+            shuffled_df['value']= shuffled_weights_series
 
     return shuffled_df
 
@@ -176,7 +177,8 @@ def renumber(input_df,           # maybe use cpdef ?
                                                                            <int*>c_major_vertices,
                                                                            <int*>c_minor_vertices,
                                                                            <float*>c_edge_weights,
-                                                                           num_local_edges).release())
+                                                                           num_local_edges,
+                                                                           weights is not None).release())
                     shuffled_df = renumber_helper(ptr_shuffled_32_32_32.get(), vertex_t, weights)
                     major_vertices = shuffled_df['major_vertices']
                     minor_vertices = shuffled_df['minor_vertices']
@@ -245,7 +247,8 @@ def renumber(input_df,           # maybe use cpdef ?
                                                                             <int*>c_major_vertices,
                                                                             <int*>c_minor_vertices,
                                                                             <double*>c_edge_weights,
-                                                                            num_local_edges).release())
+                                                                            num_local_edges,
+                                                                            weights is not None).release())
 
                     shuffled_df = renumber_helper(ptr_shuffled_32_32_64.get(), vertex_t, weights)
                     major_vertices = shuffled_df['major_vertices']
@@ -317,7 +320,8 @@ def renumber(input_df,           # maybe use cpdef ?
                                                                             <int*>c_major_vertices,
                                                                             <int*>c_minor_vertices,
                                                                             <float*>c_edge_weights,
-                                                                            num_local_edges).release())
+                                                                            num_local_edges,
+                                                                            weights is not None).release())
 
                     shuffled_df = renumber_helper(ptr_shuffled_32_64_32.get(), vertex_t, weights)
                     major_vertices = shuffled_df['major_vertices']
@@ -387,7 +391,8 @@ def renumber(input_df,           # maybe use cpdef ?
                                                                              <int*>c_major_vertices,
                                                                              <int*>c_minor_vertices,
                                                                              <double*>c_edge_weights,
-                                                                             num_local_edges).release())
+                                                                             num_local_edges,
+                                                                             weights is not None).release())
 
                     shuffled_df = renumber_helper(ptr_shuffled_32_64_64.get(), vertex_t, weights)
                     major_vertices = shuffled_df['major_vertices']
@@ -459,7 +464,8 @@ def renumber(input_df,           # maybe use cpdef ?
                                                                             <long*>c_major_vertices,
                                                                             <long*>c_minor_vertices,
                                                                             <float*>c_edge_weights,
-                                                                            num_local_edges).release())
+                                                                            num_local_edges,
+                                                                            weights is not None).release())
 
                     shuffled_df = renumber_helper(ptr_shuffled_64_64_32.get(), vertex_t, weights)
                     major_vertices = shuffled_df['major_vertices']
@@ -530,7 +536,8 @@ def renumber(input_df,           # maybe use cpdef ?
                                                                               <long*>c_major_vertices,
                                                                               <long*>c_minor_vertices,
                                                                               <double*>c_edge_weights,
-                                                                              num_local_edges).release())
+                                                                              num_local_edges,
+                                                                              weights is not None).release())
 
                     shuffled_df = renumber_helper(ptr_shuffled_64_64_64.get(), vertex_t, weights)
                     major_vertices = shuffled_df['major_vertices']


### PR DESCRIPTION
Closes #2217 

The issue identifies some issues if the partitioning ends up with some empty partitions.  There were two issues here:
 1. The `call_shuffle` method determines whether a graph has weights by comparing the weight pointer to `nullptr`.  But if an MNMG partition is empty then the weight pointer will be `nullptr` even if the graph has weights.  Added a parameter to identify if the graph is weighted.
 2. The `renumber_helper` method was missing an else and was overwriting the correct value with an invalid value if the return from shuffling on a gpu had no entries.

These are corrected in the PR.