### PR TITLE
Remove GraphCSC/GraphCSCView object, no longer used

### DIFF
--- a/cpp/include/cugraph/legacy/eidecl_graph.hpp
+++ b/cpp/include/cugraph/legacy/eidecl_graph.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,14 +57,6 @@ extern template class GraphCSRView<int64_t, int32_t, float>;
 extern template class GraphCSRView<int64_t, int32_t, double>;
 extern template class GraphCSRView<int64_t, int64_t, float>;
 extern template class GraphCSRView<int64_t, int64_t, double>;
-extern template class GraphCSCView<int32_t, int32_t, float>;
-extern template class GraphCSCView<int32_t, int32_t, double>;
-extern template class GraphCSCView<int32_t, int64_t, float>;
-extern template class GraphCSCView<int32_t, int64_t, double>;
-extern template class GraphCSCView<int64_t, int32_t, float>;
-extern template class GraphCSCView<int64_t, int32_t, double>;
-extern template class GraphCSCView<int64_t, int64_t, float>;
-extern template class GraphCSCView<int64_t, int64_t, double>;
 extern template class GraphCOO<int32_t, int32_t, float>;
 extern template class GraphCOO<int32_t, int32_t, double>;
 extern template class GraphCOO<int32_t, int64_t, float>;
@@ -81,13 +73,5 @@ extern template class GraphCSR<int64_t, int32_t, float>;
 extern template class GraphCSR<int64_t, int32_t, double>;
 extern template class GraphCSR<int64_t, int64_t, float>;
 extern template class GraphCSR<int64_t, int64_t, double>;
-extern template class GraphCSC<int32_t, int32_t, float>;
-extern template class GraphCSC<int32_t, int32_t, double>;
-extern template class GraphCSC<int32_t, int64_t, float>;
-extern template class GraphCSC<int32_t, int64_t, double>;
-extern template class GraphCSC<int64_t, int32_t, float>;
-extern template class GraphCSC<int64_t, int32_t, double>;
-extern template class GraphCSC<int64_t, int64_t, float>;
-extern template class GraphCSC<int64_t, int64_t, double>;
 }  // namespace legacy
 }  // namespace cugraph

--- a/cpp/include/cugraph/legacy/eidir_graph.hpp
+++ b/cpp/include/cugraph/legacy/eidir_graph.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,12 +47,6 @@ template class GraphCSRView<int32_t, int64_t, float>;
 template class GraphCSRView<int32_t, int64_t, double>;
 template class GraphCSRView<int64_t, int64_t, float>;
 template class GraphCSRView<int64_t, int64_t, double>;
-template class GraphCSCView<int32_t, int32_t, float>;
-template class GraphCSCView<int32_t, int32_t, double>;
-template class GraphCSCView<int32_t, int64_t, float>;
-template class GraphCSCView<int32_t, int64_t, double>;
-template class GraphCSCView<int64_t, int64_t, float>;
-template class GraphCSCView<int64_t, int64_t, double>;
 template class GraphCOO<int32_t, int32_t, float>;
 template class GraphCOO<int32_t, int32_t, double>;
 template class GraphCOO<int32_t, int64_t, float>;
@@ -65,11 +59,5 @@ template class GraphCSR<int32_t, int64_t, float>;
 template class GraphCSR<int32_t, int64_t, double>;
 template class GraphCSR<int64_t, int64_t, float>;
 template class GraphCSR<int64_t, int64_t, double>;
-template class GraphCSC<int32_t, int32_t, float>;
-template class GraphCSC<int32_t, int32_t, double>;
-template class GraphCSC<int32_t, int64_t, float>;
-template class GraphCSC<int32_t, int64_t, double>;
-template class GraphCSC<int64_t, int64_t, float>;
-template class GraphCSC<int64_t, int64_t, double>;
 }  // namespace legacy
 }  // namespace cugraph

