### PR TITLE
Fix  import in the api_docs

### DIFF
--- a/docs/cugraph/source/api_docs/dask-cugraph.rst
+++ b/docs/cugraph/source/api_docs/dask-cugraph.rst
@@ -20,7 +20,7 @@ Example
 
     from dask.distributed import Client, wait
     from dask_cuda import LocalCUDACluster
-    import cugraph.dask.comms as Comms
+    import cugraph.dask.comms.comms as Comms
     import cugraph.dask as dask_cugraph
 
     cluster = LocalCUDACluster()


### PR DESCRIPTION
This PR fixes the `comms` import in the API docs.