### PR TITLE
Delete dead code in cython.cu

### DIFF
--- a/cpp/include/cugraph/utilities/cython.hpp
+++ b/cpp/include/cugraph/utilities/cython.hpp
@@ -575,12 +575,6 @@ std::unique_ptr<random_walk_path_t> call_rw_paths(raft::handle_t const& handle,
                                                   index_t num_paths,
                                                   index_t const* vertex_path_sizes);
 
-// convertor from random_walks return type to COO:
-//
-template <typename vertex_t, typename index_t>
-std::unique_ptr<random_walk_coo_t> random_walks_to_coo(raft::handle_t const& handle,
-                                                       random_walk_ret_t& rw_ret);
-
 // wrapper for shuffling:
 //
 template <typename vertex_t, typename edge_t, typename weight_t>

--- a/python/cugraph/cugraph/structure/graph_utilities.pxd
+++ b/python/cugraph/cugraph/structure/graph_utilities.pxd
@@ -63,22 +63,6 @@ cdef extern from "cugraph/utilities/cython.hpp" namespace "cugraph::cython":
         LegacyCSC "cugraph::cython::graphTypeEnum::LegacyCSC"
         LegacyCOO "cugraph::cython::graphTypeEnum::LegacyCOO"
 
-    cdef void populate_graph_container_legacy(
-        graph_container_t &graph_container,
-        graphTypeEnum legacyType,
-        const handle_t &handle,
-        void *offsets,
-        void *indices,
-        void *weights,
-        numberTypeEnum offsetType,
-        numberTypeEnum indexType,
-        numberTypeEnum weightType,
-        size_t num_global_vertices,
-        size_t num_global_edges,
-        int *local_vertices,
-        int *local_edges,
-        int *local_offsets) except +
-
     cdef cppclass cy_multi_edgelists_t:
         size_t number_of_vertices
         size_t number_of_edges


### PR DESCRIPTION
`populate_graph_container_legacy` & `random_walks_to_coo` are no longer used.