### PR TITLE
Updates experimental warning wrapper and PropertyGraph docs for correct experimental namespace name

### DIFF
--- a/docs/cugraph/source/api_docs/property_graph.rst
+++ b/docs/cugraph/source/api_docs/property_graph.rst
@@ -1,7 +1,7 @@
 ====================
 Property Graph
 ====================
-.. currentmodule:: cugraph.structure.property_graph
+.. currentmodule:: cugraph.experimental
 
 
 Property Graph
@@ -9,21 +9,21 @@ Property Graph
 .. autosummary::
    :toctree: api/
 
-   EXPERIMENTAL__PropertySelection
-   EXPERIMENTAL__PropertyGraph
-   EXPERIMENTAL__PropertyGraph.add_edge_data
-   EXPERIMENTAL__PropertyGraph.add_vertex_data
-   EXPERIMENTAL__PropertyGraph.annotate_dataframe
-   EXPERIMENTAL__PropertyGraph.edge_props_to_graph
-   EXPERIMENTAL__PropertyGraph.extract_subgraph
-   EXPERIMENTAL__PropertyGraph.get_edge_data
-   EXPERIMENTAL__PropertyGraph.get_num_edges
-   EXPERIMENTAL__PropertyGraph.get_num_vertices
-   EXPERIMENTAL__PropertyGraph.get_vertex_data
-   EXPERIMENTAL__PropertyGraph.get_vertices
-   EXPERIMENTAL__PropertyGraph.has_duplicate_edges
-   EXPERIMENTAL__PropertyGraph.is_multigraph
-   EXPERIMENTAL__PropertyGraph.renumber_edges_by_type
-   EXPERIMENTAL__PropertyGraph.renumber_vertices_by_type
-   EXPERIMENTAL__PropertyGraph.select_edges
-   EXPERIMENTAL__PropertyGraph.select_vertices
+   PropertySelection
+   PropertyGraph
+   PropertyGraph.add_edge_data
+   PropertyGraph.add_vertex_data
+   PropertyGraph.annotate_dataframe
+   PropertyGraph.edge_props_to_graph
+   PropertyGraph.extract_subgraph
+   PropertyGraph.get_edge_data
+   PropertyGraph.get_num_edges
+   PropertyGraph.get_num_vertices
+   PropertyGraph.get_vertex_data
+   PropertyGraph.get_vertices
+   PropertyGraph.has_duplicate_edges
+   PropertyGraph.is_multigraph
+   PropertyGraph.renumber_edges_by_type
+   PropertyGraph.renumber_vertices_by_type
+   PropertyGraph.select_edges
+   PropertyGraph.select_vertices

--- a/python/pylibcugraph/pylibcugraph/utilities/api_tools.py
+++ b/python/pylibcugraph/pylibcugraph/utilities/api_tools.py
@@ -76,6 +76,7 @@ def experimental_warning_wrapper(obj):
         WarningWrapperClass.__module__ = ns_name
         WarningWrapperClass.__qualname__ = obj_name
         WarningWrapperClass.__name__ = obj_name
+        WarningWrapperClass.__doc__ = obj.__doc__
 
         return WarningWrapperClass
 
@@ -90,6 +91,7 @@ def experimental_warning_wrapper(obj):
     warning_wrapper_function.__module__ = ns_name
     warning_wrapper_function.__qualname__ = obj_name
     warning_wrapper_function.__name__ = obj_name
+    warning_wrapper_function.__doc__ = obj.__doc__
 
     return warning_wrapper_function
 


### PR DESCRIPTION
closes #3006 

* Updated experimental warning wrapper to also pass-through __doc__ attr
* Updated PropertyGraph doc .rst file to use the proper experimental namespace.