### PR TITLE
[HOTFIX] Removed unused testing code that caused a cudf dependency

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -104,7 +104,7 @@ BUILD_CPP_MG_TESTS=OFF
 BUILD_ALL_GPU_ARCH=0
 BUILD_WITH_CUGRAPHOPS=ON
 CMAKE_GENERATOR_OPTION="-G Ninja"
-PYTHON_ARGS_FOR_INSTALL="-m pip install --no-build-isolation ."
+PYTHON_ARGS_FOR_INSTALL="-m pip install --no-build-isolation --no-deps ."
 
 # Set defaults for vars that may not have been defined externally
 #  FIXME: if PREFIX is not set, check CONDA_PREFIX, but there is no fallback
@@ -175,7 +175,7 @@ if hasArg --cmake_default_generator; then
     CMAKE_GENERATOR_OPTION=""
 fi
 if hasArg --pydevelop; then
-    PYTHON_ARGS_FOR_INSTALL="-m pip install -e ."
+    PYTHON_ARGS_FOR_INSTALL="-m pip install --no-build-isolation --no-deps -e ."
 fi
 
 # If clean or uninstall targets given, run them prior to any other steps

--- a/build.sh
+++ b/build.sh
@@ -175,7 +175,7 @@ if hasArg --cmake_default_generator; then
     CMAKE_GENERATOR_OPTION=""
 fi
 if hasArg --pydevelop; then
-    PYTHON_ARGS_FOR_INSTALL="-m pip install --no-build-isolation -e ."
+    PYTHON_ARGS_FOR_INSTALL="-m pip install -e ."
 fi
 
 # If clean or uninstall targets given, run them prior to any other steps

--- a/build.sh
+++ b/build.sh
@@ -175,7 +175,7 @@ if hasArg --cmake_default_generator; then
     CMAKE_GENERATOR_OPTION=""
 fi
 if hasArg --pydevelop; then
-    PYTHON_ARGS_FOR_INSTALL="-m pip install -e ."
+    PYTHON_ARGS_FOR_INSTALL="-m pip install --no-build-isolation -e ."
 fi
 
 # If clean or uninstall targets given, run them prior to any other steps

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -54,3 +54,5 @@ dependencies:
 - gmock=1.10.0
 - py
 - versioneer
+- pip:
+    - cupy-cuda11x

--- a/conda/environments/cugraph_dev_cuda11.2.yml
+++ b/conda/environments/cugraph_dev_cuda11.2.yml
@@ -8,6 +8,7 @@ dependencies:
 - c-compiler
 - cxx-compiler
 - cudatoolkit=11.2
+- cupy>=9.5.0,<12.0.0a0
 - libcugraphops=22.12.*
 - cudf=22.12.*
 - libcudf=22.12.*
@@ -54,5 +55,3 @@ dependencies:
 - gmock=1.10.0
 - py
 - versioneer
-- pip:
-    - cupy-cuda11x

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -8,6 +8,7 @@ dependencies:
 - c-compiler
 - cxx-compiler
 - cudatoolkit=11.4
+- cupy>=9.5.0,<12.0.0a0
 - libcugraphops=22.12.*
 - cudf=22.12.*
 - libcudf=22.12.*
@@ -54,5 +55,3 @@ dependencies:
 - gmock=1.10.0
 - py
 - versioneer
-- pip:
-    - cupy-cuda11x

--- a/conda/environments/cugraph_dev_cuda11.4.yml
+++ b/conda/environments/cugraph_dev_cuda11.4.yml
@@ -54,3 +54,5 @@ dependencies:
 - gmock=1.10.0
 - py
 - versioneer
+- pip:
+    - cupy-cuda11x

--- a/conda/environments/cugraph_dev_cuda11.5.yml
+++ b/conda/environments/cugraph_dev_cuda11.5.yml
@@ -54,3 +54,5 @@ dependencies:
 - gmock=1.10.0
 - py
 - versioneer
+- pip:
+    - cupy-cuda11x

--- a/conda/environments/cugraph_dev_cuda11.5.yml
+++ b/conda/environments/cugraph_dev_cuda11.5.yml
@@ -8,6 +8,7 @@ dependencies:
 - c-compiler
 - cxx-compiler
 - cudatoolkit=11.5
+- cupy>=9.5.0,<12.0.0a0
 - libcugraphops=22.12.*
 - cudf=22.12.*
 - libcudf=22.12.*
