### PR TITLE
Switch back to PC generator

### DIFF
--- a/cpp/src/detail/utility_wrappers.cu
+++ b/cpp/src/detail/utility_wrappers.cu
@@ -32,7 +32,7 @@ void uniform_random_fill(rmm::cuda_stream_view const& stream_view,
                          value_t max_value,
                          uint64_t seed)
 {
-  raft::random::RngState rng_state(seed, raft::random::GeneratorType::GenPhilox);
+  raft::random::RngState rng_state(seed);
   raft::random::uniform<value_t, size_t>(
     rng_state, d_value, size, min_value, max_value, stream_view.value());
 }


### PR DESCRIPTION
With the RAFT changes here: https://github.com/rapidsai/raft/pull/690 we should be able to use the PC generator again.  The PC generator is significantly faster.

Closes #2266