### PR TITLE
Fix docs builds

### DIFF
--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -41,14 +41,14 @@ conda list --show-channel-urls
 gpuci_logger "Build Doxygen docs"
 wget "https://raw.githubusercontent.com/rapidsai/docs/gh-pages/api/librmm/${BRANCH_VERSION}/rmm.tag" || echo "Failed to download rmm Doxygen tag"
 cd $PROJECT_WORKSPACE/cpp/build
-make docs_cugraph
+cmake --build . -t docs_cugraph
 
 # Build Python docs
 gpuci_logger "Build Sphinx docs"
 cd $PROJECT_WORKSPACE/docs/cugraph
 make html
 
-#Commit to Website
+# Commit to Website
 cd $DOCS_WORKSPACE
 
 for PROJECT in ${PROJECTS[@]}; do


### PR DESCRIPTION
In #2684, the CMake build system was switched from `make` to `ninja`, which broke the nightly doc builds.

This PR updates the scripts for the nightly doc builds to use a generic `cmake` build option, rather than a build-system specific invocation to fix the issue and prevent a similar issue from occurring in the future.

**Note**: this PR targets `branch-22.10` since the the `22.10` docs aren't currently up-to-date because of this issue.