### PR TITLE
Fix MG PLC algos intermittent hang

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -88,7 +88,7 @@ if [ "$BUILD_LIBCUGRAPH" == '1' ]; then
   if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/libcugraph
   else
-    gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} --dirty conda/recipes/libcugraph
+    gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} --dirty --no-remove-work-dir conda/recipes/libcugraph
     mkdir -p ${CONDA_BLD_DIR}/libcugraph
     mv ${CONDA_BLD_DIR}/work ${CONDA_BLD_DIR}/libcugraph/work
   fi
@@ -104,8 +104,8 @@ if [ "$BUILD_CUGRAPH" == "1" ]; then
     gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/pylibcugraph --python=$PYTHON
     gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/cugraph --python=$PYTHON
   else
-    gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/pylibcugraph -c ${CONDA_LOCAL_CHANNEL} --dirty --python=$PYTHON
-    gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/cugraph -c ${CONDA_LOCAL_CHANNEL} --dirty --python=$PYTHON
+    gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/pylibcugraph -c ${CONDA_LOCAL_CHANNEL} --dirty --no-remove-work-dir --python=$PYTHON
+    gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/cugraph -c ${CONDA_LOCAL_CHANNEL} --dirty --no-remove-work-dir --python=$PYTHON
     mkdir -p ${CONDA_BLD_DIR}/cugraph
     mv ${CONDA_BLD_DIR}/work ${CONDA_BLD_DIR}/cugraph/work
   fi

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -88,7 +88,7 @@ if [ "$BUILD_LIBCUGRAPH" == '1' ]; then
   if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/libcugraph
   else
-    gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} --dirty --no-remove-work-dir conda/recipes/libcugraph
+    gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} --dirty conda/recipes/libcugraph
     mkdir -p ${CONDA_BLD_DIR}/libcugraph
     mv ${CONDA_BLD_DIR}/work ${CONDA_BLD_DIR}/libcugraph/work
   fi
@@ -104,8 +104,8 @@ if [ "$BUILD_CUGRAPH" == "1" ]; then
     gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/pylibcugraph --python=$PYTHON
     gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/cugraph --python=$PYTHON
   else
-    gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/pylibcugraph -c ${CONDA_LOCAL_CHANNEL} --dirty --no-remove-work-dir --python=$PYTHON
-    gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/cugraph -c ${CONDA_LOCAL_CHANNEL} --dirty --no-remove-work-dir --python=$PYTHON
+    gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/pylibcugraph -c ${CONDA_LOCAL_CHANNEL} --dirty --python=$PYTHON
+    gpuci_conda_retry mambabuild --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/cugraph -c ${CONDA_LOCAL_CHANNEL} --dirty --python=$PYTHON
     mkdir -p ${CONDA_BLD_DIR}/cugraph
     mv ${CONDA_BLD_DIR}/work ${CONDA_BLD_DIR}/cugraph/work
   fi

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -42,7 +42,6 @@ requirements:
     - ucx-proc=*=gpu
     - cudatoolkit {{ cuda_version }}.*
     - libraft-headers {{ minor_version }}
-    - setuptools=65.3.0=*0
   run:
     - python x.x
     - pylibcugraph={{ version }}

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - ucx-proc=*=gpu
     - cudatoolkit {{ cuda_version }}.*
     - libraft-headers {{ minor_version }}
-    - setuptools=65.3.0=*0
+    - setuptools<=65.2.0
   run:
     - python x.x
     - pylibcugraph={{ version }}

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -42,6 +42,7 @@ requirements:
     - ucx-proc=*=gpu
     - cudatoolkit {{ cuda_version }}.*
     - libraft-headers {{ minor_version }}
+    - setuptools=65.3.0=*0
   run:
     - python x.x
     - pylibcugraph={{ version }}

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -42,6 +42,7 @@ requirements:
     - ucx-proc=*=gpu
     - cudatoolkit {{ cuda_version }}.*
     - libraft-headers {{ minor_version }}
