### PR TITLE
Add Louvain to the C API

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -374,6 +374,7 @@ add_library(cugraph_c
         src/c_api/sssp.cpp
         src/c_api/extract_paths.cpp
         src/c_api/random_walks.cpp
+        src/c_api/louvain.cpp
         src/c_api/triangle_count.cpp
         src/c_api/uniform_neighbor_sampling.cpp
         src/c_api/labeling_result.cpp

--- a/cpp/include/cugraph_c/community_algorithms.h
+++ b/cpp/include/cugraph_c/community_algorithms.h
@@ -72,7 +72,6 @@ cugraph_type_erased_device_array_view_t* cugraph_triangle_count_result_get_count
  */
 void cugraph_triangle_count_result_free(cugraph_triangle_count_result_t* result);
 
-
 /**
  * @brief     Opaque heirarchical clustering output
  */
@@ -87,7 +86,7 @@ typedef struct {
  * @param [in]  graph        Pointer to graph.  NOTE: Graph might be modified if the storage
  *                           needs to be transposed
  * @param [in]  max_level    Maximum level in hierarchy
- * @param [in]  resolution   Resolution parameter (gamma) in modularity formula.  
+ * @param [in]  resolution   Resolution parameter (gamma) in modularity formula.
  *                           This changes the size of the communities.  Higher resolutions
  *                           lead to more smaller communities, lower resolutions lead to
  *                           fewer larger communities.
@@ -124,7 +123,6 @@ cugraph_type_erased_device_array_view_t* cugraph_heirarchical_clustering_result_
  * @param [in] result     The result from a sampling algorithm
  */
 void cugraph_heirarchical_clustering_result_free(cugraph_heirarchical_clustering_result_t* result);
-
 
 #ifdef __cplusplus
 }

--- a/cpp/include/cugraph_c/community_algorithms.h
+++ b/cpp/include/cugraph_c/community_algorithms.h
@@ -41,7 +41,7 @@ typedef struct {
  *                           the entire set of vertices in the graph is processed
  * @param [in]  do_expensive_check
  *                           A flag to run expensive checks for input arguments (if set to true)
- * @param [in]  result       Output from the triangle_count call
+ * @param [out] result       Output from the triangle_count call
  * @param [out] error        Pointer to an error object storing details of any error.  Will
  *                           be populated if error code is not CUGRAPH_SUCCESS
  * @return error code
@@ -71,6 +71,60 @@ cugraph_type_erased_device_array_view_t* cugraph_triangle_count_result_get_count
  * @param [in] result     The result from a sampling algorithm
  */
 void cugraph_triangle_count_result_free(cugraph_triangle_count_result_t* result);
+
+
+/**
+ * @brief     Opaque heirarchical clustering output
+ */
+typedef struct {
+  int32_t align_;
+} cugraph_heirarchical_clustering_result_t;
+
+/**
+ * @brief     Compute Louvain
+ *
+ * @param [in]  handle       Handle for accessing resources
+ * @param [in]  graph        Pointer to graph.  NOTE: Graph might be modified if the storage
+ *                           needs to be transposed
+ * @param [in]  max_level    Maximum level in hierarchy
+ * @param [in]  resolution   Resolution parameter (gamma) in modularity formula.  
+ *                           This changes the size of the communities.  Higher resolutions
+ *                           lead to more smaller communities, lower resolutions lead to
+ *                           fewer larger communities.
+ * @param [in]  do_expensive_check
+ *                           A flag to run expensive checks for input arguments (if set to true)
+ * @param [out] result       Output from the Louvain call
+ * @param [out] error        Pointer to an error object storing details of any error.  Will
+ *                           be populated if error code is not CUGRAPH_SUCCESS
+ * @return error code
+ */
+cugraph_error_code_t cugraph_louvain(const cugraph_resource_handle_t* handle,
+                                     cugraph_graph_t* graph,
+                                     size_t max_level,
+                                     double resolution,
+                                     bool_t do_expensive_check,
+                                     cugraph_heirarchical_clustering_result_t** result,
+                                     cugraph_error_t** error);
+
+/**
+ * @brief     Get heirarchical clustering vertices
+ */
+cugraph_type_erased_device_array_view_t* cugraph_heirarchical_clustering_result_get_vertices(
+  cugraph_heirarchical_clustering_result_t* result);
+
+/**
+ * @brief     Get heirarchical clustering clusters
+ */
+cugraph_type_erased_device_array_view_t* cugraph_heirarchical_clustering_result_get_clusters(
+  cugraph_heirarchical_clustering_result_t* result);
+
+/**
+ * @brief     Free a heirarchical clustering result
+ *
+ * @param [in] result     The result from a sampling algorithm
+ */
+void cugraph_heirarchical_clustering_result_free(cugraph_heirarchical_clustering_result_t* result);
+
 
 #ifdef __cplusplus
 }

--- a/cpp/src/c_api/louvain.cpp
+++ b/cpp/src/c_api/louvain.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cugraph_c/algorithms.h>
+
+#include <c_api/abstract_functor.hpp>
+#include <c_api/graph.hpp>
+#include <c_api/resource_handle.hpp>
+#include <c_api/utils.hpp>
+
+#include <cugraph/algorithms.hpp>
+#include <cugraph/detail/shuffle_wrappers.hpp>
+#include <cugraph/detail/utility_wrappers.hpp>
+#include <cugraph/graph_functions.hpp>
+
+#include <optional>
+
+namespace cugraph {
+namespace c_api {
+
+struct cugraph_heirarchical_clustering_result_t {
+  cugraph_type_erased_device_array_t* vertices_;
+  cugraph_type_erased_device_array_t* clusters_;
+};
+
+}  // namespace c_api
+}  // namespace cugraph
+
+namespace {
+
+struct louvain_functor : public cugraph::c_api::abstract_functor {
+  raft::handle_t const& handle_;
+  cugraph::c_api::cugraph_graph_t* graph_;
+  size_t max_level_;
+  double resolution_;
+  bool do_expensive_check_;
+  cugraph::c_api::cugraph_heirarchical_clustering_result_t* result_{};
+
+  louvain_functor(::cugraph_resource_handle_t const* handle,
+                  ::cugraph_graph_t* graph,
+                  size_t max_level,
+                  double resolution,
+                  bool do_expensive_check)
+    : abstract_functor(),
+      handle_(*reinterpret_cast<cugraph::c_api::cugraph_resource_handle_t const*>(handle)->handle_),
+      graph_(reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(graph)),
+      max_level_(max_level),
+      resolution_(resolution),
+      do_expensive_check_(do_expensive_check)
+  {
+  }
+
+  template <typename vertex_t,
+            typename edge_t,
+            typename weight_t,
+            bool store_transposed,
+            bool multi_gpu>
+  void operator()()
+  {
+    if constexpr (!cugraph::is_candidate<vertex_t, edge_t, weight_t>::value) {
+      unsupported();
+    } else {
+      // louvain expects store_transposed == false
+      if constexpr (store_transposed) {
+        error_code_ = cugraph::c_api::
+          transpose_storage<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>(
+            handle_, graph_, error_.get());
+        if (error_code_ != CUGRAPH_SUCCESS) return;
+      }
+
+      auto graph =
+        reinterpret_cast<cugraph::graph_t<vertex_t, edge_t, weight_t, false, multi_gpu>*>(
+          graph_->graph_);
+
+      auto graph_view = graph->view();
+
+      auto number_map = reinterpret_cast<rmm::device_uvector<vertex_t>*>(graph_->number_map_);
+
+      rmm::device_uvector<vertex_t> clusters(graph_view.local_vertex_partition_range_size(),
+                                             handle_.get_stream());
+
+      cugraph::louvain(
+        handle_, graph_view, clusters.data(), max_level_, static_cast<weight_t>(resolution_));
+
+      rmm::device_uvector<vertex_t> vertices(graph_view.local_vertex_partition_range_size(),
+                                             handle_.get_stream());
+      raft::copy(vertices.data(), number_map->data(), vertices.size(), handle_.get_stream());
+
+      result_ = new cugraph::c_api::cugraph_heirarchical_clustering_result_t{
+        new cugraph::c_api::cugraph_type_erased_device_array_t(vertices, graph_->vertex_type_),
+        new cugraph::c_api::cugraph_type_erased_device_array_t(clusters, graph_->vertex_type_)};
+    }
+  }
+};
+
+}  // namespace
+
+extern "C" cugraph_type_erased_device_array_view_t*
+cugraph_heirarchical_clustering_result_get_vertices(
+  cugraph_heirarchical_clustering_result_t* result)
+{
+  auto internal_pointer =
+    reinterpret_cast<cugraph::c_api::cugraph_heirarchical_clustering_result_t*>(result);
+  return reinterpret_cast<cugraph_type_erased_device_array_view_t*>(
+    internal_pointer->vertices_->view());
+}
+
+extern "C" cugraph_type_erased_device_array_view_t*
+cugraph_heirarchical_clustering_result_get_clusters(
+  cugraph_heirarchical_clustering_result_t* result)
+{
+  auto internal_pointer =
+    reinterpret_cast<cugraph::c_api::cugraph_heirarchical_clustering_result_t*>(result);
+  return reinterpret_cast<cugraph_type_erased_device_array_view_t*>(
+    internal_pointer->clusters_->view());
+}
+
+extern "C" void cugraph_heirarchical_clustering_result_free(
+  cugraph_heirarchical_clustering_result_t* result)
+{
+  auto internal_pointer =
+    reinterpret_cast<cugraph::c_api::cugraph_heirarchical_clustering_result_t*>(result);
+  delete internal_pointer->vertices_;
+  delete internal_pointer->clusters_;
+  delete internal_pointer;
+}
+
+extern "C" cugraph_error_code_t cugraph_louvain(const cugraph_resource_handle_t* handle,
+                                                cugraph_graph_t* graph,
+                                                size_t max_level,
+                                                double resolution,
+                                                bool_t do_expensive_check,
+                                                cugraph_heirarchical_clustering_result_t** result,
+                                                cugraph_error_t** error)
+{
+  louvain_functor functor(handle, graph, max_level, resolution, do_expensive_check);
+
+  return cugraph::c_api::run_algorithm(graph, functor, result, error);
+}

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -635,6 +635,7 @@ if(BUILD_CUGRAPH_MG_TESTS)
         ConfigureCTestMG(MG_CAPI_HITS c_api/mg_hits_test.c c_api/mg_test_utils.cpp)
         ConfigureCTestMG(MG_CAPI_UNIFORM_NEIGHBOR_SAMPLE c_api/mg_uniform_neighbor_sample_test.c c_api/mg_test_utils.cpp)
         ConfigureCTestMG(MG_CAPI_TRIANGLE_COUNT c_api/mg_triangle_count_test.c c_api/mg_test_utils.cpp)
+        ConfigureCTestMG(MG_CAPI_LOUVAIN c_api/mg_louvain_test.c c_api/mg_test_utils.cpp)
     else()
        message(FATAL_ERROR "OpenMPI NOT found, cannot build MG tests.")
     endif()
@@ -686,6 +687,7 @@ ConfigureCTest(CAPI_WEAKLY_CONNECTED_COMPONENTS c_api/weakly_connected_component
 ConfigureCTest(CAPI_STRONGLY_CONNECTED_COMPONENTS c_api/strongly_connected_components_test.c)
 ConfigureCTest(CAPI_UNIFORM_NEIGHBOR_SAMPLE c_api/uniform_neighbor_sample_test.c)
 ConfigureCTest(CAPI_TRIANGLE_COUNT c_api/triangle_count_test.c)
+ConfigureCTest(CAPI_LOUVAIN c_api/louvain_test.c)
 
 ###################################################################################################
 ### enable testing ################################################################################

--- a/cpp/tests/c_api/louvain_test.c
+++ b/cpp/tests/c_api/louvain_test.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "c_test_utils.h" /* RUN_TEST */
+
+#include <cugraph_c/algorithms.h>
+#include <cugraph_c/graph.h>
+
+#include <math.h>
+
+typedef int32_t vertex_t;
+typedef int32_t edge_t;
+typedef float weight_t;
+
+int generic_louvain_test(vertex_t* h_src,
+                         vertex_t* h_dst,
+                         weight_t* h_wgt,
+                         vertex_t* h_result,
+                         size_t num_vertices,
+                         size_t num_edges,
+                         size_t max_level,
+                         double resolution,
+                         bool_t store_transposed)
+{
+  int test_ret_value = 0;
+
+  cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
+  cugraph_error_t* ret_error;
+
+  cugraph_resource_handle_t* p_handle                  = NULL;
+  cugraph_graph_t* p_graph                             = NULL;
+  cugraph_heirarchical_clustering_result_t* p_result = NULL;
+
+  p_handle = cugraph_create_resource_handle(NULL);
+  TEST_ASSERT(test_ret_value, p_handle != NULL, "resource handle creation failed.");
+
+  ret_code = create_test_graph(
+    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, FALSE, FALSE, &p_graph, &ret_error);
+
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "create_test_graph failed.");
+  TEST_ALWAYS_ASSERT(ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
+
+  ret_code =
+    cugraph_louvain(p_handle, p_graph, max_level, resolution, FALSE, &p_result, &ret_error);
+
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
+  TEST_ALWAYS_ASSERT(ret_code == CUGRAPH_SUCCESS, "cugraph_louvain failed.");
+
+  if (test_ret_value == 0) {
+    cugraph_type_erased_device_array_view_t* vertices;
+    cugraph_type_erased_device_array_view_t* clusters;
+
+    vertices = cugraph_heirarchical_clustering_result_get_vertices(p_result);
+    clusters   = cugraph_heirarchical_clustering_result_get_clusters(p_result);
+
+    vertex_t h_vertices[num_vertices];
+    edge_t h_clusters[num_vertices];
+
+    ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+      p_handle, (byte_t*)h_vertices, vertices, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+    ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+      p_handle, (byte_t*)h_clusters, clusters, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+    for (int i = 0; (i < num_vertices) && (test_ret_value == 0); ++i) {
+      TEST_ASSERT(
+        test_ret_value, h_result[h_vertices[i]] == h_clusters[i], "cluster results don't match");
+    }
+
+    cugraph_heirarchical_clustering_result_free(p_result);
+  }
+
+  cugraph_sg_graph_free(p_graph);
+  cugraph_free_resource_handle(p_handle);
+  cugraph_error_free(ret_error);
+
+  return test_ret_value;
+}
+
+int test_louvain()
+{
+  size_t num_edges    = 8;
+  size_t num_vertices = 6;
+  size_t max_level    = 10;
+  weight_t resolution = 1.0;
+
+  vertex_t h_src[] = {0, 1, 1, 2, 2, 2, 3, 4, 1, 3, 4, 0, 1, 3, 5, 5};
+  vertex_t h_dst[] = {1, 3, 4, 0, 1, 3, 5, 5, 0, 1, 1, 2, 2, 2, 3, 4};
+  weight_t h_wgt[] = {
+    0.1f, 2.1f, 1.1f, 5.1f, 3.1f, 4.1f, 7.2f, 3.2f, 0.1f, 2.1f, 1.1f, 5.1f, 3.1f, 4.1f, 7.2f, 3.2f};
+  vertex_t h_result[] = {0, 1, 0, 1, 1, 1};
+
+  // Louvain wants store_transposed = FALSE
+  return generic_louvain_test(
+    h_src, h_dst, h_wgt, h_result, num_vertices, num_edges, max_level, resolution, FALSE);
+}
+
+/******************************************************************************/
+
+int main(int argc, char** argv)
+{
+  int result = 0;
+  result |= RUN_TEST(test_louvain);
+  return result;
+}

--- a/cpp/tests/c_api/mg_louvain_test.c
+++ b/cpp/tests/c_api/mg_louvain_test.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mg_test_utils.h" /* RUN_TEST */
+
+#include <cugraph_c/algorithms.h>
+#include <cugraph_c/graph.h>
+
+#include <math.h>
+
+typedef int32_t vertex_t;
+typedef int32_t edge_t;
+typedef float weight_t;
+
+int generic_louvain_test(const cugraph_resource_handle_t* p_handle,
+                         vertex_t* h_src,
+                         vertex_t* h_dst,
+                         weight_t* h_wgt,
+                         vertex_t* h_result,
+                         size_t num_vertices,
+                         size_t num_edges,
+                         size_t max_level,
+                         double resolution,
+                         bool_t store_transposed)
+{
+  int test_ret_value = 0;
+
+  cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
+  cugraph_error_t* ret_error;
+
+  cugraph_graph_t* p_graph                           = NULL;
+  cugraph_heirarchical_clustering_result_t* p_result = NULL;
+
+  ret_code = create_mg_test_graph(
+    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, FALSE, &p_graph, &ret_error);
+
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "create_test_graph failed.");
+  TEST_ALWAYS_ASSERT(ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
+
+  ret_code =
+    cugraph_louvain(p_handle, p_graph, max_level, resolution, FALSE, &p_result, &ret_error);
+
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
+  TEST_ALWAYS_ASSERT(ret_code == CUGRAPH_SUCCESS, "cugraph_louvain failed.");
+
+  if (test_ret_value == 0) {
+    cugraph_type_erased_device_array_view_t* vertices;
+    cugraph_type_erased_device_array_view_t* clusters;
+
+    vertices = cugraph_heirarchical_clustering_result_get_vertices(p_result);
+    clusters = cugraph_heirarchical_clustering_result_get_clusters(p_result);
+
+    vertex_t h_vertices[num_vertices];
+    edge_t h_clusters[num_vertices];
+
+    ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+      p_handle, (byte_t*)h_vertices, vertices, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+    ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+      p_handle, (byte_t*)h_clusters, clusters, &ret_error);
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+    size_t num_local_vertices = cugraph_type_erased_device_array_view_size(vertices);
+
+    for (int i = 0; (i < num_local_vertices) && (test_ret_value == 0); ++i) {
+      TEST_ASSERT(
+        test_ret_value, h_result[h_vertices[i]] == h_clusters[i], "cluster results don't match");
+    }
+
+    cugraph_heirarchical_clustering_result_free(p_result);
+  }
+
+  cugraph_mg_graph_free(p_graph);
+  cugraph_error_free(ret_error);
+
+  return test_ret_value;
+}
+
+int test_louvain(const cugraph_resource_handle_t* handle)
+{
+  size_t num_edges    = 8;
+  size_t num_vertices = 6;
+  size_t max_level    = 10;
+  weight_t resolution = 1.0;
+
+  vertex_t h_src[] = {0, 1, 1, 2, 2, 2, 3, 4, 1, 3, 4, 0, 1, 3, 5, 5};
+  vertex_t h_dst[] = {1, 3, 4, 0, 1, 3, 5, 5, 0, 1, 1, 2, 2, 2, 3, 4};
+  weight_t h_wgt[] = {
+    0.1f, 2.1f, 1.1f, 5.1f, 3.1f, 4.1f, 7.2f, 3.2f, 0.1f, 2.1f, 1.1f, 5.1f, 3.1f, 4.1f, 7.2f, 3.2f};
+  vertex_t h_result[] = {1, 0, 1, 0, 0, 0};
+
+  // Louvain wants store_transposed = FALSE
+  return generic_louvain_test(
+    handle, h_src, h_dst, h_wgt, h_result, num_vertices, num_edges, max_level, resolution, FALSE);
+}
+
+/******************************************************************************/
+
+int main(int argc, char** argv)
+{
+  // Set up MPI:
+  int comm_rank;
+  int comm_size;
+  int num_gpus_per_node;
+  cudaError_t status;
+  int mpi_status;
+  int result                        = 0;
+  cugraph_resource_handle_t* handle = NULL;
+  cugraph_error_t* ret_error;
+  cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
+  int prows                     = 1;
+
+  C_MPI_TRY(MPI_Init(&argc, &argv));
+  C_MPI_TRY(MPI_Comm_rank(MPI_COMM_WORLD, &comm_rank));
+  C_MPI_TRY(MPI_Comm_size(MPI_COMM_WORLD, &comm_size));
+  C_CUDA_TRY(cudaGetDeviceCount(&num_gpus_per_node));
+  C_CUDA_TRY(cudaSetDevice(comm_rank % num_gpus_per_node));
+
+  void* raft_handle = create_raft_handle(prows);
+  handle            = cugraph_create_resource_handle(raft_handle);
+
+  if (result == 0) {
+    result |= RUN_MG_TEST(test_louvain, handle);
+
+    cugraph_free_resource_handle(handle);
+  }
+
+  free_raft_handle(raft_handle);
+
+  C_MPI_TRY(MPI_Finalize());
+
+  return result;
+}


### PR DESCRIPTION
This PR adds Louvain to the C API.  This PR is a full implementation including:
 * C API definition
 * C API implementation calling the C++ version of Louvain
 * SG and MG unit tests exercising the Louvain implementation
 * A small documentation update to triangle counting that was discovered in the final review of the triangle counting C API PR