### PR TITLE
Fix sampling bug

### DIFF
--- a/cpp/src/sampling/detail/sampling_utils_impl.cuh
+++ b/cpp/src/sampling/detail/sampling_utils_impl.cuh
@@ -528,7 +528,7 @@ gather_local_edges(
           edge_index_first[index] = g_dst_index - g_degree_offset + glbl_adj_list_offsets[location];
           if (weights != nullptr) {
             weight_t const* edge_weights = *(partitions[partition_id].weights()) + sparse_offset;
-            weights[index]               = edge_weights[g_dst_index];
+            weights[index]               = edge_weights[g_dst_index - g_degree_offset];
           }
         } else {
           minors[index] = invalid_vertex_id;


### PR DESCRIPTION
@jnke2016 found a bug in the sampling code.

Fix weight lookup to match index lookup.  The weight array mirrors the indices array in its structure, but the computation to do the lookup was correct for the indices array but incorrect for the weights array.