### PR TITLE
Fix MG Louvain C API test 

### DIFF
--- a/cpp/tests/c_api/mg_louvain_test.c
+++ b/cpp/tests/c_api/mg_louvain_test.c
@@ -78,18 +78,18 @@ int generic_louvain_test(const cugraph_resource_handle_t* p_handle,
 
     vertex_t max_component_id = -1;
     for (vertex_t i = 0; (i < num_local_vertices) && (test_ret_value == 0); ++i) {
-      if (h_clusters[i] > max_component_id)
-        max_component_id = h_clusters[i];
+      if (h_clusters[i] > max_component_id) max_component_id = h_clusters[i];
     }
 
-    vertex_t component_mapping[max_component_id+1];
+    vertex_t component_mapping[max_component_id + 1];
     for (vertex_t i = 0; (i < num_local_vertices) && (test_ret_value == 0); ++i) {
-      component_mapping[h_clusters[i]] = h_result[i];
+      component_mapping[h_clusters[i]] = h_result[h_vertices[i]];
     }
 
     for (vertex_t i = 0; (i < num_local_vertices) && (test_ret_value == 0); ++i) {
-      TEST_ASSERT(
-        test_ret_value, h_result[h_vertices[i]] == component_mapping[h_clusters[i]], "cluster results don't match");
+      TEST_ASSERT(test_ret_value,
+                  h_result[h_vertices[i]] == component_mapping[h_clusters[i]],
+                  "cluster results don't match");
     }
 
     cugraph_heirarchical_clustering_result_free(p_result);

--- a/cpp/tests/c_api/mg_louvain_test.c
+++ b/cpp/tests/c_api/mg_louvain_test.c
@@ -76,9 +76,20 @@ int generic_louvain_test(const cugraph_resource_handle_t* p_handle,
 
     size_t num_local_vertices = cugraph_type_erased_device_array_view_size(vertices);
 
-    for (int i = 0; (i < num_local_vertices) && (test_ret_value == 0); ++i) {
+    vertex_t max_component_id = -1;
+    for (vertex_t i = 0; (i < num_local_vertices) && (test_ret_value == 0); ++i) {
+      if (h_clusters[i] > max_component_id)
+        max_component_id = h_clusters[i];
+    }
+
+    vertex_t component_mapping[max_component_id+1];
+    for (vertex_t i = 0; (i < num_local_vertices) && (test_ret_value == 0); ++i) {
+      component_mapping[h_clusters[i]] = h_result[i];
+    }
+
+    for (vertex_t i = 0; (i < num_local_vertices) && (test_ret_value == 0); ++i) {
       TEST_ASSERT(
-        test_ret_value, h_result[h_vertices[i]] == h_clusters[i], "cluster results don't match");
+        test_ret_value, h_result[h_vertices[i]] == component_mapping[h_clusters[i]], "cluster results don't match");
     }
 
     cugraph_heirarchical_clustering_result_free(p_result);


### PR DESCRIPTION
Add extra logic to support arbitrary numbering of clusters.

Our Louvain implementation is deterministic based on the number of GPUs (that is, with k GPUs and a given graph it will always generate the same answer).  However, in the case of this test a different number of GPUs can generate a different result based on how the vertices are numbered.

We could unrenumber the result, but that's an extra step that's not necessary in the ordinary flow.  Added a more sophisticated test that will recreate the necessary subset of the number map and validate according to that.