### PR TITLE
add API for the new uniform neighborhood sampling

### DIFF
--- a/cpp/include/cugraph_c/algorithms.h
+++ b/cpp/include/cugraph_c/algorithms.h
@@ -307,11 +307,40 @@ typedef struct {
  *                           be populated if error code is not CUGRAPH_SUCCESS
  * @return error code
  */
+// FIXME: This older API will be phased out this release in favor of the experimental one below
 cugraph_error_code_t cugraph_uniform_neighbor_sample(
   const cugraph_resource_handle_t* handle,
   cugraph_graph_t* graph,
   const cugraph_type_erased_device_array_view_t* start,
   const cugraph_type_erased_device_array_view_t* start_label,
+  const cugraph_type_erased_host_array_view_t* fan_out,
+  bool_t with_replacement,
+  bool_t do_expensive_check,
+  cugraph_sample_result_t** result,
+  cugraph_error_t** error);
+
+/**
+ * @brief     Uniform Neighborhood Sampling
+ *
+ * @param [in]  handle       Handle for accessing resources
+ * @param [in]  graph        Pointer to graph.  NOTE: Graph might be modified if the storage
+ *                           needs to be transposed
+ * @param [in]  start        Device array of start vertices for the sampling
+ * @param [in]  fanout       Host array defining the fan out at each step in the sampling algorithm
+ * @param [in]  with_replacement
+ *                           Boolean value.  If true selection of edges is done with
+ *                           replacement.  If false selection is done without replacement.
+ * @param [in]  do_expensive_check
+ *                           A flag to run expensive checks for input arguments (if set to true)
+ * @param [in]  result       Output from the uniform_neighbor_sample call
+ * @param [out] error        Pointer to an error object storing details of any error.  Will
+ *                           be populated if error code is not CUGRAPH_SUCCESS
+ * @return error code
+ */
+cugraph_error_code_t cugraph_experimental_uniform_neighbor_sample(
+  const cugraph_resource_handle_t* handle,
+  cugraph_graph_t* graph,
+  const cugraph_type_erased_device_array_view_t* start,
   const cugraph_type_erased_host_array_view_t* fan_out,
   bool_t with_replacement,
   bool_t do_expensive_check,
@@ -342,6 +371,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_destinations(
  * @param [in]   result   The result from a sampling algorithm
  * @return type erased array pointing to the start labels
  */
+// FIXME:  This will be obsolete when the older mechanism is removed
 cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_start_labels(
   const cugraph_sample_result_t* result);
 
@@ -360,6 +390,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_index(
  * @param [in]   result   The result from a sampling algorithm
  * @return type erased host array pointing to the counts
  */
+// FIXME:  This will be obsolete when the older mechanism is removed
 cugraph_type_erased_host_array_view_t* cugraph_sample_result_get_counts(
   const cugraph_sample_result_t* result);
 

--- a/cpp/src/c_api/uniform_neighbor_sampling.cpp
+++ b/cpp/src/c_api/uniform_neighbor_sampling.cpp
@@ -32,10 +32,13 @@ namespace cugraph {
 namespace c_api {
 
 struct cugraph_sample_result_t {
+  bool experimental_{true};
   cugraph_type_erased_device_array_t* src_{nullptr};
   cugraph_type_erased_device_array_t* dst_{nullptr};
+  // FIXME: Will be deleted once experimental replaces curren
   cugraph_type_erased_device_array_t* label_{nullptr};
   cugraph_type_erased_device_array_t* index_{nullptr};
+  // FIXME: Will be deleted once experimental replaces curren
   cugraph_type_erased_host_array_t* count_{nullptr};
 };
 
@@ -150,11 +153,124 @@ struct uniform_neighbor_sampling_functor : public cugraph::c_api::abstract_funct
                                                             do_expensive_check_);
 
       result_ = new cugraph::c_api::cugraph_sample_result_t{
+        false,
         new cugraph::c_api::cugraph_type_erased_device_array_t(srcs, graph_->vertex_type_),
         new cugraph::c_api::cugraph_type_erased_device_array_t(dsts, graph_->vertex_type_),
         new cugraph::c_api::cugraph_type_erased_device_array_t(labels, start_label_->type_),
         new cugraph::c_api::cugraph_type_erased_device_array_t(indices, graph_->edge_type_),
         new cugraph::c_api::cugraph_type_erased_host_array_t(counts, graph_->vertex_type_)};
+    }
+  }
+};
+
+struct experimental_uniform_neighbor_sampling_functor : public cugraph::c_api::abstract_functor {
+  raft::handle_t const& handle_;
+  cugraph::c_api::cugraph_graph_t* graph_{nullptr};
+  cugraph::c_api::cugraph_type_erased_device_array_view_t const* start_{nullptr};
+  cugraph::c_api::cugraph_type_erased_host_array_view_t const* fan_out_{nullptr};
+  bool with_replacement_{false};
+  bool do_expensive_check_{false};
+  cugraph::c_api::cugraph_sample_result_t* result_{nullptr};
+
+  experimental_uniform_neighbor_sampling_functor(
+    cugraph_resource_handle_t const* handle,
+    cugraph_graph_t* graph,
+    cugraph_type_erased_device_array_view_t const* start,
+    cugraph_type_erased_host_array_view_t const* fan_out,
+    bool with_replacement,
+    bool do_expensive_check)
+    : abstract_functor(),
+      handle_(*reinterpret_cast<cugraph::c_api::cugraph_resource_handle_t const*>(handle)->handle_),
+      graph_(reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(graph)),
+      start_(
+        reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(start)),
+      fan_out_(
+        reinterpret_cast<cugraph::c_api::cugraph_type_erased_host_array_view_t const*>(fan_out)),
+      with_replacement_(with_replacement),
+      do_expensive_check_(do_expensive_check)
+  {
+  }
+
+  template <typename vertex_t,
+            typename edge_t,
+            typename weight_t,
+            bool store_transposed,
+            bool multi_gpu>
+  void operator()()
+  {
+    // FIXME: Think about how to handle SG vice MG
+    if constexpr (!cugraph::is_candidate<vertex_t, edge_t, weight_t>::value) {
+      unsupported();
+    } else {
+#if 1
+      unsupported();
+#else
+      // IMPLEMENTATION WILL GO HERE
+
+      // uniform_nbr_sample expects store_transposed == false
+      if constexpr (store_transposed) {
+        error_code_ = cugraph::c_api::
+          transpose_storage<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>(
+            handle_, graph_, error_.get());
+        if (error_code_ != CUGRAPH_SUCCESS) return;
+      }
+
+      auto graph =
+        reinterpret_cast<cugraph::graph_t<vertex_t, edge_t, weight_t, false, multi_gpu>*>(
+          graph_->graph_);
+
+      auto graph_view = graph->view();
+
+      auto number_map = reinterpret_cast<rmm::device_uvector<vertex_t>*>(graph_->number_map_);
+
+      rmm::device_uvector<vertex_t> start(start_->size_, handle_.get_stream());
+      raft::copy(start.data(), start_->as_type<vertex_t>(), start.size(), handle_.get_stream());
+
+      //
+      // Need to renumber sources
+      //
+      cugraph::renumber_ext_vertices<vertex_t, multi_gpu>(
+        handle_,
+        start.data(),
+        start.size(),
+        number_map->data(),
+        graph_view.local_vertex_partition_range_first(),
+        graph_view.local_vertex_partition_range_last(),
+        false);
+
+      // C++ API wants an std::vector
+      std::vector<int> fan_out(fan_out_->size_);
+      std::copy_n(fan_out_->as_type<int>(), fan_out_->size_, fan_out.data());
+
+      auto&& [tmp_tuple, counts] = cugraph::uniform_nbr_sample(
+        handle_, graph_view, start.data(), start.size(), fan_out, with_replacement_);
+
+      auto&& [srcs, dsts, labels, indices] = tmp_tuple;
+
+      std::vector<vertex_t> vertex_partition_lasts = graph_view.vertex_partition_range_lasts();
+
+      cugraph::unrenumber_int_vertices<vertex_t, multi_gpu>(handle_,
+                                                            srcs.data(),
+                                                            srcs.size(),
+                                                            number_map->data(),
+                                                            vertex_partition_lasts,
+                                                            do_expensive_check_);
+
+      cugraph::unrenumber_int_vertices<vertex_t, multi_gpu>(handle_,
+                                                            dsts.data(),
+                                                            dsts.size(),
+                                                            number_map->data(),
+                                                            vertex_partition_lasts,
+                                                            do_expensive_check_);
+
+      result_ = new cugraph::c_api::cugraph_sample_result_t{
+        true,
+        new cugraph::c_api::cugraph_type_erased_device_array_t(srcs, graph_->vertex_type_),
+        new cugraph::c_api::cugraph_type_erased_device_array_t(dsts, graph_->vertex_type_),
+        nullptr,
+        new cugraph::c_api::cugraph_type_erased_device_array_t(indices, graph_->edge_type_),
+        nullptr};
+#endif
     }
   }
 };
@@ -174,6 +290,21 @@ extern "C" cugraph_error_code_t cugraph_uniform_neighbor_sample(
 {
   uniform_neighbor_sampling_functor functor{
     handle, graph, start, start_labels, fan_out, with_replacement, do_expensive_check};
+  return cugraph::c_api::run_algorithm(graph, functor, result, error);
+}
+
+extern "C" cugraph_error_code_t cugraph_experimental_uniform_neighbor_sample(
+  const cugraph_resource_handle_t* handle,
+  cugraph_graph_t* graph,
+  const cugraph_type_erased_device_array_view_t* start,
+  const cugraph_type_erased_host_array_view_t* fan_out,
+  bool_t with_replacement,
+  bool_t do_expensive_check,
+  cugraph_sample_result_t** result,
+  cugraph_error_t** error)
+{
+  experimental_uniform_neighbor_sampling_functor functor{
+    handle, graph, start, fan_out, with_replacement, do_expensive_check};
   return cugraph::c_api::run_algorithm(graph, functor, result, error);
 }
 

--- a/cpp/tests/c_api/mg_uniform_neighbor_sample_test.c
+++ b/cpp/tests/c_api/mg_uniform_neighbor_sample_test.c
@@ -25,6 +25,117 @@ typedef int32_t vertex_t;
 typedef int32_t edge_t;
 typedef float weight_t;
 
+int generic_experimental_uniform_neighbor_sample_test(const cugraph_resource_handle_t* handle,
+                                                      vertex_t* h_src,
+                                                      vertex_t* h_dst,
+                                                      weight_t* h_wgt,
+                                                      size_t num_vertices,
+                                                      size_t num_edges,
+                                                      vertex_t* h_start,
+                                                      size_t num_starts,
+                                                      int* fan_out,
+                                                      size_t max_depth,
+                                                      bool_t with_replacement,
+                                                      bool_t store_transposed)
+{
+  int test_ret_value = 0;
+
+  cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
+  cugraph_error_t* ret_error    = NULL;
+
+  cugraph_graph_t* graph          = NULL;
+  cugraph_sample_result_t* result = NULL;
+
+  cugraph_type_erased_device_array_t* d_start           = NULL;
+  cugraph_type_erased_device_array_view_t* d_start_view = NULL;
+  cugraph_type_erased_host_array_view_t* h_fan_out_view = NULL;
+
+  ret_code = create_mg_test_graph(
+    handle, h_src, h_dst, h_wgt, num_edges, store_transposed, FALSE, &graph, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "graph creation failed.");
+
+  ret_code =
+    cugraph_type_erased_device_array_create(handle, num_starts, INT32, &d_start, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "d_start create failed.");
+
+  d_start_view = cugraph_type_erased_device_array_view(d_start);
+
+  ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+    handle, d_start_view, (byte_t*)h_start, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "start copy_from_host failed.");
+
+  h_fan_out_view = cugraph_type_erased_host_array_view_create(fan_out, max_depth, INT32);
+
+  ret_code = cugraph_experimental_uniform_neighbor_sample(
+    handle, graph, d_start_view, h_fan_out_view, with_replacement, FALSE, &result, &ret_error);
+
+#if 0
+  // FIXME:  cugraph_experimental_uniform_neighbor_sample is not implemented yet
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "uniform_neighbor_sample failed.");
+
+  cugraph_type_erased_device_array_view_t* srcs;
+  cugraph_type_erased_device_array_view_t* dsts;
+  cugraph_type_erased_device_array_view_t* index;
+
+  srcs   = cugraph_sample_result_get_sources(result);
+  dsts   = cugraph_sample_result_get_destinations(result);
+  index  = cugraph_sample_result_get_index(result);
+
+  size_t result_size = cugraph_type_erased_device_array_view_size(srcs);
+
+  vertex_t h_srcs[result_size];
+  vertex_t h_dsts[result_size];
+  int h_labels[result_size];
+  edge_t h_index[result_size];
+  size_t* h_counts;
+
+  ret_code =
+    cugraph_type_erased_device_array_view_copy_to_host(handle, (byte_t*)h_srcs, srcs, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+  ret_code =
+    cugraph_type_erased_device_array_view_copy_to_host(handle, (byte_t*)h_dsts, dsts, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+  ret_code =
+    cugraph_type_erased_device_array_view_copy_to_host(handle, (byte_t*)h_index, index, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+  //  NOTE:  The C++ tester does a more thorough validation.  For our purposes
+  //  here we will do a simpler validation, merely checking that all edges
+  //  are actually part of the graph
+  weight_t M[num_vertices][num_vertices];
+
+  for (int i = 0; i < num_vertices; ++i)
+    for (int j = 0; j < num_vertices; ++j)
+      M[i][j] = 0.0;
+
+  for (int i = 0; i < num_edges; ++i)
+    M[h_src[i]][h_dst[i]] = h_wgt[i];
+
+  for (int i = 0; (i < result_size) && (test_ret_value == 0); ++i) {
+    TEST_ASSERT(test_ret_value,
+                M[h_srcs[i]][h_dsts[i]] > 0.0,
+                "uniform_neighbor_sample got edge that doesn't exist");
+
+    bool_t found = FALSE;
+    for (int j = 0; j < num_starts; ++j)
+      found = found || (h_labels[i] == h_start_label[j]);
+
+    TEST_ASSERT(test_ret_value, found, "invalid label");
+  }
+#else
+  TEST_ASSERT(test_ret_value,
+              ret_code != CUGRAPH_SUCCESS,
+              "cugraph_experimental_uniform_neighbor_sample expected to fail in SG test");
+#endif
+
+  cugraph_type_erased_host_array_view_free(h_fan_out_view);
+
+  return test_ret_value;
+}
+
 int generic_uniform_neighbor_sample_test(const cugraph_resource_handle_t* handle,
                                          vertex_t* h_src,
                                          vertex_t* h_dst,
@@ -188,6 +299,33 @@ int test_uniform_neighbor_sample(const cugraph_resource_handle_t* handle)
                                               FALSE);
 }
 
+int test_experimental_uniform_neighbor_sample(const cugraph_resource_handle_t* handle)
+{
+  size_t num_edges    = 8;
+  size_t num_vertices = 6;
+  size_t fan_out_size = 2;
+  size_t num_starts   = 2;
+
+  vertex_t src[]   = {0, 1, 1, 2, 2, 2, 3, 4};
+  vertex_t dst[]   = {1, 3, 4, 0, 1, 3, 5, 5};
+  weight_t wgt[]   = {0.1f, 2.1f, 1.1f, 5.1f, 3.1f, 4.1f, 7.2f, 3.2f};
+  vertex_t start[] = {2, 2};
+  int fan_out[]    = {1, 2};
+
+  return generic_experimental_uniform_neighbor_sample_test(handle,
+                                                           src,
+                                                           dst,
+                                                           wgt,
+                                                           num_vertices,
+                                                           num_edges,
+                                                           start,
+                                                           num_starts,
+                                                           fan_out,
+                                                           fan_out_size,
+                                                           TRUE,
+                                                           FALSE);
+}
+
 /******************************************************************************/
 
 int main(int argc, char** argv)
@@ -215,6 +353,7 @@ int main(int argc, char** argv)
 
   if (result == 0) {
     result |= RUN_MG_TEST(test_uniform_neighbor_sample, handle);
+    result |= RUN_MG_TEST(test_experimental_uniform_neighbor_sample, handle);
 
     cugraph_free_resource_handle(handle);
   }

--- a/cpp/tests/c_api/uniform_neighbor_sample_test.c
+++ b/cpp/tests/c_api/uniform_neighbor_sample_test.c
@@ -25,6 +25,119 @@ typedef int32_t vertex_t;
 typedef int32_t edge_t;
 typedef float weight_t;
 
+int generic_experimental_uniform_neighbor_sample_test(vertex_t* h_src,
+                                                      vertex_t* h_dst,
+                                                      weight_t* h_wgt,
+                                                      size_t num_vertices,
+                                                      size_t num_edges,
+                                                      vertex_t* h_start,
+                                                      size_t num_starts,
+                                                      int* fan_out,
+                                                      size_t max_depth,
+                                                      bool_t with_replacement,
+                                                      bool_t renumber,
+                                                      bool_t store_transposed)
+{
+  int test_ret_value = 0;
+
+  cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
+  cugraph_error_t* ret_error    = NULL;
+
+  cugraph_resource_handle_t* handle = NULL;
+  cugraph_graph_t* graph            = NULL;
+  cugraph_sample_result_t* result   = NULL;
+
+  cugraph_type_erased_device_array_t* d_start           = NULL;
+  cugraph_type_erased_device_array_view_t* d_start_view = NULL;
+  cugraph_type_erased_host_array_view_t* h_fan_out_view = NULL;
+
+  handle = cugraph_create_resource_handle(NULL);
+  TEST_ASSERT(test_ret_value, handle != NULL, "resource handle creation failed.");
+
+  ret_code = create_test_graph(
+    handle, h_src, h_dst, h_wgt, num_edges, store_transposed, renumber, FALSE, &graph, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "graph creation failed.");
+
+  ret_code =
+    cugraph_type_erased_device_array_create(handle, num_starts, INT32, &d_start, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "d_start create failed.");
+
+  d_start_view = cugraph_type_erased_device_array_view(d_start);
+
+  ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+    handle, d_start_view, (byte_t*)h_start, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "start copy_from_host failed.");
+
+  h_fan_out_view = cugraph_type_erased_host_array_view_create(fan_out, max_depth, INT32);
+
+  ret_code = cugraph_experimental_uniform_neighbor_sample(
+    handle, graph, d_start_view, h_fan_out_view, with_replacement, FALSE, &result, &ret_error);
+
+  TEST_ASSERT(test_ret_value,
+              ret_code != CUGRAPH_SUCCESS,
+              "cugraph_experimental_uniform_neighbor_sample expected to fail in SG test");
+
+#if 0
+  // FIXME:  cugraph_uniform_neighbor_sample does not support SG
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "uniform_neighbor_sample failed.");
+
+  cugraph_type_erased_device_array_view_t* srcs;
+  cugraph_type_erased_device_array_view_t* dsts;
+  cugraph_type_erased_device_array_view_t* index;
+
+  srcs   = cugraph_sample_result_get_sources(result);
+  dsts   = cugraph_sample_result_get_destinations(result);
+  index  = cugraph_sample_result_get_index(result);
+
+  size_t result_size = cugraph_type_erased_device_array_view_size(srcs);
+
+  vertex_t h_srcs[result_size];
+  vertex_t h_dsts[result_size];
+  edge_t h_index[result_size];
+
+  ret_code =
+    cugraph_type_erased_device_array_view_copy_to_host(handle, (byte_t*)h_srcs, srcs, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+  ret_code =
+    cugraph_type_erased_device_array_view_copy_to_host(handle, (byte_t*)h_dsts, dsts, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+  ret_code =
+    cugraph_type_erased_device_array_view_copy_to_host(handle, (byte_t*)h_index, index, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+  //  NOTE:  The C++ tester does a more thorough validation.  For our purposes
+  //  here we will do a simpler validation, merely checking that all edges
+  //  are actually part of the graph
+  weight_t M[num_vertices][num_vertices];
+
+  for (int i = 0; i < num_vertices; ++i)
+    for (int j = 0; j < num_vertices; ++j)
+      M[i][j] = 0.0;
+
+  for (int i = 0; i < num_edges; ++i)
+    M[h_src[i]][h_dst[i]] = h_wgt[i];
+
+  for (int i = 0; (i < result_size) && (test_ret_value == 0); ++i) {
+    TEST_ASSERT(test_ret_value,
+                M[h_srcs[i]][h_dsts[i]] > 0.0,
+                "uniform_neighbor_sample got edge that doesn't exist");
+
+    bool_t found = FALSE;
+    for (int j = 0; j < num_starts; ++j)
+      found = found || (h_labels[i] == h_start_label[j]);
+
+    TEST_ASSERT(test_ret_value, found, "invalid label");
+  }
+
+  cugraph_type_erased_host_array_view_free(h_fan_out_view);
+#endif
+
+  return test_ret_value;
+}
+
 int generic_uniform_neighbor_sample_test(vertex_t* h_src,
                                          vertex_t* h_dst,
                                          weight_t* h_wgt,
@@ -67,6 +180,10 @@ int generic_uniform_neighbor_sample_test(vertex_t* h_src,
 
   d_start_view = cugraph_type_erased_device_array_view(d_start);
 
+  ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+    handle, d_start_view, (byte_t*)h_start, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "start copy_from_host failed.");
+
   ret_code =
     cugraph_type_erased_device_array_create(handle, num_starts, INT32, &d_start_label, &ret_error);
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "d_start_label create failed.");
@@ -75,7 +192,7 @@ int generic_uniform_neighbor_sample_test(vertex_t* h_src,
 
   ret_code = cugraph_type_erased_device_array_view_copy_from_host(
     handle, d_start_label_view, (byte_t*)h_start_label, &ret_error);
-  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "start copy_from_host failed.");
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "start_label copy_from_host failed.");
 
   h_fan_out_view = cugraph_type_erased_host_array_view_create(fan_out, max_depth, INT32);
 
@@ -195,9 +312,37 @@ int test_uniform_neighbor_sample()
                                               FALSE);
 }
 
+int test_experimental_uniform_neighbor_sample()
+{
+  size_t num_edges    = 8;
+  size_t num_vertices = 6;
+  size_t fan_out_size = 2;
+  size_t num_starts   = 2;
+
+  vertex_t src[]   = {0, 1, 1, 2, 2, 2, 3, 4};
+  vertex_t dst[]   = {1, 3, 4, 0, 1, 3, 5, 5};
+  weight_t wgt[]   = {0.1f, 2.1f, 1.1f, 5.1f, 3.1f, 4.1f, 7.2f, 3.2f};
+  vertex_t start[] = {2, 2};
+  int fan_out[]    = {1, 2};
+
+  return generic_experimental_uniform_neighbor_sample_test(src,
+                                                           dst,
+                                                           wgt,
+                                                           num_vertices,
+                                                           num_edges,
+                                                           start,
+                                                           num_starts,
+                                                           fan_out,
+                                                           fan_out_size,
+                                                           TRUE,
+                                                           FALSE,
+                                                           FALSE);
+}
+
 int main(int argc, char** argv)
 {
   int result = 0;
   result |= RUN_TEST(test_uniform_neighbor_sample);
+  result |= RUN_TEST(test_experimental_uniform_neighbor_sample);
   return result;
 }


### PR DESCRIPTION
Added an API for the new uniform neighborhood sampling implementation.

Added the API with an experimental tag in its name so it won't break the current python code.  Plan is to have the new API replace the existing API during this release.

Plan for this release will be to have the edge weight be an edge index (passed by the calling python code), so the return "index" value will be the edge weight.  Down the road we will release this restriction and allow real edge weights.

Addresses part 1 of #2226 