### PR TITLE
C++ implementation for unweighted Jaccard/Sorensen/Overlap

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -161,9 +161,17 @@ endif()
 ################################################################################
 # - libcugraph library target --------------------------------------------------
 
+# NOTE: The most expensive compilations are listed first
+#       since ninja will run them in parallel in this order,
+#       which should give us a better parallel schedule.
+
 set(CUGRAPH_SOURCES
-    src/detail/utility_wrappers.cu
     src/detail/shuffle_wrappers.cu
+    src/sampling/random_walks_mg.cu
+    src/community/detail/common_methods_mg.cu
+    src/community/detail/common_methods_sg.cu
+    src/detail/utility_wrappers.cu
+    src/structure/graph_view_mg.cu
     src/utilities/cython.cu
     src/utilities/path_retrieval.cu
     src/utilities/graph_bcast.cpp
@@ -181,8 +189,6 @@ set(CUGRAPH_SOURCES
     src/layout/legacy/force_atlas2.cu
     src/converters/legacy/COOtoCSR.cu
     src/community/legacy/spectral_clustering.cu
-    src/community/detail/common_methods_sg.cu
-    src/community/detail/common_methods_mg.cu
     src/community/louvain_sg.cu
     src/community/louvain_mg.cu
     src/community/leiden_sg.cu
@@ -195,7 +201,6 @@ set(CUGRAPH_SOURCES
     src/community/legacy/egonet.cu
     src/sampling/random_walks.cu
     src/sampling/random_walks_sg.cu
-    src/sampling/random_walks_mg.cu
     src/sampling/detail/sampling_utils_mg.cu
     src/sampling/detail/sampling_utils_sg.cu
     src/sampling/uniform_neighbor_sampling_mg.cpp
@@ -215,7 +220,6 @@ set(CUGRAPH_SOURCES
     src/structure/graph_sg.cu
     src/structure/graph_mg.cu
     src/structure/graph_view_sg.cu
-    src/structure/graph_view_mg.cu
     src/structure/coarsen_graph_sg.cu
     src/structure/coarsen_graph_mg.cu
     src/structure/renumber_edgelist_sg.cu

--- a/cpp/src/link_prediction/jaccard_impl.cuh
+++ b/cpp/src/link_prediction/jaccard_impl.cuh
@@ -25,26 +25,19 @@ namespace detail {
 
 struct jaccard_functor_t {
   template <typename weight_t>
-  weight_t __device__ compute_score(size_t cardinality_a,
-                                    size_t cardinality_b,
-                                    size_t cardinality_a_intersect_b,
-                                    weight_t,
-                                    weight_t,
-                                    weight_t)
+  weight_t __device__ compute_score(weight_t cardinality_a,
+                                    weight_t cardinality_b,
+                                    weight_t cardinality_a_intersect_b) const
   {
-    return static_cast<weight_t>(cardinality_a_intersect_b) /
-           static_cast<weight_t>(cardinality_a + cardinality_b - cardinality_a_intersect_b);
+    return cardinality_a_intersect_b / cardinality_a + cardinality_b - cardinality_a_intersect_b;
   }
 };
 
 struct weighted_jaccard_functor_t {
   template <typename weight_t>
-  weight_t __device__ compute_score(size_t cardinality_a,
-                                    size_t cardinality_b,
-                                    size_t cardinality_a_intersect_b,
-                                    weight_t weight_a,
+  weight_t __device__ compute_score(weight_t weight_a,
                                     weight_t weight_b,
-                                    weight_t min_weight_a_intersect_b)
+                                    weight_t min_weight_a_intersect_b) const
   {
     return min_weight_a_intersect_b / (weight_a + weight_b - min_weight_a_intersect_b);
   }

--- a/cpp/src/link_prediction/overlap_impl.cuh
+++ b/cpp/src/link_prediction/overlap_impl.cuh
@@ -25,26 +25,19 @@ namespace detail {
 
 struct overlap_functor_t {
   template <typename weight_t>
-  weight_t __device__ compute_score(size_t cardinality_a,
-                                    size_t cardinality_b,
-                                    size_t cardinality_a_intersect_b,
-                                    weight_t,
-                                    weight_t,
-                                    weight_t)
+  weight_t __device__ compute_score(weight_t cardinality_a,
+                                    weight_t cardinality_b,
+                                    weight_t cardinality_a_intersect_b) const
   {
-    return static_cast<weight_t>(cardinality_a_intersect_b) /
-           static_cast<weight_t>(std::min(cardinality_a, cardinality_b));
+    return cardinality_a_intersect_b / std::min(cardinality_a, cardinality_b);
   }
 };
 
 struct weighted_overlap_functor_t {
   template <typename weight_t>
-  weight_t __device__ compute_score(size_t cardinality_a,
-                                    size_t cardinality_b,
-                                    size_t cardinality_a_intersect_b,
-                                    weight_t weight_a,
+  weight_t __device__ compute_score(weight_t weight_a,
                                     weight_t weight_b,
-                                    weight_t min_weight_a_intersect_b)
+                                    weight_t min_weight_a_intersect_b) const
   {
     return min_weight_a_intersect_b / std::min(weight_a, weight_b);
   }

--- a/cpp/src/link_prediction/similarity_impl.cuh
+++ b/cpp/src/link_prediction/similarity_impl.cuh
@@ -76,12 +76,6 @@ rmm::device_uvector<weight_t> similarity(
       vertex_pairs_begin + num_vertex_pairs,
       out_degrees.begin(),
       [functor] __device__(auto v1, auto v2, auto v1_degree, auto v2_degree, auto intersection) {
-        printf("v1 = %d, v2 = %d, v1_degree = %d, v2_degree = %d, intersection size = %d\n",
-               (int)v1,
-               (int)v2,
-               (int)v1_degree,
-               (int)v2_degree,
-               (int)intersection.size());
         return functor.compute_score(static_cast<weight_t>(v1_degree),
                                      static_cast<weight_t>(v2_degree),
                                      static_cast<weight_t>(intersection.size()));

--- a/cpp/src/link_prediction/sorensen_impl.cuh
+++ b/cpp/src/link_prediction/sorensen_impl.cuh
@@ -25,26 +25,19 @@ namespace detail {
 
 struct sorensen_functor_t {
   template <typename weight_t>
-  weight_t __device__ compute_score(size_t cardinality_a,
-                                    size_t cardinality_b,
-                                    size_t cardinality_a_intersect_b,
-                                    weight_t,
-                                    weight_t,
-                                    weight_t)
+  weight_t __device__ compute_score(weight_t cardinality_a,
+                                    weight_t cardinality_b,
+                                    weight_t cardinality_a_intersect_b) const
   {
-    return static_cast<weight_t>(2 * cardinality_a_intersect_b) /
-           static_cast<weight_t>(cardinality_a + cardinality_b);
+    return (2 * cardinality_a_intersect_b) / (cardinality_a + cardinality_b);
   }
 };
 
 struct weighted_sorensen_functor_t {
   template <typename weight_t>
-  weight_t __device__ compute_score(size_t cardinality_a,
-                                    size_t cardinality_b,
-                                    size_t cardinality_a_intersect_b,
-                                    weight_t weight_a,
+  weight_t __device__ compute_score(weight_t weight_a,
                                     weight_t weight_b,
-                                    weight_t min_weight_a_intersect_b)
+                                    weight_t min_weight_a_intersect_b) const
   {
     return (2 * min_weight_a_intersect_b) / (weight_a + weight_b);
   }

--- a/cpp/src/prims/per_v_pair_transform_dst_nbr_intersection.cuh
+++ b/cpp/src/prims/per_v_pair_transform_dst_nbr_intersection.cuh
@@ -147,7 +147,7 @@ struct call_intersection_op_t {
       auto src_offset   = GraphViewType::is_storage_transposed ? minor_offset : major_offset;
       auto dst_offset   = GraphViewType::is_storage_transposed ? major_offset : minor_offset;
       src_prop          = *(vertex_property_first + src_offset);
-      dst_prop          = *(vertex_property_first + src_offset);
+      dst_prop          = *(vertex_property_first + dst_offset);
     }
     *(major_minor_pair_value_output_first + index) =
       evaluate_intersection_op<GraphViewType,
@@ -264,7 +264,7 @@ void per_v_pair_transform_dst_nbr_intersection(
   std::vector<vertex_t> h_edge_partition_major_range_lasts(
     graph_view.number_of_local_edge_partitions());
   for (size_t i = 0; i < graph_view.number_of_local_edge_partitions(); ++i) {
-    h_edge_partition_major_range_lasts[i] = graph_view.local_edge_partition_src_range_first(i);
+    h_edge_partition_major_range_lasts[i] = graph_view.local_edge_partition_src_range_last(i);
   }
   rmm::device_uvector<vertex_t> d_edge_partition_major_range_lasts(
     h_edge_partition_major_range_lasts.size(), handle.get_stream());

--- a/cpp/tests/link_prediction/mg_similarity_test.cpp
+++ b/cpp/tests/link_prediction/mg_similarity_test.cpp
@@ -92,7 +92,7 @@ class Tests_MGSimilarity
     rmm::device_uvector<vertex_t> d_v1(0, handle_->get_stream());
     rmm::device_uvector<vertex_t> d_v2(0, handle_->get_stream());
 
-    {
+    if (handle_->get_comms().get_rank() == 0) {
       auto [src, dst, wgt] = cugraph::test::graph_to_host_coo(*handle_, mg_graph_view);
 
       size_t max_vertices = std::min(static_cast<size_t>(mg_graph_view.number_of_vertices()),
@@ -191,14 +191,8 @@ class Tests_MGSimilarity
         std::vector<vertex_t> h_vertex_pair_2(check_size);
         std::vector<weight_t> h_result_score(check_size);
 
-        raft::update_host(h_vertex_pair_1.data(),
-                          std::get<0>(vertex_pairs).data(),
-                          check_size,
-                          handle_->get_stream());
-        raft::update_host(h_vertex_pair_2.data(),
-                          std::get<1>(vertex_pairs).data(),
-                          check_size,
-                          handle_->get_stream());
+        raft::update_host(h_vertex_pair_1.data(), d_v1.data(), check_size, handle_->get_stream());
+        raft::update_host(h_vertex_pair_2.data(), d_v2.data(), check_size, handle_->get_stream());
         raft::update_host(
           h_result_score.data(), result_score.data(), check_size, handle_->get_stream());
 
@@ -307,9 +301,7 @@ INSTANTIATE_TEST_SUITE_P(
     // 100}),
     ::testing::Values(Similarity_Usecase{false, true, 20, 100}),
     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
+                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
   rmat_small_test,

--- a/cpp/tests/link_prediction/similarity_compare.cpp
+++ b/cpp/tests/link_prediction/similarity_compare.cpp
@@ -39,10 +39,10 @@ namespace test {
 template <typename vertex_t, typename weight_t, typename test_t>
 void similarity_compare(
   vertex_t num_vertices,
-  std::tuple<std::vector<vertex_t>, std::vector<vertex_t>, std::optional<std::vector<weight_t>>>&&
+  std::tuple<std::vector<vertex_t>&, std::vector<vertex_t>&, std::optional<std::vector<weight_t>>&>
     edge_list,
-  std::tuple<std::vector<vertex_t>, std::vector<vertex_t>>&& vertex_pairs,
-  std::vector<weight_t>&& similarity_score,
+  std::tuple<std::vector<vertex_t>&, std::vector<vertex_t>&> vertex_pairs,
+  std::vector<weight_t>& similarity_score,
   test_t const& test_functor)
 {
   // TBD
@@ -50,50 +50,50 @@ void similarity_compare(
 
 template void similarity_compare(
   int32_t num_vertices,
-  std::tuple<std::vector<int32_t>, std::vector<int32_t>, std::optional<std::vector<float>>>&&
+  std::tuple<std::vector<int32_t>&, std::vector<int32_t>&, std::optional<std::vector<float>>&>
     edge_list,
-  std::tuple<std::vector<int32_t>, std::vector<int32_t>>&& vertex_pairs,
-  std::vector<float>&& result_score,
+  std::tuple<std::vector<int32_t>&, std::vector<int32_t>&> vertex_pairs,
+  std::vector<float>& result_score,
   test_jaccard_t const& test_functor);
 
 template void similarity_compare(
   int32_t num_vertices,
-  std::tuple<std::vector<int32_t>, std::vector<int32_t>, std::optional<std::vector<float>>>&&
+  std::tuple<std::vector<int32_t>&, std::vector<int32_t>&, std::optional<std::vector<float>>&>
     edge_list,
-  std::tuple<std::vector<int32_t>, std::vector<int32_t>>&& vertex_pairs,
-  std::vector<float>&& result_score,
+  std::tuple<std::vector<int32_t>&, std::vector<int32_t>&> vertex_pairs,
+  std::vector<float>& result_score,
   test_sorensen_t const& test_functor);
 
 template void similarity_compare(
   int32_t num_vertices,
-  std::tuple<std::vector<int32_t>, std::vector<int32_t>, std::optional<std::vector<float>>>&&
+  std::tuple<std::vector<int32_t>&, std::vector<int32_t>&, std::optional<std::vector<float>>&>
     edge_list,
-  std::tuple<std::vector<int32_t>, std::vector<int32_t>>&& vertex_pairs,
-  std::vector<float>&& result_score,
+  std::tuple<std::vector<int32_t>&, std::vector<int32_t>&> vertex_pairs,
+  std::vector<float>& result_score,
   test_overlap_t const& test_functor);
 
 template void similarity_compare(
   int64_t num_vertices,
-  std::tuple<std::vector<int64_t>, std::vector<int64_t>, std::optional<std::vector<float>>>&&
+  std::tuple<std::vector<int64_t>&, std::vector<int64_t>&, std::optional<std::vector<float>>&>
     edge_list,
-  std::tuple<std::vector<int64_t>, std::vector<int64_t>>&& vertex_pairs,
-  std::vector<float>&& result_score,
+  std::tuple<std::vector<int64_t>&, std::vector<int64_t>&> vertex_pairs,
+  std::vector<float>& result_score,
   test_jaccard_t const& test_functor);
 
 template void similarity_compare(
   int64_t num_vertices,
-  std::tuple<std::vector<int64_t>, std::vector<int64_t>, std::optional<std::vector<float>>>&&
+  std::tuple<std::vector<int64_t>&, std::vector<int64_t>&, std::optional<std::vector<float>>&>
     edge_list,
-  std::tuple<std::vector<int64_t>, std::vector<int64_t>>&& vertex_pairs,
-  std::vector<float>&& result_score,
+  std::tuple<std::vector<int64_t>&, std::vector<int64_t>&> vertex_pairs,
+  std::vector<float>& result_score,
   test_sorensen_t const& test_functor);
 
 template void similarity_compare(
   int64_t num_vertices,
-  std::tuple<std::vector<int64_t>, std::vector<int64_t>, std::optional<std::vector<float>>>&&
+  std::tuple<std::vector<int64_t>&, std::vector<int64_t>&, std::optional<std::vector<float>>&>
     edge_list,
-  std::tuple<std::vector<int64_t>, std::vector<int64_t>>&& vertex_pairs,
-  std::vector<float>&& result_score,
+  std::tuple<std::vector<int64_t>&, std::vector<int64_t>&> vertex_pairs,
+  std::vector<float>& result_score,
   test_overlap_t const& test_functor);
 
 }  // namespace test

--- a/cpp/tests/link_prediction/similarity_compare.cpp
+++ b/cpp/tests/link_prediction/similarity_compare.cpp
@@ -45,6 +45,9 @@ void similarity_compare(
   std::vector<weight_t>& similarity_score,
   test_t const& test_functor)
 {
+  raft::print_host_vector("pair1", std::get<0>(vertex_pairs).data(), std::get<0>(vertex_pairs).size(), std::cout);
+  raft::print_host_vector("pair2", std::get<1>(vertex_pairs).data(), std::get<1>(vertex_pairs).size(), std::cout);
+  raft::print_host_vector("score", similarity_score.data(), similarity_score.size(), std::cout);
   // TBD
 }
 

--- a/cpp/tests/link_prediction/similarity_compare.hpp
+++ b/cpp/tests/link_prediction/similarity_compare.hpp
@@ -90,11 +90,10 @@ struct test_overlap_t {
 template <typename vertex_t, typename weight_t, typename test_t>
 void similarity_compare(
   vertex_t num_vertices,
-  std::tuple<std::vector<vertex_t> &,
-             std::vector<vertex_t> &,
-             std::optional<std::vector<weight_t>> &> edge_list,
-  std::tuple<std::vector<vertex_t> &, std::vector<vertex_t> &> vertex_pairs,
-  std::vector<weight_t> & similarity_score,
+  std::tuple<std::vector<vertex_t>&, std::vector<vertex_t>&, std::optional<std::vector<weight_t>>&>
+    edge_list,
+  std::tuple<std::vector<vertex_t>&, std::vector<vertex_t>&> vertex_pairs,
+  std::vector<weight_t>& similarity_score,
   test_t const& test_functor);
 
 }  // namespace test

--- a/cpp/tests/link_prediction/similarity_compare.hpp
+++ b/cpp/tests/link_prediction/similarity_compare.hpp
@@ -90,10 +90,11 @@ struct test_overlap_t {
 template <typename vertex_t, typename weight_t, typename test_t>
 void similarity_compare(
   vertex_t num_vertices,
-  std::tuple<std::vector<vertex_t>, std::vector<vertex_t>, std::optional<std::vector<weight_t>>>&&
-    edge_list,
-  std::tuple<std::vector<vertex_t>, std::vector<vertex_t>>&& vertex_pairs,
-  std::vector<weight_t>&& similarity_score,
+  std::tuple<std::vector<vertex_t> &,
+             std::vector<vertex_t> &,
+             std::optional<std::vector<weight_t>> &> edge_list,
+  std::tuple<std::vector<vertex_t> &, std::vector<vertex_t> &> vertex_pairs,
+  std::vector<weight_t> & similarity_score,
   test_t const& test_functor);
 
 }  // namespace test

--- a/cpp/tests/prims/mg_per_v_pair_transform_dst_nbr_intersection.cu
+++ b/cpp/tests/prims/mg_per_v_pair_transform_dst_nbr_intersection.cu
@@ -46,12 +46,14 @@
 template <typename vertex_t, typename edge_t>
 struct intersection_op_t {
   __device__ thrust::tuple<edge_t, edge_t> operator()(
-    vertex_t,
-    vertex_t,
+    vertex_t v1,
+    vertex_t v2,
     edge_t v0_prop /* out degree */,
     edge_t v1_prop /* out degree */,
     raft::device_span<vertex_t const> intersection) const
   {
+printf("v1 = %d, v2 = %d, v1_degree = %d, v2_degree = %d, intersection_size = %d\n",
+         (int) v1, (int) v2, (int) v0_prop, (int) v1_prop, (int) intersection.size());
     return thrust::make_tuple(v0_prop + v1_prop, static_cast<edge_t>(intersection.size()));
   }
 };

--- a/cpp/tests/prims/mg_per_v_pair_transform_dst_nbr_intersection.cu
+++ b/cpp/tests/prims/mg_per_v_pair_transform_dst_nbr_intersection.cu
@@ -52,8 +52,6 @@ struct intersection_op_t {
     edge_t v1_prop /* out degree */,
     raft::device_span<vertex_t const> intersection) const
   {
-printf("v1 = %d, v2 = %d, v1_degree = %d, v2_degree = %d, intersection_size = %d\n",
-         (int) v1, (int) v2, (int) v0_prop, (int) v1_prop, (int) intersection.size());
     return thrust::make_tuple(v0_prop + v1_prop, static_cast<edge_t>(intersection.size()));
   }
 };
@@ -144,7 +142,7 @@ class Tests_MGPerVPairTransformDstNbrIntersection
     std::tie(mg_vertex_pair_buffer, std::ignore) = cugraph::groupby_gpu_id_and_shuffle_values(
       handle_->get_comms(),
       cugraph::get_dataframe_buffer_begin(mg_vertex_pair_buffer),
-      cugraph::get_dataframe_buffer_begin(mg_vertex_pair_buffer),
+      cugraph::get_dataframe_buffer_end(mg_vertex_pair_buffer),
       cugraph::detail::compute_gpu_id_from_int_edge_endpoints_t<vertex_t>{
         raft::device_span<vertex_t const>(d_vertex_partition_range_lasts.data(),
                                           d_vertex_partition_range_lasts.size()),

--- a/cpp/tests/utilities/test_utilities.hpp
+++ b/cpp/tests/utilities/test_utilities.hpp
@@ -408,5 +408,17 @@ graph_to_host_coo(
   cugraph::graph_view_t<vertex_t, edge_t, weight_t, store_transposed, is_multi_gpu> const&
     graph_view);
 
+template <typename type_t>
+struct nearly_equal {
+  const type_t threshold_ratio;
+  const type_t threshold_magnitude;
+
+  bool operator()(type_t lhs, type_t rhs) const
+  {
+    return std::abs(lhs - rhs) <
+           std::max(std::max(lhs, rhs) * threshold_ratio, threshold_magnitude);
+  }
+};
+
 }  // namespace test
 }  // namespace cugraph


### PR DESCRIPTION
Closes #2543 

Implements unweighted similarity algorithms using the new primitive defined in #2728.

Weighted implementations will be tracked by issue #2749