### PR TITLE
cudf moved the default_hash into the cudf::detail namespace

### DIFF
--- a/cpp/libcugraph_etl/include/hash/concurrent_unordered_map.cuh
+++ b/cpp/libcugraph_etl/include/hash/concurrent_unordered_map.cuh
@@ -118,7 +118,7 @@ union pair_packer<pair_type, std::enable_if_t<is_packable<pair_type>()>> {
  */
 template <typename Key,
           typename Element,
-          typename Hasher    = default_hash<Key>,
+          typename Hasher    = cudf::detail::default_hash<Key>,
           typename Equality  = equal_to<Key>,
           typename Allocator = default_allocator<thrust::pair<Key, Element>>>
 class concurrent_unordered_map {

--- a/python/cugraph/cugraph/structure/hypergraph.py
+++ b/python/cugraph/cugraph/structure/hypergraph.py
@@ -503,7 +503,7 @@ def _create_direct_edges(
 def _str_scalar_to_category(size, val):
     return cudf.core.column.build_categorical_column(
         categories=cudf.core.column.as_column([val], dtype="str"),
-        codes=cudf.core.column.column.full(size, 0, dtype=np.int32)
+        codes=cudf.core.column.column.full(size, 0, dtype=np.int32),
         mask=None,
         size=size,
         offset=0,

--- a/python/cugraph/cugraph/structure/hypergraph.py
+++ b/python/cugraph/cugraph/structure/hypergraph.py
@@ -503,7 +503,7 @@ def _create_direct_edges(
 def _str_scalar_to_category(size, val):
     return cudf.core.column.build_categorical_column(
         categories=cudf.core.column.as_column([val], dtype="str"),
-        codes=cudf.utils.utils.scalar_broadcast_to(0, size, dtype=np.int32),
+        codes=cudf.core.column.column.full(size, 0, dtype=np.int32)
         mask=None,
         size=size,
         offset=0,


### PR DESCRIPTION
Updated as part of https://github.com/rapidsai/cudf/pull/10462

Update namespace for default_hash.

Also update a python call that was changed in cudf.
