### PR TITLE
Small fix to the MG PyG Test to Account for Current Sampling Behavior

### DIFF
--- a/python/cugraph/cugraph/tests/mg/test_mg_pyg_extensions.py
+++ b/python/cugraph/cugraph/tests/mg/test_mg_pyg_extensions.py
@@ -430,6 +430,9 @@ def test_neighbor_sample(single_vertex_graph):
 
     noi_groups, row_dict, col_dict, _ = graph_store.neighbor_sample(
         index=cupy.array([0, 1, 2, 3, 4], dtype='int32'),
+        # FIXME The following line should be num_neighbors=[-1] but
+        # there is currently a bug in MG uniform_neighbor_sample.
+        # Once this bug is fixed, this line should be changed.
         num_neighbors=[8],
         replace=True,
         directed=True,
@@ -487,7 +490,10 @@ def test_neighbor_sample_multi_vertex(
 
     noi_groups, row_dict, col_dict, _ = graph_store.neighbor_sample(
         index=cupy.array([0, 1, 2, 3, 4], dtype='int32'),
-        num_neighbors=[-1],
+        # FIXME The following line should be num_neighbors=[-1] but
+        # there is currently a bug in MG uniform_neighbor_sample.
+        # Once this bug is fixed, this line should be changed.
+        num_neighbors=[8],
         replace=True,
         directed=True,
         edge_types=[

--- a/python/cugraph/cugraph/tests/mg/test_mg_pyg_extensions.py
+++ b/python/cugraph/cugraph/tests/mg/test_mg_pyg_extensions.py
@@ -430,7 +430,7 @@ def test_neighbor_sample(single_vertex_graph):
 
     noi_groups, row_dict, col_dict, _ = graph_store.neighbor_sample(
         index=cupy.array([0, 1, 2, 3, 4], dtype='int32'),
-        num_neighbors=[-1],
+        num_neighbors=[8],
         replace=True,
         directed=True,
         edge_types=[


### PR DESCRIPTION
This PR will correct an error that shows up occasionally in the MG tests, especially when running on an odd number of GPUs.  This error is related to issue #2665 and resolves it temporarily while the C++ team works on a permanent fix.