### PR TITLE
Release notebook: Nx Generators & Adding Perf_counter

### DIFF
--- a/notebooks/cugraph_benchmarks/release.ipynb
+++ b/notebooks/cugraph_benchmarks/release.ipynb
@@ -90,6 +90,7 @@
     "| Brad Rees     | 10/06/2020 | created             | 0.16            | GV100, CUDA 10.2       |\n",
     "| Brad Rees     | 01/20/2022 | updated             | 22.02           | Quadro A6000 CUDA 11.5 |\n",
     "| Brad Rees     | 01/20/2022 | added perf w/Nx obj | 22.02           | Quadro A6000 CUDA 11.5 |\n",
+    "| Ralph Liu     | 06/01/2022 | Fix: Generators     | 22.06           | Tesla V100, CUDA 11.5  |\n",
     "\n",
     "\n",
     "\n"
@@ -104,14 +105,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# system and other\n",
     "import gc\n",
     "import os\n",
-    "import time\n",
+    "from time import perf_counter\n",
     "import numpy as np\n",
     "import math\n",
     "\n",
@@ -128,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,13 +170,13 @@
     "}\n",
     "\n",
     "\n",
-    "\n",
-    "data = data_full\n"
+    "# TODO: Was set to quick for test\n",
+    "data = data_quick\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,29 +264,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "def nx_katz(_df, alpha):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)\n",
     "    _ = nx.katz_centrality(_G, alpha)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_katz(_df, alpha):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_cu_ugraph(_df)\n",
     "    _ = cugraph.katz_centrality(_G, alpha)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_katz_nx(_df, alpha):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)\n",
     "    _ = cugraph.katz_centrality(_G, alpha)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2"
    ]
   },
@@ -298,30 +299,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "def nx_bc(_df, _k):\n",
     "    print(f\" k = {_k}\", end=' ')\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)\n",
     "    _ = nx.betweenness_centrality(_G, k=_k)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_bc(_df, _k):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_cu_ugraph(_df)\n",
     "    _ = cugraph.betweenness_centrality(_G, k=_k)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_bc_nx(_df, _k):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)\n",
     "    _ = cugraph.betweenness_centrality(_G, k=_k)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2"
    ]
   },
@@ -334,33 +335,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "def nx_louvain(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)\n",
     "    parts = community.best_partition(_G)\n",
     "    \n",
     "    # Calculating modularity scores for comparison \n",
     "    _ = community.modularity(parts, _G)  \n",
     "    \n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_louvain(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_cu_ugraph(_df)\n",
     "    _,_ = cugraph.louvain(_G)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_louvain_nx(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)\n",
     "    _,_ = cugraph.louvain(_G)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2"
    ]
   },
@@ -373,12 +374,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "def nx_tc(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)\n",
     "    nx_count = nx.triangles(_G)\n",
     "    \n",
@@ -387,21 +388,21 @@
     "    for key, value in nx_count.items():\n",
     "        count = count + value    \n",
     "    \n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_tc(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_cu_ugraph(_df)\n",
     "    _ = cugraph.triangles(_G)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_tc_nx(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)\n",
     "    _ = cugraph.triangles(_G)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2"
    ]
   },
@@ -414,12 +415,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "def nx_wcc(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_digraph(_df)\n",
     "    gen = nx.weakly_connected_components(_G)\n",
     "\n",
@@ -428,21 +429,21 @@
     "    for subgraph in gen:\n",
     "        list_of_digraphs.append(nx.subgraph(_G, subgraph))\n",
     "    \n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_wcc(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_cu_digraph(_df)    \n",
     "    _ = cugraph.weakly_connected_components(_G)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_wcc_nx(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_digraph(_df)    \n",
     "    _ = cugraph.weakly_connected_components(_G)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2"
    ]
   },
@@ -455,12 +456,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "def nx_core_num(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)\n",
     "    nx_count = nx.core_number(_G)\n",
     "    \n",
@@ -468,21 +469,21 @@
     "    for key, value in nx_count.items():\n",
     "        count = count + value       \n",
     "    \n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_core_num(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_cu_ugraph(_df)    \n",
     "    _ = cugraph.core_number(_G)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_core_num_nx(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)    \n",
     "    _ = cugraph.core_number(_G)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2"
    ]
   },
