### PR TITLE
[WIP] Bug fix (providing invalid sentinel value for cuCollection).

### DIFF
--- a/cpp/include/cugraph/prims/detail/nbr_intersection.cuh
+++ b/cpp/include/cugraph/prims/detail/nbr_intersection.cuh
@@ -852,7 +852,7 @@ nbr_intersection(raft::handle_t const& handle,
         std::max(static_cast<size_t>(static_cast<double>(unique_majors.size()) / load_factor),
                  static_cast<size_t>(unique_majors.size()) + 1),
         cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-        cuco::sentinel::empty_value<vertex_t>{0},
+        cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
         stream_adapter,
         handle.get_stream());
       auto pair_first = thrust::make_zip_iterator(unique_majors.begin(),

--- a/cpp/src/structure/relabel_impl.cuh
+++ b/cpp/src/structure/relabel_impl.cuh
@@ -120,7 +120,7 @@ void relabel(raft::handle_t const& handle,
                                static_cast<double>(rx_label_pair_old_labels.size()) / load_factor),
                              rx_label_pair_old_labels.size() + 1),
                     cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-                    cuco::sentinel::empty_value<vertex_t>{0},
+                    cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
                     stream_adapter,
                     handle.get_stream()};
 
@@ -185,7 +185,7 @@ void relabel(raft::handle_t const& handle,
           std::max(static_cast<size_t>(static_cast<double>(unique_old_labels.size()) / load_factor),
                    unique_old_labels.size() + 1),
           cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-          cuco::sentinel::empty_value<vertex_t>{0},
+          cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
           stream_adapter,
           handle.get_stream()};
 
@@ -212,7 +212,7 @@ void relabel(raft::handle_t const& handle,
         std::max(static_cast<size_t>(static_cast<double>(num_label_pairs) / load_factor),
                  static_cast<size_t>(num_label_pairs) + 1),
         cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-        cuco::sentinel::empty_value<vertex_t>{0},
+        cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
         stream_adapter,
         handle.get_stream());
 

--- a/cpp/src/structure/renumber_edgelist_impl.cuh
+++ b/cpp/src/structure/renumber_edgelist_impl.cuh
@@ -760,7 +760,7 @@ renumber_edgelist(
                      load_factor),
                    static_cast<size_t>(partition.local_edge_partition_major_range_size(i)) + 1),
           cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-          cuco::sentinel::empty_value<vertex_t>{0},
