### PR TITLE
Initialize CUDA architectures for all Python cugraph builds

### DIFF
--- a/python/cugraph/CMakeLists.txt
+++ b/python/cugraph/CMakeLists.txt
@@ -18,6 +18,11 @@ set(cugraph_version 22.12.00)
 
 include(../../fetch_rapids.cmake)
 
+# We always need CUDA for cuML because the raft dependency brings in a
+# header-only cuco dependency that enables CUDA unconditionally.
+include(rapids-cuda)
+rapids_cuda_init_architectures(cugraph-python)
+
 project(
   cugraph-python
   VERSION ${cugraph_version}
@@ -25,7 +30,7 @@ project(
             # language to be enabled here. The test project that is built in scikit-build to verify
             # various linking options for the python library is hardcoded to build with C, so until
             # that is fixed we need to keep C.
-            C CXX
+            C CXX CUDA
 )
 
 ################################################################################
@@ -51,16 +56,6 @@ endif()
 include(rapids-cython)
 
 if(NOT cugraph_FOUND)
-  # TODO: This will not be necessary once we upgrade to CMake 3.22, which will pull in the required
-  # languages for the C++ project even if this project does not require those languges.
-  include(rapids-cuda)
-  rapids_cuda_init_architectures(cugraph-python)
-  enable_language(CUDA)
-
-  # Since cugraph only enables CUDA optionally, we need to manually include the file that
-  # rapids_cuda_init_architectures relies on `project` including.
-  include("${CMAKE_PROJECT_cugraph-python_INCLUDE}")
-
   set(BUILD_TESTS OFF)
   set(BUILD_CUGRAPH_MG_TESTS OFF)
   set(BUILD_CUGRAPH_OPS_CPP_TESTS OFF)

--- a/python/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/CMakeLists.txt
@@ -18,6 +18,11 @@ set(pylibcugraph_version 22.12.00)
 
 include(../../fetch_rapids.cmake)
 
+# We always need CUDA for cuML because the raft dependency brings in a
+# header-only cuco dependency that enables CUDA unconditionally.
+include(rapids-cuda)
+rapids_cuda_init_architectures(pylibcugraph-python)
+
 project(
   pylibcugraph-python
   VERSION ${pylibcugraph_version}
@@ -25,7 +30,7 @@ project(
             # language to be enabled here. The test project that is built in scikit-build to verify
             # various linking options for the python library is hardcoded to build with C, so until
             # that is fixed we need to keep C.
-            C CXX
+            C CXX CUDA
 )
 
 ################################################################################
@@ -51,16 +56,6 @@ endif()
 include(rapids-cython)
 
 if (NOT cugraph_FOUND)
-  # TODO: This will not be necessary once we upgrade to CMake 3.22, which will pull in the required
-  # languages for the C++ project even if this project does not require those languges.
-  include(rapids-cuda)
-  rapids_cuda_init_architectures(pylibcugraph-python)
-  enable_language(CUDA)
-
-  # Since cugraph only enables CUDA optionally, we need to manually include the file that
-  # rapids_cuda_init_architectures relies on `project` including.
-  include("${CMAKE_PROJECT_pylibcugraph-python_INCLUDE}")
-
   set(BUILD_TESTS OFF)
   set(BUILD_CUGRAPH_MG_TESTS OFF)
   set(BUILD_CUGRAPH_OPS_CPP_TESTS OFF)


### PR DESCRIPTION
This is necessary because our dependencies are pulling in the CUDA language.