### PR TITLE
[BUG] Properly Distribute Start Vertices for MG Uniform Neighbor Sample

### DIFF
--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -135,7 +135,6 @@ def uniform_neighbor_sample(input_graph,
         start_list = input_graph.lookup_internal_vertex_id(
             start_list).compute()
 
-    
     start_list = dask_cudf.from_cudf(
         start_list,
         npartitions=min(input_graph._npartitions, len(start_list))

--- a/python/cugraph/cugraph/tests/mg/test_mg_uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/tests/mg/test_mg_uniform_neighbor_sample.py
@@ -257,23 +257,27 @@ def test_mg_uniform_neighbor_sample_unweighted(dask_client):
     actual_dst = actual_dst.compute().to_arrow().to_pylist()
     assert sorted(actual_dst) == sorted(expected_dst)
 
+
 def test_mg_uniform_neighbor_sample_ensure_no_duplicates(dask_client):
     # See issue #2760
     # This ensures that the starts are properly distributed
-    
-    df = cudf.DataFrame({'src':[6, 6, 6, 6],
-                     'dst':[7, 9, 10, 11]
-                    })
+
+    df = cudf.DataFrame({
+        'src': [6, 6, 6, 6],
+        'dst': [7, 9, 10, 11]
+    })
     df = df.astype('int32')
 
     dask_df = dask_cudf.from_cudf(df, npartitions=2)
 
     mg_G = cugraph.MultiGraph(directed=True)
-    mg_G.from_dask_cudf_edgelist(dask_df,
-                                source='src',
-                                destination='dst',
-                                renumber=True,
-                                legacy_renum_only=True)
+    mg_G.from_dask_cudf_edgelist(
+        dask_df,
+        source='src',
+        destination='dst',
+        renumber=True,
+        legacy_renum_only=True
+    )
 
     output_df = cugraph.dask.uniform_neighbor_sample(
         mg_G,
@@ -281,5 +285,5 @@ def test_mg_uniform_neighbor_sample_ensure_no_duplicates(dask_client):
         fanout_vals=[3],
         with_replacement=False,
     )
-    
+
     assert len(output_df.compute()) == 3

--- a/python/cugraph/cugraph/tests/mg/test_mg_uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/tests/mg/test_mg_uniform_neighbor_sample.py
@@ -220,8 +220,14 @@ def test_mg_uniform_neighbor_sample_tree(dask_client, directed):
 
 def test_mg_uniform_neighbor_sample_unweighted(dask_client):
     df = cudf.DataFrame({
-        'src': [0, 1, 2, 2, 0, 1, 4, 4],
-        'dst': [3, 2, 1, 4, 1, 3, 1, 2]
+        'src': cudf.Series(
+            [0, 1, 2, 2, 0, 1, 4, 4],
+            dtype='int32'
+        ),
+        'dst': cudf.Series(
+            [3, 2, 1, 4, 1, 3, 1, 2],
+            dtype='int32'
+        )
     })
 
     df = dask_cudf.from_cudf(df, npartitions=2)
@@ -250,3 +256,30 @@ def test_mg_uniform_neighbor_sample_unweighted(dask_client):
     actual_dst = sampling_results.destinations
     actual_dst = actual_dst.compute().to_arrow().to_pylist()
     assert sorted(actual_dst) == sorted(expected_dst)
+
+def test_mg_uniform_neighbor_sample_ensure_no_duplicates(dask_client):
+    # See issue #2760
+    # This ensures that the starts are properly distributed
+    
+    df = cudf.DataFrame({'src':[6, 6, 6, 6],
+                     'dst':[7, 9, 10, 11]
+                    })
+    df = df.astype('int32')
+
+    dask_df = dask_cudf.from_cudf(df, npartitions=2)
+
+    mg_G = cugraph.MultiGraph(directed=True)
+    mg_G.from_dask_cudf_edgelist(dask_df,
+                                source='src',
+                                destination='dst',
+                                renumber=True,
+                                legacy_renum_only=True)
+
+    output_df = cugraph.dask.uniform_neighbor_sample(
+        mg_G,
+        cudf.Series([6]).astype('int32'),
+        fanout_vals=[3],
+        with_replacement=False,
+    )
+    
+    assert len(output_df.compute()) == 3


### PR DESCRIPTION
Resolves a critical bug where the whole start list was sent to every vertex resulting in duplicate samples.
Closes #2760 