@@ -495,29 +496,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "def nx_pagerank(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_digraph(_df)\n",
     "    _ = nx.pagerank(_G)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_pagerank(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_cu_digraph(_df)\n",
     "    _ = cugraph.pagerank(_G)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_pagerank_nx(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_digraph(_df)\n",
     "    _ = cugraph.pagerank(_G)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2"
    ]
   },
@@ -530,29 +531,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "def nx_jaccard(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)\n",
-    "    _ = nx.jaccard_coefficient(_G)\n",
-    "    t2 = time.time() - t1\n",
+    "    nj = nx.jaccard_coefficient(_G)\n",
+    "    nj_list = list(nj) # gen -> list\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_jaccard(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_cu_ugraph(_df)\n",
     "    _ = cugraph.jaccard_coefficient(_G)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_jaccard_nx(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)\n",
     "    _ = cugraph.jaccard_coefficient(_G)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2"
    ]
   },
@@ -565,29 +567,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "def nx_bfs(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)\n",
-    "    _ = nx.bfs_edges(_G, 1)\n",
-    "    t2 = time.time() - t1\n",
+    "    nb = nx.bfs_edges(_G, 1) \n",
+    "    nb_list = list(nb) # gen -> list\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_bfs(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_cu_ugraph(_df)\n",
     "    _ = cugraph.bfs(_G, 1)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_bfs_nx(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)\n",
     "    _ = cugraph.bfs(_G, 1)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2"
    ]
   },
@@ -600,38 +603,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "def nx_sssp(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)\n",
     "    _ = nx.shortest_path(_G, 1)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_sssp(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_cu_ugraph(_df)    \n",
     "    _ = cugraph.sssp(_G, 1)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2\n",
     "\n",
     "def cu_sssp_nx(_df):\n",
-    "    t1 = time.time()\n",
+    "    t1 = perf_counter()\n",
     "    _G = create_nx_ugraph(_df)    \n",
     "    _ = cugraph.sssp(_G, 1)\n",
-    "    t2 = time.time() - t1\n",
+    "    t2 = perf_counter() - t1\n",
     "    return t2"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -644,7 +640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -654,32 +650,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Reading ./data/preferentialAttachment.mtx...\n",
-      "\tGDF Size 999970\n",
-      "\tcugraph Size 499985\n",
-      "\tcugraph Order 100000\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# do a simple pass just to get all the libraries initiallized\n",
+    "# do a simple pass just to get all the libraries initialized\n",
     "# This cell might not be needed\n",
     "v = './data/preferentialAttachment.mtx'\n",
     "gdf = read_data(v)\n",
