### PR TITLE
Also use build isolation for editable builds.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -104,7 +104,7 @@ BUILD_CPP_MG_TESTS=OFF
 BUILD_ALL_GPU_ARCH=0
 BUILD_WITH_CUGRAPHOPS=ON
 CMAKE_GENERATOR_OPTION="-G Ninja"
-PYTHON_ARGS_FOR_INSTALL="-m pip install ."
+PYTHON_ARGS_FOR_INSTALL="-m pip install --no-build-isolation ."
 
 # Set defaults for vars that may not have been defined externally
 #  FIXME: if PREFIX is not set, check CONDA_PREFIX, but there is no fallback


### PR DESCRIPTION
This was an oversight in #3052. This change only impacts developers, so it is not necessary to hotfix like #3052.