### PR TITLE
Fix num_vertices() on Non-Renumbered Graphs

### DIFF
--- a/python/cugraph/cugraph/_version.py
+++ b/python/cugraph/cugraph/_version.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -576,8 +576,22 @@ class simpleGraphImpl:
             elif self.transposedadjlist is not None:
                 self.properties.node_count = len(self.transposedadjlist.offsets) - 1
             elif self.edgelist is not None:
-                df = self.edgelist.edgelist_df[["src", "dst"]]
-                self.properties.node_count = df.max().max() + 1
+                if self.properties.renumbered:
+                    # If renumbering has occurred, then the vertices have been
+                    # given sequential ids starting from 0
+                    df = self.edgelist.edgelist_df[["src", "dst"]]
+                    self.properties.node_count = df.max().max() + 1
+                else:
+                    self.properties.node_count = (
+                        cudf.concat(
+                            [
+                                self.edgelist.edgelist_df["src"],
+                                self.edgelist.edgelist_df["dst"],
+                            ]
+                        )
+                        .unique()
+                        .count()
+                    )
             else:
                 raise RuntimeError("Graph is Empty")
         return self.properties.node_count

--- a/python/cugraph/cugraph/tests/test_graph.py
+++ b/python/cugraph/cugraph/tests/test_graph.py
@@ -509,6 +509,20 @@ def test_number_of_vertices(graph_file):
     assert G.number_of_vertices() == Gnx.number_of_nodes()
 
 
+def test_number_of_vertices_unrenumber():
+    df = cudf.DataFrame(
+        {
+            "source": [9001, 9002, 9003],
+            "destination": [9003, 9002, 9001],
+        }
+    )
+
+    G = cugraph.Graph()
+    G.from_cudf_edgelist(df, source="source", destination="destination", renumber=False)
+
+    assert 3 == G.number_of_vertices()
+
+
 # Test
 @pytest.mark.parametrize("graph_file", utils.DATASETS_SMALL)
 def test_to_directed(graph_file):


### PR DESCRIPTION
Properly counts the number of unique vertices when sequential vertex ids starting from 0 are not guaranteed.