### PR TITLE
Remove the comms import from cugraph's init file

### DIFF
--- a/python/cugraph/cugraph/__init__.py
+++ b/python/cugraph/cugraph/__init__.py
@@ -107,7 +107,6 @@ from cugraph.experimental import find_bicliques
 from cugraph.linear_assignment import hungarian, dense_hungarian
 from cugraph.layout import force_atlas2
 from raft import raft_include_test
-from cugraph.dask.comms import comms
 
 from cugraph.sampling import (
     random_walks,


### PR DESCRIPTION
A breaking change in 22.06 moved the functionalities of `comms` to `cugraph/dask` where it should belong as it is only part of the multi GPU API. However `cugraph/__init__.py` is still importing the the comms when it shouldn't.

This PR removes the `comms` import in `cugraph/__init__.py `

closes #2379
closes #2329 