### PR TITLE
Use new rapids-cmake functionality for rpath handling.

### DIFF
--- a/python/cugraph/CMakeLists.txt
+++ b/python/cugraph/CMakeLists.txt
@@ -57,6 +57,8 @@ else()
   set(cugraph_FOUND OFF)
 endif()
 
+include(rapids-cython)
+
 if(NOT cugraph_FOUND)
   # TODO: This will not be necessary once we upgrade to CMake 3.22, which will pull in the required
   # languages for the C++ project even if this project does not require those languges.
@@ -76,10 +78,10 @@ if(NOT cugraph_FOUND)
 
   add_subdirectory(../../cpp cugraph-cpp)
 
-  install(TARGETS cugraph DESTINATION cugraph/library)
+  set(cython_lib_dir cugraph)
+  install(TARGETS cugraph DESTINATION ${cython_lib_dir})
 endif()
 
-include(rapids-cython)
 rapids_cython_init()
 
 add_subdirectory(cugraph/centrality)
@@ -99,3 +101,7 @@ add_subdirectory(cugraph/sampling)
 add_subdirectory(cugraph/structure)
 add_subdirectory(cugraph/tree)
 add_subdirectory(cugraph/utilities)
+
+if(DEFINED cython_lib_dir)
+  rapids_cython_add_rpath_entries(TARGET cuml PATHS "${cython_lib_dir}")
+endif()

--- a/python/cugraph/CMakeLists.txt
+++ b/python/cugraph/CMakeLists.txt
@@ -103,5 +103,5 @@ add_subdirectory(cugraph/tree)
 add_subdirectory(cugraph/utilities)
 
 if(DEFINED cython_lib_dir)
-  rapids_cython_add_rpath_entries(TARGET cuml PATHS "${cython_lib_dir}")
+  rapids_cython_add_rpath_entries(TARGET cugraph PATHS "${cython_lib_dir}")
 endif()

--- a/python/cugraph/cugraph/centrality/CMakeLists.txt
+++ b/python/cugraph/cugraph/centrality/CMakeLists.txt
@@ -22,8 +22,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX centrality_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cugraph/cugraph/community/CMakeLists.txt
+++ b/python/cugraph/cugraph/community/CMakeLists.txt
@@ -25,8 +25,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX community_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cugraph/cugraph/components/CMakeLists.txt
+++ b/python/cugraph/cugraph/components/CMakeLists.txt
@@ -18,8 +18,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX components_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cugraph/cugraph/cores/CMakeLists.txt
+++ b/python/cugraph/cugraph/cores/CMakeLists.txt
@@ -18,8 +18,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX cores_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cugraph/cugraph/dask/centrality/CMakeLists.txt
+++ b/python/cugraph/cugraph/dask/centrality/CMakeLists.txt
@@ -18,8 +18,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX centrality_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../../library")
-endforeach()

--- a/python/cugraph/cugraph/dask/comms/CMakeLists.txt
+++ b/python/cugraph/cugraph/dask/comms/CMakeLists.txt
@@ -18,8 +18,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX comms_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../../library")
-endforeach()

--- a/python/cugraph/cugraph/dask/components/CMakeLists.txt
+++ b/python/cugraph/cugraph/dask/components/CMakeLists.txt
@@ -18,8 +18,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX components_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../../library")
-endforeach()

--- a/python/cugraph/cugraph/dask/structure/CMakeLists.txt
+++ b/python/cugraph/cugraph/dask/structure/CMakeLists.txt
@@ -18,8 +18,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX structure_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../../library")
-endforeach()