+    # FIXME: this pin can be removed once we move to the GitHub Actions build process
     - setuptools<=65.2.0
   run:
     - python x.x

--- a/python/cugraph/cugraph/dask/cores/core_number.py
+++ b/python/cugraph/cugraph/dask/cores/core_number.py
@@ -133,6 +133,7 @@ def core_number(input_graph,
     # the past iteration's futures and this can cause a hang if some
     # of those futures get released midway
     del result
+    del cudf_result
 
     ddf = dask_cudf.from_delayed(cudf_result).persist()
     wait(ddf)

--- a/python/cugraph/cugraph/dask/cores/core_number.py
+++ b/python/cugraph/cugraph/dask/cores/core_number.py
@@ -114,6 +114,7 @@ def core_number(input_graph,
             degree_type,
             do_expensive_check,
             workers=[w],
+            allow_other_workers=False,
         )
         for w in Comms.get_workers()
     ]
@@ -124,16 +125,18 @@ def core_number(input_graph,
                                  cp_arrays)
                    for cp_arrays in result]
 
-    # Dask doesn't always release it fast enough.
+    wait(cudf_result)
+
+    # FIXME: Dask doesn't always release it fast enough.
     # For instance if the algo is run several times with
     # the same PLC graph, the current iteration might try to cache
     # the past iteration's futures and this can cause a hang if some
     # of those futures get released midway
     del result
 
-    wait(cudf_result)
+    ddf = dask_cudf.from_delayed(cudf_result).persist()
+    wait(ddf)
 
-    ddf = dask_cudf.from_delayed(cudf_result)
     if input_graph.renumbered:
         ddf = input_graph.unrenumber(ddf, "vertex")
 

