### PR TITLE
Allow all integer types with renumber=False

### DIFF
--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -167,8 +167,8 @@ class simpleGraphImpl:
         else:
             if type(source) is list and type(destination) is list:
                 raise ValueError("set renumber to True for multi column ids")
-            elif (elist[source].dtype not in [np.int32, np.int64] or
-                  elist[destination].dtype not in [np.int32, np.int64]):
+            elif (not np.issubdtype(elist[source].dtype, np.integer) or
+                  not np.issubdtype(elist[destination].dtype, np.integer)):
                 raise ValueError(
                     "set renumber to True for non integer columns ids"
                 )


### PR DESCRIPTION
Resolves #2670.

`np.integer` is a superclass of all signed and unsigned integer types from `byte` to `longlong`. (https://numpy.org/doc/stable/reference/arrays.scalars.html) Let me know if that's too broad.