### PR TITLE
Fix bug in how is_symmetric is set when transposing storage

### DIFF
--- a/cpp/src/c_api/core_number.cpp
+++ b/cpp/src/c_api/core_number.cpp
@@ -67,8 +67,6 @@ struct core_number_functor : public cugraph::c_api::abstract_functor {
         if (error_code_ != CUGRAPH_SUCCESS)
           ;
       }
-      // FIXME: Transpose_storage may have a bug, since if store_transposed is True it can reverse
-      // the bool value of is_symmetric
       auto graph =
         reinterpret_cast<cugraph::graph_t<vertex_t, edge_t, weight_t, false, multi_gpu>*>(
           graph_->graph_);

--- a/cpp/src/structure/transpose_graph_impl.cuh
+++ b/cpp/src/structure/transpose_graph_impl.cuh
@@ -89,7 +89,7 @@ transpose_graph_impl(raft::handle_t const& handle,
       std::move(edgelist_srcs),
       std::move(edgelist_weights),
       std::nullopt,
-      graph_properties_t{is_multigraph, false},
+      graph_properties_t{false, is_multigraph},
       true);
 
   return std::make_tuple(std::move(transposed_graph), std::move(new_renumber_map));
@@ -150,7 +150,7 @@ transpose_graph_impl(raft::handle_t const& handle,
       std::move(edgelist_srcs),
       std::move(edgelist_weights),
       std::nullopt,
-      graph_properties_t{is_multigraph, false},
+      graph_properties_t{false, is_multigraph},
       renumber);
 
   return std::make_tuple(std::move(transposed_graph), std::move(new_renumber_map));

--- a/cpp/src/structure/transpose_graph_storage_impl.cuh
+++ b/cpp/src/structure/transpose_graph_storage_impl.cuh
@@ -62,7 +62,7 @@ transpose_graph_storage_impl(
   }
 
   auto is_multigraph = graph.is_multigraph();
-  auto is_symmetric = graph.is_symmetric();
+  auto is_symmetric  = graph.is_symmetric();
 
   // FIXME: if is_symmetric is true we can do this more efficiently,
   //        since the graph contents should be exactly the same
@@ -127,7 +127,7 @@ transpose_graph_storage_impl(
   auto number_of_vertices = graph.number_of_vertices();
   auto is_multigraph      = graph.is_multigraph();
   bool renumber           = renumber_map.has_value();
-  auto is_symmetric = graph.is_symmetric();
+  auto is_symmetric       = graph.is_symmetric();
 
   // FIXME: if is_symmetric is true we can do this more efficiently,
   //        since the graph contents should be exactly the same
@@ -161,8 +161,10 @@ transpose_graph_storage_impl(
       graph_properties_t{is_symmetric, is_multigraph},
       renumber);
 
-  std::cout << "should have created graph with is_symmetric = " << (is_symmetric ? "TRUE" : "FALSE") << std::endl;
-  std::cout << "  store_transposed_graph is_symmetric = " << (storage_transposed_graph.is_symmetric() ? "TRUE" : "FALSE") << std::endl;
+  std::cout << "should have created graph with is_symmetric = " << (is_symmetric ? "TRUE" : "FALSE")
+            << std::endl;
+  std::cout << "  store_transposed_graph is_symmetric = "
+            << (storage_transposed_graph.is_symmetric() ? "TRUE" : "FALSE") << std::endl;
 
   return std::make_tuple(std::move(storage_transposed_graph), std::move(new_renumber_map));
 }

--- a/cpp/src/structure/transpose_graph_storage_impl.cuh
+++ b/cpp/src/structure/transpose_graph_storage_impl.cuh
@@ -62,6 +62,10 @@ transpose_graph_storage_impl(
   }
 
   auto is_multigraph = graph.is_multigraph();
