### PR TITLE
[REVIEW] Pin `dask` & `distributed` for release

### DIFF
--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -16,8 +16,8 @@ dependencies:
 - libraft-headers=22.08.*
 - pyraft=22.08.*
 - cuda-python>=11.5,<11.7.1
-- dask>=2022.05.2
-- distributed>=2022.05.2
+- dask==2022.7.1
+- distributed==2022.7.1
 - dask-cuda=22.08.*
 - dask-cudf=22.08.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -16,8 +16,8 @@ dependencies:
 - libraft-headers=22.08.*
 - pyraft=22.08.*
 - cuda-python>=11.5,<11.7.1
-- dask>=2022.05.2
-- distributed>=2022.05.2
+- dask==2022.7.1
+- distributed==2022.7.1
 - dask-cuda=22.08.*
 - dask-cudf=22.08.*
 - nccl>=2.9.9

--- a/conda/environments/cugraph_dev_cuda11.5.yml
+++ b/conda/environments/cugraph_dev_cuda11.5.yml
@@ -16,8 +16,8 @@ dependencies:
 - libraft-headers=22.08.*
 - pyraft=22.08.*
 - cuda-python>=11.5,<11.7.1
-- dask>=2022.05.2
-- distributed>=2022.05.2
+- dask==2022.7.1
+- distributed==2022.7.1
 - dask-cuda=22.08.*
 - dask-cudf=22.08.*
 - nccl>=2.9.9

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -51,8 +51,8 @@ requirements:
     - cudf={{ minor_version }}
     - dask-cudf {{ minor_version }}
     - dask-cuda {{ minor_version }}
-    - dask>=2022.05.2
-    - distributed>=2022.05.2
+    - dask==2022.7.1
+    - distributed==2022.7.1
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}


### PR DESCRIPTION
This PR pins `dask` & `distributed` to `2022.7.1` for `22.08` release.

xref: https://github.com/rapidsai/cudf/pull/11433