### PR TITLE
Ensure correct data type

### DIFF
--- a/python/cugraph/cugraph/dask/traversal/bfs.py
+++ b/python/cugraph/cugraph/dask/traversal/bfs.py
@@ -35,17 +35,19 @@ def convert_to_cudf(cp_arrays):
     return df
 
 
-def _call_plc_bfs(sID, mg_graph_x, st_x, depth_limit=None, return_distances=True):
+def _call_plc_bfs(
+    sID, mg_graph_x, st_x, depth_limit=None, direction_optimizing=False,
+    return_distances=True, do_expensive_check=False):
+    print("python: the start type in _call_plc_bfs is \n", st_x.dtype)
     return pylibcugraph_bfs(
         ResourceHandle(Comms.get_handle(sID).getHandle()),
-        mg_graph_x,
-        cudf.Series(st_x, dtype="int32"),
-        False,
-        depth_limit if depth_limit is not None else 0,
-        return_distances,
-        True,
+        graph=mg_graph_x,
+        sources=st_x,
+        direction_optimizing=direction_optimizing,
+        depth_limit=depth_limit if depth_limit is not None else 0,
+        compute_predecessors=return_distances,
+        do_expensive_check=do_expensive_check,
     )
-
 
 def bfs(input_graph, start, depth_limit=None, return_distances=True, check_start=True):
     """
@@ -156,6 +158,10 @@ def bfs(input_graph, start, depth_limit=None, return_distances=True, check_start
         start = input_graph.lookup_internal_vertex_id(start, tmp_col_names)
 
     data_start = get_distributed_data(start)
+    do_expensive_check = False
+    # FIXME: Why is 'direction_optimizing' not part of the python cugraph API
+    # and why is it set to 'False' by default
+    direction_optimizing = False
 
     cupy_result = [
         client.submit(
@@ -164,7 +170,9 @@ def bfs(input_graph, start, depth_limit=None, return_distances=True, check_start
             input_graph._plc_graph[w],
             st[0],
             depth_limit,
+            direction_optimizing,
             return_distances,
+            do_expensive_check,
             workers=[w],
             allow_other_workers=False,
         )

--- a/python/cugraph/cugraph/dask/traversal/bfs.py
+++ b/python/cugraph/cugraph/dask/traversal/bfs.py
@@ -44,7 +44,6 @@ def _call_plc_bfs(
     return_distances=True,
     do_expensive_check=False,
 ):
-    print("python: the start type in _call_plc_bfs is \n", st_x.dtype)
     return pylibcugraph_bfs(
         ResourceHandle(Comms.get_handle(sID).getHandle()),
         graph=mg_graph_x,

--- a/python/cugraph/cugraph/dask/traversal/bfs.py
+++ b/python/cugraph/cugraph/dask/traversal/bfs.py
@@ -36,8 +36,14 @@ def convert_to_cudf(cp_arrays):
 
 
 def _call_plc_bfs(
-    sID, mg_graph_x, st_x, depth_limit=None, direction_optimizing=False,
-    return_distances=True, do_expensive_check=False):
+    sID,
+    mg_graph_x,
+    st_x,
+    depth_limit=None,
+    direction_optimizing=False,
+    return_distances=True,
+    do_expensive_check=False,
+):
     print("python: the start type in _call_plc_bfs is \n", st_x.dtype)
     return pylibcugraph_bfs(
         ResourceHandle(Comms.get_handle(sID).getHandle()),
@@ -48,6 +54,7 @@ def _call_plc_bfs(
         compute_predecessors=return_distances,
         do_expensive_check=do_expensive_check,
     )
+
 
 def bfs(input_graph, start, depth_limit=None, return_distances=True, check_start=True):
     """

--- a/python/cugraph/cugraph/structure/number_map.py
+++ b/python/cugraph/cugraph/structure/number_map.py
@@ -266,9 +266,10 @@ class NumberMap:
             self.ddf = tmp_ddf
             return tmp_ddf
 
-    def __init__(self, id_type=np.int32, renumber_type=None):
+    def __init__(self, renumber_id_type=np.int32, unrenumbered_id_type=np.int32):
         self.implementation = None
-        self.id_type = id_type
+        self.renumber_id_type = renumber_id_type
+        self.unrenumbered_id_type = unrenumbered_id_type
         # The default src/dst column names in the resulting renumbered
         # dataframe. These may be updated by the renumbering methods if the
         # input dataframe uses the default names.
@@ -482,9 +483,19 @@ class NumberMap:
     ):
         renumbered = True
 
