### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -28,7 +28,7 @@ dependencies:
 - networkx>=2.5.1
 - clang=11.1.0
 - clang-tools=11.1.0
-- cmake>=3.23.1
+- cmake>=3.23.1,!=3.25.0
 - ninja
 - scikit-build>=0.13.1
 - python>=3.8,<3.10

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -28,7 +28,7 @@ dependencies:
 - networkx>=2.5.1
 - clang=11.1.0
 - clang-tools=11.1.0
-- cmake>=3.23.1
+- cmake>=3.23.1,!=3.25.0
 - ninja
 - scikit-build>=0.13.1
 - python>=3.8,<3.10

--- a/conda/environments/cugraph_dev_cuda11.5.yml
+++ b/conda/environments/cugraph_dev_cuda11.5.yml
@@ -28,7 +28,7 @@ dependencies:
 - networkx>=2.5.1
 - clang=11.1.0
 - clang-tools=11.1.0
-- cmake>=3.23.1
+- cmake>=3.23.1,!=3.25.0
 - ninja
 - scikit-build>=0.13.1
 - python>=3.8,<3.10

--- a/conda/recipes/cugraph/conda_build_config.yaml
+++ b/conda/recipes/cugraph/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - nvcc
 
 cmake_version:
-  - ">=3.23.1"
+  - ">=3.23.1,!=3.25.0"
 
 sysroot_version:
   - "2.17"

--- a/conda/recipes/libcugraph/conda_build_config.yaml
+++ b/conda/recipes/libcugraph/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - nvcc
 
 cmake_version:
-  - ">=3.23.1"
+  - ">=3.23.1,!=3.25.0"
 
 doxygen_version:
   - ">=1.8.11"

--- a/conda/recipes/pylibcugraph/conda_build_config.yaml
+++ b/conda/recipes/pylibcugraph/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - nvcc
 
 cmake_version:
-  - ">=3.23.1"
+  - ">=3.23.1,!=3.25.0"
 
 sysroot_version:
   - "2.17"

--- a/python/cugraph/pyproject.toml
+++ b/python/cugraph/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     "setuptools",
     "cython>=0.29,<0.30",
     "scikit-build>=0.13.1",
-    "cmake>=3.23.1",
+    "cmake>=3.23.1,!=3.25.0",
     "ninja",
 ]
 

--- a/python/pylibcugraph/pyproject.toml
+++ b/python/pylibcugraph/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     "setuptools",
     "cython>=0.29,<0.30",
     "scikit-build>=0.13.1",
-    "cmake>=3.23.1",
+    "cmake>=3.23.1,!=3.25.0",
     "ninja",
 ]
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.