--- a/python/cugraph/cugraph/dask/cores/core_number.py
+++ b/python/cugraph/cugraph/dask/cores/core_number.py
@@ -123,6 +123,13 @@ def core_number(input_graph,
     cudf_result = [client.submit(convert_to_cudf,
                                  cp_arrays)
                    for cp_arrays in result]
+    
+    # Dask doesn't always release it fast enough.
+    # For instance if the algo is run several times with
+    # the same PLC graph, the current iteration might try to cache
+    # the past iteration's futures and this can cause a hang if some
+    # of those futures get released midway
+    del result
 
     wait(cudf_result)
 

--- a/python/cugraph/cugraph/dask/cores/core_number.py
+++ b/python/cugraph/cugraph/dask/cores/core_number.py
@@ -127,6 +127,9 @@ def core_number(input_graph,
 
     wait(cudf_result)
 
+    ddf = dask_cudf.from_delayed(cudf_result).persist()
+    wait(ddf)
+
     # FIXME: Dask doesn't always release it fast enough.
     # For instance if the algo is run several times with
     # the same PLC graph, the current iteration might try to cache
@@ -134,9 +137,6 @@ def core_number(input_graph,
     # of those futures get released midway
     del result
     del cudf_result
-
-    ddf = dask_cudf.from_delayed(cudf_result).persist()
-    wait(ddf)
 
     if input_graph.renumbered:
         ddf = input_graph.unrenumber(ddf, "vertex")

--- a/python/cugraph/cugraph/dask/cores/core_number.py
+++ b/python/cugraph/cugraph/dask/cores/core_number.py
@@ -123,7 +123,7 @@ def core_number(input_graph,
     cudf_result = [client.submit(convert_to_cudf,
                                  cp_arrays)
                    for cp_arrays in result]
-    
+
     # Dask doesn't always release it fast enough.
     # For instance if the algo is run several times with
     # the same PLC graph, the current iteration might try to cache

--- a/python/cugraph/cugraph/dask/link_analysis/pagerank.py
+++ b/python/cugraph/cugraph/dask/link_analysis/pagerank.py
@@ -318,6 +318,9 @@ def pagerank(input_graph,
 
     wait(cudf_result)
 
+    ddf = dask_cudf.from_delayed(cudf_result).persist()
+    wait(ddf)
+
     # FIXME: Dask doesn't always release it fast enough.
     # For instance if the algo is run several times with
     # the same PLC graph, the current iteration might try to cache
@@ -325,9 +328,6 @@ def pagerank(input_graph,
     # of those futures get released midway
     del result
     del cudf_result
-
-    ddf = dask_cudf.from_delayed(cudf_result).persist()
-    wait(ddf)
 
     if input_graph.renumbered:
         ddf = input_graph.unrenumber(ddf, "vertex")

--- a/python/cugraph/cugraph/dask/link_analysis/pagerank.py
+++ b/python/cugraph/cugraph/dask/link_analysis/pagerank.py
@@ -314,6 +314,13 @@ def pagerank(input_graph,
                                  cp_arrays)
                    for cp_arrays in result]
 
+    # Dask doesn't always release it fast enough.
+    # For instance if the algo is run several times with
+    # the same PLC graph, the current iteration might try to cache
+    # the past iteration's futures and this can cause a hang if some
+    # of those futures get released midway
+    del result
+
     wait(cudf_result)
 
     ddf = dask_cudf.from_delayed(cudf_result)

--- a/python/cugraph/cugraph/dask/link_analysis/pagerank.py
+++ b/python/cugraph/cugraph/dask/link_analysis/pagerank.py
@@ -324,6 +324,7 @@ def pagerank(input_graph,
     # the past iteration's futures and this can cause a hang if some
     # of those futures get released midway
     del result
+    del cudf_result
 
     ddf = dask_cudf.from_delayed(cudf_result).persist()
     wait(ddf)

--- a/python/cugraph/cugraph/dask/link_analysis/pagerank.py
+++ b/python/cugraph/cugraph/dask/link_analysis/pagerank.py
@@ -286,6 +286,7 @@ def pagerank(input_graph,
                 max_iter,
                 do_expensive_check,
                 workers=[w],
+                allow_other_workers=False,
             )
             for w, data_personalization in data_prsztn.worker_to_parts.items()
         ]
@@ -304,6 +305,7 @@ def pagerank(input_graph,
                 max_iter,
                 do_expensive_check,
                 workers=[w],
+                allow_other_workers=False,
             )
             for w in Comms.get_workers()
         ]
@@ -314,16 +316,18 @@ def pagerank(input_graph,
                                  cp_arrays)
                    for cp_arrays in result]
 
-    # Dask doesn't always release it fast enough.
+    wait(cudf_result)
+
+    # FIXME: Dask doesn't always release it fast enough.
     # For instance if the algo is run several times with
     # the same PLC graph, the current iteration might try to cache
     # the past iteration's futures and this can cause a hang if some
     # of those futures get released midway
     del result
 
-    wait(cudf_result)
+    ddf = dask_cudf.from_delayed(cudf_result).persist()
+    wait(ddf)
 
-    ddf = dask_cudf.from_delayed(cudf_result)
     if input_graph.renumbered:
         ddf = input_graph.unrenumber(ddf, "vertex")
 

--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -152,6 +152,7 @@ def uniform_neighbor_sample(input_graph,
             fanout_vals,
             with_replacement,
             workers=[w],
+            allow_other_workers=False,
         )
         for w in Comms.get_workers()
     ]
@@ -164,7 +165,15 @@ def uniform_neighbor_sample(input_graph,
 
     wait(cudf_result)
 
-    ddf = dask_cudf.from_delayed(cudf_result)
+    # FIXME: Dask doesn't always release it fast enough.
+    # For instance if the algo is run several times with
+    # the same PLC graph, the current iteration might try to cache
+    # the past iteration's futures and this can cause a hang if some
+    # of those futures get released midway
+    del result
+
+    ddf = dask_cudf.from_delayed(cudf_result).persist()
+    wait(ddf)
 
     if input_graph.renumbered:
         ddf = input_graph.unrenumber(ddf, "sources", preserve_order=True)

--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -165,6 +165,9 @@ def uniform_neighbor_sample(input_graph,
 
     wait(cudf_result)
 
+    ddf = dask_cudf.from_delayed(cudf_result).persist()
+    wait(ddf)
+
     # FIXME: Dask doesn't always release it fast enough.
     # For instance if the algo is run several times with
     # the same PLC graph, the current iteration might try to cache
@@ -172,9 +175,6 @@ def uniform_neighbor_sample(input_graph,
     # of those futures get released midway
     del result
     del cudf_result
-
-    ddf = dask_cudf.from_delayed(cudf_result).persist()
-    wait(ddf)
 
     if input_graph.renumbered:
         ddf = input_graph.unrenumber(ddf, "sources", preserve_order=True)

--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -171,6 +171,7 @@ def uniform_neighbor_sample(input_graph,
     # the past iteration's futures and this can cause a hang if some
     # of those futures get released midway
     del result
+    del cudf_result
 
     ddf = dask_cudf.from_delayed(cudf_result).persist()
     wait(ddf)

--- a/python/cugraph/cugraph/dask/traversal/bfs.py
+++ b/python/cugraph/cugraph/dask/traversal/bfs.py
@@ -194,7 +194,7 @@ def bfs(input_graph,
     # the same PLC graph, the current iteration might try to cache
     # the past iteration's futures and this can cause a hang if some
     # of those futures get released midway
-    del result
+    del cupy_result
 
     ddf = dask_cudf.from_delayed(cudf_result).persist()
     wait(ddf)

--- a/python/cugraph/cugraph/dask/traversal/bfs.py
+++ b/python/cugraph/cugraph/dask/traversal/bfs.py
@@ -195,6 +195,7 @@ def bfs(input_graph,
     # the past iteration's futures and this can cause a hang if some
     # of those futures get released midway
     del cupy_result
+    del cudf_result
 
     ddf = dask_cudf.from_delayed(cudf_result).persist()
     wait(ddf)

--- a/python/cugraph/cugraph/dask/traversal/bfs.py
+++ b/python/cugraph/cugraph/dask/traversal/bfs.py
@@ -176,7 +176,8 @@ def bfs(input_graph,
             st[0],
             depth_limit,
             return_distances,
-            workers=[w]
+            workers=[w],
+            allow_other_workers=False,
         )
         for w, st in data_start.worker_to_parts.items()
     ]
@@ -188,7 +189,15 @@ def bfs(input_graph,
                    for cp_arrays in cupy_result]
     wait(cudf_result)
 
-    ddf = dask_cudf.from_delayed(cudf_result)
+    # FIXME: Dask doesn't always release it fast enough.
+    # For instance if the algo is run several times with
+    # the same PLC graph, the current iteration might try to cache
+    # the past iteration's futures and this can cause a hang if some
+    # of those futures get released midway
+    del result
+
+    ddf = dask_cudf.from_delayed(cudf_result).persist()
+    wait(ddf)
 
     if input_graph.renumbered:
         ddf = input_graph.unrenumber(ddf, 'vertex')

--- a/python/cugraph/cugraph/dask/traversal/bfs.py
+++ b/python/cugraph/cugraph/dask/traversal/bfs.py
@@ -189,6 +189,9 @@ def bfs(input_graph,
                    for cp_arrays in cupy_result]
     wait(cudf_result)
 
+    ddf = dask_cudf.from_delayed(cudf_result).persist()
+    wait(ddf)
+
     # FIXME: Dask doesn't always release it fast enough.
     # For instance if the algo is run several times with
     # the same PLC graph, the current iteration might try to cache
@@ -196,9 +199,6 @@ def bfs(input_graph,
     # of those futures get released midway
     del cupy_result
     del cudf_result
-
-    ddf = dask_cudf.from_delayed(cudf_result).persist()
-    wait(ddf)
 
     if input_graph.renumbered:
         ddf = input_graph.unrenumber(ddf, 'vertex')


### PR DESCRIPTION
Dask doesn't always release some of the inactive futures fast enough. This can be problematic when running the same `algo` several times with the same `PLC graph` because those futures can be cache in the next iteration causing a hang if some get released midway.

This PR manually delete inactive futures.
closes #2568 