@@ -706,75 +681,6 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Reading ./data/preferentialAttachment.mtx...\n",
-      "\tdata in gdf 999970 and data in pandas 999970\n",
-      "\tKatz  n.c.cx.\n",
-      "\tBC k=100  n. k = 100 c.cx. \n",
-      "\tLouvain  n.c.cx. \n",
-      "\tTC  n.c.cx. \n",
-      "\tWCC  n.c.cx. \n",
-      "\tCore Number  n.c.cx. \n",
-      "\tPageRank  n.c.cx. \n",
-      "\tJaccard  n.c.cx. \n",
-      "\tBFS  n.c.cx. \n",
-      "\tSSSP  n.c.cx. \n",
-      "Reading ./data/dblp-2010.mtx...\n",
-      "\tdata in gdf 1615400 and data in pandas 1615400\n",
-      "\tKatz  n.c.cx.\n",
-      "\tBC k=100  n. k = 100 c.cx. \n",
-      "\tLouvain  n.c.cx. \n",
-      "\tTC  n.c.cx. \n",
-      "\tWCC  n.c.cx. \n",
-      "\tCore Number  n.c.cx. \n",
-      "\tPageRank  n.c.cx. \n",
-      "\tJaccard  n.c.cx. \n",
-      "\tBFS  n.c.cx. \n",
-      "\tSSSP  n.c.cx. \n",
-      "Reading ./data/coPapersCiteseer.mtx...\n",
-      "\tdata in gdf 32073440 and data in pandas 32073440\n",
-      "\tKatz  n.c.cx.\n",
-      "\tBC k=100  n. k = 100 c.cx. \n",
-      "\tLouvain  n.c.cx. \n",
-      "\tTC  n.c.cx. \n",
-      "\tWCC  n.c.cx. \n",
-      "\tCore Number  n.c.cx. \n",
-      "\tPageRank  n.c.cx. \n",
-      "\tJaccard  n.c.cx. \n",
-      "\tBFS  n.c.cx. \n",
-      "\tSSSP  n.c.cx. \n",
-      "Reading ./data/as-Skitter.mtx...\n",
-      "\tdata in gdf 22190596 and data in pandas 22190596\n",
-      "\tKatz  n.c.cx.\n",
-      "\tBC k=100  n. k = 100 c.cx. \n",
-      "\tLouvain  n.c.cx. \n",
-      "\tTC  n.c.cx. \n",
-      "\tWCC  n.c.cx. \n",
-      "\tCore Number  n.c.cx. \n",
-      "\tPageRank  n.c.cx. \n",
-      "\tJaccard  n.c.cx. \n",
-      "\tBFS  n.c.cx. \n",
-      "\tSSSP  n.c.cx. \n"
-     ]
-    }
-   ],
    "source": [
     "# arrays to capture performance gains\n",
     "names = []\n",
@@ -1037,25 +943,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['   ', 'Katz', 'BC Estimate fixed', 'Louvain', 'TC', 'WCC', 'Core Number', 'PageRank', 'Jaccard', 'BFS', 'SSP']\n",
-      "preferentialAttachment\n",
-      "[531.5083672005737, 713.2091362850375, 5404.871910284401, 378.8714209575697, 70.72927362986779, 76.7855488460584, 369.8407050216162, 100.5242813104882, 4.378275208783683, 162.25090274331285]\n",
-      "dblp\n",
-      "[263.7293255857766, 1558.1884974132756, 622.282663375948, 142.59215746942343, 88.19197528607465, 116.20873484788576, 460.3603070425029, 121.2753931555862, 38.357311342936576, 186.59598139534884]\n",
-      "coPapersCiteseer\n",
-      "[2270.9739290077137, 2436.608230097977, 1057.486186959562, 2300.0750485569533, 233.7511393615408, 246.97401172398136, 853.279646090366, 112.73241487709193, 233.03646005823012, 267.6295226503849]\n",
-      "as-Skitter\n",
-      "[1037.8761480097223, 7091.970778835749, 1475.2901788933452, 3950.5098941991014, 228.11245124984197, 245.35607830599636, 547.8739313855568, 98.81747467270701, 222.20389619850272, 326.73959437931654]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Print results\n",
     "print(algos)\n",
@@ -1067,28 +957,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "------------\n",
-      "\n",
-      "['   ', 'Katz', 'BC Estimate fixed', 'Louvain', 'TC', 'WCC', 'Core Number', 'PageRank', 'Jaccard', 'BFS', 'SSP']\n",
-      "preferentialAttachment\n",
-      "[4.003601795825807, 93.08063351361315, 204.47865340368915, 2.7097492953036797, 0.8666907616338123, 1.2867491927399868, 1.9752328393020735, 0.1240993236960286, 0.7203119096547798, 179.41122927863145]\n",
-      "dblp\n",
-      "[4.885862057048338, 122.87364779256156, 31.02199520144101, 2.180625966164683, 1.4324289723528034, 1.3579940932619847, 2.348198022642711, 0.11145559203860335, 0.7265996313793216, 202.49957600312277]\n",
-      "coPapersCiteseer\n",
-      "[8.158465907417547, 49.369787236543914, 9.28701234947398, 12.067711445592089, 0.8232363804394461, 1.3752921888176353, 2.8151237928186994, 0.08727548257474192, 0.798480184263566, 322.0841686740297]\n",
-      "as-Skitter\n",
-      "[3.66123817526995, 631.2091494372795, 20.617572936160165, 34.49437773532841, 0.9264442180418646, 4.828647431829589, 2.2476285215684615, 0.12267649645919085, 0.8469181921567667, 431.6171964493335]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Print results\n",
     "print(\"\\n------------\\n\")\n",
@@ -1199,10 +1070,13 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "f708a36acfaef0acf74ccd43dfb58100269bf08fb79032a1e0a6f35bd9856f51"
+  },
   "kernelspec": {
-   "display_name": "cugraph_dev",
+   "display_name": "Python 3.8.10 ('base')",
    "language": "python",
-   "name": "cugraph_dev"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1214,7 +1088,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
There was an issue where some Nx methods return a generator and not a full answer. These functions (WCC, Jaccard, and BFS) were identified and fixed for the purpose of getting more accurate ("apples-to-apples") comparisons against cuGraph methods. 

Next, `time.time()` was replaced with `time.perf_counter()` to get appropriate interval timings. 