### PR TITLE
Add and test mechanism for creating graph with edge index as weight

### DIFF
--- a/cpp/include/cugraph_c/array.h
+++ b/cpp/include/cugraph_c/array.h
@@ -88,6 +88,30 @@ cugraph_type_erased_device_array_view_t* cugraph_type_erased_device_array_view(
   cugraph_type_erased_device_array_t* array);
 
 /**
+ * @brief Create a type erased device array view with a different type
+ *
+ *    Create a type erased device array view from
+ *    a type erased device array treating the underlying
+ *    pointer as a different type.
+ *
+ *    Note: This is only viable when the underlying types are the same size.  That
+ *    is, you can switch between INT32 and FLOAT32, or between INT64 and FLOAT64.
+ *    But if the types are different sizes this will be an error.
+ *
+ * @param [in]  array        Pointer to the type erased device array
+ * @param [in]  dtype        The type to cast the pointer to
+ * @param [out] result_view  Address where to put the allocated device view
+ * @param [out] error        Pointer to an error object storing details of any error.  Will
+ *                           be populated if error code is not CUGRAPH_SUCCESS
+ * @return error code
+ */
+cugraph_error_code_t cugraph_type_erased_device_array_view_as_type(
+  cugraph_type_erased_device_array_t* array,
+  data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** result_view,
+  cugraph_error_t** error);
+
+/**
  * @brief    Create a type erased device array view from
  *           a raw device pointer.
  *

--- a/cpp/src/c_api/array.cpp
+++ b/cpp/src/c_api/array.cpp
@@ -364,3 +364,28 @@ extern "C" cugraph_error_code_t cugraph_type_erased_device_array_view_copy(
     return CUGRAPH_UNKNOWN_ERROR;
   }
 }
+
+extern "C" cugraph_error_code_t cugraph_type_erased_device_array_view_as_type(
+  cugraph_type_erased_device_array_t* array,
+  data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** result_view,
+  cugraph_error_t** error)
+{
+  auto internal_pointer =
+    reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_t*>(array);
+
+  if (data_type_sz[dtype] == data_type_sz[internal_pointer->type_]) {
+    *result_view = reinterpret_cast<cugraph_type_erased_device_array_view_t*>(
+      new cugraph::c_api::cugraph_type_erased_device_array_view_t{internal_pointer->data_.data(),
+                                                                  internal_pointer->size_,
+                                                                  internal_pointer->data_.size(),
+                                                                  dtype});
+    return CUGRAPH_SUCCESS;
+  } else {
+    std::stringstream ss;
+    ss << "Could not treat type " << internal_pointer->type_ << " as type " << dtype;
+    auto tmp_error = new cugraph::c_api::cugraph_error_t{ss.str().c_str()};
+    *error         = reinterpret_cast<cugraph_error_t*>(tmp_error);
+    return CUGRAPH_INVALID_INPUT;
+  }
+}

--- a/cpp/src/sampling/detail/graph_functions.hpp
+++ b/cpp/src/sampling/detail/graph_functions.hpp
@@ -143,7 +143,7 @@ rmm::device_uvector<typename GraphViewType::edge_type> get_active_major_global_d
 template <typename GraphViewType>
 std::tuple<rmm::device_uvector<typename GraphViewType::vertex_type>,
            rmm::device_uvector<typename GraphViewType::vertex_type>,
-           thrust::optional<rmm::device_uvector<typename GraphViewType::weight_type>>>
+           std::optional<rmm::device_uvector<typename GraphViewType::weight_type>>>
 gather_local_edges(
   raft::handle_t const& handle,
   GraphViewType const& graph_view,
@@ -169,7 +169,7 @@ gather_local_edges(
 template <typename GraphViewType>
 std::tuple<rmm::device_uvector<typename GraphViewType::vertex_type>,
            rmm::device_uvector<typename GraphViewType::vertex_type>,
-           thrust::optional<rmm::device_uvector<typename GraphViewType::weight_type>>>
+           std::optional<rmm::device_uvector<typename GraphViewType::weight_type>>>
 gather_one_hop_edgelist(
   raft::handle_t const& handle,
   GraphViewType const& graph_view,

--- a/cpp/src/sampling/detail/sampling_utils_mg.cu
+++ b/cpp/src/sampling/detail/sampling_utils_mg.cu
@@ -180,7 +180,7 @@ partition_information(raft::handle_t const& handle,
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<float>>>
+                    std::optional<rmm::device_uvector<float>>>
 gather_local_edges(raft::handle_t const& handle,
                    graph_view_t<int32_t, int32_t, float, false, true> const& graph_view,
                    const rmm::device_uvector<int32_t>& active_majors,
@@ -191,7 +191,7 @@ gather_local_edges(raft::handle_t const& handle,
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<float>>>
+                    std::optional<rmm::device_uvector<float>>>
 gather_local_edges(raft::handle_t const& handle,
                    graph_view_t<int32_t, int64_t, float, false, true> const& graph_view,
                    const rmm::device_uvector<int32_t>& active_majors,
@@ -202,7 +202,7 @@ gather_local_edges(raft::handle_t const& handle,
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
-                    thrust::optional<rmm::device_uvector<float>>>
+                    std::optional<rmm::device_uvector<float>>>
 gather_local_edges(raft::handle_t const& handle,
                    graph_view_t<int64_t, int64_t, float, false, true> const& graph_view,
                    const rmm::device_uvector<int64_t>& active_majors,
@@ -213,7 +213,7 @@ gather_local_edges(raft::handle_t const& handle,
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<double>>>
+                    std::optional<rmm::device_uvector<double>>>
 gather_local_edges(raft::handle_t const& handle,
                    graph_view_t<int32_t, int32_t, double, false, true> const& graph_view,
                    const rmm::device_uvector<int32_t>& active_majors,
@@ -224,7 +224,7 @@ gather_local_edges(raft::handle_t const& handle,
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<double>>>
+                    std::optional<rmm::device_uvector<double>>>
 gather_local_edges(raft::handle_t const& handle,
                    graph_view_t<int32_t, int64_t, double, false, true> const& graph_view,
                    const rmm::device_uvector<int32_t>& active_majors,
@@ -235,7 +235,7 @@ gather_local_edges(raft::handle_t const& handle,
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
-                    thrust::optional<rmm::device_uvector<double>>>
+                    std::optional<rmm::device_uvector<double>>>
 gather_local_edges(raft::handle_t const& handle,
                    graph_view_t<int64_t, int64_t, double, false, true> const& graph_view,
                    const rmm::device_uvector<int64_t>& active_majors,
@@ -246,42 +246,42 @@ gather_local_edges(raft::handle_t const& handle,
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<float>>>
+                    std::optional<rmm::device_uvector<float>>>
 gather_one_hop_edgelist(raft::handle_t const& handle,
                         graph_view_t<int32_t, int32_t, float, false, true> const& graph_view,
                         rmm::device_uvector<int32_t> const& active_majors);
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<float>>>
+                    std::optional<rmm::device_uvector<float>>>
 gather_one_hop_edgelist(raft::handle_t const& handle,
                         graph_view_t<int32_t, int64_t, float, false, true> const& graph_view,
                         rmm::device_uvector<int32_t> const& active_majors);
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
-                    thrust::optional<rmm::device_uvector<float>>>
+                    std::optional<rmm::device_uvector<float>>>
 gather_one_hop_edgelist(raft::handle_t const& handle,
                         graph_view_t<int64_t, int64_t, float, false, true> const& graph_view,
                         rmm::device_uvector<int64_t> const& active_majors);
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<double>>>
+                    std::optional<rmm::device_uvector<double>>>
 gather_one_hop_edgelist(raft::handle_t const& handle,
                         graph_view_t<int32_t, int32_t, double, false, true> const& graph_view,
                         rmm::device_uvector<int32_t> const& active_majors);
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<double>>>
+                    std::optional<rmm::device_uvector<double>>>
 gather_one_hop_edgelist(raft::handle_t const& handle,
                         graph_view_t<int32_t, int64_t, double, false, true> const& graph_view,
                         rmm::device_uvector<int32_t> const& active_majors);
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
-                    thrust::optional<rmm::device_uvector<double>>>
+                    std::optional<rmm::device_uvector<double>>>
 gather_one_hop_edgelist(raft::handle_t const& handle,
                         graph_view_t<int64_t, int64_t, double, false, true> const& graph_view,
                         rmm::device_uvector<int64_t> const& active_majors);

--- a/cpp/src/sampling/detail/sampling_utils_sg.cu
+++ b/cpp/src/sampling/detail/sampling_utils_sg.cu
@@ -123,7 +123,7 @@ template rmm::device_uvector<int64_t> get_active_major_global_degrees(
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<float>>>
+                    std::optional<rmm::device_uvector<float>>>
 gather_local_edges(raft::handle_t const& handle,
                    graph_view_t<int32_t, int32_t, float, false, false> const& graph_view,
                    const rmm::device_uvector<int32_t>& active_majors,
@@ -134,7 +134,7 @@ gather_local_edges(raft::handle_t const& handle,
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<float>>>
+                    std::optional<rmm::device_uvector<float>>>
 gather_local_edges(raft::handle_t const& handle,
                    graph_view_t<int32_t, int64_t, float, false, false> const& graph_view,
                    const rmm::device_uvector<int32_t>& active_majors,
@@ -145,7 +145,7 @@ gather_local_edges(raft::handle_t const& handle,
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
-                    thrust::optional<rmm::device_uvector<float>>>
+                    std::optional<rmm::device_uvector<float>>>
 gather_local_edges(raft::handle_t const& handle,
                    graph_view_t<int64_t, int64_t, float, false, false> const& graph_view,
                    const rmm::device_uvector<int64_t>& active_majors,
@@ -156,7 +156,7 @@ gather_local_edges(raft::handle_t const& handle,
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<double>>>
+                    std::optional<rmm::device_uvector<double>>>
 gather_local_edges(raft::handle_t const& handle,
                    graph_view_t<int32_t, int32_t, double, false, false> const& graph_view,
                    const rmm::device_uvector<int32_t>& active_majors,
@@ -167,7 +167,7 @@ gather_local_edges(raft::handle_t const& handle,
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<double>>>
+                    std::optional<rmm::device_uvector<double>>>
 gather_local_edges(raft::handle_t const& handle,
                    graph_view_t<int32_t, int64_t, double, false, false> const& graph_view,
                    const rmm::device_uvector<int32_t>& active_majors,
@@ -178,7 +178,7 @@ gather_local_edges(raft::handle_t const& handle,
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
-                    thrust::optional<rmm::device_uvector<double>>>
+                    std::optional<rmm::device_uvector<double>>>
 gather_local_edges(raft::handle_t const& handle,
                    graph_view_t<int64_t, int64_t, double, false, false> const& graph_view,
                    const rmm::device_uvector<int64_t>& active_majors,
@@ -189,42 +189,42 @@ gather_local_edges(raft::handle_t const& handle,
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<float>>>
+                    std::optional<rmm::device_uvector<float>>>
 gather_one_hop_edgelist(raft::handle_t const& handle,
                         graph_view_t<int32_t, int32_t, float, false, false> const& graph_view,
                         rmm::device_uvector<int32_t> const& active_majors);
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<float>>>
+                    std::optional<rmm::device_uvector<float>>>
 gather_one_hop_edgelist(raft::handle_t const& handle,
                         graph_view_t<int32_t, int64_t, float, false, false> const& graph_view,
                         rmm::device_uvector<int32_t> const& active_majors);
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
-                    thrust::optional<rmm::device_uvector<float>>>
+                    std::optional<rmm::device_uvector<float>>>
 gather_one_hop_edgelist(raft::handle_t const& handle,
                         graph_view_t<int64_t, int64_t, float, false, false> const& graph_view,
                         rmm::device_uvector<int64_t> const& active_majors);
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<double>>>
+                    std::optional<rmm::device_uvector<double>>>
 gather_one_hop_edgelist(raft::handle_t const& handle,
                         graph_view_t<int32_t, int32_t, double, false, false> const& graph_view,
                         rmm::device_uvector<int32_t> const& active_majors);
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
-                    thrust::optional<rmm::device_uvector<double>>>
+                    std::optional<rmm::device_uvector<double>>>
 gather_one_hop_edgelist(raft::handle_t const& handle,
                         graph_view_t<int32_t, int64_t, double, false, false> const& graph_view,
                         rmm::device_uvector<int32_t> const& active_majors);
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
-                    thrust::optional<rmm::device_uvector<double>>>
+                    std::optional<rmm::device_uvector<double>>>
 gather_one_hop_edgelist(raft::handle_t const& handle,
                         graph_view_t<int64_t, int64_t, double, false, false> const& graph_view,
                         rmm::device_uvector<int64_t> const& active_majors);

--- a/cpp/src/sampling/uniform_neighbor_sampling_impl.hpp
+++ b/cpp/src/sampling/uniform_neighbor_sampling_impl.hpp
@@ -86,8 +86,7 @@ uniform_nbr_sample_impl(
 
     rmm::device_uvector<vertex_t> d_out_src(0, handle.get_stream());
     rmm::device_uvector<vertex_t> d_out_dst(0, handle.get_stream());
-    auto d_out_indices =
-      thrust::make_optional(rmm::device_uvector<weight_t>(0, handle.get_stream()));
+    auto d_out_indices = std::make_optional(rmm::device_uvector<weight_t>(0, handle.get_stream()));
 
     if (k_level != 0) {
       // extract out-degs(sources):

--- a/cpp/src/sampling/uniform_neighbor_sampling_impl.hpp
+++ b/cpp/src/sampling/uniform_neighbor_sampling_impl.hpp
@@ -103,13 +103,16 @@ uniform_nbr_sample_impl(
       raft::random::RngState rng_state(seed);
       seed += d_rnd_indices.size() * row_comm_size;
 
-      cugraph_ops::get_sampling_index(d_rnd_indices.data(),
-                                      rng_state,
-                                      d_out_degs.data(),
-                                      static_cast<edge_t>(d_out_degs.size()),
-                                      static_cast<int32_t>(k_level),
-                                      with_replacement,
-                                      handle.get_stream());
+      if (d_rnd_indices.size() > 0) {
+        // FIXME: This cugraph_ops function does not handle 0 inputs properly
+        cugraph_ops::get_sampling_index(d_rnd_indices.data(),
+                                        rng_state,
+                                        d_out_degs.data(),
+                                        static_cast<edge_t>(d_out_degs.size()),
+                                        static_cast<int32_t>(k_level),
+                                        with_replacement,
+                                        handle.get_stream());
+      }
 
       std::tie(d_out_src, d_out_dst, d_out_indices) =
         gather_local_edges(handle,

--- a/cpp/tests/c_api/mg_test_utils.cpp
+++ b/cpp/tests/c_api/mg_test_utils.cpp
@@ -191,15 +191,15 @@ extern "C" int create_mg_test_graph(const cugraph_resource_handle_t* handle,
 
   return test_ret_value;
 }
-extern "C" int create_mg_test_graph_with_ids(const cugraph_resource_handle_t* handle,
-                                             int32_t* h_src,
-                                             int32_t* h_dst,
-                                             int32_t* h_idx,
-                                             size_t num_edges,
-                                             bool_t store_transposed,
-                                             bool_t is_symmetric,
-                                             cugraph_graph_t** p_graph,
-                                             cugraph_error_t** ret_error)
+extern "C" int create_mg_test_graph_with_edge_ids(const cugraph_resource_handle_t* handle,
+                                                  int32_t* h_src,
+                                                  int32_t* h_dst,
+                                                  int32_t* h_idx,
+                                                  size_t num_edges,
+                                                  bool_t store_transposed,
+                                                  bool_t is_symmetric,
+                                                  cugraph_graph_t** p_graph,
+                                                  cugraph_error_t** ret_error)
 {
   int test_ret_value = 0;
   cugraph_error_code_t ret_code;

--- a/cpp/tests/c_api/mg_test_utils.cpp
+++ b/cpp/tests/c_api/mg_test_utils.cpp
@@ -191,3 +191,102 @@ extern "C" int create_mg_test_graph(const cugraph_resource_handle_t* handle,
 
   return test_ret_value;
 }
+extern "C" int create_mg_test_graph_with_ids(const cugraph_resource_handle_t* handle,
+                                             int32_t* h_src,
+                                             int32_t* h_dst,
+                                             int32_t* h_idx,
+                                             size_t num_edges,
+                                             bool_t store_transposed,
+                                             bool_t is_symmetric,
+                                             cugraph_graph_t** p_graph,
+                                             cugraph_error_t** ret_error)
+{
+  int test_ret_value = 0;
+  cugraph_error_code_t ret_code;
+  cugraph_graph_properties_t properties;
+
+  properties.is_symmetric  = is_symmetric;
+  properties.is_multigraph = FALSE;
+
+  data_type_id_t vertex_tid = INT32;
+  data_type_id_t edge_tid   = INT32;
+  data_type_id_t weight_tid = FLOAT32;
+
+  cugraph_type_erased_device_array_t* src;
+  cugraph_type_erased_device_array_t* dst;
+  cugraph_type_erased_device_array_t* idx;
+  cugraph_type_erased_device_array_view_t* src_view;
+  cugraph_type_erased_device_array_view_t* dst_view;
+  cugraph_type_erased_device_array_view_t* idx_view;
+  cugraph_type_erased_device_array_view_t* wgt_view;
+
+  int rank = 0;
+
+  rank = cugraph_resource_handle_get_rank(handle);
+
+  if (rank == 0) {
+    ret_code =
+      cugraph_type_erased_device_array_create(handle, num_edges, vertex_tid, &src, ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src create failed.");
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(*ret_error));
+
+    ret_code =
+      cugraph_type_erased_device_array_create(handle, num_edges, vertex_tid, &dst, ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "dst create failed.");
+
+    ret_code =
+      cugraph_type_erased_device_array_create(handle, num_edges, weight_tid, &idx, ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "idx create failed.");
+  } else {
+    ret_code = cugraph_type_erased_device_array_create(handle, 0, vertex_tid, &src, ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src create failed.");
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(*ret_error));
+
+    ret_code = cugraph_type_erased_device_array_create(handle, 0, vertex_tid, &dst, ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "dst create failed.");
+
+    ret_code = cugraph_type_erased_device_array_create(handle, 0, weight_tid, &idx, ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "wgt create failed.");
+  }
+
+  src_view = cugraph_type_erased_device_array_view(src);
+  dst_view = cugraph_type_erased_device_array_view(dst);
+  idx_view = cugraph_type_erased_device_array_view(idx);
+
+  ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+    handle, src_view, (byte_t*)h_src, ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src copy_from_host failed.");
+
+  ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+    handle, dst_view, (byte_t*)h_dst, ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "dst copy_from_host failed.");
+
+  ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+    handle, idx_view, (byte_t*)h_idx, ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "wgt copy_from_host failed.");
+
+  ret_code = cugraph_type_erased_device_array_view_as_type(idx, weight_tid, &wgt_view, ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "wgt cast from idx failed.");
+
+  ret_code = cugraph_mg_graph_create(handle,
+                                     &properties,
+                                     src_view,
+                                     dst_view,
+                                     wgt_view,
+                                     store_transposed,
+                                     num_edges,
+                                     FALSE,
+                                     p_graph,
+                                     ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "graph creation failed.");
+
+  cugraph_type_erased_device_array_view_free(wgt_view);
+  cugraph_type_erased_device_array_view_free(idx_view);
+  cugraph_type_erased_device_array_view_free(dst_view);
+  cugraph_type_erased_device_array_view_free(src_view);
+  cugraph_type_erased_device_array_free(idx);
+  cugraph_type_erased_device_array_free(dst);
+  cugraph_type_erased_device_array_free(src);
+
+  return test_ret_value;
+}

--- a/cpp/tests/c_api/mg_test_utils.h
+++ b/cpp/tests/c_api/mg_test_utils.h
@@ -67,12 +67,12 @@ int create_mg_test_graph(const cugraph_resource_handle_t* p_handle,
                          cugraph_graph_t** p_graph,
                          cugraph_error_t** ret_error);
 
-int create_mg_test_graph_with_ids(const cugraph_resource_handle_t* p_handle,
-                                  int32_t* h_src,
-                                  int32_t* h_dst,
-                                  int32_t* h_idx,
-                                  size_t num_edges,
-                                  bool_t store_transposed,
-                                  bool_t is_symmetric,
-                                  cugraph_graph_t** p_graph,
-                                  cugraph_error_t** ret_error);
+int create_mg_test_graph_with_edge_ids(const cugraph_resource_handle_t* p_handle,
+                                       int32_t* h_src,
+                                       int32_t* h_dst,
+                                       int32_t* h_idx,
+                                       size_t num_edges,
+                                       bool_t store_transposed,
+                                       bool_t is_symmetric,
+                                       cugraph_graph_t** p_graph,
+                                       cugraph_error_t** ret_error);

--- a/cpp/tests/c_api/mg_test_utils.h
+++ b/cpp/tests/c_api/mg_test_utils.h
@@ -66,3 +66,13 @@ int create_mg_test_graph(const cugraph_resource_handle_t* p_handle,
                          bool_t is_symmetric,
                          cugraph_graph_t** p_graph,
                          cugraph_error_t** ret_error);
+
+int create_mg_test_graph_with_ids(const cugraph_resource_handle_t* p_handle,
+                                  int32_t* h_src,
+                                  int32_t* h_dst,
+                                  int32_t* h_idx,
+                                  size_t num_edges,
+                                  bool_t store_transposed,
+                                  bool_t is_symmetric,
+                                  cugraph_graph_t** p_graph,
+                                  cugraph_error_t** ret_error);

--- a/cpp/tests/c_api/mg_uniform_neighbor_sample_test.c
+++ b/cpp/tests/c_api/mg_uniform_neighbor_sample_test.c
@@ -50,7 +50,7 @@ int generic_experimental_uniform_neighbor_sample_test(const cugraph_resource_han
   cugraph_type_erased_device_array_view_t* d_start_view = NULL;
   cugraph_type_erased_host_array_view_t* h_fan_out_view = NULL;
 
-  ret_code = create_mg_test_graph_with_ids(
+  ret_code = create_mg_test_graph_with_edge_ids(
     handle, h_src, h_dst, h_idx, num_edges, store_transposed, FALSE, &graph, &ret_error);
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "graph creation failed.");
 

--- a/cpp/tests/c_api/mg_uniform_neighbor_sample_test.c
+++ b/cpp/tests/c_api/mg_uniform_neighbor_sample_test.c
@@ -28,7 +28,7 @@ typedef float weight_t;
 int generic_experimental_uniform_neighbor_sample_test(const cugraph_resource_handle_t* handle,
                                                       vertex_t* h_src,
                                                       vertex_t* h_dst,
-                                                      weight_t* h_wgt,
+                                                      edge_t* h_idx,
                                                       size_t num_vertices,
                                                       size_t num_edges,
                                                       vertex_t* h_start,
@@ -50,8 +50,8 @@ int generic_experimental_uniform_neighbor_sample_test(const cugraph_resource_han
   cugraph_type_erased_device_array_view_t* d_start_view = NULL;
   cugraph_type_erased_host_array_view_t* h_fan_out_view = NULL;
 
-  ret_code = create_mg_test_graph(
-    handle, h_src, h_dst, h_wgt, num_edges, store_transposed, FALSE, &graph, &ret_error);
+  ret_code = create_mg_test_graph_with_ids(
+    handle, h_src, h_dst, h_idx, num_edges, store_transposed, FALSE, &graph, &ret_error);
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "graph creation failed.");
 
   ret_code =
@@ -69,8 +69,6 @@ int generic_experimental_uniform_neighbor_sample_test(const cugraph_resource_han
   ret_code = cugraph_experimental_uniform_neighbor_sample(
     handle, graph, d_start_view, h_fan_out_view, with_replacement, FALSE, &result, &ret_error);
 
-#if 0
-  // FIXME:  cugraph_experimental_uniform_neighbor_sample is not implemented yet
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "uniform_neighbor_sample failed.");
 
@@ -78,9 +76,9 @@ int generic_experimental_uniform_neighbor_sample_test(const cugraph_resource_han
   cugraph_type_erased_device_array_view_t* dsts;
   cugraph_type_erased_device_array_view_t* index;
 
-  srcs   = cugraph_sample_result_get_sources(result);
-  dsts   = cugraph_sample_result_get_destinations(result);
-  index  = cugraph_sample_result_get_index(result);
+  srcs  = cugraph_sample_result_get_sources(result);
+  dsts  = cugraph_sample_result_get_destinations(result);
+  index = cugraph_sample_result_get_index(result);
 
   size_t result_size = cugraph_type_erased_device_array_view_size(srcs);
 
@@ -105,31 +103,20 @@ int generic_experimental_uniform_neighbor_sample_test(const cugraph_resource_han
   //  NOTE:  The C++ tester does a more thorough validation.  For our purposes
   //  here we will do a simpler validation, merely checking that all edges
   //  are actually part of the graph
-  weight_t M[num_vertices][num_vertices];
+  edge_t M[num_vertices][num_vertices];
 
   for (int i = 0; i < num_vertices; ++i)
     for (int j = 0; j < num_vertices; ++j)
-      M[i][j] = 0.0;
+      M[i][j] = -1;
 
   for (int i = 0; i < num_edges; ++i)
-    M[h_src[i]][h_dst[i]] = h_wgt[i];
+    M[h_src[i]][h_dst[i]] = h_idx[i];
 
   for (int i = 0; (i < result_size) && (test_ret_value == 0); ++i) {
     TEST_ASSERT(test_ret_value,
-                M[h_srcs[i]][h_dsts[i]] > 0.0,
+                M[h_srcs[i]][h_dsts[i]] >= 0,
                 "uniform_neighbor_sample got edge that doesn't exist");
-
-    bool_t found = FALSE;
-    for (int j = 0; j < num_starts; ++j)
-      found = found || (h_labels[i] == h_start_label[j]);
-
-    TEST_ASSERT(test_ret_value, found, "invalid label");
   }
-#else
-  TEST_ASSERT(test_ret_value,
-              ret_code != CUGRAPH_SUCCESS,
-              "cugraph_experimental_uniform_neighbor_sample expected to fail in SG test");
-#endif
 
   cugraph_type_erased_host_array_view_free(h_fan_out_view);
 
@@ -308,14 +295,14 @@ int test_experimental_uniform_neighbor_sample(const cugraph_resource_handle_t* h
 
   vertex_t src[]   = {0, 1, 1, 2, 2, 2, 3, 4};
   vertex_t dst[]   = {1, 3, 4, 0, 1, 3, 5, 5};
-  weight_t wgt[]   = {0.1f, 2.1f, 1.1f, 5.1f, 3.1f, 4.1f, 7.2f, 3.2f};
+  edge_t idx[]     = {0, 1, 2, 3, 4, 5, 6, 7};
   vertex_t start[] = {2, 2};
   int fan_out[]    = {1, 2};
 
   return generic_experimental_uniform_neighbor_sample_test(handle,
                                                            src,
                                                            dst,
-                                                           wgt,
+                                                           idx,
                                                            num_vertices,
                                                            num_edges,
                                                            start,

--- a/cpp/tests/c_api/uniform_neighbor_sample_test.c
+++ b/cpp/tests/c_api/uniform_neighbor_sample_test.c
@@ -25,16 +25,16 @@ typedef int32_t vertex_t;
 typedef int32_t edge_t;
 typedef float weight_t;
 
-int create_test_graph_with_ids(const cugraph_resource_handle_t* p_handle,
-                               vertex_t* h_src,
-                               vertex_t* h_dst,
-                               edge_t* h_ids,
-                               size_t num_edges,
-                               bool_t store_transposed,
-                               bool_t renumber,
-                               bool_t is_symmetric,
-                               cugraph_graph_t** p_graph,
-                               cugraph_error_t** ret_error)
+int create_test_graph_with_edge_ids(const cugraph_resource_handle_t* p_handle,
+                                    vertex_t* h_src,
+                                    vertex_t* h_dst,
+                                    edge_t* h_ids,
+                                    size_t num_edges,
+                                    bool_t store_transposed,
+                                    bool_t renumber,
+                                    bool_t is_symmetric,
+                                    cugraph_graph_t** p_graph,
+                                    cugraph_error_t** ret_error)
 {
   int test_ret_value = 0;
   cugraph_error_code_t ret_code;
@@ -139,7 +139,7 @@ int generic_experimental_uniform_neighbor_sample_test(vertex_t* h_src,
   handle = cugraph_create_resource_handle(NULL);
   TEST_ASSERT(test_ret_value, handle != NULL, "resource handle creation failed.");
 
-  ret_code = create_test_graph_with_ids(
+  ret_code = create_test_graph_with_edge_ids(
     handle, h_src, h_dst, h_ids, num_edges, store_transposed, renumber, FALSE, &graph, &ret_error);
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "graph creation failed.");
 

--- a/cpp/tests/c_api/uniform_neighbor_sample_test.c
+++ b/cpp/tests/c_api/uniform_neighbor_sample_test.c
@@ -25,9 +25,94 @@ typedef int32_t vertex_t;
 typedef int32_t edge_t;
 typedef float weight_t;
 
+int create_test_graph_with_ids(const cugraph_resource_handle_t* p_handle,
+                               vertex_t* h_src,
+                               vertex_t* h_dst,
+                               edge_t* h_ids,
+                               size_t num_edges,
+                               bool_t store_transposed,
+                               bool_t renumber,
+                               bool_t is_symmetric,
+                               cugraph_graph_t** p_graph,
+                               cugraph_error_t** ret_error)
+{
+  int test_ret_value = 0;
+  cugraph_error_code_t ret_code;
+  cugraph_graph_properties_t properties;
+
+  properties.is_symmetric  = is_symmetric;
+  properties.is_multigraph = FALSE;
+
+  data_type_id_t vertex_tid = INT32;
+  data_type_id_t edge_tid   = INT32;
+  data_type_id_t weight_tid = FLOAT32;
+
+  cugraph_type_erased_device_array_t* src;
+  cugraph_type_erased_device_array_t* dst;
+  cugraph_type_erased_device_array_t* ids;
+  cugraph_type_erased_device_array_view_t* src_view;
+  cugraph_type_erased_device_array_view_t* dst_view;
+  cugraph_type_erased_device_array_view_t* ids_view;
+  cugraph_type_erased_device_array_view_t* wgt_view;
+
+  ret_code =
+    cugraph_type_erased_device_array_create(p_handle, num_edges, vertex_tid, &src, ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src create failed.");
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(*ret_error));
+
+  ret_code =
+    cugraph_type_erased_device_array_create(p_handle, num_edges, vertex_tid, &dst, ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "dst create failed.");
+
+  ret_code =
+    cugraph_type_erased_device_array_create(p_handle, num_edges, edge_tid, &ids, ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "ids create failed.");
+
+  src_view = cugraph_type_erased_device_array_view(src);
+  dst_view = cugraph_type_erased_device_array_view(dst);
+  ids_view = cugraph_type_erased_device_array_view(ids);
+
+  ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+    p_handle, src_view, (byte_t*)h_src, ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src copy_from_host failed.");
+
+  ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+    p_handle, dst_view, (byte_t*)h_dst, ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "dst copy_from_host failed.");
+
+  ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+    p_handle, ids_view, (byte_t*)h_ids, ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "wgt copy_from_host failed.");
+
+  ret_code = cugraph_type_erased_device_array_view_as_type(ids, weight_tid, &wgt_view, ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "wgt cast from ids failed.");
+
+  ret_code = cugraph_sg_graph_create(p_handle,
+                                     &properties,
+                                     src_view,
+                                     dst_view,
+                                     wgt_view,
+                                     store_transposed,
+                                     renumber,
+                                     FALSE,
+                                     p_graph,
+                                     ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "graph creation failed.");
+
+  cugraph_type_erased_device_array_view_free(wgt_view);
+  cugraph_type_erased_device_array_view_free(ids_view);
+  cugraph_type_erased_device_array_view_free(dst_view);
+  cugraph_type_erased_device_array_view_free(src_view);
+  cugraph_type_erased_device_array_free(ids);
+  cugraph_type_erased_device_array_free(dst);
+  cugraph_type_erased_device_array_free(src);
+
+  return test_ret_value;
+}
+
 int generic_experimental_uniform_neighbor_sample_test(vertex_t* h_src,
                                                       vertex_t* h_dst,
-                                                      weight_t* h_wgt,
+                                                      edge_t* h_ids,
                                                       size_t num_vertices,
                                                       size_t num_edges,
                                                       vertex_t* h_start,
@@ -54,8 +139,8 @@ int generic_experimental_uniform_neighbor_sample_test(vertex_t* h_src,
   handle = cugraph_create_resource_handle(NULL);
   TEST_ASSERT(test_ret_value, handle != NULL, "resource handle creation failed.");
 
-  ret_code = create_test_graph(
-    handle, h_src, h_dst, h_wgt, num_edges, store_transposed, renumber, FALSE, &graph, &ret_error);
+  ret_code = create_test_graph_with_ids(
+    handle, h_src, h_dst, h_ids, num_edges, store_transposed, renumber, FALSE, &graph, &ret_error);
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "graph creation failed.");
 
   ret_code =
@@ -80,9 +165,9 @@ int generic_experimental_uniform_neighbor_sample_test(vertex_t* h_src,
   cugraph_type_erased_device_array_view_t* dsts;
   cugraph_type_erased_device_array_view_t* index;
 
-  srcs   = cugraph_sample_result_get_sources(result);
-  dsts   = cugraph_sample_result_get_destinations(result);
-  index  = cugraph_sample_result_get_index(result);
+  srcs  = cugraph_sample_result_get_sources(result);
+  dsts  = cugraph_sample_result_get_destinations(result);
+  index = cugraph_sample_result_get_index(result);
 
   size_t result_size = cugraph_type_erased_device_array_view_size(srcs);
 
@@ -105,18 +190,18 @@ int generic_experimental_uniform_neighbor_sample_test(vertex_t* h_src,
   //  NOTE:  The C++ tester does a more thorough validation.  For our purposes
   //  here we will do a simpler validation, merely checking that all edges
   //  are actually part of the graph
-  weight_t M[num_vertices][num_vertices];
+  edge_t M[num_vertices][num_vertices];
 
   for (int i = 0; i < num_vertices; ++i)
     for (int j = 0; j < num_vertices; ++j)
-      M[i][j] = 0.0;
+      M[i][j] = -1;
 
   for (int i = 0; i < num_edges; ++i)
-    M[h_src[i]][h_dst[i]] = h_wgt[i];
+    M[h_src[i]][h_dst[i]] = h_ids[i];
 
   for (int i = 0; (i < result_size) && (test_ret_value == 0); ++i) {
     TEST_ASSERT(test_ret_value,
-                M[h_srcs[i]][h_dsts[i]] > 0.0,
+                M[h_srcs[i]][h_dsts[i]] > 0,
                 "uniform_neighbor_sample got edge that doesn't exist");
   }
 
@@ -306,15 +391,15 @@ int test_experimental_uniform_neighbor_sample()
   size_t fan_out_size = 2;
   size_t num_starts   = 2;
 
-  vertex_t src[]   = {0, 1, 1, 2, 2, 2, 3, 4};
-  vertex_t dst[]   = {1, 3, 4, 0, 1, 3, 5, 5};
-  weight_t wgt[]   = {0.1f, 2.1f, 1.1f, 5.1f, 3.1f, 4.1f, 7.2f, 3.2f};
-  vertex_t start[] = {2, 2};
-  int fan_out[]    = {1, 2};
+  vertex_t src[]    = {0, 1, 1, 2, 2, 2, 3, 4};
+  vertex_t dst[]    = {1, 3, 4, 0, 1, 3, 5, 5};
+  edge_t edge_ids[] = {0, 1, 2, 3, 4, 5, 6, 7};
+  vertex_t start[]  = {2, 2};
+  int fan_out[]     = {1, 2};
 
   return generic_experimental_uniform_neighbor_sample_test(src,
                                                            dst,
-                                                           wgt,
+                                                           edge_ids,
                                                            num_vertices,
                                                            num_edges,
                                                            start,


### PR DESCRIPTION
Missed this in the last uniform neighborhood sampling updates.

Added a mechanism for creating a graph using an edge index as the weight.  This is a temporary mechanism until we add direct support for edge indexes in the graph.