### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/conda/recipes/cugraph-dgl/meta.yaml
+++ b/conda/recipes/cugraph-dgl/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - cugraph={{ version }}
     - numba >=0.56.2
     - numpy
-    - dgl >=0.8
+    - dgl-cuda11.6 >=0.9
     - pytorch
     - cudatoolkit =11.6
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.