### PR TITLE
Correct build failures when doing a local build

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(cugraphtestutil
         NCCL::NCCL
     PRIVATE
         cuco::cuco
+        GTest::gtest
 )
 
 ###################################################################################################

--- a/cpp/tests/centrality/betweenness_centrality_validate.cu
+++ b/cpp/tests/centrality/betweenness_centrality_validate.cu
@@ -32,7 +32,7 @@ void betweenness_centrality_validate(
   std::optional<rmm::device_uvector<vertex_t>>& d_reference_vertex_ids,
   rmm::device_uvector<weight_t>& d_reference_results)
 {
-  auto compare_functor = cugraph::test::nearly_equal<weight_t>{
+  auto compare_functor = cugraph::test::device_nearly_equal<weight_t>{
     weight_t{1e-3},
     weight_t{(weight_t{1} / static_cast<weight_t>(d_cugraph_results.size())) * weight_t{1e-3}}};
 
@@ -69,7 +69,7 @@ void edge_betweenness_centrality_validate(raft::handle_t const& handle,
                                           rmm::device_uvector<vertex_t>& d_reference_dst_vertex_ids,
                                           rmm::device_uvector<weight_t>& d_reference_results)
 {
-  auto compare_functor = cugraph::test::nearly_equal<weight_t>{
+  auto compare_functor = cugraph::test::device_nearly_equal<weight_t>{
     weight_t{1e-3},
     weight_t{(weight_t{1} / static_cast<weight_t>(d_reference_results.size())) * weight_t{1e-3}}};
 


### PR DESCRIPTION
I found two errors when building locally that this PR fixes.

- The cugraph test util target relies on gtest headers but doesn't use the `GTest::gtest` target. This works in CI due to the conda env placing the GTest headers in a directory found by other `-I`
- The `cpp/tests/centrality/betweenness_centrality_validate.cu` test uses the wrong `nearly_equal` function which fails due to calling a host only function from a device/host function.