### PR TITLE
Fix cugraph_c target name in Python builds

### DIFF
--- a/python/pylibcugraph/pylibcugraph/internal_types/CMakeLists.txt
+++ b/python/pylibcugraph/pylibcugraph/internal_types/CMakeLists.txt
@@ -15,7 +15,7 @@
 set(cython_sources
     sampling_result.pyx
 )
-set(linked_libraries cugraph::cugraph;cugraph_c)
+set(linked_libraries cugraph::cugraph;cugraph::cugraph_c)
 
 rapids_cython_create_modules(
   CXX

--- a/python/pylibcugraph/pylibcugraph/testing/CMakeLists.txt
+++ b/python/pylibcugraph/pylibcugraph/testing/CMakeLists.txt
@@ -15,7 +15,7 @@
 set(cython_sources
     type_utils.pyx
 )
-set(linked_libraries cugraph::cugraph;cugraph_c)
+set(linked_libraries cugraph::cugraph;cugraph::cugraph_c)
 
 rapids_cython_create_modules(
   CXX


### PR DESCRIPTION
pylibcugraph is currently linking to the `cugraph_c` target directly rather than via the exported alias `cugraph::cugraph_c`. I am unsure under exactly what circumstances the former should be working, but I don't think it is reliable. I see failures locally without the change. I have currently made this PR into 22.12 because it seems like an important fix, but I can push it to 23.02 if needed.