### PR TITLE
[REVIEW] Optimize has_duplicate_edges 

### DIFF
--- a/python/cugraph/cugraph/dask/structure/mg_property_graph.py
+++ b/python/cugraph/cugraph/dask/structure/mg_property_graph.py
@@ -654,7 +654,7 @@ class EXPERIMENTAL__MGPropertyGraph:
         if len(df.columns) == 0:
             return False
 
-        unique_pair_len = df.drop_duplicates(split_out=df.npartitions).shape[0]
+        unique_pair_len = df.drop_duplicates(split_out=df.npartitions, ignore_index=True).shape[0]
         # if unique_pairs == len(df)
         # then no duplicate edges
         return unique_pair_len != df.shape[0]

--- a/python/cugraph/cugraph/dask/structure/mg_property_graph.py
+++ b/python/cugraph/cugraph/dask/structure/mg_property_graph.py
@@ -656,10 +656,14 @@ class EXPERIMENTAL__MGPropertyGraph:
             return False
 
         def has_duplicate_dst(df):
-            return df[cls.dst_col_name].nunique() != \
-                df[cls.dst_col_name].size
-
-        return df.groupby(cls.src_col_name).apply(has_duplicate_dst).any()
+        # may need to split out for dask frames
+        # to scale
+        unique_pair_len = len(
+            df[[cls.src_col_name, cls.dst_col_name]].drop_duplicates()
+        )
+        # if unique_pairs == len(df)
+        # then no duplicate edges
+        return unique_pair_len != len(df)
 
     def __create_property_lookup_table(self, edge_prop_df):
         """

--- a/python/cugraph/cugraph/dask/structure/mg_property_graph.py
+++ b/python/cugraph/cugraph/dask/structure/mg_property_graph.py
@@ -654,10 +654,10 @@ class EXPERIMENTAL__MGPropertyGraph:
         if len(df.columns) == 0:
             return False
 
-        unique_pair_len = df.drop_duplicates(split_out=df.npartitions).size
+        unique_pair_len = df.drop_duplicates(split_out=df.npartitions).shape[0]
         # if unique_pairs == len(df)
         # then no duplicate edges
-        return unique_pair_len != df.size
+        return unique_pair_len != df.shape[0]
 
     def __create_property_lookup_table(self, edge_prop_df):
         """

--- a/python/cugraph/cugraph/dask/structure/mg_property_graph.py
+++ b/python/cugraph/cugraph/dask/structure/mg_property_graph.py
@@ -654,14 +654,10 @@ class EXPERIMENTAL__MGPropertyGraph:
         if len(df.columns) == 0:
             return False
 
-        # may need to split out for dask frames
-        # to scale
-        unique_pair_len = len(
-            df[[cls.src_col_name, cls.dst_col_name]].drop_duplicates()
-        )
+        unique_pair_len = df.drop_duplicates(split_out=df.npartitions).size
         # if unique_pairs == len(df)
         # then no duplicate edges
-        return unique_pair_len != len(df)
+        return unique_pair_len != df.size
 
     def __create_property_lookup_table(self, edge_prop_df):
         """

--- a/python/cugraph/cugraph/dask/structure/mg_property_graph.py
+++ b/python/cugraph/cugraph/dask/structure/mg_property_graph.py
@@ -654,7 +654,8 @@ class EXPERIMENTAL__MGPropertyGraph:
         if len(df.columns) == 0:
             return False
 
-        unique_pair_len = df.drop_duplicates(split_out=df.npartitions, ignore_index=True).shape[0]
+        unique_pair_len = df.drop_duplicates(split_out=df.npartitions,
+                                             ignore_index=True).shape[0]
         # if unique_pairs == len(df)
         # then no duplicate edges
         return unique_pair_len != df.shape[0]

--- a/python/cugraph/cugraph/dask/structure/mg_property_graph.py
+++ b/python/cugraph/cugraph/dask/structure/mg_property_graph.py
@@ -654,7 +654,6 @@ class EXPERIMENTAL__MGPropertyGraph:
         if len(df.columns) == 0:
             return False
 
-        def has_duplicate_dst(df):
         # may need to split out for dask frames
         # to scale
         unique_pair_len = len(

--- a/python/cugraph/cugraph/dask/structure/mg_property_graph.py
+++ b/python/cugraph/cugraph/dask/structure/mg_property_graph.py
@@ -650,7 +650,6 @@ class EXPERIMENTAL__MGPropertyGraph:
         """
         Return True if df has >1 of the same src, dst pair
         """
-        # FIXME: this can be very expensive for large DataFrames
         # empty not supported by dask
         if len(df.columns) == 0:
             return False

--- a/python/cugraph/cugraph/structure/property_graph.py
+++ b/python/cugraph/cugraph/structure/property_graph.py
@@ -804,7 +804,6 @@ class EXPERIMENTAL__PropertyGraph:
         """
         Return True if df has >1 of the same src, dst pair
         """
-        # empty not supported by dask
         if df.empty:
             return False
 

--- a/python/cugraph/cugraph/structure/property_graph.py
+++ b/python/cugraph/cugraph/structure/property_graph.py
@@ -805,7 +805,7 @@ class EXPERIMENTAL__PropertyGraph:
         Return True if df has >1 of the same src, dst pair
         """
         # empty not supported by dask
