### PR TITLE
Change default return type `PropertyGraph.extract_subgraph() -> cugraph.Graph(directed=True)`

### DIFF
--- a/python/cugraph/cugraph/dask/structure/mg_property_graph.py
+++ b/python/cugraph/cugraph/dask/structure/mg_property_graph.py
@@ -480,7 +480,7 @@ class EXPERIMENTAL__MGPropertyGraph:
             edge_selection_series=selected_col)
 
     def extract_subgraph(self,
-                         create_using=cugraph.Graph,
+                         create_using=None,
                          selection=None,
                          edge_weight_property=None,
                          default_edge_weight=None,
@@ -494,12 +494,12 @@ class EXPERIMENTAL__MGPropertyGraph:
 
         Parameters
         ----------
-        create_using : cugraph Graph type or instance
+        create_using : cugraph Graph type or instance, optional
             Creates a Graph to return using the type specified. If an instance
             is specified, the type of the instance is used to construct the
             return Graph, and all relevant attributes set on the instance are
             copied to the return Graph (eg. directed). If not specified the
-            returned Graph will be a cugraph.Graph instance.
+            returned Graph will be a directed cugraph.Graph instance.
         selection : PropertySelection
             A PropertySelection returned from one or more calls to
             select_vertices() and/or select_edges(), used for creating a Graph
@@ -576,6 +576,12 @@ class EXPERIMENTAL__MGPropertyGraph:
         # values. Restore the original dtypes in the resulting edges df prior
         # to creating a Graph.
         self.__update_dataframe_dtypes(edges, self.__edge_prop_dtypes)
+
+        # Default create_using set here instead of function signature to
+        # prevent cugraph from running on import. This may help diagnose errors
+        if create_using is None:
+            create_using = cugraph.Graph(directed=True)
+
         return self.edge_props_to_graph(
             edges,
             create_using=create_using,

--- a/python/cugraph/cugraph/structure/property_graph.py
+++ b/python/cugraph/cugraph/structure/property_graph.py
@@ -563,7 +563,7 @@ class EXPERIMENTAL__PropertyGraph:
             edge_selection_series=selected_col)
 
     def extract_subgraph(self,
-                         create_using=cugraph.Graph,
+                         create_using=None,
                          selection=None,
                          edge_weight_property=None,
                          default_edge_weight=None,
@@ -577,12 +577,12 @@ class EXPERIMENTAL__PropertyGraph:
 
         Parameters
         ----------
-        create_using : cugraph Graph type or instance
+        create_using : cugraph Graph type or instance, optional
             Creates a Graph to return using the type specified. If an instance
             is specified, the type of the instance is used to construct the
             return Graph, and all relevant attributes set on the instance are
             copied to the return Graph (eg. directed). If not specified the
-            returned Graph will be a cugraph.Graph instance.
+            returned Graph will be a directed cugraph.Graph instance.
         selection : PropertySelection
             A PropertySelection returned from one or more calls to
             select_vertices() and/or select_edges(), used for creating a Graph
@@ -660,6 +660,11 @@ class EXPERIMENTAL__PropertyGraph:
         # values. Restore the original dtypes in the resulting edges df prior
         # to creating a Graph.
         edges = self.__update_dataframe_dtypes(edges, self.__edge_prop_dtypes)
+
+        # Default create_using set here instead of function signature to
+        # prevent cugraph from running on import. This may help diagnose errors
+        if create_using is None:
+            create_using = cugraph.Graph(directed=True)
 
         return self.edge_props_to_graph(
             edges,

--- a/python/cugraph/cugraph/tests/test_property_graph.py
+++ b/python/cugraph/cugraph/tests/test_property_graph.py
@@ -755,6 +755,7 @@ def test_extract_subgraph_no_edges(dataset1_PropertyGraph):
 
     selection = pG.select_vertices("(_TYPE_=='merchants') & (merchant_id==86)")
     G = pG.extract_subgraph(selection=selection)
+    assert G.is_directed()
 
     assert len(G.edgelist.edgelist_df) == 0
 


### PR DESCRIPTION
Fixes #2459

The tests already specify the use of directed graphs most places, so this required minimal changes.