### PR TITLE
Fix concat with different index dtypes in SG PropertyGraph

### DIFF
--- a/python/cugraph/cugraph/structure/property_graph.py
+++ b/python/cugraph/cugraph/structure/property_graph.py
@@ -1334,11 +1334,6 @@ class EXPERIMENTAL__PropertyGraph:
         if epd is not None:
             vert_sers.append(epd[self.src_col_name])
             vert_sers.append(epd[self.dst_col_name])
-        if len(vert_sers) > 1 and not all(
-            cudf.api.types.is_dtype_equal(vert_sers[0].index.dtype, s.index.dtype)
-            for s in vert_sers
-        ):
-            vert_sers = [s.reset_index(drop=True) for s in vert_sers]
         return vert_sers
 
     @staticmethod

--- a/python/cugraph/cugraph/structure/property_graph.py
+++ b/python/cugraph/cugraph/structure/property_graph.py
@@ -262,9 +262,13 @@ class EXPERIMENTAL__PropertyGraph:
             vert_sers = self.__get_all_vertices_series()
             if vert_sers:
                 if self.__series_type is cudf.Series:
-                    self.__num_vertices = cudf.concat(vert_sers).nunique()
+                    self.__num_vertices = cudf.concat(
+                        vert_sers, ignore_index=True
+                    ).nunique()
                 else:
-                    self.__num_vertices = pd.concat(vert_sers).nunique()
+                    self.__num_vertices = pd.concat(
+                        vert_sers, ignore_index=True
+                    ).nunique()
             return self.__num_vertices
 
         value_counts = self._vertex_type_value_counts
@@ -312,9 +316,13 @@ class EXPERIMENTAL__PropertyGraph:
         vert_sers = self.__get_all_vertices_series()
         if vert_sers:
             if self.__series_type is cudf.Series:
-                return self.__series_type(cudf.concat(vert_sers).unique())
+                return self.__series_type(
+                    cudf.concat(vert_sers, ignore_index=True).unique()
+                )
             else:
-                return self.__series_type(pd.concat(vert_sers).unique())
+                return self.__series_type(
+                    pd.concat(vert_sers, ignore_index=True).unique()
+                )
         return self.__series_type()
 
     def vertices_ids(self):
@@ -1326,6 +1334,11 @@ class EXPERIMENTAL__PropertyGraph:
         if epd is not None:
             vert_sers.append(epd[self.src_col_name])
             vert_sers.append(epd[self.dst_col_name])
+        if len(vert_sers) > 1 and not all(
+            cudf.api.types.is_dtype_equal(vert_sers[0].index.dtype, s.index.dtype)
+            for s in vert_sers
+        ):
+            vert_sers = [s.reset_index(drop=True) for s in vert_sers]
         return vert_sers
 
     @staticmethod

--- a/python/cugraph/cugraph/tests/test_dataset.py
+++ b/python/cugraph/cugraph/tests/test_dataset.py
@@ -99,6 +99,9 @@ def test_set_download_dir(datasets):
     tmpd.cleanup()
 
 
+@pytest.mark.skip(
+    reason="Timeout errors; see: https://github.com/rapidsai/cugraph/issues/2810"
+)
 def test_load_all(datasets):
     tmpd = TemporaryDirectory()
     cfg = create_config(custom_path=tmpd.name)

--- a/python/cugraph/cugraph/tests/test_property_graph.py
+++ b/python/cugraph/cugraph/tests/test_property_graph.py
@@ -1845,6 +1845,27 @@ def test_add_data_noncontiguous(df_type):
         )
 
 
+@pytest.mark.parametrize("df_type", df_types, ids=df_type_id)
+def test_get_num_vertices(df_type):
+    from cugraph.experimental import PropertyGraph
+
+    if df_type is pd.DataFrame:
+        series_type = pd.Series
+    else:
+        series_type = cudf.Series
+    pg = PropertyGraph()
+    node_df = df_type()
+    node_df["node_id"] = series_type([0, 1, 2]).astype("int32")
+    pg.add_vertex_data(node_df, "node_id", type_name="_N")
+
+    edge_df = df_type()
+    edge_df["src"] = series_type([0, 1, 2]).astype("int32")
+    edge_df["dst"] = series_type([0, 1, 2]).astype("int32")
+    pg.add_edge_data(edge_df, ["src", "dst"], type_name="_E")
+
+    assert pg.get_num_vertices() == 3
+
+
 @pytest.mark.skip(reason="feature not implemented")
 def test_single_csv_multi_vertex_edge_attrs():
     """

--- a/python/cugraph/cugraph/tests/test_property_graph.py
+++ b/python/cugraph/cugraph/tests/test_property_graph.py
@@ -1846,7 +1846,11 @@ def test_add_data_noncontiguous(df_type):
 
 
 @pytest.mark.parametrize("df_type", df_types, ids=df_type_id)
-def test_get_num_vertices(df_type):
+def test_vertex_ids_different_type(df_type):
+    """Getting the number of vertices requires combining vertex ids from multiples columns.
+
+    This tests ensures combining these columns works even if they are different types.
+    """
     from cugraph.experimental import PropertyGraph
 
     if df_type is pd.DataFrame:
@@ -1860,7 +1864,7 @@ def test_get_num_vertices(df_type):
 
     edge_df = df_type()
     edge_df["src"] = series_type([0, 1, 2]).astype("int32")
-    edge_df["dst"] = series_type([0, 1, 2]).astype("int32")
+    edge_df["dst"] = series_type([0, 1, 2]).astype("int64")
     pg.add_edge_data(edge_df, ["src", "dst"], type_name="_E")
 
     assert pg.get_num_vertices() == 3


### PR DESCRIPTION
@alexbarghi-nv want to give this a try?  I previously made these changes to MG (was there an issue for it?), but not SG.