+  auto is_symmetric = graph.is_symmetric();
+
+  // FIXME: if is_symmetric is true we can do this more efficiently,
+  //        since the graph contents should be exactly the same
 
   auto [edgelist_srcs, edgelist_dsts, edgelist_weights] =
     decompress_to_edgelist(handle,
@@ -89,7 +93,7 @@ transpose_graph_storage_impl(
       std::move(edgelist_dsts),
       std::move(edgelist_weights),
       std::nullopt,
-      graph_properties_t{is_multigraph, false},
+      graph_properties_t{is_symmetric, is_multigraph},
       true);
 
   return std::make_tuple(std::move(storage_transposed_graph), std::move(new_renumber_map));
@@ -123,6 +127,10 @@ transpose_graph_storage_impl(
   auto number_of_vertices = graph.number_of_vertices();
   auto is_multigraph      = graph.is_multigraph();
   bool renumber           = renumber_map.has_value();
+  auto is_symmetric = graph.is_symmetric();
+
+  // FIXME: if is_symmetric is true we can do this more efficiently,
+  //        since the graph contents should be exactly the same
 
   auto [edgelist_srcs, edgelist_dsts, edgelist_weights] =
     decompress_to_edgelist(handle,
@@ -150,8 +158,11 @@ transpose_graph_storage_impl(
       std::move(edgelist_dsts),
       std::move(edgelist_weights),
       std::nullopt,
-      graph_properties_t{is_multigraph, false},
+      graph_properties_t{is_symmetric, is_multigraph},
       renumber);
+
+  std::cout << "should have created graph with is_symmetric = " << (is_symmetric ? "TRUE" : "FALSE") << std::endl;
+  std::cout << "  store_transposed_graph is_symmetric = " << (storage_transposed_graph.is_symmetric() ? "TRUE" : "FALSE") << std::endl;
 
   return std::make_tuple(std::move(storage_transposed_graph), std::move(new_renumber_map));
 }

--- a/cpp/src/structure/transpose_graph_storage_impl.cuh
+++ b/cpp/src/structure/transpose_graph_storage_impl.cuh
@@ -161,11 +161,6 @@ transpose_graph_storage_impl(
       graph_properties_t{is_symmetric, is_multigraph},
       renumber);
 
-  std::cout << "should have created graph with is_symmetric = " << (is_symmetric ? "TRUE" : "FALSE")
-            << std::endl;
-  std::cout << "  store_transposed_graph is_symmetric = "
-            << (storage_transposed_graph.is_symmetric() ? "TRUE" : "FALSE") << std::endl;
-
   return std::make_tuple(std::move(storage_transposed_graph), std::move(new_renumber_map));
 }
 

--- a/cpp/tests/c_api/weakly_connected_components_test.c
+++ b/cpp/tests/c_api/weakly_connected_components_test.c
@@ -117,11 +117,30 @@ int test_weakly_connected_components()
   return generic_wcc_test(h_src, h_dst, h_wgt, h_result, num_vertices, num_edges, FALSE);
 }
 
+int test_weakly_connected_components_transpose()
+{
+  size_t num_edges    = 32;
+  size_t num_vertices = 12;
+
+  vertex_t h_src[]    = {0, 1, 1, 2, 2, 2, 3, 4, 6, 7, 7,  8, 8, 8, 9,  10,
+                      1, 3, 4, 0, 1, 3, 5, 5, 7, 9, 10, 6, 7, 9, 11, 11};
+  vertex_t h_dst[]    = {1, 3, 4, 0, 1, 3, 5, 5, 7, 9, 10, 6, 7, 9, 11, 11,
+                      0, 1, 1, 2, 2, 2, 3, 4, 6, 7, 7,  8, 8, 8, 9,  10};
+  weight_t h_wgt[]    = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+  vertex_t h_result[] = {0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1};
+
+  // WCC wants store_transposed = FALSE
+  return generic_wcc_test(h_src, h_dst, h_wgt, h_result, num_vertices, num_edges, TRUE);
+}
+
 /******************************************************************************/
 
 int main(int argc, char** argv)
 {
   int result = 0;
   result |= RUN_TEST(test_weakly_connected_components);
+  result |= RUN_TEST(test_weakly_connected_components_transpose);
   return result;
 }


### PR DESCRIPTION
The `tranpose_storage` function was incorrectly setting graph properties.