### PR TITLE
Pin cuda-python.

### DIFF
--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -13,7 +13,7 @@ dependencies:
 - librmm=22.08.*
 - libraft-headers=22.08.*
 - pyraft=22.08.*
-- cuda-python>=11.5,<12.0
+- cuda-python>=11.5,<11.7.1
 - dask>=2022.05.2
 - distributed>=2022.05.2
 - dask-cuda=22.08.*

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -13,7 +13,7 @@ dependencies:
 - librmm=22.08.*
 - libraft-headers=22.08.*
 - pyraft=22.08.*
-- cuda-python>=11.5,<12.0
+- cuda-python>=11.5,<11.7.1
 - dask>=2022.05.2
 - distributed>=2022.05.2
 - dask-cuda=22.08.*

--- a/conda/environments/cugraph_dev_cuda11.5.yml
+++ b/conda/environments/cugraph_dev_cuda11.5.yml
@@ -13,7 +13,7 @@ dependencies:
 - librmm=22.08.*
 - libraft-headers=22.08.*
 - pyraft=22.08.*
-- cuda-python>=11.5,<12.0
+- cuda-python>=11.5,<11.7.1
 - dask>=2022.05.2
 - distributed>=2022.05.2
 - dask-cuda=22.08.*

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
-    - cuda-python >=11.5,<12.0
+    - cuda-python >=11.5,<11.7.1
 
 tests:                                 # [linux64]
   requirements:                        # [linux64]


### PR DESCRIPTION
Recent changes to cuda-python lead to incompatibilities with the CTK available via conda.

If necessary, these changes can be backported to 22.06.