@@ -54,5 +55,3 @@ dependencies:
 - gmock=1.10.0
 - py
 - versioneer
-- pip:
-    - cupy-cuda11x

--- a/conda/environments/cugraph_dev_cuda11.6.yml
+++ b/conda/environments/cugraph_dev_cuda11.6.yml
@@ -10,6 +10,7 @@ dependencies:
 - c-compiler
 - cxx-compiler
 - cudatoolkit=11.6
+- cupy>=9.5.0,<12.0.0a0
 - libcugraphops=22.12.*
 - cudf=22.12.*
 - libcudf=22.12.*
@@ -58,5 +59,3 @@ dependencies:
 - pytorch=1.12.0
 - dgl-cuda11.6
 - versioneer
-- pip:
-    - cupy-cuda11x

--- a/conda/environments/cugraph_dev_cuda11.6.yml
+++ b/conda/environments/cugraph_dev_cuda11.6.yml
@@ -58,3 +58,5 @@ dependencies:
 - pytorch=1.12.0
 - dgl-cuda11.6
 - versioneer
+- pip:
+    - cupy-cuda11x

--- a/python/cugraph-service/server/setup.py
+++ b/python/cugraph-service/server/setup.py
@@ -19,7 +19,7 @@ cmdclass = versioneer.get_cmdclass()
 install_requires = [
     "cugraph-service-client",
     "cugraph",
-    "cupy >=9.5.0,<12.0.0a0",
+    "cupy-cuda11x",
     "numpy",
     "ucx-py",
     "distributed ==2022.11.1",

--- a/python/pylibcugraph/pylibcugraph/egonet.pyx
+++ b/python/pylibcugraph/pylibcugraph/egonet.pyx
@@ -73,8 +73,8 @@ def ego_graph(ResourceHandle resource_handle,
 
     graph : SGGraph or MGGraph
         The input graph.
-    
-    source_vertices : cudf.Series
+
+    source_vertices : cupy array
         The centered nodes from which the induced subgraph will be extracted
 
     radius: size_t

--- a/python/pylibcugraph/pylibcugraph/testing/utils.py
+++ b/python/pylibcugraph/pylibcugraph/testing/utils.py
@@ -16,22 +16,11 @@ from pathlib import Path
 from itertools import product
 
 import pytest
-import cudf
-
 
 RAPIDS_DATASET_ROOT_DIR = os.getenv(
     "RAPIDS_DATASET_ROOT_DIR", os.path.join(os.path.dirname(__file__), "../datasets")
 )
 RAPIDS_DATASET_ROOT_DIR_PATH = Path(RAPIDS_DATASET_ROOT_DIR)
-
-
-def read_csv_file(csv_file, weights_dtype="float32"):
-    return cudf.read_csv(
-        csv_file,
-        delimiter=" ",
-        dtype=["int32", "int32", weights_dtype],
-        header=None,
-    )
 
 
 def genFixtureParamsProduct(*args):

--- a/python/pylibcugraph/setup.py
+++ b/python/pylibcugraph/setup.py
@@ -92,7 +92,6 @@ setup(
     package_data={key: ["*.pxd"] for key in find_packages(include=["pylibcugraph*"])},
     include_package_data=True,
     install_requires=[
-        f"cudf{cuda_suffix}",
         f"pylibraft{cuda_suffix}",
         f"rmm{cuda_suffix}",
     ],

--- a/python/pylibcugraph/setup.py
+++ b/python/pylibcugraph/setup.py
@@ -108,6 +108,7 @@ setup(
             "dask",
             "distributed",
             "dask-cuda",
+            f"cudf{cuda_suffix}",
         ]
     },
     cmake_process_manifest_hook=exclude_libcxx_symlink,


### PR DESCRIPTION
closes #3064 
closes #3057 

* Removed unused testing code that caused a `cudf` dependency
* Updated setup.py to remove cudf dependency
* Minor update to docstring to not specify cudf type
* Changed `cupy` dependency in `cugraph-service-server` to match the `cupy-cuda11x` dependency in `cugraph`
* Updated conda environment .yml files to add cupy

Note that the `pylibcugraph.testing` package is part of every install, and therefore any dependencies added to `testing` will cause all users to require them. The separate `extras_requires` are optional dependencies, in this case for running the unit tests. Some unit tests still use `cudf`, so cudf should be in `extras_require` and not `install_requires` since the ability to run the separate unit tests is optional.