### PR TITLE
[REVIEW] Fix dask mixup in CI

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -36,6 +36,10 @@ export CONDA_BLD_DIR="${WORKSPACE}/.conda-bld"
 # ucx-py version
 export UCX_PY_VERSION='0.28.*'
 
+# Whether to keep `dask/label/dev` channel in the env. If INSTALL_DASK_MAIN=0,
+# `dask/label/dev` channel is removed.
+export INSTALL_DASK_MAIN=0
+
 ################################################################################
 # SETUP - Check environment
 ################################################################################
@@ -50,6 +54,12 @@ conda activate rapids
 # Remove rapidsai-nightly channel if we are building main branch
 if [ "$SOURCE_BRANCH" = "main" ]; then
   conda config --system --remove channels rapidsai-nightly
+  conda config --system --remove channels dask/label/dev
+fi
+
+# Remove `dask/label/dev` channel if INSTALL_DASK_MAIN=0
+if [[ "${INSTALL_DASK_MAIN}" == 0 ]]; then
+  conda config --system --remove channels dask/label/dev
 fi
 
 gpuci_logger "Check versions"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -43,6 +43,10 @@ unset GIT_DESCRIBE_TAG
 # ucx-py version
 export UCX_PY_VERSION='0.28.*'
 
+# Whether to keep `dask/label/dev` channel in the env. If INSTALL_DASK_MAIN=0,
+# `dask/label/dev` channel is removed.
+export INSTALL_DASK_MAIN=0
+
 ################################################################################
 # SETUP - Check environment
 ################################################################################
@@ -57,6 +61,12 @@ gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 export PATH=$(conda info --base)/envs/rapids/bin:$PATH
+
+
+# Remove `dask/label/dev` channel if INSTALL_DASK_MAIN=0
+if [[ "${INSTALL_DASK_MAIN}" == 0 ]]; then
+  conda config --system --remove channels dask/label/dev
+fi
 
 gpuci_logger "Install dependencies"
 # Assume libcudf and librmm will be installed via cudf and rmm respectively.


### PR DESCRIPTION
This PR fixes a `dask` & `dask-core` library mixup with stable & nightly happening, because of this we see the following error:
```python
/opt/conda/envs/rapids/lib/python3.8/site-packages/distributed/deploy/utils.py in <module>
      4 
      5 from dask.system import CPU_COUNT
----> 6 from dask.utils import factors
      7 
      8 
ImportError: cannot import name 'factors' from 'dask.utils' (/opt/conda/envs/rapids/lib/python3.8/site-packages/dask/utils.py)
```