### PR TITLE
Update dask-cuda version and disable wheel builds in CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,6 @@
 name: cuGraph wheels
 
 on:
-  push:
-    branches:
-      - 'pull-request/[0-9]+'
   workflow_call:
     inputs:
       versioneer-override:
@@ -35,7 +32,7 @@ jobs:
     with:
       repo: rapidsai/cugraph
 
-      build-type: ${{ inputs.build-type || 'pull-request' }}
+      build-type: ${{ inputs.build-type }}
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
@@ -68,7 +65,7 @@ jobs:
     with:
       repo: rapidsai/cugraph
 
-      build-type: ${{ inputs.build-type || 'pull-request' }}
+      build-type: ${{ inputs.build-type }}
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -89,9 +89,9 @@ jobs:
       skbuild-configure-options: "-DDETECT_CONDA_ENV=OFF -DCUGRAPH_BUILD_WHEELS=ON -DCPM_cugraph-ops_SOURCE=/project/cugraph-ops/"
 
       # Always want to test against latest dask/distributed.
-      test-before-amd64: "pip install git+https://github.com/dask/dask.git@main git+https://github.com/dask/distributed.git@main"
+      test-before-amd64: "pip install git+https://github.com/dask/dask.git@main git+https://github.com/dask/distributed.git@main git+https://github.com/rapidsai/dask-cuda.git@branch-22.12"
       # On arm also need to install cupy from the specific webpage.
-      test-before-arm64: "pip install cupy-cuda11x -f https://pip.cupy.dev/aarch64 && pip install git+https://github.com/dask/dask.git@main git+https://github.com/dask/distributed.git@main"
+      test-before-arm64: "pip install cupy-cuda11x -f https://pip.cupy.dev/aarch64 && pip install git+https://github.com/dask/dask.git@main git+https://github.com/dask/distributed.git@main git+https://github.com/rapidsai/dask-cuda.git@branch-22.12"
       test-extras: test
       test-unittest: "RAPIDS_DATASET_ROOT_DIR=`pwd`/datasets pytest -v ./python/cugraph/cugraph/tests"
     secrets: inherit

--- a/python/cugraph/cugraph/dask/cores/k_core.py
+++ b/python/cugraph/cugraph/dask/cores/k_core.py
@@ -112,7 +112,7 @@ def k_core(input_graph, k=None, core_number=None, degree_type="bidirectional"):
     ...                          chunksize=chunksize, delimiter=" ",
     ...                          names=["src", "dst", "value"],
     ...                          dtype=["int32", "int32", "float32"])
-    >>> dg = cugraph.Graph(directed=True)
+    >>> dg = cugraph.Graph(directed=False)
     >>> dg.from_dask_cudf_edgelist(ddf, source='src', destination='dst',
     ...                            edge_attr='value')
     >>> KCore_df = dcg.k_core(dg)


### PR DESCRIPTION
We need to install dask-cuda from source during wheel builds for cugraph CI to pass because dask evolves too fast to pin. We also don't want to build wheels on every PR, so we'll need that disabled. I'll make that change once I confirm that wheel builds pass tests here.

This PR also fixes an unrelated issue causing doctests to fail. I'm guessing that because the docstring is in tests/mg it isn't being discovered during conda gpuCI because we exclude that directory from the pytest command in ci/test.sh.