### PR TITLE
Add package to the list of dependencies

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -91,7 +91,7 @@ gpuci_mamba_retry install -c rapidsai-nightly/label/testing -y \
       "ucx-proc=*=gpu" \
       "rapids-build-env=$MINOR_VERSION.*" \
       "rapids-notebook-env=$MINOR_VERSION.*" \
-      "py"
+      "py" \
       rapids-pytest-benchmark
 
 # https://docs.rapids.ai/maintainers/depmgmt/

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -91,6 +91,7 @@ gpuci_mamba_retry install -c rapidsai-nightly/label/testing -y \
       "ucx-proc=*=gpu" \
       "rapids-build-env=$MINOR_VERSION.*" \
       "rapids-notebook-env=$MINOR_VERSION.*" \
+      "py"
       rapids-pytest-benchmark
 
 # https://docs.rapids.ai/maintainers/depmgmt/

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -85,6 +85,8 @@ elif hasArg "--run-cpp-tests"; then
 fi
 
 if hasArg "--run-python-tests"; then
+    # install 'py' which is a dependency of 'pytest-benchmark'
+    mamba install py
     echo "Python pytest for pylibcugraph..."
     cd ${CUGRAPH_ROOT}/python/pylibcugraph/pylibcugraph
     pytest --cache-clear --junitxml=${CUGRAPH_ROOT}/junit-pylibcugraph-pytests.xml -v --cov-config=.coveragerc --cov=pylibcugraph --cov-report=xml:${WORKSPACE}/python/pylibcugraph/pylibcugraph-coverage.xml --cov-report term --ignore=raft --benchmark-disable

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -85,8 +85,6 @@ elif hasArg "--run-cpp-tests"; then
 fi
 
 if hasArg "--run-python-tests"; then
-    # install 'py' which is a dependency of 'pytest-benchmark'
-    mamba install py
     echo "Python pytest for pylibcugraph..."
     cd ${CUGRAPH_ROOT}/python/pylibcugraph/pylibcugraph
     pytest --cache-clear --junitxml=${CUGRAPH_ROOT}/junit-pylibcugraph-pytests.xml -v --cov-config=.coveragerc --cov=pylibcugraph --cov-report=xml:${WORKSPACE}/python/pylibcugraph/pylibcugraph-coverage.xml --cov-report term --ignore=raft --benchmark-disable

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -52,3 +52,4 @@ dependencies:
 - pytest-cov
 - gtest=1.10.0
 - gmock=1.10.0
+- py

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -52,3 +52,4 @@ dependencies:
 - pytest-cov
 - gtest=1.10.0
 - gmock=1.10.0
+- py

--- a/conda/environments/cugraph_dev_cuda11.5.yml
+++ b/conda/environments/cugraph_dev_cuda11.5.yml
@@ -52,3 +52,4 @@ dependencies:
 - pytest-cov
 - gtest=1.10.0
 - gmock=1.10.0
+- py

--- a/python/cugraph/cugraph/structure/graph_primtypes.pyx
+++ b/python/cugraph/cugraph/structure/graph_primtypes.pyx
@@ -21,20 +21,20 @@ from libc.stdint cimport uintptr_t
 from libcpp.utility cimport move
 
 from rmm._lib.device_buffer cimport DeviceBuffer
-from cudf.core.buffer import Buffer
+from cudf.core.buffer import as_buffer
 import cudf
 
 
 cdef move_device_buffer_to_column(
     unique_ptr[device_buffer] device_buffer_unique_ptr, dtype):
     """
-    Transfers ownership of device_buffer_unique_ptr to a cuDF Buffer which is
+    Transfers ownership of device_buffer_unique_ptr to a cuDF buffer which is
     used to construct a cudf column object, which is then returned. If the
-    intermediate Buffer is empty, the device_buffer_unique_ptr is still
+    intermediate buffer is empty, the device_buffer_unique_ptr is still
     transfered but None is returned.
     """
     buff = DeviceBuffer.c_from_unique_ptr(move(device_buffer_unique_ptr))
-    buff = Buffer(buff)
+    buff = as_buffer(buff)
     if buff.nbytes != 0:
         column = cudf.core.column.build_column(buff, dtype=dtype)
         return column
@@ -44,9 +44,9 @@ cdef move_device_buffer_to_column(
 cdef move_device_buffer_to_series(
     unique_ptr[device_buffer] device_buffer_unique_ptr, dtype, series_name):
     """
-    Transfers ownership of device_buffer_unique_ptr to a cuDF Buffer which is
+    Transfers ownership of device_buffer_unique_ptr to a cuDF buffer which is
     used to construct a cudf.Series object with name series_name, which is then
-    returned. If the intermediate Buffer is empty, the device_buffer_unique_ptr
+    returned. If the intermediate buffer is empty, the device_buffer_unique_ptr
     is still transfered but None is returned.
     """
     column = move_device_buffer_to_column(move(device_buffer_unique_ptr), dtype)

--- a/python/cugraph/cugraph/tests/mg/test_mg_uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/tests/mg/test_mg_uniform_neighbor_sample.py
@@ -87,7 +87,7 @@ def input_combo(request):
     parameters["MGGraph"] = dg
 
     # sample k vertices from the cuGraph graph
-    k = random.randint(1, 10)
+    k = random.randint(1, 3)
     srcs = dg.input_df["src"]
     dsts = dg.input_df["dst"]
 

--- a/python/cugraph/cugraph/tests/test_uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/tests/test_uniform_neighbor_sample.py
@@ -77,7 +77,7 @@ def input_combo(request):
     parameters["Graph"] = G
 
     # sample k vertices from the cuGraph graph
-    k = random.randint(1, 10)
+    k = random.randint(1, 3)
     srcs = G.view_edge_list()["src"]
     dsts = G.view_edge_list()["dst"]
 


### PR DESCRIPTION
A breaking `pytest `change removed the `py` package from its list of dependencies causing the SG/MG tests to fail.
This PR  adds the package to our list of dependencies. 
In addition to the above, this PR also:
1. Reduces the value of the `fanout_vals` when testing `uniform_neighbor_sampling`
2. Updates the ownership transfer of `device_buffer_unique_ptr` to cuDF buffer through the call `as_buffer()`

closes #2857 
closes #2881 