-        # This assumes that the vertex columns are of the same type
-        # which should be the case
-        id_type = df.dtypes[0]
+        # For columns with mismatch dtypes, set the renumbered
+        # id_type to either 'int32' or 'int64'
+        if df.dtypes.nunique() > 1:
+            # can't determine the edgelist input type
+            unrenumbered_id_type = None
+        else:
+            unrenumbered_id_type = df.dtypes[0]
+
+        if np.int64 in list(df.dtypes):
+            renumber_id_type = np.int64
+        else:
+            # renumber the edgelist to 'int32'
+            renumber_id_type = np.int32
 
         # FIXME: Drop the renumber_type 'experimental' once all the
         # algos follow the C/Pylibcugraph path
@@ -493,12 +504,11 @@ class NumberMap:
         # C++ renumbering.
         if isinstance(src_col_names, list):
             renumber_type = "legacy"
+
         elif not (
             df[src_col_names].dtype == np.int32 or df[src_col_names].dtype == np.int64
         ):
             renumber_type = "legacy"
-            # If the vertices are non-integers, set the renumber 'id_type' to "int32"
-            id_type = "int32"
         else:
             # The renumber_type 'experimental' only runs the C++
             # renumbering
@@ -509,7 +519,7 @@ class NumberMap:
             renumber_type = "skip_renumbering"
             renumbered = False
 
-        renumber_map = NumberMap(id_type=id_type)
+        renumber_map = NumberMap(renumber_id_type, unrenumbered_id_type)
         if not isinstance(src_col_names, list):
             src_col_names = [src_col_names]
             dst_col_names = [dst_col_names]
@@ -521,11 +531,19 @@ class NumberMap:
 
         if isinstance(df, cudf.DataFrame):
             renumber_map.implementation = NumberMap.SingleGPU(
-                df, src_col_names, dst_col_names, renumber_map.id_type, store_transposed
+                df,
+                src_col_names,
+                dst_col_names,
+                renumber_map.renumber_id_type,
+                store_transposed,
             )
         elif isinstance(df, dask_cudf.DataFrame):
             renumber_map.implementation = NumberMap.MultiGPU(
-                df, src_col_names, dst_col_names, renumber_map.id_type, store_transposed
+                df,
+                src_col_names,
+                dst_col_names,
+                renumber_map.renumber_id_type,
+                store_transposed,
             )
         else:
             raise TypeError("df must be cudf.DataFrame or dask_cudf.DataFrame")

--- a/python/cugraph/cugraph/structure/number_map.py
+++ b/python/cugraph/cugraph/structure/number_map.py
@@ -497,8 +497,7 @@ class NumberMap:
             df[src_col_names].dtype == np.int32 or df[src_col_names].dtype == np.int64
         ):
             renumber_type = "legacy"
-            # If the vertices are of type 'string', set the renumber id_type
-            # to "int32"
+            # If the vertices are non-integers, set the renumber 'id_type' to "int32"
             id_type = "int32"
         else:
             # The renumber_type 'experimental' only runs the C++

--- a/python/cugraph/cugraph/tests/mg/test_mg_renumber.py
+++ b/python/cugraph/cugraph/tests/mg/test_mg_renumber.py
@@ -327,8 +327,8 @@ def test_pagerank_string_vertex_ids(dask_client):
 @pytest.mark.parametrize("dtype", ["int32", "int64"])
 def test_mg_renumber_multi_column(dtype, dask_client):
     df = cudf.DataFrame(
-        {"src_a":[i for i in range(0,10)], "dst_a":[i for i in range(10, 20)]}).\
-            astype(dtype)
+        {"src_a": [i for i in range(0, 10)], "dst_a": [i for i in range(10, 20)]}
+    ).astype(dtype)
 
     df["src_b"] = df["src_a"] + 10
     df["dst_b"] = df["dst_a"] + 20
@@ -343,6 +343,3 @@ def test_mg_renumber_multi_column(dtype, dask_client):
     renumbered_edgelist_type = list(renumbered_ddf.dtypes)
 
     assert set(renumbered_edgelist_type).issubset(set(edgelist_type))
-
-
-


### PR DESCRIPTION
The `global_id` column representing the renumbered `edgelist` are of type int64 by default and this is problematic if the user's input dataframe is of type `int32`. 

This PR:
1. Ensures the renumbered edgelist matches the original edgelist `dtype `unless non integers vertices are provided.
2. Add tests verifying the above.
3. Ensures the `source`'s `dtype` in `BFS` matches edgelist `dtype`.

closes #2845 
close #2846 
