### PR TITLE
suppress expansion of unused raft spectral templates

### DIFF
--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -15,6 +15,7 @@ dependencies:
 - librmm=22.10.*
 - libraft-headers=22.10.*
 - pyraft=22.10.*
+- libraft-distance=22.10.*
 - cuda-python>=11.5,<11.7.1
 - dask>=2022.7.1
 - distributed>=2022.7.1

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -15,6 +15,7 @@ dependencies:
 - librmm=22.10.*
 - libraft-headers=22.10.*
 - pyraft=22.10.*
+- libraft-distance=22.10.*
 - cuda-python>=11.5,<11.7.1
 - dask>=2022.7.1
 - distributed>=2022.7.1

--- a/conda/environments/cugraph_dev_cuda11.5.yml
+++ b/conda/environments/cugraph_dev_cuda11.5.yml
@@ -15,6 +15,7 @@ dependencies:
 - librmm=22.10.*
 - libraft-headers=22.10.*
 - pyraft=22.10.*
+- libraft-distance=22.10.*
 - cuda-python>=11.5,<11.7.1
 - dask>=2022.7.1
 - distributed>=2022.7.1

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - scikit-build>=0.13.1
     - libcugraph={{ version }}
     - libraft-headers {{ minor_version }}
+    - libraft-distance {{ minor_version }}
     - raft-dask {{ minor_version }}
     - pylibraft {{ minor_version}}
     - cudf={{ minor_version }}
@@ -50,6 +51,7 @@ requirements:
     - pylibcugraph={{ version }}
     - libcugraph={{ version }}
     - libraft-headers {{ minor_version }}
+    - libraft-distance {{ minor_version }}
     - raft-dask {{ minor_version }}
     - pylibraft {{ minor_version }}
     - cudf={{ minor_version }}

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -38,8 +38,8 @@ requirements:
   host:
     - doxygen {{ doxygen_version }}
     - cudatoolkit {{ cuda_version }}.*
-    - libraft-headers {{ minor_version }}.*
-    - libraft-distance {{ minor_version }}.*
+    - libraft-headers {{ minor_version }}
+    - libraft-distance {{ minor_version }}
     - libcugraphops {{ minor_version }}.*
     - librmm {{ minor_version }}.*
     - libcudf {{ minor_version }}.*
@@ -63,8 +63,8 @@ outputs:
         - cmake {{ cmake_version }}
       run:
         - cudatoolkit {{ cuda_spec }}
-        - libraft-headers {{ minor_version }}.*
-        - libraft-distance {{ minor_version }}.*
+        - libraft-headers {{ minor_version }}
+        - libraft-distance {{ minor_version }}
         - librmm {{ minor_version }}
         - nccl {{ nccl_version }}
         - ucx-proc=*=gpu

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -63,11 +63,8 @@ outputs:
         - cmake {{ cmake_version }}
       run:
         - cudatoolkit {{ cuda_spec }}
-<<<<<<< HEAD
-        - libraft-headers {{ minor_version }}
-        - libraft-distance {{ minor_version }}
-=======
->>>>>>> branch-22.10
+        - libraft-headers {{ minor_version }}.*
+        - libraft-distance {{ minor_version }}.*
         - librmm {{ minor_version }}
         - nccl {{ nccl_version }}
         - ucx-proc=*=gpu

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -39,6 +39,7 @@ requirements:
     - doxygen {{ doxygen_version }}
     - cudatoolkit {{ cuda_version }}.*
     - libraft-headers {{ minor_version }}.*
+    - libraft-distance {{ minor_version }}.*
     - libcugraphops {{ minor_version }}.*
     - librmm {{ minor_version }}.*
     - libcudf {{ minor_version }}.*
@@ -63,6 +64,7 @@ outputs:
       run:
         - cudatoolkit {{ cuda_spec }}
         - libraft-headers {{ minor_version }}
+        - libraft-distance {{ minor_version }}
         - librmm {{ minor_version }}
         - nccl {{ nccl_version }}
         - ucx-proc=*=gpu

--- a/conda/recipes/pylibcugraph/meta.yaml
+++ b/conda/recipes/pylibcugraph/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - scikit-build>=0.13.1
     - libcugraph={{ version }}
     - libraft-headers={{ minor_version }}
+    - libraft-distance {{ minor_version }}
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
     - cudatoolkit {{ cuda_version }}.*

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -146,7 +146,6 @@ include(${rapids-cmake-dir}/cpm/cuco.cmake)
 rapids_cpm_cuco(BUILD_EXPORT_SET cugraph-exports)
 
 include(cmake/thirdparty/get_raft.cmake)
-find_package(raft COMPONENTS distance)
 
 if(USE_CUGRAPH_OPS)
   include(cmake/thirdparty/get_libcugraphops.cmake)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -146,6 +146,7 @@ include(${rapids-cmake-dir}/cpm/cuco.cmake)
 rapids_cpm_cuco(BUILD_EXPORT_SET cugraph-exports)
 
 include(cmake/thirdparty/get_raft.cmake)
