### PR TITLE
[REVIEW] Optimize  `PG.add_data`

### DIFF
--- a/python/cugraph/cugraph/dask/structure/mg_property_graph.py
+++ b/python/cugraph/cugraph/dask/structure/mg_property_graph.py
@@ -408,6 +408,8 @@ class EXPERIMENTAL__MGPropertyGraph:
         tmp_df[self.vertex_col_name] = tmp_df[vertex_col_name]
         # FIXME: handle case of a type_name column already being in tmp_df
 
+        # FIXME: We should do categorization first
+        # Related issue: https://github.com/rapidsai/cugraph/issues/2903
         tmp_df[TCN] = type_name
         tmp_df[TCN] = tmp_df[TCN].astype(cat_dtype)
 
@@ -625,6 +627,9 @@ class EXPERIMENTAL__MGPropertyGraph:
         tmp_df = dataframe.copy()
         tmp_df[self.src_col_name] = tmp_df[vertex_col_names[0]]
         tmp_df[self.dst_col_name] = tmp_df[vertex_col_names[1]]
+
+        # FIXME: We should do categorization first
+        # Related issue: https://github.com/rapidsai/cugraph/issues/2903
 
         tmp_df[TCN] = type_name
         tmp_df[TCN] = tmp_df[TCN].astype(cat_dtype)

--- a/python/cugraph/cugraph/structure/property_graph.py
+++ b/python/cugraph/cugraph/structure/property_graph.py
@@ -618,7 +618,8 @@ class EXPERIMENTAL__PropertyGraph:
         if self.__series_type is cudf.Series:
             # cudf does not yet support initialization with a scalar
             tmp_df[TCN] = cudf.Series(
-                np.repeat(type_name, len(tmp_df)), index=tmp_df.index, dtype=cat_dtype
+                cudf.Series([type_name], dtype=cat_dtype).repeat(len(tmp_df)),
+                index=tmp_df.index,
             )
         else:
             # pandas is oddly slow if dtype is passed to the constructor here
@@ -909,7 +910,8 @@ class EXPERIMENTAL__PropertyGraph:
         if self.__series_type is cudf.Series:
             # cudf does not yet support initialization with a scalar
             tmp_df[TCN] = cudf.Series(
-                np.repeat(type_name, len(tmp_df)), index=tmp_df.index, dtype=cat_dtype
+                cudf.Series([type_name], dtype=cat_dtype).repeat(len(tmp_df)),
+                index=tmp_df.index,
             )
         else:
             # pandas is oddly slow if dtype is passed to the constructor here

--- a/python/cugraph/cugraph/tests/test_property_graph.py
+++ b/python/cugraph/cugraph/tests/test_property_graph.py
@@ -18,6 +18,7 @@ import pytest
 import pandas as pd
 import numpy as np
 import cudf
+import cupy as cp
 from cudf.testing import assert_frame_equal, assert_series_equal
 from cugraph.experimental.datasets import cyber
 
@@ -1963,6 +1964,20 @@ def bench_extract_subgraph_for_rmat(gpubenchmark, rmat_PropertyGraph):
         default_edge_weight=1.0,
         check_multi_edges=False,
     )
+
+
+@pytest.mark.parametrize("n_rows", [15_000_000, 30_000_000, 60_000_000, 120_000_000])
+def bench_add_edge_data(gpubenchmark, n_rows):
+    from cugraph.experimental import PropertyGraph
+
+    def func():
+        pg = PropertyGraph()
+        src = cp.arange(n_rows)
+        dst = src - 1
+        df = cudf.DataFrame({"src": src, "dst": dst})
+        pg.add_edge_data(df, ["src", "dst"], type_name="('_N', '_E', '_N')")
+
+    gpubenchmark(func)
 
 
 # This test runs for *minutes* with the current implementation, and since


### PR DESCRIPTION
This PR fixes #2903  . 

We reduce the memory foot print by  `3.5x` and speeds up the add_data by `557x` and also allows us to not be limited in the size of edges we can save.  (Time is in seconds vs ms) 

Before PR:
```python3
Name (time in s, mem in bytes)       Mean                  GPU mem            GPU Leaked mem            Rounds            GPU Rounds          
----------------------------------------------------------------------------------------------------------------------------------------------
bench_add_edge_data[15000000]      2.3044 (1.0)      2,160,000,064 (1.0)                   0 (1.0)           1           1
bench_add_edge_data[30000000]      4.7941 (2.08)     4,320,000,064 (2.00)                  0 (1.0)           1           1
bench_add_edge_data[60000000]      8.7235 (3.79)     8,640,000,064 (4.00)                  0 (1.0)           1           1
bench_add_edge_data[120000000]  FAILED
----------------------------------------------------------------------------------------------------------------------------------------------
```


After PR
```python
-------------------------------------------------------------- benchmark: 4 tests --------------------------------------------------------------
Name (time in ms, mem in bytes)        Mean                  GPU mem            GPU Leaked mem            Rounds            GPU Rounds          
------------------------------------------------------------------------------------------------------------------------------------------------
bench_add_edge_data[15000000]       16.3785 (1.0)        615,000,080 (1.0)                   0 (1.0)           1           1
bench_add_edge_data[30000000]       17.3631 (1.06)     1,230,000,080 (2.00)                  0 (1.0)           1           1
bench_add_edge_data[60000000]       22.2947 (1.36)     2,460,000,080 (4.00)                  0 (1.0)           1           1
bench_add_edge_data[120000000]      26.9747 (1.65)     4,920,000,080 (8.00)                  0 (1.0)           1           1
------------------------------------------------------------------------------------------------------------------------------------------------
```