### PR TITLE
Update gitignore to Exclude Egg Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ test-results
 dask-worker-space/
 htmlcov
 dist/
-cugraph.egg-info/
+*.egg-info/
 python/build
 python/cugraph/bindings/*.cpp
 wheels/


### PR DESCRIPTION
Resolves #2947 

Excludes egg files from git.  Previously, only egg files in a certain directory were excluded.  This broadens the exclusion to the whole repository.