### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,7 @@ VALIDARGS="
    --pydevelop
    --allgpuarch
    --skip_cpp_tests
+   --without_cugraphops
    --cmake_default_generator
    --clean
    -h
@@ -250,6 +251,7 @@ if buildAll || hasArg libcugraph; then
               -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
               -DBUILD_TESTS=${BUILD_CPP_TESTS} \
               -DBUILD_CUGRAPH_MG_TESTS=${BUILD_CPP_MG_TESTS} \
+	      -DUSE_CUGRAPH_OPS=${BUILD_WITH_CUGRAPHOPS} \
               ${CMAKE_GENERATOR_OPTION} \
               ${CMAKE_VERBOSE_OPTION}
         cmake --build "${LIBCUGRAPH_BUILD_DIR}" -j${PARALLEL_LEVEL} ${INSTALL_TARGET} ${VERBOSE_FLAG}
@@ -296,8 +298,14 @@ if buildAll || hasArg pylibcugraph; then
         # setup.py references an env var CUGRAPH_BUILD_PATH to find the libcugraph
         # build. If not set by the user, set it to LIBCUGRAPH_BUILD_DIR
         CUGRAPH_BUILD_PATH=${CUGRAPH_BUILD_PATH:=${LIBCUGRAPH_BUILD_DIR}}
-        python setup.py build_ext --inplace -- -DFIND_CUGRAPH_CPP=ON \
-               -Dcugraph_ROOT=${LIBCUGRAPH_BUILD_DIR} -- -j${PARALLEL_LEVEL:-1}
+        python setup.py build_ext \
+	       --inplace \
+	       -- \
+	       -DFIND_CUGRAPH_CPP=ON \
+	       -DUSE_CUGRAPH_OPS=${BUILD_WITH_CUGRAPHOPS} \
+               -Dcugraph_ROOT=${LIBCUGRAPH_BUILD_DIR} \
+	       -- \
+	       -j${PARALLEL_LEVEL:-1}
         if [[ ${INSTALL_TARGET} != "" ]]; then
             env CUGRAPH_BUILD_PATH=${CUGRAPH_BUILD_PATH} python ${PYTHON_ARGS_FOR_INSTALL}
         fi
@@ -314,8 +322,14 @@ if buildAll || hasArg cugraph; then
         # setup.py references an env var CUGRAPH_BUILD_PATH to find the libcugraph
         # build. If not set by the user, set it to LIBCUGRAPH_BUILD_DIR
         CUGRAPH_BUILD_PATH=${CUGRAPH_BUILD_PATH:=${LIBCUGRAPH_BUILD_DIR}}
-        python setup.py build_ext --inplace -- -DFIND_CUGRAPH_CPP=ON \
-               -Dcugraph_ROOT=${LIBCUGRAPH_BUILD_DIR} -- -j${PARALLEL_LEVEL:-1}
+        python setup.py build_ext \
+	       --inplace \
+	       -- \
+	       -DFIND_CUGRAPH_CPP=ON \
+	       -DUSE_CUGRAPH_OPS=${BUILD_WITH_CUGRAPHOPS} \
+               -Dcugraph_ROOT=${LIBCUGRAPH_BUILD_DIR} \
+	       -- \
+	       -j${PARALLEL_LEVEL:-1}
         if [[ ${INSTALL_TARGET} != "" ]]; then
             env CUGRAPH_BUILD_PATH=${CUGRAPH_BUILD_PATH} python ${PYTHON_ARGS_FOR_INSTALL}
         fi


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.