### PR TITLE
Adds `.git-blame-ignore-revs` for recent .py files reformatting by `black`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Migrate code style to Black (#2778)
+84a5ed391647125c9f23fd62cf1b07fb196ab039

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -135,7 +135,7 @@ class simpleGraphImpl:
                 edge_attr = [edge_attr]
             if not (set(edge_attr).issubset(set(input_df.columns))):
                 raise ValueError(
-                    "edge_attr column name not found in input."
+                    f"edge_attr column {edge_attr} not found in input."
                     "Recheck the edge_attr parameter"
                 )
             self.properties.weighted = True


### PR DESCRIPTION
closes #2808 

* Adds `.git-blame-ignore-revs` for recent .py files reformatting by `black`
* Minor change to improve an exception message, realized after seeing [this log](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cugraph/job/prb/job/cugraph-gpu-test/CUDA=11.2,GPU_LABEL=driver-450,LINUX_VER=centos7,PYTHON=3.8/2361/testReport/junit/cugraph.tests/test_egonet/test_ego_graph_nx_1_0_graph_file0_/).