### PR TITLE
Fix uniform neighborhood sampling memory leak

### DIFF
--- a/cpp/src/c_api/uniform_neighbor_sampling.cpp
+++ b/cpp/src/c_api/uniform_neighbor_sampling.cpp
@@ -310,5 +310,6 @@ extern "C" void cugraph_sample_result_free(cugraph_sample_result_t* result)
   delete internal_pointer->label_;
   delete internal_pointer->index_;
   delete internal_pointer->count_;
+  delete internal_pointer->experimental_count_;
   delete internal_pointer;
 }

--- a/python/pylibcugraph/pylibcugraph/tests/test_neighborhood_sampling.py
+++ b/python/pylibcugraph/pylibcugraph/tests/test_neighborhood_sampling.py
@@ -248,11 +248,7 @@ def test_neighborhood_sampling_large_sg_graph(gpubenchmark):
     expected_delta = free_memory_before - free_before_cleanup
     leak = expected_delta - actual_delta
     print(f"  {result_size=} {actual_delta=} {expected_delta=} {leak=}")
-    # FIXME: this assertion is commented out until the memory leak is
-    # found. This should be the only failing assertion, so commenting it out
-    # will allow CI to make any other failures more noticeable.
-    #
-    # assert free_memory_before == device.mem_info[0]
+    assert free_memory_before == device.mem_info[0]
 
 
 def test_sample_result():

--- a/python/pylibcugraph/pylibcugraph/tests/test_neighborhood_sampling.py
+++ b/python/pylibcugraph/pylibcugraph/tests/test_neighborhood_sampling.py
@@ -254,7 +254,7 @@ def test_neighborhood_sampling_large_sg_graph(gpubenchmark):
     actual_delta = free_after_cleanup - free_before_cleanup
     expected_delta = free_memory_before - free_before_cleanup
     leak = expected_delta - actual_delta
-    print(f"  {result_size=} {actual_delta=} {expected_delta=} {leak=}")
+    print(f"  {result_bytes=} {actual_delta=} {expected_delta=} {leak=}")
     assert free_memory_before == device.mem_info[0]
 
 


### PR DESCRIPTION
Fix memory leak in uniform neighborhood sampling.  Earlier updates adjusted the results but didn't fix the free method.

Closes #2788