### PR TITLE
Add modularity to return result for louvain

### DIFF
--- a/cpp/include/cugraph_c/community_algorithms.h
+++ b/cpp/include/cugraph_c/community_algorithms.h
@@ -123,6 +123,12 @@ cugraph_type_erased_device_array_view_t* cugraph_heirarchical_clustering_result_
   cugraph_heirarchical_clustering_result_t* result);
 
 /**
+ * @brief     Get modularity
+ */
+double cugraph_heirarchical_clustering_result_get_modularity(
+  cugraph_heirarchical_clustering_result_t* result);
+
+/**
  * @brief     Free a heirarchical clustering result
  *
  * @param [in] result     The result from a sampling algorithm

--- a/cpp/tests/c_api/louvain_test.c
+++ b/cpp/tests/c_api/louvain_test.c
@@ -29,6 +29,7 @@ int generic_louvain_test(vertex_t* h_src,
                          vertex_t* h_dst,
                          weight_t* h_wgt,
                          vertex_t* h_result,
+                         weight_t expected_modularity,
                          size_t num_vertices,
                          size_t num_edges,
                          size_t max_level,
@@ -40,8 +41,8 @@ int generic_louvain_test(vertex_t* h_src,
   cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
   cugraph_error_t* ret_error;
 
-  cugraph_resource_handle_t* p_handle                  = NULL;
-  cugraph_graph_t* p_graph                             = NULL;
+  cugraph_resource_handle_t* p_handle                = NULL;
+  cugraph_graph_t* p_graph                           = NULL;
   cugraph_heirarchical_clustering_result_t* p_result = NULL;
 
   p_handle = cugraph_create_resource_handle(NULL);
@@ -63,8 +64,9 @@ int generic_louvain_test(vertex_t* h_src,
     cugraph_type_erased_device_array_view_t* vertices;
     cugraph_type_erased_device_array_view_t* clusters;
 
-    vertices = cugraph_heirarchical_clustering_result_get_vertices(p_result);
-    clusters   = cugraph_heirarchical_clustering_result_get_clusters(p_result);
+    vertices          = cugraph_heirarchical_clustering_result_get_vertices(p_result);
+    clusters          = cugraph_heirarchical_clustering_result_get_clusters(p_result);
+    double modularity = cugraph_heirarchical_clustering_result_get_modularity(p_result);
 
     vertex_t h_vertices[num_vertices];
     edge_t h_clusters[num_vertices];
@@ -81,6 +83,10 @@ int generic_louvain_test(vertex_t* h_src,
       TEST_ASSERT(
         test_ret_value, h_result[h_vertices[i]] == h_clusters[i], "cluster results don't match");
     }
+
+    TEST_ASSERT(test_ret_value,
+                nearlyEqual(modularity, expected_modularity, 0.001),
+                "modularity doesn't match");
 
     cugraph_heirarchical_clustering_result_free(p_result);
   }
@@ -103,11 +109,20 @@ int test_louvain()
   vertex_t h_dst[] = {1, 3, 4, 0, 1, 3, 5, 5, 0, 1, 1, 2, 2, 2, 3, 4};
   weight_t h_wgt[] = {
     0.1f, 2.1f, 1.1f, 5.1f, 3.1f, 4.1f, 7.2f, 3.2f, 0.1f, 2.1f, 1.1f, 5.1f, 3.1f, 4.1f, 7.2f, 3.2f};
-  vertex_t h_result[] = {0, 1, 0, 1, 1, 1};
+  vertex_t h_result[]          = {0, 1, 0, 1, 1, 1};
+  weight_t expected_modularity = 0.218166;
 
   // Louvain wants store_transposed = FALSE
-  return generic_louvain_test(
-    h_src, h_dst, h_wgt, h_result, num_vertices, num_edges, max_level, resolution, FALSE);
+  return generic_louvain_test(h_src,
+                              h_dst,
+                              h_wgt,
+                              h_result,
+                              expected_modularity,
+                              num_vertices,
+                              num_edges,
+                              max_level,
+                              resolution,
+                              FALSE);
 }
 
 /******************************************************************************/


### PR DESCRIPTION
The C API defined for Louvain was missing the modularity score.  Add the modularity score to the result and add an accessor that allows the modularity score to be accessed.