+find_package(raft COMPONENTS distance)
 
 if(USE_CUGRAPH_OPS)
   include(cmake/thirdparty/get_libcugraphops.cmake)
@@ -304,6 +305,7 @@ if (USE_CUGRAPH_OPS)
         PUBLIC
             cugraph-ops::cugraph-ops++
             raft::raft
+	    raft::distance
         PRIVATE
             cuco::cuco
             cugraph::cuHornet
@@ -313,6 +315,7 @@ else()
     target_link_libraries(cugraph
         PUBLIC
             raft::raft
+	    raft::distance
         PRIVATE
             cuco::cuco
             cugraph::cuHornet
@@ -383,6 +386,7 @@ target_link_libraries(cugraph_c
                 CUDA::cusolver
                 CUDA::cusparse
                 raft::raft
+	        raft::distance
         PRIVATE
                 cuco::cuco
                 cugraph::cugraph

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -304,7 +304,7 @@ if (USE_CUGRAPH_OPS)
         PUBLIC
             cugraph-ops::cugraph-ops++
             raft::raft
-	    raft::distance
+	    raft::raft_distance_lib
         PRIVATE
             cuco::cuco
             cugraph::cuHornet
@@ -314,7 +314,7 @@ else()
     target_link_libraries(cugraph
         PUBLIC
             raft::raft
-	    raft::distance
+	    raft::raft_distance_lib
         PRIVATE
             cuco::cuco
             cugraph::cuHornet
@@ -385,7 +385,7 @@ target_link_libraries(cugraph_c
                 CUDA::cusolver
                 CUDA::cusparse
                 raft::raft
-	        raft::distance
+	        raft::raft_distance_lib
         PRIVATE
                 cuco::cuco
                 cugraph::cugraph

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -304,7 +304,7 @@ if (USE_CUGRAPH_OPS)
         PUBLIC
             cugraph-ops::cugraph-ops++
             raft::raft
-	    raft::raft_distance_lib
+    	    raft::distance
         PRIVATE
             cuco::cuco
             cugraph::cuHornet
@@ -314,7 +314,7 @@ else()
     target_link_libraries(cugraph
         PUBLIC
             raft::raft
-	    raft::raft_distance_lib
+   	        raft::distance
         PRIVATE
             cuco::cuco
             cugraph::cuHornet
@@ -385,7 +385,7 @@ target_link_libraries(cugraph_c
                 CUDA::cusolver
                 CUDA::cusparse
                 raft::raft
-	        raft::raft_distance_lib
+     	        raft::distance
         PRIVATE
                 cuco::cuco
                 cugraph::cugraph

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -36,8 +36,10 @@ function(find_and_configure_raft)
             GIT_REPOSITORY https://github.com/${PKG_FORK}/raft.git
             GIT_TAG        ${PKG_PINNED_TAG}
             SOURCE_SUBDIR  cpp
+            FIND_PACKAGE_ARGUMENTS "COMPONENTS distance"
             OPTIONS
                 "RAFT_COMPILE_LIBRARIES OFF"
+                "RAFT_COMPILE_DIST_LIBRARY ON"
                 "BUILD_TESTS OFF"
                 "BUILD_BENCH OFF"
                 "RAFT_ENABLE_cuco_DEPENDENCY OFF"

--- a/cpp/src/community/legacy/spectral_clustering.cu
+++ b/cpp/src/community/legacy/spectral_clustering.cu
@@ -24,10 +24,9 @@
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 
+#include <raft/distance/specializations.cuh>
 #include <raft/spectral/modularity_maximization.cuh>
 #include <raft/spectral/partition.cuh>
-#include <raft/distance/specializations.cuh>
-
 
 namespace cugraph {
 

--- a/cpp/src/community/legacy/spectral_clustering.cu
+++ b/cpp/src/community/legacy/spectral_clustering.cu
@@ -26,6 +26,8 @@
 
 #include <raft/spectral/modularity_maximization.cuh>
 #include <raft/spectral/partition.cuh>
+#include <raft/distance/specializations.cuh>
+
 
 namespace cugraph {
 

--- a/python/cugraph/CMakeLists.txt
+++ b/python/cugraph/CMakeLists.txt
@@ -36,6 +36,18 @@ option(FIND_CUGRAPH_CPP "Search for existing CUGRAPH C++ installations before de
 
 # If the user requested it,  we attempt to find CUGRAPH.
 if(FIND_CUGRAPH_CPP)
+
+  include(rapids-cpm)
+  rapids_cpm_init()
+  include(rapids-cuda)
+  rapids_cuda_init_architectures(cugraph-python)
+  enable_language(CUDA)
+
+  # We need to call get_raft due to cuML asking for raft::nn and
+  # raft::distance targets
+  # see issue https://github.com/rapidsai/cuml/issues/4843
+  include(../cpp/cmake/thirdparty/get_raft.cmake)
+
   find_package(cugraph ${cugraph_version} REQUIRED)
 else()
   set(cugraph_FOUND OFF)
@@ -52,6 +64,8 @@ if(NOT cugraph_FOUND)
   # rapids_cuda_init_architectures relies on `project` including.
   
   include("${CMAKE_PROJECT_cugraph-python_INCLUDE}")
+
+  include(../cpp/cmake/thirdparty/get_raft.cmake)
 
   add_subdirectory(../../cpp cugraph-cpp)
 

--- a/python/cugraph/CMakeLists.txt
+++ b/python/cugraph/CMakeLists.txt
@@ -43,10 +43,14 @@ if(FIND_CUGRAPH_CPP)
   rapids_cuda_init_architectures(cugraph-python)
   enable_language(CUDA)
 
+  set(CUGRAPH_VERSION_MAJOR "${cugraph-python_VERSION_MAJOR}")
+  set(CUGRAPH_VERSION_MINOR "${cugraph-python_VERSION_MINOR}")
+
+
   # We need to call get_raft due to cuML asking for raft::nn and
   # raft::distance targets
   # see issue https://github.com/rapidsai/cuml/issues/4843
-  include(../cpp/cmake/thirdparty/get_raft.cmake)
+  include(../../cpp/cmake/thirdparty/get_raft.cmake)
 
   find_package(cugraph ${cugraph_version} REQUIRED)
 else()
@@ -65,7 +69,10 @@ if(NOT cugraph_FOUND)
   
   include("${CMAKE_PROJECT_cugraph-python_INCLUDE}")
 
-  include(../cpp/cmake/thirdparty/get_raft.cmake)
+  set(CUGRAPH_VERSION_MAJOR "${cugraph-python_VERSION_MAJOR}")
+  set(CUGRAPH_VERSION_MINOR "${cugraph-python_VERSION_MINOR}")
+
+  include(../../cpp/cmake/thirdparty/get_raft.cmake)
 
   add_subdirectory(../../cpp cugraph-cpp)
 

--- a/python/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/CMakeLists.txt
@@ -38,6 +38,17 @@ option(FIND_CUGRAPH_CPP "Search for existing CUGRAPH C++ installations before de
 
 if(FIND_CUGRAPH_CPP)
   message(STATUS "Trying to find the package")
+  include(rapids-cpm)
+  rapids_cpm_init()
+  include(rapids-cuda)
+  rapids_cuda_init_architectures(pylibcugraph-python)
+  enable_language(CUDA)
+
+  # We need to call get_raft due to cuML asking for raft::nn and
+  # raft::distance targets
+  # see issue https://github.com/rapidsai/cuml/issues/4843
+  include(../cpp/cmake/thirdparty/get_raft.cmake)
+
   find_package(cugraph ${cugraph_version} REQUIRED)
 else()
   set(cugraph_FOUND OFF)

--- a/python/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/CMakeLists.txt
@@ -44,10 +44,14 @@ if(FIND_CUGRAPH_CPP)
   rapids_cuda_init_architectures(pylibcugraph-python)
   enable_language(CUDA)
 
+  set(CUGRAPH_VERSION_MAJOR "${pylibcugraph-python_VERSION_MAJOR}")
+  set(CUGRAPH_VERSION_MINOR "${pylibcugraph-python_VERSION_MINOR}")
+
+
   # We need to call get_raft due to cuML asking for raft::nn and
   # raft::distance targets
   # see issue https://github.com/rapidsai/cuml/issues/4843
-  include(../cpp/cmake/thirdparty/get_raft.cmake)
+  include(../../cpp/cmake/thirdparty/get_raft.cmake)
 
   find_package(cugraph ${cugraph_version} REQUIRED)
 else()
@@ -67,6 +71,10 @@ if(NOT cugraph_FOUND)
   # rapids_cuda_init_architectures relies on `project` including.
   
   include("${CMAKE_PROJECT_pylibcugraph-python_INCLUDE}")
+
+  set(CUGRAPH_VERSION_MAJOR "${pylibcugraph-python_VERSION_MAJOR}")
+  set(CUGRAPH_VERSION_MINOR "${pylibcugraph-python_VERSION_MINOR}")
+
   include(../../cpp/cmake/thirdparty/get_raft.cmake)
 
   add_subdirectory(../../cpp cugraph-cpp)

--- a/python/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/CMakeLists.txt
@@ -56,6 +56,7 @@ if(NOT cugraph_FOUND)
   # rapids_cuda_init_architectures relies on `project` including.
   
   include("${CMAKE_PROJECT_pylibcugraph-python_INCLUDE}")
+  include(../../cpp/cmake/thirdparty/get_raft.cmake)
 
   add_subdirectory(../../cpp cugraph-cpp)
 


### PR DESCRIPTION
Closes #2678 

raft updated some k-means logic and dramatically increased the compile time of our spectral clustering implementation.  This PR adds an include that will suppress the expansion of templates that we are not using.