### PR TITLE
Don't install dependencies with pip in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -104,7 +104,7 @@ BUILD_CPP_MG_TESTS=OFF
 BUILD_ALL_GPU_ARCH=0
 BUILD_WITH_CUGRAPHOPS=ON
 CMAKE_GENERATOR_OPTION="-G Ninja"
-PYTHON_ARGS_FOR_INSTALL="-m pip install --no-build-isolation ."
+PYTHON_ARGS_FOR_INSTALL="-m pip install --no-build-isolation --no-deps ."
 
 # Set defaults for vars that may not have been defined externally
 #  FIXME: if PREFIX is not set, check CONDA_PREFIX, but there is no fallback
@@ -175,7 +175,7 @@ if hasArg --cmake_default_generator; then
     CMAKE_GENERATOR_OPTION=""
 fi
 if hasArg --pydevelop; then
-    PYTHON_ARGS_FOR_INSTALL="-m pip install -e ."
+    PYTHON_ARGS_FOR_INSTALL="-m pip install -e --no-build-isolation --no-deps ."
 fi
 
 # If clean or uninstall targets given, run them prior to any other steps


### PR DESCRIPTION
build.sh should assume that all dependencies are already installed, for the same reasons as #3052.

Resolves #3057 