### PR TITLE
[HOTFIX] Makes `cugraph-pyg` an optional depenency for `cugraph-service` tests

### DIFF
--- a/python/cugraph-service/tests/test_remote_graph.py
+++ b/python/cugraph-service/tests/test_remote_graph.py
@@ -26,7 +26,6 @@ import pandas as pd
 import numpy as np
 
 import cugraph
-from cugraph_pyg.loader.dispatch import call_cugraph_algorithm
 from cugraph.experimental import PropertyGraph
 from cugraph_service_client import RemoteGraph
 
@@ -717,6 +716,11 @@ def test_backend_torch(
 def test_remote_graph_neighbor_sample(
     client_with_property_csvs_loaded, pG_with_property_csvs_loaded
 ):
+    # FIXME: consider moving the call dispatcher into cugraph-service-client or
+    # cugraph proper. Import it here for now to allow tests to run in an
+    # environment without cugraph-pyg.
+    from cugraph_pyg.loader.dispatch import call_cugraph_algorithm
+
     rpG = RemoteGraph(client_with_property_csvs_loaded, 0)
     pG = pG_with_property_csvs_loaded
     selection = '_TYPE_=="transactions"'
@@ -758,6 +762,11 @@ def test_remote_graph_neighbor_sample(
 def test_remote_graph_neighbor_sample_implicit_subgraph(
     client_with_property_csvs_loaded, pG_with_property_csvs_loaded
 ):
+    # FIXME: consider moving the call dispatcher into cugraph-service-client or
+    # cugraph proper. Import it here for now to allow tests to run in an
+    # environment without cugraph-pyg.
+    from cugraph_pyg.loader.dispatch import call_cugraph_algorithm
+
     rpG = RemoteGraph(client_with_property_csvs_loaded, 0)
     pG = pG_with_property_csvs_loaded
 


### PR DESCRIPTION
closes #3050 

Docker image builds that include `cugraph-service` but do/can not include `cugraph-pyg` are blocked since they cannot run cugraph-service tests.  This PR allows those builds to skip the tests that use the cugraph-pyg feature and avoid the import of `cugraph_pyg`