### PR TITLE
Fix typos in Python CMakeLists CUDA arch file

### DIFF
--- a/python/cugraph/CMakeLists.txt
+++ b/python/cugraph/CMakeLists.txt
@@ -45,7 +45,7 @@ if(NOT cugraph_FOUND)
   # TODO: This will not be necessary once we upgrade to CMake 3.22, which will pull in the required
   # languages for the C++ project even if this project does not require those languges.
   include(rapids-cuda)
-  rapids_cuda_init_architectures(CUGRAPH)
+  rapids_cuda_init_architectures(cugraph-python)
   enable_language(CUDA)
 
   # Since cugraph only enables CUDA optionally, we need to manually include the file that

--- a/python/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/CMakeLists.txt
@@ -49,7 +49,7 @@ if(NOT cugraph_FOUND)
   # TODO: This will not be necessary once we upgrade to CMake 3.22, which will pull in the required
   # languages for the C++ project even if this project does not require those languges.
   include(rapids-cuda)
-  rapids_cuda_init_architectures(CUGRAPH)
+  rapids_cuda_init_architectures(pylibcugraph-python)
   enable_language(CUDA)
 
   # Since cugraph only enables CUDA optionally, we need to manually include the file that

--- a/python/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/CMakeLists.txt
@@ -55,7 +55,7 @@ if(NOT cugraph_FOUND)
   # Since cugraph only enables CUDA optionally, we need to manually include the file that
   # rapids_cuda_init_architectures relies on `project` including.
   
-  include("${CMAKE_PROJECT_cugraph-python_INCLUDE}")
+  include("${CMAKE_PROJECT_pylibcugraph-python_INCLUDE}")
 
   add_subdirectory(../../cpp cugraph-cpp)
 


### PR DESCRIPTION
These typos would prevent properly handling required CMake features as determined by `rapids_cuda_init_architectures`. This only affects compilations where `FIND_CUGRAPH_CPP=OFF`.