--- a/cpp/include/cugraph/legacy/graph.hpp
+++ b/cpp/include/cugraph/legacy/graph.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -292,57 +292,6 @@ class GraphCSRView : public GraphCompressedSparseBaseView<vertex_t, edge_t, weig
 };
 
 /**
- * @brief       A graph stored in CSC (Compressed Sparse Column) format.
- *
- * @tparam vertex_t   Type of vertex id
- * @tparam edge_t     Type of edge id
- * @tparam weight_t   Type of weight
- */
-template <typename vertex_t, typename edge_t, typename weight_t>
-class GraphCSCView : public GraphCompressedSparseBaseView<vertex_t, edge_t, weight_t> {
- public:
-  /**
-   * @brief      Default constructor
-   */
-  GraphCSCView()
-    : GraphCompressedSparseBaseView<vertex_t, edge_t, weight_t>(nullptr, nullptr, nullptr, 0, 0)
-  {
-  }
-
-  /**
-   * @brief      Wrap existing arrays representing transposed adjacency lists in
-   * a Graph.
-   *             GraphCSCView does not own the memory used to represent this
-   * graph. This
-   *             function does not allocate memory.
-   *
-   * @param  offsets               This array of size V+1 (V is number of
-   * vertices) contains the
-   * offset of adjacency lists of every vertex. Offsets must be in the range [0,
-   * E] (number of
-   * edges).
-   * @param  indices               This array of size E contains the index of
-   * the destination for
-   * each edge. Indices must be in the range [0, V-1].
-   * @param  edge_data             This array of size E (number of edges)
-   * contains the weight for
-   * each edge.  This array can be null in which case the graph is considered
-   * unweighted.
-   * @param  number_of_vertices    The number of vertices in the graph
-   * @param  number_of_edges       The number of edges in the graph
-   */
-  GraphCSCView(edge_t* offsets,
-               vertex_t* indices,
-               weight_t* edge_data,
-               vertex_t number_of_vertices,
-               edge_t number_of_edges)
-    : GraphCompressedSparseBaseView<vertex_t, edge_t, weight_t>(
-        offsets, indices, edge_data, number_of_vertices, number_of_edges)
-  {
-  }
-};
-
-/**
  * @brief      TODO : Change this Take ownership of the provided graph arrays in
  * COO format
  *
@@ -589,58 +538,6 @@ class GraphCSR : public GraphCompressedSparseBase<vertex_t, edge_t, weight_t> {
   GraphCSRView<vertex_t, edge_t, weight_t> view(void) noexcept
   {
     return GraphCSRView<vertex_t, edge_t, weight_t>(
-      GraphCompressedSparseBase<vertex_t, edge_t, weight_t>::offsets(),
-      GraphCompressedSparseBase<vertex_t, edge_t, weight_t>::indices(),
-      GraphCompressedSparseBase<vertex_t, edge_t, weight_t>::edge_data(),
-      GraphCompressedSparseBase<vertex_t, edge_t, weight_t>::number_of_vertices(),
-      GraphCompressedSparseBase<vertex_t, edge_t, weight_t>::number_of_edges());
-  }
-};
-
-/**
- * @brief       A constructed graph stored in CSC (Compressed Sparse Column)
- * format.
- *
- * @tparam vertex_t   Type of vertex id
- * @tparam edge_t   Type of edge id
- * @tparam weight_t   Type of weight
- */
-template <typename vertex_t, typename edge_t, typename weight_t>
-class GraphCSC : public GraphCompressedSparseBase<vertex_t, edge_t, weight_t> {
- public:
-  /**
-   * @brief      Default constructor
-   */
-  GraphCSC() : GraphCompressedSparseBase<vertex_t, edge_t, weight_t>() {}
-
-  /**
-   * @brief      Take ownership of the provided graph arrays in CSR format
-   *
-   * @param  number_of_vertices    The number of vertices in the graph
-   * @param  number_of_edges       The number of edges in the graph
-   * @param  has_data              Wiether or not the class has data, default = False
-   * @param  stream                Specify the cudaStream, default = null
-   * @param mr                     Specify the memory resource
-   */
-  GraphCSC(vertex_t number_of_vertices_in,
-           edge_t number_of_edges_in,
-           bool has_data_in                    = false,
-           cudaStream_t stream                 = nullptr,
-           rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
-    : GraphCompressedSparseBase<vertex_t, edge_t, weight_t>(
-        number_of_vertices_in, number_of_edges_in, has_data_in, stream, mr)
-  {
-  }
-
-  GraphCSC(GraphSparseContents<vertex_t, edge_t, weight_t>&& contents)
-    : GraphCompressedSparseBase<vertex_t, edge_t, weight_t>(
-        std::forward<GraphSparseContents<vertex_t, edge_t, weight_t>>(contents))
-  {
-  }
-
-  GraphCSCView<vertex_t, edge_t, weight_t> view(void) noexcept
-  {
-    return GraphCSCView<vertex_t, edge_t, weight_t>(
       GraphCompressedSparseBase<vertex_t, edge_t, weight_t>::offsets(),
       GraphCompressedSparseBase<vertex_t, edge_t, weight_t>::indices(),
       GraphCompressedSparseBase<vertex_t, edge_t, weight_t>::edge_data(),

--- a/cpp/include/cugraph/utilities/cython.hpp
+++ b/cpp/include/cugraph/utilities/cython.hpp
@@ -43,8 +43,6 @@ enum class graphTypeEnum : int {
   // graph_container_t.
   GraphCSRViewFloat,
   GraphCSRViewDouble,
-  GraphCSCViewFloat,
-  GraphCSCViewDouble,
   GraphCOOViewFloat,
   GraphCOOViewDouble,
   // represents values present in the graph_container_t to construct a graph_t,
@@ -69,8 +67,6 @@ struct graph_container_t {
     void* null;
     std::unique_ptr<legacy::GraphCSRView<int32_t, int32_t, float>> GraphCSRViewFloatPtr;
     std::unique_ptr<legacy::GraphCSRView<int32_t, int32_t, double>> GraphCSRViewDoublePtr;
-    std::unique_ptr<legacy::GraphCSCView<int32_t, int32_t, float>> GraphCSCViewFloatPtr;
-    std::unique_ptr<legacy::GraphCSCView<int32_t, int32_t, double>> GraphCSCViewDoublePtr;
     std::unique_ptr<legacy::GraphCOOView<int32_t, int32_t, float>> GraphCOOViewFloatPtr;
     std::unique_ptr<legacy::GraphCOOView<int32_t, int32_t, double>> GraphCOOViewDoublePtr;
   };

--- a/cpp/src/utilities/cython.cu
+++ b/cpp/src/utilities/cython.cu
@@ -309,19 +309,6 @@ void populate_graph_container_legacy(graph_container_t& graph_container,
         (graph_container.graph_ptr_union.GraphCSRViewFloatPtr)
           ->set_handle(const_cast<raft::handle_t*>(&handle));
       } break;
-      case graphTypeEnum::LegacyCSC: {
-        graph_container.graph_ptr_union.GraphCSCViewFloatPtr =
-          std::make_unique<legacy::GraphCSCView<int, int, float>>(reinterpret_cast<int*>(offsets),
-                                                                  reinterpret_cast<int*>(indices),
-                                                                  reinterpret_cast<float*>(weights),
-                                                                  num_global_vertices,
-                                                                  num_global_edges);
-        graph_container.graph_type = graphTypeEnum::GraphCSCViewFloat;
-        (graph_container.graph_ptr_union.GraphCSCViewFloatPtr)
-          ->set_local_data(local_vertices, local_edges, local_offsets);
-        (graph_container.graph_ptr_union.GraphCSCViewFloatPtr)
-          ->set_handle(const_cast<raft::handle_t*>(&handle));
-      } break;
       case graphTypeEnum::LegacyCOO: {
         graph_container.graph_ptr_union.GraphCOOViewFloatPtr =
           std::make_unique<legacy::GraphCOOView<int, int, float>>(reinterpret_cast<int*>(offsets),
@@ -352,20 +339,6 @@ void populate_graph_container_legacy(graph_container_t& graph_container,
         (graph_container.graph_ptr_union.GraphCSRViewDoublePtr)
           ->set_local_data(local_vertices, local_edges, local_offsets);
         (graph_container.graph_ptr_union.GraphCSRViewDoublePtr)
-          ->set_handle(const_cast<raft::handle_t*>(&handle));
-      } break;
-      case graphTypeEnum::LegacyCSC: {
-        graph_container.graph_ptr_union.GraphCSCViewDoublePtr =
-          std::make_unique<legacy::GraphCSCView<int, int, double>>(
-            reinterpret_cast<int*>(offsets),
-            reinterpret_cast<int*>(indices),
-            reinterpret_cast<double*>(weights),
-            num_global_vertices,
-            num_global_edges);
-        graph_container.graph_type = graphTypeEnum::GraphCSCViewDouble;
-        (graph_container.graph_ptr_union.GraphCSCViewDoublePtr)
-          ->set_local_data(local_vertices, local_edges, local_offsets);
-        (graph_container.graph_ptr_union.GraphCSCViewDoublePtr)
           ->set_handle(const_cast<raft::handle_t*>(&handle));
       } break;
       case graphTypeEnum::LegacyCOO: {


### PR DESCRIPTION
Delete the legacy CSC graph objects.  They are no longer used (all transposed=True algorithms have been migrated to the new graph objects).

Marked `breaking` since it deletes a C++ API feature, although should no longer be used.