### PR TITLE
Support building without cugraph-ops

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -80,6 +80,7 @@ option(BUILD_SHARED_LIBS "Build cuGraph shared libraries" ON)
 option(BUILD_CUGRAPH_MG_TESTS "Build cuGraph multigpu algorithm tests" OFF)
 option(CMAKE_CUDA_LINEINFO "Enable the -lineinfo option for nvcc (useful for cuda-memcheck / profiler" OFF)
 option(BUILD_TESTS "Configure CMake to build tests" ON)
+option(USE_CUGRAPH_OPS "Enable all functions that call cugraph-ops" ON)
 
 ################################################################################
 # - compiler options -----------------------------------------------------------
@@ -116,6 +117,12 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     list(APPEND CUGRAPH_CUDA_FLAGS -G -Xcompiler=-rdynamic)
 endif()
 
+if(NOT USE_CUGRAPH_OPS)
+    message(STATUS "Disabling functions that reference cugraph-ops")
+    list(APPEND CUGRAPH_CXX_FLAGS -DNO_CUGRAPH_OPS)
+    list(APPEND CUGRAPH_CUDA_FLAGS -DNO_CUGRAPH_OPS)
+endif()
+
 ################################################################################
 # - find openmp ----------------------------------------------------------------
 
@@ -149,7 +156,10 @@ include(cmake/thirdparty/get_libcudacxx.cmake)
 include(cmake/thirdparty/get_cuco.cmake)
 
 include(cmake/thirdparty/get_raft.cmake)
-include(cmake/thirdparty/get_libcugraphops.cmake)
+
+if(USE_CUGRAPH_OPS)
+  include(cmake/thirdparty/get_libcugraphops.cmake)
+endif()
 
 include(cmake/thirdparty/get_nccl.cmake)
 include(cmake/thirdparty/get_cuhornet.cmake)
@@ -161,7 +171,7 @@ endif()
 ################################################################################
 # - libcugraph library target --------------------------------------------------
 
