### PR TITLE
Default GPU_COUNT to 1 in cmake file

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -512,13 +512,11 @@ if(BUILD_CUGRAPH_MG_TESTS)
     # - find MPI - only enabled if MG tests are to be built
     find_package(MPI REQUIRED)
 
-    execute_process(
-      COMMAND nvidia-smi -L
-      COMMAND wc -l
-      OUTPUT_VARIABLE GPU_COUNT)
-
-    string(REGEX REPLACE "\n$" "" GPU_COUNT ${GPU_COUNT})
-    MESSAGE(STATUS "GPU_COUNT: " ${GPU_COUNT})
+    # Set the GPU count to 1.  If the caller wants to execute MG tests using
+    # more than 1, override from the command line using -DGPU_COUNT=<gpucount>
+    if (NOT DEFINED GPU_COUNT)
+      set(GPU_COUNT "1")
+    endif()
 
     if(MPI_CXX_FOUND)
         ###########################################################################################


### PR DESCRIPTION
Closes #2314

Rather than relying on the output from nvidia-smi, MG C++ tests will default to 1 GPU.  This default can be overridden by the developer by calling `cmake` with the option: `-DGPU_COUNT=` and specifying the desired number of GPUs.

Note that the user can always run individual tests by directly calling `mpirun`.  This only affects the default used by `ctest`, `make test` or `ninja test` to run the entire suite of tests.