### PR TITLE
Generalize ModuleNotFoundError exception handling to ImportError for Amazon SMS libnuma.so.1 bug

### DIFF
--- a/python/cugraph/cugraph/dask/common/input_utils.py
+++ b/python/cugraph/cugraph/dask/common/input_utils.py
@@ -25,8 +25,10 @@ import cugraph.dask.comms.comms as Comms
 from cugraph.dask.common.read_utils import MissingUCXPy
 try:
     from raft.dask.common.utils import get_client
-except ModuleNotFoundError as err:
-    if err.name == "ucp":
+except ImportError as err:
+    # FIXME: Generalize since err.name is arr when
+    # libnuma.so.1 is not available
+    if err.name == "ucp" or err.name == "arr":
         get_client = MissingUCXPy()
     else:
         raise

--- a/python/cugraph/cugraph/dask/common/mg_utils.py
+++ b/python/cugraph/cugraph/dask/common/mg_utils.py
@@ -23,8 +23,10 @@ from dask.distributed import Client
 from cugraph.dask.common.read_utils import MissingUCXPy
 try:
     from raft.dask.common.utils import default_client
-except ModuleNotFoundError as err:
-    if err.name == "ucp":
+except ImportError as err:
+    # FIXME: Generalize since err.name is arr when
+    # libnuma.so.1 is not available
+    if err.name == "ucp" or err.name == "arr":
         default_client = MissingUCXPy()
     else:
         raise

--- a/python/cugraph/cugraph/dask/comms/comms.py
+++ b/python/cugraph/cugraph/dask/comms/comms.py
@@ -17,8 +17,10 @@ from cugraph.dask.common.read_utils import MissingUCXPy
 try:
     from raft.dask.common.comms import Comms as raftComms
     from raft.dask.common.comms import get_raft_comm_state
-except ModuleNotFoundError as err:
-    if err.name == "ucp":
+except ImportError as err:
+    # FIXME: Generalize since err.name is arr when
+    # libnuma.so.1 is not available
+    if err.name == "ucp" or err.name == "arr":
         raftComms = MissingUCXPy()
         get_raft_comm_state = MissingUCXPy()
     else:


### PR DESCRIPTION
Generalize ModuleNotFoundError exception handling to ImportError for Amazon SMS libnuma.so.1 bug
https://github.com/rapidsai/cugraph/issues/2113

This allows cugraph to be imported in a SageMaker environment without having to remove `ucx-py`

NOTE: This is also being applied as a hotfix to 22.06 [here](https://github.com/rapidsai/cugraph/pull/2385).