### PR TITLE
Add view_concat for edge_minor_property_view_t and update transform_reduce_e_by_dst_key to support reduce_op on tuple types

### DIFF
--- a/cpp/include/cugraph/edge_src_dst_property.hpp
+++ b/cpp/include/cugraph/edge_src_dst_property.hpp
@@ -581,7 +581,6 @@ auto view_concat(detail::edge_major_property_view_t<vertex_t, Ts> const&... view
   }
 }
 
-//
 template <typename vertex_t, typename... Ts>
 auto view_concat(detail::edge_minor_property_view_t<vertex_t, Ts> const&... views)
 {

--- a/cpp/include/cugraph/edge_src_dst_property.hpp
+++ b/cpp/include/cugraph/edge_src_dst_property.hpp
@@ -581,4 +581,31 @@ auto view_concat(detail::edge_major_property_view_t<vertex_t, Ts> const&... view
   }
 }
 
+//
+template <typename vertex_t, typename... Ts>
+auto view_concat(detail::edge_minor_property_view_t<vertex_t, Ts> const&... views)
+{
+  using concat_value_iterator = decltype(
+    thrust::make_zip_iterator(thrust_tuple_cat(detail::to_thrust_tuple(views.value_first())...)));
+
+  concat_value_iterator edge_partition_concat_value_first{};
+
+  auto first_view = detail::get_first_of_pack(views...);
+
+  edge_partition_concat_value_first =
+    thrust::make_zip_iterator(thrust_tuple_cat(detail::to_thrust_tuple(views.value_first())...));
+
+  if (first_view.key_chunk_size()) {
+    return detail::edge_minor_property_view_t<vertex_t, concat_value_iterator>(
+      *(first_view.keys()),
+      *(first_view.key_chunk_start_offsets()),
+      *(first_view.key_chunk_size()),
+      edge_partition_concat_value_first,
+      first_view.minor_range_first());
+  } else {
+    return detail::edge_minor_property_view_t<vertex_t, concat_value_iterator>(
+      edge_partition_concat_value_first, first_view.minor_range_first());
+  }
+}
+
 }  // namespace cugraph

--- a/cpp/src/prims/transform_reduce_e_by_src_dst_key.cuh
+++ b/cpp/src/prims/transform_reduce_e_by_src_dst_key.cuh
@@ -81,16 +81,16 @@ __device__ void update_buffer_element(
     ((GraphViewType::is_storage_transposed != edge_partition_src_key) ? major_offset
                                                                       : minor_offset));
   *value_iter = evaluate_edge_op<GraphViewType,
-                                  vertex_t,
-                                  EdgePartitionSrcValueInputWrapper,
-                                  EdgePartitionDstValueInputWrapper,
-                                  EdgeOp>()
-                   .compute(src,
-                            dst,
-                            weight,
-                            edge_partition_src_value_input.get(src_offset),
-                            edge_partition_dst_value_input.get(dst_offset),
-                            e_op);
+                                 vertex_t,
+                                 EdgePartitionSrcValueInputWrapper,
+                                 EdgePartitionDstValueInputWrapper,
+                                 EdgeOp>()
+                  .compute(src,
+                           dst,
+                           weight,
+                           edge_partition_src_value_input.get(src_offset),
+                           edge_partition_dst_value_input.get(dst_offset),
+                           e_op);
 }
 
 template <bool edge_partition_src_key,