+          cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
           stream_adapter,
           handle.get_stream()};
       auto pair_first = thrust::make_zip_iterator(thrust::make_tuple(
@@ -800,9 +800,6 @@ renumber_edgelist(
                    i,
                    handle.get_stream());
 
-      RAFT_CUDA_TRY(cudaStreamSynchronize(
-        handle.get_stream()));  // cuco::static_map currently does not take stream
-
       auto poly_alloc =
         rmm::mr::polymorphic_allocator<char>(rmm::mr::get_current_device_resource());
       auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(poly_alloc, handle.get_stream());
@@ -811,7 +808,7 @@ renumber_edgelist(
                      std::max(static_cast<size_t>(static_cast<double>(segment_size) / load_factor),
                               static_cast<size_t>(segment_size) + 1),
                      cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-                     cuco::sentinel::empty_value<vertex_t>{0},
+                     cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
                      stream_adapter,
                      handle.get_stream()};
       auto pair_first = thrust::make_zip_iterator(thrust::make_tuple(
@@ -857,7 +854,7 @@ renumber_edgelist(
                               static_cast<double>(renumber_map_minor_labels.size()) / load_factor),
                             renumber_map_minor_labels.size() + 1),
                    cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-                   cuco::sentinel::empty_value<vertex_t>{0},
+                   cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
                    stream_adapter,
                    handle.get_stream()};
     auto pair_first = thrust::make_zip_iterator(thrust::make_tuple(
@@ -930,7 +927,7 @@ renumber_edgelist(raft::handle_t const& handle,
       std::max(static_cast<size_t>(static_cast<double>(renumber_map_labels.size()) / load_factor),
                renumber_map_labels.size() + 1),
       cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-      cuco::sentinel::empty_value<vertex_t>{0},
+      cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
       stream_adapter,
       handle.get_stream()};
   auto pair_first = thrust::make_zip_iterator(

--- a/cpp/src/structure/renumber_utils_impl.cuh
+++ b/cpp/src/structure/renumber_utils_impl.cuh
@@ -203,7 +203,7 @@ void unrenumber_local_int_edges(
                                 static_cast<double>(edge_partition_major_range_size) / load_factor),
                               static_cast<size_t>(edge_partition_major_range_size) + 1),
                      cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-                     cuco::sentinel::empty_value<vertex_t>{0},
+                     cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
                      stream_adapter,
                      handle.get_stream()};
       auto pair_first = thrust::make_zip_iterator(
@@ -266,7 +266,7 @@ void unrenumber_local_int_edges(
                      std::max(static_cast<size_t>(static_cast<double>(segment_size) / load_factor),
                               static_cast<size_t>(segment_size) + 1),
                      cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-                     cuco::sentinel::empty_value<vertex_t>{0},
+                     cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
                      stream_adapter,
                      handle.get_stream()};
       auto pair_first = thrust::make_zip_iterator(
@@ -319,7 +319,7 @@ void unrenumber_local_int_edges(
                               static_cast<double>(renumber_map_minor_labels.size()) / load_factor),
                             renumber_map_minor_labels.size() + 1),
                    cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-                   cuco::sentinel::empty_value<vertex_t>{0},
+                   cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
                    stream_adapter,
                    handle.get_stream()};
     auto pair_first = thrust::make_zip_iterator(
@@ -373,7 +373,7 @@ void renumber_ext_vertices(raft::handle_t const& handle,
     cuco::static_map<vertex_t, vertex_t, cuda::thread_scope_device, decltype(stream_adapter)>>(
     size_t{0},
     cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-    cuco::sentinel::empty_value<vertex_t>{0},
+    cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
     stream_adapter,
     handle.get_stream());
   if (multi_gpu) {
@@ -421,7 +421,7 @@ void renumber_ext_vertices(raft::handle_t const& handle,
         static_cast<size_t>(static_cast<double>(sorted_unique_ext_vertices.size()) / load_factor),
         sorted_unique_ext_vertices.size() + 1),
       cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-      cuco::sentinel::empty_value<vertex_t>{0},
+      cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
       stream_adapter,
       handle.get_stream());
 
@@ -442,7 +442,7 @@ void renumber_ext_vertices(raft::handle_t const& handle,
                  static_cast<double>(local_int_vertex_last - local_int_vertex_first) / load_factor),
                static_cast<size_t>(local_int_vertex_last - local_int_vertex_first) + 1),
       cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-      cuco::sentinel::empty_value<vertex_t>{0},
+      cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
       stream_adapter,
       handle.get_stream());
 
@@ -508,7 +508,7 @@ void renumber_local_ext_vertices(raft::handle_t const& handle,
                static_cast<double>(local_int_vertex_last - local_int_vertex_first) / load_factor),
              static_cast<size_t>(local_int_vertex_last - local_int_vertex_first) + 1),
     cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-    cuco::sentinel::empty_value<vertex_t>{0},
+    cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
     stream_adapter,
     handle.get_stream());
 
@@ -677,7 +677,7 @@ void unrenumber_int_vertices(raft::handle_t const& handle,
                               static_cast<double>(sorted_unique_int_vertices.size()) / load_factor),
                             sorted_unique_int_vertices.size() + 1),
                    cuco::sentinel::empty_key<vertex_t>{invalid_vertex_id<vertex_t>::value},
-                   cuco::sentinel::empty_value<vertex_t>{0},
+                   cuco::sentinel::empty_value<vertex_t>{invalid_vertex_id<vertex_t>::value},
                    stream_adapter,
                    handle.get_stream()};
 


### PR DESCRIPTION
- [ ] Fix when value_t is vertex_t
- [ ] Fix when value_t is not vertex_t (and can be any arithmetic or thrust::tuple of arithmetic types).