-        if len(df.columns) == 0:
+        if df.empty:
             return False
 
         unique_pair_len = len(df[[cls.src_col_name,cls.dst_col_name]].drop_duplicates())

--- a/python/cugraph/cugraph/structure/property_graph.py
+++ b/python/cugraph/cugraph/structure/property_graph.py
@@ -804,15 +804,15 @@ class EXPERIMENTAL__PropertyGraph:
         """
         Return True if df has >1 of the same src, dst pair
         """
-        # FIXME: this can be very expensive for large DataFrames
-        if df.empty:
+        # empty not supported by dask
+        if len(df.columns) == 0:
             return False
 
-        def has_duplicate_dst(df):
-            return df[cls.dst_col_name].nunique() != \
-                df[cls.dst_col_name].size
+        unique_pair_len = len(df[[cls.src_col_name,cls.dst_col_name]].drop_duplicates())
 
-        return df.groupby(cls.src_col_name).apply(has_duplicate_dst).any()
+        # if unique_pairs == len(df)
+        # then no duplicate edges
+        return unique_pair_len!=len(df)
 
     def __create_property_lookup_table(self, edge_prop_df):
         """

--- a/python/cugraph/cugraph/structure/property_graph.py
+++ b/python/cugraph/cugraph/structure/property_graph.py
@@ -807,11 +807,12 @@ class EXPERIMENTAL__PropertyGraph:
         if df.empty:
             return False
 
-        unique_pair_len = len(df[[cls.src_col_name,cls.dst_col_name]].drop_duplicates())
+        unique_pair_len = len(df[[cls.src_col_name,
+                                  cls.dst_col_name]].drop_duplicates())
 
         # if unique_pairs == len(df)
         # then no duplicate edges
-        return unique_pair_len!=len(df)
+        return unique_pair_len != len(df)
 
     def __create_property_lookup_table(self, edge_prop_df):
         """

--- a/python/cugraph/cugraph/structure/property_graph.py
+++ b/python/cugraph/cugraph/structure/property_graph.py
@@ -808,7 +808,8 @@ class EXPERIMENTAL__PropertyGraph:
             return False
 
         unique_pair_len = len(df[[cls.src_col_name,
-                                  cls.dst_col_name]].drop_duplicates(ignore_index=True))
+                                  cls.dst_col_name]].drop_duplicates(
+                                  ignore_index=True))
 
         # if unique_pairs == len(df)
         # then no duplicate edges

--- a/python/cugraph/cugraph/structure/property_graph.py
+++ b/python/cugraph/cugraph/structure/property_graph.py
@@ -808,7 +808,7 @@ class EXPERIMENTAL__PropertyGraph:
             return False
 
         unique_pair_len = len(df[[cls.src_col_name,
-                                  cls.dst_col_name]].drop_duplicates())
+                                  cls.dst_col_name]].drop_duplicates(ignore_index=True))
 
         # if unique_pairs == len(df)
         # then no duplicate edges


### PR DESCRIPTION
This PR fixes drop duplicates scalability by removing apply which does serial processing. 

**Benchmark Data**
```python
n_nodes = 100_000 
n_rows  = 1_500_000
df = cudf.DataFrame({'src':cp.random.randint(0,n_nodes,n_rows),
                    'dst':cp.random.randint(0,n_nodes,n_rows)})
```

**### After PR:**
```python
17.8 ms ± 536 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

**### Before PR:**
```python
26.3 s ± 78.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```