-add_library(cugraph
+set(CUGRAPH_SOURCES
     src/detail/utility_wrappers.cu
     src/detail/shuffle_wrappers.cu
     src/utilities/cython.cu
@@ -184,7 +194,6 @@ add_library(cugraph
     src/community/legacy/triangles_counting.cu
     src/community/legacy/extract_subgraph_by_vertex.cu
     src/community/legacy/egonet.cu
-    src/sampling/neighborhood.cu
     src/sampling/random_walks.cu
     src/sampling/detail/sampling_utils_mg.cu
     src/sampling/detail/sampling_utils_sg.cu
@@ -240,6 +249,14 @@ add_library(cugraph
     src/community/triangle_count_mg.cu
 )
 
+if(USE_CUGRAPH_OPS)
+    list(APPEND CUGRAPH_SOURCES
+        src/sampling/neighborhood.cu
+    )
+endif()
+
+add_library(cugraph ${CUGRAPH_SOURCES})
+
 set_target_properties(cugraph
     PROPERTIES BUILD_RPATH                         "\$ORIGIN"
                INSTALL_RPATH                       "\$ORIGIN"
@@ -287,15 +304,26 @@ target_include_directories(cugraph
 
 ################################################################################
 # - link libraries -------------------------------------------------------------
-target_link_libraries(cugraph
-    PUBLIC
-        cugraph-ops::cugraph-ops++
-        raft::raft
-        cuco::cuco
-    PRIVATE
-        cugraph::cuHornet
-        NCCL::NCCL
-)
+if (USE_CUGRAPH_OPS)
+    target_link_libraries(cugraph
+        PUBLIC
+            cugraph-ops::cugraph-ops++
+            raft::raft
+            cuco::cuco
+        PRIVATE
+            cugraph::cuHornet
+            NCCL::NCCL
+    )
+else()
+    target_link_libraries(cugraph
+        PUBLIC
+            raft::raft
+            cuco::cuco
+        PRIVATE
+            cugraph::cuHornet
+            NCCL::NCCL
+    )
+endif()
 
 if(OpenMP_CXX_FOUND)
 target_link_libraries(cugraph PRIVATE

--- a/cpp/include/cugraph/algorithms.hpp
+++ b/cpp/include/cugraph/algorithms.hpp
@@ -24,7 +24,9 @@
 #include <cugraph/internals.hpp>
 #include <cugraph/legacy/graph.hpp>
 
+#ifndef NO_CUGRAPH_OPS
 #include <cugraph-ops/graph/sampling.hpp>
+#endif
 
 #include <raft/handle.hpp>
 #include <raft/random/rng_state.hpp>
@@ -1348,6 +1350,7 @@ random_walks(raft::handle_t const& handle,
              bool use_padding                                     = false,
              std::unique_ptr<sampling_params_t> sampling_strategy = nullptr);
 
+#ifndef NO_CUGRAPH_OPS
 /**
  * @brief generate sub-sampled graph as an adjacency list (CSR format) given input graph,
  * list of vertices and sample size per vertex. The output graph consists of the given
@@ -1409,6 +1412,7 @@ sample_neighbors_edgelist(raft::handle_t const& handle,
                           size_t num_start_vertices,
                           size_t sampling_size,
                           ops::gnn::graph::SamplingAlgoT sampling_algo);
+#endif
 
 /**
  * @brief Finds (weakly-connected-)component IDs of each vertices in the input graph.

--- a/cpp/src/sampling/uniform_neighbor_sampling_impl.hpp
+++ b/cpp/src/sampling/uniform_neighbor_sampling_impl.hpp
@@ -27,7 +27,9 @@
 
 #include <rmm/device_uvector.hpp>
 
+#ifndef NO_CUGRAPH_OPS
 #include <cugraph-ops/graph/sampling.hpp>
+#endif
 
 #include <thrust/optional.h>
 
@@ -58,6 +60,11 @@ uniform_nbr_sample_impl(
   using vertex_t = typename graph_view_t::vertex_type;
   using edge_t   = typename graph_view_t::edge_type;
   using weight_t = typename graph_view_t::weight_type;
+
+#ifdef NO_CUGRAPH_OPS
+  CUGRAPH_FAIL(
+    "uniform_nbr_sampl_impl not supported in this configuration, built with NO_CUGRAPH_OPS");
+#else
 
   namespace cugraph_ops = cugraph::ops::gnn::graph;
 
@@ -153,6 +160,7 @@ uniform_nbr_sample_impl(
 
   return count_and_remove_duplicates<vertex_t, edge_t, weight_t>(
     handle, std::move(d_result_src), std::move(d_result_dst), std::move(*d_result_indices));
+#endif
 }
 }  // namespace detail
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -285,6 +285,11 @@ function(ConfigureCTestMG CMAKE_TEST_NAME)
             EXCLUDE_FROM_ALL)
 endfunction()
 
+if(NOT USE_CUGRAPH_OPS)
+    list(APPEND CMAKE_C_FLAGS -DNO_CUGRAPH_OPS)
+    list(APPEND CMAKE_CXX_FLAGS -DNO_CUGRAPH_OPS)
+    list(APPEND CMAKE_CUDA_FLAGS -DNO_CUGRAPH_OPS)
+endif()
 
 ###################################################################################################
 # - set rapids dataset path ----------------------------------------------------------------------

--- a/cpp/tests/c_api/mg_uniform_neighbor_sample_test.c
+++ b/cpp/tests/c_api/mg_uniform_neighbor_sample_test.c
@@ -69,6 +69,10 @@ int generic_uniform_neighbor_sample_test(const cugraph_resource_handle_t* handle
   ret_code = cugraph_uniform_neighbor_sample(
     handle, graph, d_start_view, h_fan_out_view, with_replacement, FALSE, &result, &ret_error);
 
+#ifdef NO_CUGRAPH_OPS
+  TEST_ASSERT(
+    test_ret_value, ret_code != CUGRAPH_SUCCESS, "uniform_neighbor_sample should have failed");
+#else
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "uniform_neighbor_sample failed.");
 
@@ -118,7 +122,12 @@ int generic_uniform_neighbor_sample_test(const cugraph_resource_handle_t* handle
                 "uniform_neighbor_sample got edge that doesn't exist");
   }
 
+  cugraph_sample_result_free(result);
+#endif
+
   cugraph_type_erased_host_array_view_free(h_fan_out_view);
+  cugraph_mg_graph_free(graph);
+  cugraph_error_free(ret_error);
 
   return test_ret_value;
 }

--- a/cpp/tests/c_api/uniform_neighbor_sample_test.c
+++ b/cpp/tests/c_api/uniform_neighbor_sample_test.c
@@ -74,6 +74,7 @@ int create_test_graph_with_edge_ids(const cugraph_resource_handle_t* p_handle,
 
   ret_code = cugraph_type_erased_device_array_view_copy_from_host(
     p_handle, src_view, (byte_t*)h_src, ret_error);
+
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "src copy_from_host failed.");
 
   ret_code = cugraph_type_erased_device_array_view_copy_from_host(
@@ -151,6 +152,7 @@ int generic_uniform_neighbor_sample_test(vertex_t* h_src,
 
   ret_code = cugraph_type_erased_device_array_view_copy_from_host(
     handle, d_start_view, (byte_t*)h_start, &ret_error);
+
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "start copy_from_host failed.");
 
   h_fan_out_view = cugraph_type_erased_host_array_view_create(fan_out, max_depth, INT32);
@@ -158,6 +160,10 @@ int generic_uniform_neighbor_sample_test(vertex_t* h_src,
   ret_code = cugraph_uniform_neighbor_sample(
     handle, graph, d_start_view, h_fan_out_view, with_replacement, FALSE, &result, &ret_error);
 
+#ifdef NO_CUGRAPH_OPS
+  TEST_ASSERT(
+    test_ret_value, ret_code != CUGRAPH_SUCCESS, "uniform_neighbor_sample should have failed")
+#else
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "uniform_neighbor_sample failed.");
 
@@ -205,7 +211,13 @@ int generic_uniform_neighbor_sample_test(vertex_t* h_src,
                 "uniform_neighbor_sample got edge that doesn't exist");
   }
 
+  cugraph_sample_result_free(result);
+#endif
+
   cugraph_type_erased_host_array_view_free(h_fan_out_view);
+  cugraph_sg_graph_free(graph);
+  cugraph_free_resource_handle(handle);
+  cugraph_error_free(ret_error);
 
   return test_ret_value;
 }

--- a/cpp/tests/sampling/mg_uniform_neighbor_sampling.cu
+++ b/cpp/tests/sampling/mg_uniform_neighbor_sampling.cu
@@ -102,6 +102,15 @@ class Tests_MG_Nbr_Sampling
 
     std::vector<int> h_fan_out{indices_per_source};  // depth = 1
 
+#ifdef NO_CUGRAPH_OPS
+    EXPECT_THROW(cugraph::uniform_nbr_sample(
+                   handle,
+                   mg_graph_view,
+                   raft::device_span<vertex_t>(random_sources.data(), random_sources.size()),
+                   raft::host_span<const int>(h_fan_out.data(), h_fan_out.size()),
+                   prims_usecase.flag_replacement),
+                 std::exception);
+#else
     auto&& [d_src_out, d_dst_out, d_indices, d_counts] = cugraph::uniform_nbr_sample(
       handle,
       mg_graph_view,
@@ -165,6 +174,7 @@ class Tests_MG_Nbr_Sampling
                                                h_fan_out.size());
       }
     }
+#endif
   }
 };
 

--- a/cpp/tests/sampling/sg_uniform_neighbor_sampling.cu
+++ b/cpp/tests/sampling/sg_uniform_neighbor_sampling.cu
@@ -80,6 +80,15 @@ class Tests_Uniform_Neighbor_Sampling
 
     std::vector<int> h_fan_out{indices_per_source};  // depth = 1
 
+#ifdef NO_CUGRAPH_OPS
+    EXPECT_THROW(cugraph::uniform_nbr_sample(
+                   handle,
+                   graph_view,
+                   raft::device_span<vertex_t>(random_sources.data(), random_sources.size()),
+                   raft::host_span<const int>(h_fan_out.data(), h_fan_out.size()),
+                   prims_usecase.flag_replacement),
+                 std::exception);
+#else
     auto&& [d_src_out, d_dst_out, d_indices, d_counts] = cugraph::uniform_nbr_sample(
       handle,
       graph_view,
@@ -127,6 +136,7 @@ class Tests_Uniform_Neighbor_Sampling
                                              std::move(random_sources),
                                              h_fan_out.size());
     }
+#endif
   }
 };
 


### PR DESCRIPTION
Add -DUSE_CUGRAPH_OPS=OFF option for building where you can't access cugraph-ops.  By default USE_CUGRAPH_OPS is set to ON.

If USE_CUGRAPH_OPS is set to OFF then the software will build without those features.  At runtime functions that rely on cugraph-ops (currently this is only `uniform neighborhood sampling`) will fail with an exception.