### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -14,8 +14,8 @@ dependencies:
 - libraft-headers=22.06.*
 - pyraft=22.06.*
 - cuda-python>=11.5,<12.0
-- dask>=2022.03.0
-- distributed>=2022.03.0
+- dask==2022.05.1
+- distributed==2022.05.1
 - dask-cuda=22.06.*
 - dask-cudf=22.06.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -14,8 +14,8 @@ dependencies:
 - libraft-headers=22.06.*
 - pyraft=22.06.*
 - cuda-python>=11.5,<12.0
-- dask>=2022.03.0
-- distributed>=2022.03.0
+- dask==2022.05.1
+- distributed==2022.05.1
 - dask-cuda=22.06.*
 - dask-cudf=22.06.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.5.yml
+++ b/conda/environments/cugraph_dev_cuda11.5.yml
@@ -14,8 +14,8 @@ dependencies:
 - libraft-headers=22.06.*
 - pyraft=22.06.*
 - cuda-python>=11.5,<12.0
-- dask>=2022.03.0
-- distributed>=2022.03.0
+- dask==2022.05.1
+- distributed==2022.05.1
 - dask-cuda=22.06.*
 - dask-cudf=22.06.*
 - nccl>=2.9.9

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -49,8 +49,8 @@ requirements:
     - cudf={{ minor_version }}
     - dask-cudf {{ minor_version }}
     - dask-cuda {{ minor_version }}
-    - dask>=2022.03.0
-    - distributed>=2022.03.0
+    - dask==2022.05.1
+    - distributed==2022.05.1
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.