--- a/python/cugraph/cugraph/generators/CMakeLists.txt
+++ b/python/cugraph/cugraph/generators/CMakeLists.txt
@@ -18,8 +18,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX generators_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cugraph/cugraph/internals/CMakeLists.txt
+++ b/python/cugraph/cugraph/internals/CMakeLists.txt
@@ -18,10 +18,7 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX internals_
+  ASSOCIATED_TARGETS cugraph
 )
 
 target_include_directories(internals_internals PRIVATE "${CMAKE_CURRENT_LIST_DIR}")
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cugraph/cugraph/layout/CMakeLists.txt
+++ b/python/cugraph/cugraph/layout/CMakeLists.txt
@@ -18,8 +18,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX layout_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cugraph/cugraph/linear_assignment/CMakeLists.txt
+++ b/python/cugraph/cugraph/linear_assignment/CMakeLists.txt
@@ -18,8 +18,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX linear_assignment_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cugraph/cugraph/link_prediction/CMakeLists.txt
+++ b/python/cugraph/cugraph/link_prediction/CMakeLists.txt
@@ -18,8 +18,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX link_prediction_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cugraph/cugraph/sampling/CMakeLists.txt
+++ b/python/cugraph/cugraph/sampling/CMakeLists.txt
@@ -18,8 +18,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX sampling_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cugraph/cugraph/structure/CMakeLists.txt
+++ b/python/cugraph/cugraph/structure/CMakeLists.txt
@@ -18,8 +18,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX structure_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cugraph/cugraph/tree/CMakeLists.txt
+++ b/python/cugraph/cugraph/tree/CMakeLists.txt
@@ -18,8 +18,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX tree_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/cugraph/cugraph/utilities/CMakeLists.txt
+++ b/python/cugraph/cugraph/utilities/CMakeLists.txt
@@ -18,8 +18,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX utilities_
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/CMakeLists.txt
@@ -60,6 +60,8 @@ endif()
 
 message(STATUS "check if it was found ${cugraph_FOUND}")
 
+include(rapids-cython)
+
 if(NOT cugraph_FOUND)
   # TODO: This will not be necessary once we upgrade to CMake 3.22, which will pull in the required
   # languages for the C++ project even if this project does not require those languges.
@@ -79,10 +81,14 @@ if(NOT cugraph_FOUND)
 
   add_subdirectory(../../cpp cugraph-cpp)
 
-  install(TARGETS cugraph DESTINATION pylibcugraph/library)
+  set(cython_lib_dir pylibcugraph)
+  install(TARGETS cugraph DESTINATION ${cython_lib_dir})
 endif()
 
-include(rapids-cython)
 rapids_cython_init()
 
 add_subdirectory(pylibcugraph)
+
+if(DEFINED cython_lib_dir)
+  rapids_cython_add_rpath_entries(TARGET cuml PATHS "${cython_lib_dir}")
+endif()

--- a/python/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/CMakeLists.txt
@@ -90,5 +90,5 @@ rapids_cython_init()
 add_subdirectory(pylibcugraph)
 
 if(DEFINED cython_lib_dir)
-  rapids_cython_add_rpath_entries(TARGET cuml PATHS "${cython_lib_dir}")
+  rapids_cython_add_rpath_entries(TARGET cugraph PATHS "${cython_lib_dir}")
 endif()

--- a/python/pylibcugraph/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/pylibcugraph/CMakeLists.txt
@@ -39,8 +39,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES ${linked_libraries}
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/library")
-endforeach()

--- a/python/pylibcugraph/pylibcugraph/components/CMakeLists.txt
+++ b/python/pylibcugraph/pylibcugraph/components/CMakeLists.txt
@@ -21,8 +21,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}"
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/pylibcugraph/pylibcugraph/internal_types/CMakeLists.txt
+++ b/python/pylibcugraph/pylibcugraph/internal_types/CMakeLists.txt
@@ -21,8 +21,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}"
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/pylibcugraph/pylibcugraph/raft/common/CMakeLists.txt
+++ b/python/pylibcugraph/pylibcugraph/raft/common/CMakeLists.txt
@@ -22,8 +22,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}"
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../../library")
-endforeach()

--- a/python/pylibcugraph/pylibcugraph/testing/CMakeLists.txt
+++ b/python/pylibcugraph/pylibcugraph/testing/CMakeLists.txt
@@ -21,8 +21,5 @@ rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}"
+  ASSOCIATED_TARGETS cugraph
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()


### PR DESCRIPTION
The new functionality creates a single source of truth defining the location at which a library will be, allowing rapids-cmake to handle the necessary relative paths in the RPATH and avoiding the current error-prone approach that requires each CMakeLists.txt to correctly assign the relative path.