### PR TITLE
REL Fix main branch builds

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -55,10 +55,8 @@ conda activate rapids
 if [ "$SOURCE_BRANCH" = "main" ]; then
   conda config --system --remove channels rapidsai-nightly
   conda config --system --remove channels dask/label/dev
-fi
-
-# Remove `dask/label/dev` channel if INSTALL_DASK_MAIN=0
-if [[ "${INSTALL_DASK_MAIN}" == 0 ]]; then
+elif [[ "${INSTALL_DASK_MAIN}" == 0 ]]; then
+  # Remove `dask/label/dev` channel if INSTALL_DASK_MAIN=0
   conda config --system --remove channels dask/label/dev
 fi
 


### PR DESCRIPTION
When building `main` and `INSTALL_DASK_MAIN=0` results in removing the `dask/label/dev` twice which fails on the second one. This change prevents this behavior.