### PR TITLE
C++ minimal CSV reader

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -20,6 +20,7 @@
 
 add_library(cugraphtestutil STATIC
             utilities/matrix_market_file_utilities.cu
+            utilities/csv_file_utilities.cu
             utilities/thrust_wrapper.cu
             utilities/misc_utilities.cpp
             utilities/test_utilities_sg.cu

--- a/cpp/tests/community/mg_louvain_test.cpp
+++ b/cpp/tests/community/mg_louvain_test.cpp
@@ -101,8 +101,7 @@ class Tests_MGLouvain
             d_vertices,
             number_of_vertices,
             is_symmetric] =
-        input_usecase.template construct_edgelist<vertex_t, edge_t, weight_t, false, false>(handle,
-                                                                                            true);
+        input_usecase.template construct_edgelist<vertex_t, weight_t>(handle, true, false, false);
 
       d_clustering_v.resize(d_vertices.size(), handle_->get_stream());
 

--- a/cpp/tests/community/mg_louvain_test.cpp
+++ b/cpp/tests/community/mg_louvain_test.cpp
@@ -95,15 +95,13 @@ class Tests_MGLouvain
     if (rank == 0) {
       // Create initial SG graph, renumbered according to the MNMG renumber map
 
-      auto [d_edgelist_srcs,
-            d_edgelist_dsts,
-            d_edgelist_weights,
-            d_vertices,
-            number_of_vertices,
-            is_symmetric] =
+      auto [d_edgelist_srcs, d_edgelist_dsts, d_edgelist_weights, d_vertices, is_symmetric] =
         input_usecase.template construct_edgelist<vertex_t, weight_t>(handle, true, false, false);
 
-      d_clustering_v.resize(d_vertices.size(), handle_->get_stream());
+      EXPECT_TRUE(d_vertices.has_value())
+        << "This test expects d_vertices are defined and d_vertices elements are consecutive "
+           "integers starting from 0.";
+      d_clustering_v.resize((*d_vertices).size(), handle_->get_stream());
 
       // renumber using d_renumber_map_gathered_v
       cugraph::test::single_gpu_renumber_edgelist_given_number_map(

--- a/cpp/tests/link_analysis/mg_pagerank_test.cpp
+++ b/cpp/tests/link_analysis/mg_pagerank_test.cpp
@@ -318,7 +318,7 @@ INSTANTIATE_TEST_SUITE_P(
                       PageRank_Usecase{0.5, false},
                       PageRank_Usecase{0.0, true},
                       PageRank_Usecase{0.5, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.csv"),
                       cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));

--- a/cpp/tests/link_analysis/mg_pagerank_test.cpp
+++ b/cpp/tests/link_analysis/mg_pagerank_test.cpp
@@ -318,7 +318,7 @@ INSTANTIATE_TEST_SUITE_P(
                       PageRank_Usecase{0.5, false},
                       PageRank_Usecase{0.0, true},
                       PageRank_Usecase{0.5, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.csv"),
+    ::testing::Values(cugraph::test::File_Usecase("karate.csv"),
                       cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));

--- a/cpp/tests/link_analysis/pagerank_test.cpp
+++ b/cpp/tests/link_analysis/pagerank_test.cpp
@@ -407,8 +407,8 @@ INSTANTIATE_TEST_SUITE_P(
                       PageRank_Usecase{0.5, false},
                       PageRank_Usecase{0.0, true},
                       PageRank_Usecase{0.5, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/dolphins.mtx"))));
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.csv"),
+                      cugraph::test::File_Usecase("test/datasets/dolphins.csv"))));
 
 INSTANTIATE_TEST_SUITE_P(
   rmat_small_test,

--- a/cpp/tests/link_analysis/pagerank_test.cpp
+++ b/cpp/tests/link_analysis/pagerank_test.cpp
@@ -398,17 +398,16 @@ TEST_P(Tests_PageRank_Rmat, CheckInt64Int64FloatFloat)
     override_Rmat_Usecase_with_cmd_line_arguments(GetParam()));
 }
 
-INSTANTIATE_TEST_SUITE_P(
-  file_test,
-  Tests_PageRank_File,
-  ::testing::Combine(
-    // enable correctness checks
-    ::testing::Values(PageRank_Usecase{0.0, false},
-                      PageRank_Usecase{0.5, false},
-                      PageRank_Usecase{0.0, true},
-                      PageRank_Usecase{0.5, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.csv"),
-                      cugraph::test::File_Usecase("test/datasets/dolphins.csv"))));
+INSTANTIATE_TEST_SUITE_P(file_test,
+                         Tests_PageRank_File,
+                         ::testing::Combine(
+                           // enable correctness checks
+                           ::testing::Values(PageRank_Usecase{0.0, false},
+                                             PageRank_Usecase{0.5, false},
+                                             PageRank_Usecase{0.0, true},
+                                             PageRank_Usecase{0.5, true}),
+                           ::testing::Values(cugraph::test::File_Usecase("karate.csv"),
+                                             cugraph::test::File_Usecase("dolphins.csv"))));
 
 INSTANTIATE_TEST_SUITE_P(
   rmat_small_test,

--- a/cpp/tests/structure/graph_test.cpp
+++ b/cpp/tests/structure/graph_test.cpp
@@ -37,32 +37,32 @@
 
 template <bool store_transposed, typename vertex_t, typename edge_t, typename weight_t>
 std::tuple<std::vector<edge_t>, std::vector<vertex_t>, std::optional<std::vector<weight_t>>>
-graph_reference(vertex_t const* p_src_vertices,
-                vertex_t const* p_dst_vertices,
-                std::optional<weight_t const*> p_edge_weights,
+graph_reference(vertex_t const* edge_srcs,
+                vertex_t const* edge_dsts,
+                std::optional<weight_t const*> edge_weights,
                 vertex_t number_of_vertices,
                 edge_t number_of_edges)
 {
   std::vector<edge_t> offsets(number_of_vertices + 1, edge_t{0});
   std::vector<vertex_t> indices(number_of_edges, vertex_t{0});
-  auto weights = p_edge_weights
+  auto weights = edge_weights
                    ? std::make_optional<std::vector<weight_t>>(number_of_edges, weight_t{0.0})
                    : std::nullopt;
 
   for (edge_t i = 0; i < number_of_edges; ++i) {
-    auto major = store_transposed ? p_dst_vertices[i] : p_src_vertices[i];
+    auto major = store_transposed ? edge_dsts[i] : edge_srcs[i];
     offsets[1 + major]++;
   }
   std::partial_sum(offsets.begin() + 1, offsets.end(), offsets.begin() + 1);
 
   for (edge_t i = 0; i < number_of_edges; ++i) {
-    auto major           = store_transposed ? p_dst_vertices[i] : p_src_vertices[i];
-    auto minor           = store_transposed ? p_src_vertices[i] : p_dst_vertices[i];
+    auto major           = store_transposed ? edge_dsts[i] : edge_srcs[i];
+    auto minor           = store_transposed ? edge_srcs[i] : edge_dsts[i];
     auto start           = offsets[major];
     auto degree          = offsets[major + 1] - start;
     auto idx             = indices[start + degree - 1]++;
     indices[start + idx] = minor;
-    if (p_edge_weights) { (*weights)[start + idx] = (*p_edge_weights)[i]; }
+    if (edge_weights) { (*weights)[start + idx] = (*edge_weights)[i]; }
   }
 
   return std::make_tuple(std::move(offsets), std::move(indices), std::move(weights));
@@ -97,18 +97,6 @@ class Tests_Graph : public ::testing::TestWithParam<std::tuple<Graph_Usecase, in
 
     edge_t number_of_edges = static_cast<edge_t>(d_srcs.size());
 
-    auto h_srcs    = cugraph::test::to_host(handle, d_srcs);
-    auto h_dsts    = cugraph::test::to_host(handle, d_dsts);
-    auto h_weights = cugraph::test::to_host(handle, d_weights);
-
-    auto [h_reference_offsets, h_reference_indices, h_reference_weights] =
-      graph_reference<store_transposed>(
-        h_srcs.data(),
-        h_dsts.data(),
-        h_weights ? std::optional<weight_t const*>{(*h_weights).data()} : std::nullopt,
-        number_of_vertices,
-        number_of_edges);
-
     cugraph::edgelist_t<vertex_t, edge_t, weight_t> edgelist{
       raft::device_span<vertex_t const>(d_srcs.data(), d_srcs.size()),
       raft::device_span<vertex_t const>(d_dsts.data(), d_dsts.size()),
@@ -135,6 +123,18 @@ class Tests_Graph : public ::testing::TestWithParam<std::tuple<Graph_Usecase, in
     ASSERT_EQ(graph_view.number_of_edges(), number_of_edges);
 
     if (graph_usecase.check_correctness) {
+      auto h_srcs    = cugraph::test::to_host(handle, d_srcs);
+      auto h_dsts    = cugraph::test::to_host(handle, d_dsts);
+      auto h_weights = cugraph::test::to_host(handle, d_weights);
+
+      auto [h_reference_offsets, h_reference_indices, h_reference_weights] =
+        graph_reference<store_transposed>(
+          h_srcs.data(),
+          h_dsts.data(),
+          h_weights ? std::optional<weight_t const*>{(*h_weights).data()} : std::nullopt,
+          number_of_vertices,
+          number_of_edges);
+
       auto h_cugraph_offsets =
         cugraph::test::to_host(handle, graph_view.local_edge_partition_view().offsets());
       auto h_cugraph_indices =

--- a/cpp/tests/structure/graph_test.cpp
+++ b/cpp/tests/structure/graph_test.cpp
@@ -92,9 +92,8 @@ class Tests_Graph : public ::testing::TestWithParam<std::tuple<Graph_Usecase, in
     auto [graph_usecase, input_usecase] = param;
 
     auto [d_srcs, d_dsts, d_weights, d_vertices, number_of_vertices, is_symmetric] =
-      input_usecase
-        .template construct_edgelist<vertex_t, edge_t, weight_t, store_transposed, false>(
-          handle, graph_usecase.test_weighted);
+      input_usecase.template construct_edgelist<vertex_t, weight_t>(
+        handle, graph_usecase.test_weighted, store_transposed, false);
 
     edge_t number_of_edges = static_cast<edge_t>(d_srcs.size());
 

--- a/cpp/tests/structure/renumbering_test.cpp
+++ b/cpp/tests/structure/renumbering_test.cpp
@@ -70,7 +70,7 @@ class Tests_Renumbering
     rmm::device_uvector<vertex_t> dst_v(0, handle.get_stream());
     rmm::device_uvector<vertex_t> renumber_map_labels_v(0, handle.get_stream());
 
-    std::tie(src_v, dst_v, std::ignore, std::ignore, std::ignore, std::ignore) =
+    std::tie(src_v, dst_v, std::ignore, std::ignore, std::ignore) =
       input_usecase.template construct_edgelist<vertex_t, weight_t>(handle, false, false, false);
 
     if (renumbering_usecase.check_correctness) {

--- a/cpp/tests/structure/renumbering_test.cpp
+++ b/cpp/tests/structure/renumbering_test.cpp
@@ -69,9 +69,8 @@ class Tests_Renumbering
     rmm::device_uvector<vertex_t> src_v(0, handle.get_stream());
     rmm::device_uvector<vertex_t> dst_v(0, handle.get_stream());
     rmm::device_uvector<vertex_t> renumber_map_labels_v(0, handle.get_stream());
-    vertex_t number_of_vertices{};
 
-    std::tie(src_v, dst_v, std::ignore, std::ignore, number_of_vertices, std::ignore) =
+    std::tie(src_v, dst_v, std::ignore, std::ignore, std::ignore, std::ignore) =
       input_usecase.template construct_edgelist<vertex_t, weight_t>(handle, false, false, false);
 
     if (renumbering_usecase.check_correctness) {

--- a/cpp/tests/structure/renumbering_test.cpp
+++ b/cpp/tests/structure/renumbering_test.cpp
@@ -72,8 +72,7 @@ class Tests_Renumbering
     vertex_t number_of_vertices{};
 
     std::tie(src_v, dst_v, std::ignore, std::ignore, number_of_vertices, std::ignore) =
-      input_usecase.template construct_edgelist<vertex_t, edge_t, weight_t, false, false>(handle,
-                                                                                          false);
+      input_usecase.template construct_edgelist<vertex_t, weight_t>(handle, false, false, false);
 
     if (renumbering_usecase.check_correctness) {
       h_original_src_v = cugraph::test::to_host(handle, src_v);

--- a/cpp/tests/utilities/csv_file_reader.cpp
+++ b/cpp/tests/utilities/csv_file_reader.cpp
@@ -1,0 +1,495 @@
+/*
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <detail/graph_utils.cuh>
+#include <utilities/test_utilities.hpp>
+
+#include <cugraph/graph_functions.hpp>
+#include <cugraph/legacy/functions.hpp>
+#include <cugraph/partition_manager.hpp>
+#include <cugraph/utilities/error.hpp>
+
+#include <raft/cudart_utils.h>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/distance.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/remove.h>
+#include <thrust/sequence.h>
+#include <thrust/tuple.h>
+
+#include <cstdint>
+
+namespace cugraph {
+namespace test {
+namespace detail {
+
+template <typename vertex_t, typename weight_t>
+bool check_symmetric(raft::handle_t const& handle,
+                     raft::device_span<vertex_t const> edgelist_srcs,
+                     raft::device_span<vertex_t const> edgelist_dsts,
+                     std::optional<raft::device_span<weight_t const>> edgelist_weights)
+{
+  rmm::device_uvector<vertex_t> org_srcs(edgelist_srcs.size(), handle.get_stream());
+  rmm::device_uvector<vertex_t> org_dsts(edgelist_dsts.size(), handle.get_stream());
+  auto org_weights = edgelist_weights ? std::make_optional<rmm::device_uvector<weight_t>>(
+                                          (*edgelist_weights).size(), handle.get_stream())
+                                      : std::nullopt;
+  rmm::device_uvector<vertex_t> symmetrized_srcs(edgelist_srcs.size(), handle.get_stream());
+  rmm::device_uvector<vertex_t> symmetrized_dsts(edgelist_dsts.size(), handle.get_stream());
+  auto symmetrized_weights = edgelist_weights ? std::make_optional<rmm::device_uvector<weight_t>>(
+                                                  (*edgelist_weights).size(), handle.get_stream())
+                                              : std::nullopt;
+
+  thrust::copy(
+    handle.get_thrust_policy(), edgelist_srcs.begin(), edgelist_srcs.end(), org_srcs.begin());
+  thrust::copy(handle.get_thrust_policy(),
+               edgelist_srcs.begin(),
+               edgelist_srcs.end(),
+               symmetrized_srcs.begin());
+  thrust::copy(
+    handle.get_thrust_policy(), edgelist_dsts.begin(), edgelist_dsts.end(), org_dsts.begin());
+  thrust::copy(handle.get_thrust_policy(),
+               edgelist_dsts.begin(),
+               edgelist_dsts.end(),
+               symmetrized_dsts.begin());
+  if (edgelist_weights) {
+    thrust::copy(handle.get_thrust_policy(),
+                 (*edgelist_weights).begin(),
+                 (*edgelist_weights).end(),
+                 (*org_weights).begin());
+    thrust::copy(handle.get_thrust_policy(),
+                 (*edgelist_weights).begin(),
+                 (*edgelist_weights).end(),
+                 (*symmetrized_weights).begin());
+  }
+
+  [ symmetrized_srcs, symmetrized_dsts, symmetrized_weights ] =
+    symmetrize_edgelist<vertex_t, weight_t, false, false>(std::move(symmetrized_srcs),
+                                                          std::move(symmetrized_dsts),
+                                                          std::move(symmetrized_weights),
+                                                          true);
+
+  if (edgelist_weights) {
+    auto org_first = thrust::make_zip_iterator(
+      thrust::make_tuple(org_srcs.begin(), org_dsts.begin(), (*org_weights).begin()));
+    thrust::sort(handle.get_thrust_policy(), org_first, org_first + org_srcs.size());
+    auto symmetrized_first = thrust::make_zip_iterator(thrust::make_tuple(
+      symmetrized_srcs.begin(), symmetrized_dsts.begin(), (*symmetrized_weights).begin()));
+    thrust::sort(
+      handle.get_thrust_policy(), symmetrized_first, symmetrized_first + symmetrized_srcs.size());
+    return thrust::equal(
+      handle.get_thrust_policy(), org_first, org_first + org_srcs.size(), symmetrized_first);
+  } else {
+    auto org_first =
+      thrust::make_zip_iterator(thrust::make_tuple(org_srcs.begin(), org_dsts.begin()));
+    thrust::sort(handle.get_thrust_policy(), org_first, org_first + org_srcs.size());
+    auto symmetrized_first = thrust::make_zip_iterator(
+      thrust::make_tuple(symmetrized_srcs.begin(), symmetrized_dsts.begin()));
+    thrust::sort(
+      handle.get_thrust_policy(), symmetrized_first, symmetrized_first + symmetrized_srcs.size());
+    return thrust::equal(
+      handle.get_thrust_policy(), org_first, org_first + org_srcs.size(), symmetrized_first);
+  }
+}
+
+}  // namespace detail
+
+template <typename vertex_t, typename weight_t>
+std::tuple<rmm::device_uvector<vertex_t>,
+           rmm::device_uvector<vertex_t>,
+           std::optional<rmm::device_uvector<weight_t>>,
+           bool>
+read_edgelist_from_csv_file(raft::handle_t const& handle,
+                            std::string const& graph_file_full_path,
+                            bool test_weighted,
+                            bool store_transposed,
+                            bool multi_gpu)
+{
+  std::ifstream file(graph_file_full_path);
+  CUGRAPH_EXPECTS(file.is_open(), "File open (" << graph_file_full_path << ") failure.");
+
+  std::vector<vertex_t> h_edgelist_srcs{};
+  std::vector<vertex_t> h_edgelist_dsts{};
+  std::vector<weight_t> h_edgelist_weights{};
+
+  std::string line{};
+  const char* delimiters = ", \t" while (std::getline(file, line))
+  {
+    if (line.length() == 0) { continue; }
+
+    char* token = std::strtok(line.c_str(), delimiters);
+    size_t num_tokens{0};
+    while (token) {
+      if (num_tokens < 2) {
+        auto id = atoll(token);
+        CUGRAPH_EXPECTS(id <= std::numeric_limits<vertex_t>::max(),
+                        "Vertex ID overflows vertex_t.");
+        if (num_tokens == 0) {
+          h_edgelist_srcs.push_back(static_cast<vertex_t>(id));
+        } else {
+          h_edgelist_dsts.push_back(static_cast<vertex_t>(id));
+        }
+      } else if (num_tokens == 2) {
+        auto w = atof(token);
+        h_edgelist_weights.push_back(w);
+      }
+      ++num_tokens;
+      CUGRAPH_EXPECTS(num_tokens <= 3, "Too many tokens in a line.");
+      token = std::strtok(nullptr, delimiters);
+    }
+  }
+
+  CUGRAPH_EXPECTS(h_edgelist_srcs.size() == h_edgelist_dsts.size(),
+                  "Invalid input file contents (# source IDs != # destination IDs).");
+
+  CUGRAPH_EXPECTS(
+    (h_edgelist_weights.size() == 0) || (h_edgelist_srcs.size() == h_edgelist_weights.size()),
+    "Invalid input file contents (# source IDs != # weights).");
+  CUGRAPH_EXPECTS(!test_weighted || (h_edgelist_weights.size() > 0),
+                  "test_weighted set but weights are not provided.");
+
+  rmm::device_uvector<vertex_t> d_edgelist_srcs(h_edgelist_srcs.size(), handle.get_stream());
+  rmm::device_uvector<vertex_t> d_edgelist_dsts(h_edgelist_dsts.size(), handle.get_stream());
+  auto d_edgelist_weights = test_weighted ? std::make_optional<rmm::device_uvector<weight_t>>(
+                                              h_edgelist_weights.size(), handle.get_stream())
+                                          : std::nullopt;
+
+  raft::update_device(
+    d_edgelist_srcs.data(), h_edgelist_srcs.data(), h_edgelist_srcs.size(), handle.get_stream());
+  raft::update_device(
+    d_edgelist_dsts.data(), h_edgelist_dsts.data(), h_edgelist_dsts.size(), handle.get_stream());
+  if (d_edgelist_weights) {
+    raft::update_device((*d_edgelist_weights).data(),
+                        h_edgelist_weights.data(),
+                        h_edgelist_weights.size(),
+                        handle.get_stream());
+  }
+
+  bool is_symmetric = detail::check_symmetric(
+    handle,
+    raft::device_span<vertex_t const>(d_edgelist_srcs.data(), d_edgelist_srcs.size()),
+    raft::device_span<vertex_t const>(d_edgelist_dsts.data(), d_edgelist_dsts.size()),
+    d_edgelist_weights ? std::make_optional<raft::device_span<weight_t const>>(
+                           (*d_edgelist_weights).data(), (*d_edgelist_weights).size())
+                       : std::nullopt);
+
+  if (multi_gpu) {
+    auto& comm               = handle.get_comms();
+    auto const comm_size     = comm.get_size();
+    auto const comm_rank     = comm.get_rank();
+    auto& row_comm           = handle.get_subcomm(cugraph::partition_2d::key_naming_t().row_name());
+    auto const row_comm_size = row_comm.get_size();
+    auto& col_comm           = handle.get_subcomm(cugraph::partition_2d::key_naming_t().col_name());
+    auto const col_comm_size = col_comm.get_size();
+
+    auto edge_key_func = cugraph::detail::compute_gpu_id_from_ext_edge_endpoints_t<vertex_t>{
+      comm_size, row_comm_size, col_comm_size};
+    size_t number_of_local_edges{};
+    if (d_edgelist_weights) {
+      auto edge_first       = thrust::make_zip_iterator(thrust::make_tuple(
+        d_edgelist_srcs.begin(), d_edgelist_dsts.begin(), (*d_edgelist_weights).begin()));
+      number_of_local_edges = thrust::distance(
+        edge_first,
+        thrust::remove_if(execution_policy,
+                          edge_first,
+                          edge_first + d_edgelist_srcs.size(),
+                          [comm_rank, key_func = edge_key_func] __device__(auto e) {
+                            auto major = thrust::get<0>(e);
+                            auto minor = thrust::get<1>(e);
+                            return store_transposed ? key_func(minor, major) != comm_rank
+                                                    : key_func(major, minor) != comm_rank;
+                          }));
+    } else {
+      auto edge_first = thrust::make_zip_iterator(
+        thrust::make_tuple(d_edgelist_srcs.begin(), d_edgelist_dsts.begin()));
+      number_of_local_edges = thrust::distance(
+        edge_first,
+        thrust::remove_if(execution_policy,
+                          edge_first,
+                          edge_first + d_edgelist_srcs.size(),
+                          [comm_rank, key_func = edge_key_func] __device__(auto e) {
+                            auto major = thrust::get<0>(e);
+                            auto minor = thrust::get<1>(e);
+                            return store_transposed ? key_func(minor, major) != comm_rank
+                                                    : key_func(major, minor) != comm_rank;
+                          }));
+    }
+
+    d_edgelist_srcs.resize(number_of_local_edges, handle.get_stream());
+    d_edgelist_srcs.shrink_to_fit(handle.get_stream());
+    d_edgelist_dsts.resize(number_of_local_edges, handle.get_stream());
+    d_edgelist_dsts.shrink_to_fit(handle.get_stream());
+    if (d_edgelist_weights) {
+      (*d_edgelist_weights).resize(number_of_local_edges, handle.get_stream());
+      (*d_edgelist_weights).shrink_to_fit(handle.get_stream());
+    }
+  }
+
+  return std::make_tuple(std::move(d_edgelist_srcs),
+                         std::move(d_edgelist_dsts),
+                         std::move(d_edgelist_weights),
+                         is_symmetric);
+}
+
+template <typename vertex_t,
+          typename edge_t,
+          typename weight_t,
+          bool store_transposed,
+          bool multi_gpu>
+std::tuple<cugraph::graph_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>,
+           std::optional<rmm::device_uvector<vertex_t>>>
+read_graph_from_csv_file(raft::handle_t const& handle,
+                         std::string const& graph_file_full_path,
+                         bool test_weighted,
+                         bool renumber)
+{
+  auto [d_edgelist_srcs, d_edgelist_dsts, d_edgelist_weights, is_symmetric] =
+    read_edgelist_from_csv_file<vertex_t, weight_t, store_transposed, multi_gpu>(
+      handle, graph_file_full_path, test_weighted, store_transposed, multi_gpu);
+
+  graph_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu> graph(handle);
+  std::optional<rmm::device_uvector<vertex_t>> renumber_map{std::nullopt};
+  std::tie(graph, std::ignore, renumber_map) = cugraph::
+    create_graph_from_edgelist<vertex_t, edge_t, weight_t, int32_t, store_transposed, multi_gpu>(
+      handle,
+      std::nullopt,
+      std::move(d_edgelist_srcs),
+      std::move(d_edgelist_dsts),
+      std::move(d_edgelist_weights),
+      std::nullopt,
+      cugraph::graph_properties_t{is_symmetric, false},
+      renumber);
+
+  return std::make_tuple(std::move(graph), std::move(renumber_map));
+}
+
+// explicit instantiations
+
+template std::tuple<rmm::device_uvector<int32_t>,
+                    rmm::device_uvector<int32_t>,
+                    std::optional<rmm::device_uvector<float>>,
+                    bool>
+read_edgelist_from_csv_file<int32_t, float>(raft::handle_t const& handle,
+                                            std::string const& graph_file_full_path,
+                                            bool test_weighted,
+                                            bool store_transposed,
+                                            bool multi_gpu);
+
+template std::tuple<rmm::device_uvector<int32_t>,
+                    rmm::device_uvector<int32_t>,
+                    std::optional<rmm::device_uvector<double>>,
+                    bool>
+read_edgelist_from_csv_file<int32_t, double>(raft::handle_t const& handle,
+                                             std::string const& graph_file_full_path,
+                                             bool test_weighted,
+                                             bool store_transposed,
+                                             bool multi_gpu);
+
+template std::tuple<cugraph::graph_t<int32_t, int32_t, float, false, false>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int32_t, float, false, false>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int32_t, int32_t, float, false, true>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int32_t, float, false, true>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int32_t, int32_t, float, true, false>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int32_t, float, true, false>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int32_t, int32_t, float, true, true>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int32_t, float, true, true>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int32_t, int32_t, double, false, false>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int32_t, double, false, false>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int32_t, int32_t, double, false, true>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int32_t, double, false, true>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int32_t, int32_t, double, true, false>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int32_t, double, true, false>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int32_t, int32_t, double, true, true>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int32_t, double, true, true>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int32_t, int64_t, float, false, false>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int64_t, float, false, false>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int32_t, int64_t, float, false, true>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int64_t, float, false, true>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int32_t, int64_t, float, true, false>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int64_t, float, true, false>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int32_t, int64_t, float, true, true>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int64_t, float, true, true>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int32_t, int64_t, double, false, false>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int64_t, double, false, false>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int32_t, int64_t, double, false, true>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int64_t, double, false, true>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int32_t, int64_t, double, true, false>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int64_t, double, true, false>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int32_t, int64_t, double, true, true>,
+                    std::optional<rmm::device_uvector<int32_t>>>
+read_graph_from_csv_file<int32_t, int64_t, double, true, true>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int64_t, int64_t, float, false, false>,
+                    std::optional<rmm::device_uvector<int64_t>>>
+read_graph_from_csv_file<int64_t, int64_t, float, false, false>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int64_t, int64_t, float, false, true>,
+                    std::optional<rmm::device_uvector<int64_t>>>
+read_graph_from_csv_file<int64_t, int64_t, float, false, true>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int64_t, int64_t, float, true, false>,
+                    std::optional<rmm::device_uvector<int64_t>>>
+read_graph_from_csv_file<int64_t, int64_t, float, true, false>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int64_t, int64_t, float, true, true>,
+                    std::optional<rmm::device_uvector<int64_t>>>
+read_graph_from_csv_file<int64_t, int64_t, float, true, true>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int64_t, int64_t, double, false, false>,
+                    std::optional<rmm::device_uvector<int64_t>>>
+read_graph_from_csv_file<int64_t, int64_t, double, false, false>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int64_t, int64_t, double, false, true>,
+                    std::optional<rmm::device_uvector<int64_t>>>
+read_graph_from_csv_file<int64_t, int64_t, double, false, true>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int64_t, int64_t, double, true, false>,
+                    std::optional<rmm::device_uvector<int64_t>>>
+read_graph_from_csv_file<int64_t, int64_t, double, true, false>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+template std::tuple<cugraph::graph_t<int64_t, int64_t, double, true, true>,
+                    std::optional<rmm::device_uvector<int64_t>>>
+read_graph_from_csv_file<int64_t, int64_t, double, true, true>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber);
+
+}  // namespace test
+}  // namespace cugraph

--- a/cpp/tests/utilities/csv_file_utilities.cu
+++ b/cpp/tests/utilities/csv_file_utilities.cu
@@ -145,7 +145,7 @@ read_edgelist_from_csv_file(raft::handle_t const& handle,
   size_t num_tokens_this_line{0};
   while (cur) {
     char const* prev = cur;
-    cur         = strpbrk(prev, delimiters);
+    cur              = strpbrk(prev, delimiters);
     if (cur) {
       auto token = std::string(prev, cur);
       if (num_tokens_this_line == 0) {  // source

--- a/cpp/tests/utilities/csv_file_utilities.cu
+++ b/cpp/tests/utilities/csv_file_utilities.cu
@@ -145,7 +145,7 @@ read_edgelist_from_csv_file(raft::handle_t const& handle,
   size_t num_tokens_this_line{0};
   while (cur) {
     char const* prev = cur;
-    auto cur         = strpbrk(prev, delimiters);
+    cur         = strpbrk(prev, delimiters);
     if (cur) {
       auto token = std::string(prev, cur);
       if (num_tokens_this_line == 0) {  // source

--- a/cpp/tests/utilities/matrix_market_file_utilities.cu
+++ b/cpp/tests/utilities/matrix_market_file_utilities.cu
@@ -263,7 +263,7 @@ std::unique_ptr<cugraph::legacy::GraphCSR<vertex_t, edge_t, weight_t>> generate_
   return cugraph::coo_to_csr(cooview);
 }
 
-template <typename vertex_t, typename weight_t, bool store_transposed, bool multi_gpu>
+template <typename vertex_t, typename weight_t>
 std::tuple<rmm::device_uvector<vertex_t>,
            rmm::device_uvector<vertex_t>,
            std::optional<rmm::device_uvector<weight_t>>,
@@ -272,7 +272,9 @@ std::tuple<rmm::device_uvector<vertex_t>,
            bool>
 read_edgelist_from_matrix_market_file(raft::handle_t const& handle,
                                       std::string const& graph_file_full_path,
-                                      bool test_weighted)
+                                      bool test_weighted,
+                                      bool store_transposed,
+                                      bool multi_gpu)
 {
   MM_typecode mc{};
   vertex_t m{};
@@ -318,9 +320,7 @@ read_edgelist_from_matrix_market_file(raft::handle_t const& handle,
       (*d_edgelist_weights).data(), h_weights.data(), h_weights.size(), handle.get_stream());
   }
 
-  auto execution_policy = handle.get_thrust_policy();
-  thrust::sequence(execution_policy, d_vertices.begin(), d_vertices.end(), vertex_t{0});
-  handle.sync_stream();
+  thrust::sequence(handle.get_thrust_policy(), d_vertices.begin(), d_vertices.end(), vertex_t{0});
 
   if (multi_gpu) {
     auto& comm               = handle.get_comms();
@@ -334,7 +334,7 @@ read_edgelist_from_matrix_market_file(raft::handle_t const& handle,
     auto vertex_key_func = cugraph::detail::compute_gpu_id_from_ext_vertex_t<vertex_t>{comm_size};
     d_vertices.resize(
       thrust::distance(d_vertices.begin(),
-                       thrust::remove_if(execution_policy,
+                       thrust::remove_if(handle.get_thrust_policy(),
                                          d_vertices.begin(),
                                          d_vertices.end(),
                                          [comm_rank, key_func = vertex_key_func] __device__(
@@ -350,29 +350,31 @@ read_edgelist_from_matrix_market_file(raft::handle_t const& handle,
         d_edgelist_srcs.begin(), d_edgelist_dsts.begin(), (*d_edgelist_weights).begin()));
       number_of_local_edges = thrust::distance(
         edge_first,
-        thrust::remove_if(execution_policy,
-                          edge_first,
-                          edge_first + d_edgelist_srcs.size(),
-                          [comm_rank, key_func = edge_key_func] __device__(auto e) {
-                            auto major = thrust::get<0>(e);
-                            auto minor = thrust::get<1>(e);
-                            return store_transposed ? key_func(minor, major) != comm_rank
-                                                    : key_func(major, minor) != comm_rank;
-                          }));
+        thrust::remove_if(
+          handle.get_thrust_policy(),
+          edge_first,
+          edge_first + d_edgelist_srcs.size(),
+          [store_transposed, comm_rank, key_func = edge_key_func] __device__(auto e) {
+            auto major = thrust::get<0>(e);
+            auto minor = thrust::get<1>(e);
+            return store_transposed ? key_func(minor, major) != comm_rank
+                                    : key_func(major, minor) != comm_rank;
+          }));
     } else {
       auto edge_first = thrust::make_zip_iterator(
         thrust::make_tuple(d_edgelist_srcs.begin(), d_edgelist_dsts.begin()));
       number_of_local_edges = thrust::distance(
         edge_first,
-        thrust::remove_if(execution_policy,
-                          edge_first,
-                          edge_first + d_edgelist_srcs.size(),
-                          [comm_rank, key_func = edge_key_func] __device__(auto e) {
-                            auto major = thrust::get<0>(e);
-                            auto minor = thrust::get<1>(e);
-                            return store_transposed ? key_func(minor, major) != comm_rank
-                                                    : key_func(major, minor) != comm_rank;
-                          }));
+        thrust::remove_if(
+          handle.get_thrust_policy(),
+          edge_first,
+          edge_first + d_edgelist_srcs.size(),
+          [store_transposed, comm_rank, key_func = edge_key_func] __device__(auto e) {
+            auto major = thrust::get<0>(e);
+            auto minor = thrust::get<1>(e);
+            return store_transposed ? key_func(minor, major) != comm_rank
+                                    : key_func(major, minor) != comm_rank;
+          }));
     }
 
     d_edgelist_srcs.resize(number_of_local_edges, handle.get_stream());
@@ -384,8 +386,6 @@ read_edgelist_from_matrix_market_file(raft::handle_t const& handle,
       (*d_edgelist_weights).shrink_to_fit(handle.get_stream());
     }
   }
-
-  handle.sync_stream();
 
   return std::make_tuple(std::move(d_edgelist_srcs),
                          std::move(d_edgelist_dsts),
@@ -413,8 +413,8 @@ read_graph_from_matrix_market_file(raft::handle_t const& handle,
         d_vertices,
         number_of_vertices,
         is_symmetric] =
-    read_edgelist_from_matrix_market_file<vertex_t, weight_t, store_transposed, multi_gpu>(
-      handle, graph_file_full_path, test_weighted);
+    read_edgelist_from_matrix_market_file<vertex_t, weight_t>(
+      handle, graph_file_full_path, test_weighted, store_transposed, multi_gpu);
 
   graph_t<vertex_t, edge_t, weight_t, store_transposed, multi_gpu> graph(handle);
   std::optional<rmm::device_uvector<vertex_t>> renumber_map{std::nullopt};
@@ -469,6 +469,18 @@ generate_graph_csr_from_mm(bool& directed, std::string mm_file);
 
 template std::unique_ptr<cugraph::legacy::GraphCSR<int64_t, int64_t, float>>
 generate_graph_csr_from_mm(bool& directed, std::string mm_file);
+
+template std::tuple<rmm::device_uvector<int32_t>,
+                    rmm::device_uvector<int32_t>,
+                    std::optional<rmm::device_uvector<float>>,
+                    rmm::device_uvector<int32_t>,
+                    int32_t,
+                    bool>
+read_edgelist_from_matrix_market_file<int32_t, float>(raft::handle_t const& handle,
+                                                      std::string const& graph_file_full_path,
+                                                      bool test_weighted,
+                                                      bool store_transposed,
+                                                      bool multi_gpu);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, float, false, false>,
                     std::optional<rmm::device_uvector<int32_t>>>
@@ -661,42 +673,6 @@ read_graph_from_matrix_market_file<int64_t, int64_t, double, true, true>(
   std::string const& graph_file_full_path,
   bool test_weighted,
   bool renumber);
-
-template std::tuple<rmm::device_uvector<int32_t>,
-                    rmm::device_uvector<int32_t>,
-                    std::optional<rmm::device_uvector<float>>,
-                    rmm::device_uvector<int32_t>,
-                    int32_t,
-                    bool>
-read_edgelist_from_matrix_market_file<int32_t, float, true, true>(
-  raft::handle_t const& handle, std::string const& graph_file_full_path, bool test_weighted);
-
-template std::tuple<rmm::device_uvector<int32_t>,
-                    rmm::device_uvector<int32_t>,
-                    std::optional<rmm::device_uvector<float>>,
-                    rmm::device_uvector<int32_t>,
-                    int32_t,
-                    bool>
-read_edgelist_from_matrix_market_file<int32_t, float, true, false>(
-  raft::handle_t const& handle, std::string const& graph_file_full_path, bool test_weighted);
-
-template std::tuple<rmm::device_uvector<int32_t>,
-                    rmm::device_uvector<int32_t>,
-                    std::optional<rmm::device_uvector<float>>,
-                    rmm::device_uvector<int32_t>,
-                    int32_t,
-                    bool>
-read_edgelist_from_matrix_market_file<int32_t, float, false, true>(
-  raft::handle_t const& handle, std::string const& graph_file_full_path, bool test_weighted);
-
-template std::tuple<rmm::device_uvector<int32_t>,
-                    rmm::device_uvector<int32_t>,
-                    std::optional<rmm::device_uvector<float>>,
-                    rmm::device_uvector<int32_t>,
-                    int32_t,
-                    bool>
-read_edgelist_from_matrix_market_file<int32_t, float, false, false>(
-  raft::handle_t const& handle, std::string const& graph_file_full_path, bool test_weighted);
 
 }  // namespace test
 }  // namespace cugraph

--- a/cpp/tests/utilities/matrix_market_file_utilities.cu
+++ b/cpp/tests/utilities/matrix_market_file_utilities.cu
@@ -268,7 +268,6 @@ std::tuple<rmm::device_uvector<vertex_t>,
            rmm::device_uvector<vertex_t>,
            std::optional<rmm::device_uvector<weight_t>>,
            rmm::device_uvector<vertex_t>,
-           vertex_t,
            bool>
 read_edgelist_from_matrix_market_file(raft::handle_t const& handle,
                                       std::string const& graph_file_full_path,
@@ -391,7 +390,6 @@ read_edgelist_from_matrix_market_file(raft::handle_t const& handle,
                          std::move(d_edgelist_dsts),
                          std::move(d_edgelist_weights),
                          std::move(d_vertices),
-                         number_of_vertices,
                          is_symmetric);
 }
 
@@ -407,12 +405,7 @@ read_graph_from_matrix_market_file(raft::handle_t const& handle,
                                    bool test_weighted,
                                    bool renumber)
 {
-  auto [d_edgelist_srcs,
-        d_edgelist_dsts,
-        d_edgelist_weights,
-        d_vertices,
-        number_of_vertices,
-        is_symmetric] =
+  auto [d_edgelist_srcs, d_edgelist_dsts, d_edgelist_weights, d_vertices, is_symmetric] =
     read_edgelist_from_matrix_market_file<vertex_t, weight_t>(
       handle, graph_file_full_path, test_weighted, store_transposed, multi_gpu);
 
@@ -474,7 +467,6 @@ template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
                     std::optional<rmm::device_uvector<float>>,
                     rmm::device_uvector<int32_t>,
-                    int32_t,
                     bool>
 read_edgelist_from_matrix_market_file<int32_t, float>(raft::handle_t const& handle,
                                                       std::string const& graph_file_full_path,

--- a/cpp/tests/utilities/test_utilities.hpp
+++ b/cpp/tests/utilities/test_utilities.hpp
@@ -114,8 +114,8 @@ static const std::string& get_rapids_dataset_root_dir()
   return rdrd;
 }
 
-// returns a tuple of (rows, columns, weights, number_of_vertices, is_symmetric)
-template <typename vertex_t, typename weight_t, bool store_transposed, bool multi_gpu>
+// returns a tuple of (rows, columns, weights, vertices, number_of_vertices, is_symmetric)
+template <typename vertex_t, typename weight_t>
 std::tuple<rmm::device_uvector<vertex_t>,
            rmm::device_uvector<vertex_t>,
            std::optional<rmm::device_uvector<weight_t>>,
@@ -124,7 +124,9 @@ std::tuple<rmm::device_uvector<vertex_t>,
            bool>
 read_edgelist_from_matrix_market_file(raft::handle_t const& handle,
                                       std::string const& graph_file_full_path,
-                                      bool test_weighted);
+                                      bool test_weighted,
+                                      bool store_transposed,
+                                      bool multi_gpu);
 
 // renumber must be true if multi_gpu is true
 template <typename vertex_t,

--- a/cpp/tests/utilities/test_utilities.hpp
+++ b/cpp/tests/utilities/test_utilities.hpp
@@ -114,13 +114,12 @@ static const std::string& get_rapids_dataset_root_dir()
   return rdrd;
 }
 
-// returns a tuple of (rows, columns, weights, vertices, number_of_vertices, is_symmetric)
+// returns a tuple of (rows, columns, weights, vertices, is_symmetric)
 template <typename vertex_t, typename weight_t>
 std::tuple<rmm::device_uvector<vertex_t>,
            rmm::device_uvector<vertex_t>,
            std::optional<rmm::device_uvector<weight_t>>,
            rmm::device_uvector<vertex_t>,
-           vertex_t,
            bool>
 read_edgelist_from_matrix_market_file(raft::handle_t const& handle,
                                       std::string const& graph_file_full_path,
@@ -140,6 +139,17 @@ read_graph_from_matrix_market_file(raft::handle_t const& handle,
                                    std::string const& graph_file_full_path,
                                    bool test_weighted,
                                    bool renumber);
+
+template <typename vertex_t, typename weight_t>
+std::tuple<rmm::device_uvector<vertex_t>,
+           rmm::device_uvector<vertex_t>,
+           std::optional<rmm::device_uvector<weight_t>>,
+           bool>
+read_edgelist_from_csv_file(raft::handle_t const& handle,
+                            std::string const& graph_file_full_path,
+                            bool test_weighted,
+                            bool store_transposed,
+                            bool multi_gpu);
 
 // alias for easy customization for debug purposes:
 //

--- a/cpp/tests/utilities/thrust_wrapper.hpp
+++ b/cpp/tests/utilities/thrust_wrapper.hpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <raft/core/device_span.hpp>
 #include <raft/handle.hpp>
 #include <rmm/device_uvector.hpp>
 
@@ -29,9 +30,11 @@ std::tuple<key_buffer_type, value_buffer_type> sort_by_key(raft::handle_t const&
                                                            value_buffer_type const& values);
 
 template <typename vertex_t>
+vertex_t max_element(raft::handle_t const& handle, raft::device_span<vertex_t const> vertices);
+
+template <typename vertex_t>
 void translate_vertex_ids(raft::handle_t const& handle,
-                          rmm::device_uvector<vertex_t>& d_src_v /* [INOUT] */,
-                          rmm::device_uvector<vertex_t>& d_dst_v /* [INOUT] */,
+                          rmm::device_uvector<vertex_t>& vertices /* [INOUT] */,
                           vertex_t vertex_id_offset);
 
 template <typename vertex_t>


### PR DESCRIPTION
Clean-up the C++ test graph generation code and add a minimal C++ CSV (this can read edge lists only in a strict format this reader is expecting) reader.

The CSV reader is added to support edge list with non-stand vertex IDs (e.g. negative vertex IDs). 