### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ test-results
 dask-worker-space/
 htmlcov
 dist/
-cugraph.egg-info/
+*.egg-info/
 python/build
 python/cugraph/bindings/*.cpp
 wheels/


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.