--- a/cpp/src/prims/transform_reduce_e_by_src_dst_key.cuh
+++ b/cpp/src/prims/transform_reduce_e_by_src_dst_key.cuh
@@ -66,7 +66,7 @@ __device__ void update_buffer_element(
   EdgePartitionSrcDstKeyInputWrapper edge_partition_src_dst_key_input,
   EdgeOp e_op,
   typename GraphViewType::vertex_type* key,
-  ValueIterator value_first)
+  ValueIterator value_iter)
 {
   using vertex_t = typename GraphViewType::vertex_type;
 
@@ -80,7 +80,7 @@ __device__ void update_buffer_element(
   *key = edge_partition_src_dst_key_input.get(
     ((GraphViewType::is_storage_transposed != edge_partition_src_key) ? major_offset
                                                                       : minor_offset));
-  *value_first = evaluate_edge_op<GraphViewType,
+  *value_iter = evaluate_edge_op<GraphViewType,
                                   vertex_t,
                                   EdgePartitionSrcValueInputWrapper,
                                   EdgePartitionDstValueInputWrapper,
@@ -110,7 +110,7 @@ __global__ void transform_reduce_by_src_dst_key_hypersparse(
   EdgePartitionSrcDstKeyInputWrapper edge_partition_src_dst_key_input,
   EdgeOp e_op,
   typename GraphViewType::vertex_type* keys,
-  ValueIterator value_first)
+  ValueIterator value_iter)
 {
   using vertex_t = typename GraphViewType::vertex_type;
   using edge_t   = typename GraphViewType::edge_type;
@@ -145,7 +145,7 @@ __global__ void transform_reduce_by_src_dst_key_hypersparse(
         edge_partition_src_dst_key_input,
         e_op,
         keys + local_offset + i,
-        value_first + local_offset + i);
+        value_iter + local_offset + i);
     }
 
     idx += gridDim.x * blockDim.x;
@@ -171,7 +171,7 @@ __global__ void transform_reduce_by_src_dst_key_low_degree(
   EdgePartitionSrcDstKeyInputWrapper edge_partition_src_dst_key_input,
   EdgeOp e_op,
   typename GraphViewType::vertex_type* keys,
-  ValueIterator value_first)
+  ValueIterator value_iter)
 {
   using vertex_t = typename GraphViewType::vertex_type;
   using edge_t   = typename GraphViewType::edge_type;
@@ -203,7 +203,7 @@ __global__ void transform_reduce_by_src_dst_key_low_degree(
         edge_partition_src_dst_key_input,
         e_op,
         keys + local_offset + i,
-        value_first + local_offset + i);
+        value_iter + local_offset + i);
     }
 
     idx += gridDim.x * blockDim.x;
@@ -229,7 +229,7 @@ __global__ void transform_reduce_by_src_dst_key_mid_degree(
   EdgePartitionSrcDstKeyInputWrapper edge_partition_src_dst_key_input,
   EdgeOp e_op,
   typename GraphViewType::vertex_type* keys,
-  ValueIterator value_first)
+  ValueIterator value_iter)
 {
   using vertex_t = typename GraphViewType::vertex_type;
   using edge_t   = typename GraphViewType::edge_type;
@@ -263,7 +263,7 @@ __global__ void transform_reduce_by_src_dst_key_mid_degree(
         edge_partition_src_dst_key_input,
         e_op,
         keys + local_offset + i,
-        value_first + local_offset + i);
+        value_iter + local_offset + i);
     }
 
     idx += gridDim.x * (blockDim.x / raft::warp_size());
@@ -289,7 +289,7 @@ __global__ void transform_reduce_by_src_dst_key_high_degree(
   EdgePartitionSrcDstKeyInputWrapper edge_partition_src_dst_key_input,
   EdgeOp e_op,
   typename GraphViewType::vertex_type* keys,
-  ValueIterator value_first)
+  ValueIterator value_iter)
 {
   using vertex_t = typename GraphViewType::vertex_type;
   using edge_t   = typename GraphViewType::edge_type;
@@ -320,7 +320,7 @@ __global__ void transform_reduce_by_src_dst_key_high_degree(
         edge_partition_src_dst_key_input,
         e_op,
         keys + local_offset + i,
-        value_first + local_offset + i);
+        value_iter + local_offset + i);
     }
 
     idx += gridDim.x;


### PR DESCRIPTION
- Add view_concat for edge_minor_property_view_t 
- update transform_reduce_e_by_dst_key to support reduce_ops on tuple types
closes #2878