### PR TITLE
Fixes bug in `NumberMap` preventing use of string vertex IDs for MG graphs

### DIFF
--- a/python/cugraph/cugraph/structure/number_map.py
+++ b/python/cugraph/cugraph/structure/number_map.py
@@ -533,7 +533,6 @@ class NumberMap:
         renumber_map.set_renumbered_col_names(
             src_col_names, dst_col_names, df.columns)
 
-        id_type = df[src_col_names[0]].dtype
         if isinstance(df, cudf.DataFrame):
             renumber_map.implementation = NumberMap.SingleGPU(
                 df, src_col_names, dst_col_names, renumber_map.id_type,
@@ -615,6 +614,7 @@ class NumberMap:
                         .astype(id_type)
                     return data[2]
 
+                id_type = df[renumber_map.renumbered_src_col_name].dtype
                 renumbering_map = dask_cudf.from_delayed(
                                     [client.submit(get_renumber_map,
                                                    id_type,

--- a/python/cugraph/cugraph/testing/utils.py
+++ b/python/cugraph/cugraph/testing/utils.py
@@ -447,24 +447,25 @@ def genFixtureParamsProduct(*args):
     paramLists = []
     ids = []
     paramType = pytest.param().__class__
-    for (paramList, id) in args:
+    for (paramList, paramId) in args:
+        paramListCopy = paramList[:]  # do not modify the incoming lists!
         for i in range(len(paramList)):
             if not isinstance(paramList[i], paramType):
-                paramList[i] = pytest.param(paramList[i])
-        paramLists.append(paramList)
-        ids.append(id)
+                paramListCopy[i] = pytest.param(paramList[i])
+        paramLists.append(paramListCopy)
+        ids.append(paramId)
 
     retList = []
     for paramCombo in product(*paramLists):
         values = [p.values[0] for p in paramCombo]
         marks = [m for p in paramCombo for m in p.marks]
         id_strings = []
-        for (p, id) in zip(paramCombo, ids):
-            # Assume id is either a string or a callable
-            if isinstance(id, str):
-                id_strings.append("%s=%s" % (id, p.values[0]))
+        for (p, paramId) in zip(paramCombo, ids):
+            # Assume paramId is either a string or a callable
+            if isinstance(paramId, str):
+                id_strings.append("%s=%s" % (paramId, p.values[0]))
             else:
-                id_strings.append(id(p.values[0]))
+                id_strings.append(paramId(p.values[0]))
         comboid = ",".join(id_strings)
         retList.append(pytest.param(values, marks=marks, id=comboid))
     return retList

--- a/python/cugraph/cugraph/tests/mg/test_mg_doctests.py
+++ b/python/cugraph/cugraph/tests/mg/test_mg_doctests.py
@@ -86,6 +86,7 @@ def _fetch_doctests():
     yield from _find_doctests_in_obj(finder, cugraph.dask, 'dask',
                                      _is_public_name)
 
+
 @pytest.fixture(scope="module",
                 params=_fetch_doctests(),
                 ids=lambda docstring: docstring.name)


### PR DESCRIPTION
fixes #2686 

### Summary
* Moved assignment of a variable that sets a dtype to a point _after_ the mappings from vertex strings to integer IDs are applied in order to capture the correct dtype of the internal dataframes. This bug was not detected earlier since integer vertex IDs had matching dtypes before and after any initial mappings were applied, and there was no test coverage for MG string vertex IDs.
* Added test that uses a graph containing string vertex IDs then runs `pagerank` using both SG and MG versions and ensures the results are identical.  This new test was based on the code provided in issue #2686 
* Fixed several bugs in MG test code that prevented `pytest` from collecting tests when the entire `mg` suite was specified. This probably would have been uncovered sooner if the MNMG nightly tests were configured to run differently (they run individual test files instead of having `pytest` collect all tests from the `mg` directory).

