### PR TITLE
Update unit tests to leverage the datasets API

### DIFF
--- a/python/cugraph/cugraph/__init__.py
+++ b/python/cugraph/cugraph/__init__.py
@@ -106,7 +106,7 @@ from cugraph.experimental import find_bicliques
 
 from cugraph.linear_assignment import hungarian, dense_hungarian
 from cugraph.layout import force_atlas2
-from raft import raft_include_test
+from raft_dask import raft_include_test
 
 from cugraph.sampling import (
     random_walks,

--- a/python/cugraph/cugraph/dask/common/input_utils.py
+++ b/python/cugraph/cugraph/dask/common/input_utils.py
@@ -24,7 +24,7 @@ import cugraph.dask.comms.comms as Comms
 # not available. They are necessary only when doing MG work.
 from cugraph.dask.common.read_utils import MissingUCXPy
 try:
-    from raft.dask.common.utils import get_client
+    from raft_dask.common.utils import get_client
 except ImportError as err:
     # FIXME: Generalize since err.name is arr when
     # libnuma.so.1 is not available

--- a/python/cugraph/cugraph/dask/common/mg_utils.py
+++ b/python/cugraph/cugraph/dask/common/mg_utils.py
@@ -22,7 +22,7 @@ from dask.distributed import Client
 # not available. They are necessary only when doing MG work.
 from cugraph.dask.common.read_utils import MissingUCXPy
 try:
-    from raft.dask.common.utils import default_client
+    from raft_dask.common.utils import default_client
 except ImportError as err:
     # FIXME: Generalize since err.name is arr when
     # libnuma.so.1 is not available

--- a/python/cugraph/cugraph/dask/comms/comms.py
+++ b/python/cugraph/cugraph/dask/comms/comms.py
@@ -15,8 +15,8 @@
 # not available. They are necessary only when doing MG work.
 from cugraph.dask.common.read_utils import MissingUCXPy
 try:
-    from raft.dask.common.comms import Comms as raftComms
-    from raft.dask.common.comms import get_raft_comm_state
+    from raft_dask.common.comms import Comms as raftComms
+    from raft_dask.common.comms import get_raft_comm_state
 except ImportError as err:
     # FIXME: Generalize since err.name is arr when
     # libnuma.so.1 is not available

--- a/python/cugraph/cugraph/experimental/datasets/__init__.py
+++ b/python/cugraph/cugraph/experimental/datasets/__init__.py
@@ -30,12 +30,26 @@ karate = Dataset(meta_path / "karate.yaml")
 karate_data = Dataset(meta_path / "karate_data.yaml")
 karate_undirected = Dataset(meta_path / "karate_undirected.yaml")
 karate_asymmetric = Dataset(meta_path / "karate_asymmetric.yaml")
+karate_disjoint = Dataset(meta_path / "karate-disjoint.yaml")
 dolphins = Dataset(meta_path / "dolphins.yaml")
 polbooks = Dataset(meta_path / "polbooks.yaml")
 netscience = Dataset(meta_path / "netscience.yaml")
 cyber = Dataset(meta_path / "cyber.yaml")
 small_line = Dataset(meta_path / "small_line.yaml")
 small_tree = Dataset(meta_path / "small_tree.yaml")
+
+DATASETS_UNDIRECTED = [karate, dolphins]
+
+DATASETS_UNDIRECTED_WEIGHTS = [netscience]
+
+DATASETS_UNRENUMBERED = [karate_disjoint]
+
+# karate-disjoint, 
+DATASETS = [dolphins, netscience, karate_disjoint]
+
+
+
+
 
 
 MEDIUM_DATASETS = [polbooks]

--- a/python/cugraph/cugraph/experimental/datasets/metadata/karate-disjoint.yaml
+++ b/python/cugraph/cugraph/experimental/datasets/metadata/karate-disjoint.yaml
@@ -1,0 +1,21 @@
+name: karate-disjoint
+file_type: .csv
+author: null
+url: https://raw.githubusercontent.com/rapidsai/cugraph/branch-22.08/datasets/karate-disjoint.csv
+refs: null
+delim: " "
+col_names:
+  - src
+  - dst
+  - wgt
+col_types:
+  - int32
+  - int32
+  - float32
+has_loop: false
+is_directed: True
+is_multigraph: false
+is_symmetric: true
+number_of_edges: 312
+number_of_nodes: 68
+number_of_lines: 312


### PR DESCRIPTION
This PR updates the unit tests to leverage the datasets API by updating the utils functions. This greatly simplifies the graph creation from an edgelist with a single call `get_edgelist()` by abstracting the following calls: `cudf.read_csv`, `from_cudf_edgelist`