### PR TITLE
Benchmark tool for uniform neighbor sampling C API

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(cugraphtestutil
     PRIVATE
         cuco::cuco
         GTest::gtest
+	rt
 )
 
 ###################################################################################################
@@ -68,6 +69,7 @@ function(ConfigureTest CMAKE_TEST_NAME)
             GTest::gtest
             GTest::gtest_main
             NCCL::NCCL
+	    rt
     )
 
     add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
@@ -95,6 +97,7 @@ function(ConfigureTestMG CMAKE_TEST_NAME)
         GTest::gtest_main
         NCCL::NCCL
         MPI::MPI_CXX
+	rt
     )
 
     add_test(NAME ${CMAKE_TEST_NAME}
@@ -126,6 +129,7 @@ function(ConfigureCTest CMAKE_TEST_NAME)
             cugraph_c_testutil
             GTest::gtest
             GTest::gtest_main
+	    rt
     )
 
     add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
@@ -152,6 +156,7 @@ function(ConfigureCTestMG CMAKE_TEST_NAME)
             GTest::gtest_main
             NCCL::NCCL
             MPI::MPI_CXX
+	    rt
     )
 
     add_test(NAME ${CMAKE_TEST_NAME}
@@ -412,6 +417,7 @@ if(BUILD_CUGRAPH_MG_TESTS)
             MPI::MPI_CXX
         PRIVATE
             GTest::gtest
+	    rt
     )
 
     # Set the GPU count to 1.  If the caller wants to execute MG tests using
@@ -581,6 +587,7 @@ if(BUILD_CUGRAPH_MG_TESTS)
 
     ###############################################################################################
     # - MG C API tests ----------------------------------------------------------------------------
+    ConfigureCTestMG(MG_CAPI_UNIFORM_NEIGHBOR_SAMPLE_BENCHMARK c_api/mg_uniform_neighbor_sample_benchmark.cpp c_api/mg_test_utils.cpp)
     ConfigureCTestMG(MG_CAPI_CREATE_GRAPH_TEST c_api/mg_create_graph_test.c c_api/mg_test_utils.cpp)
     ConfigureCTestMG(MG_CAPI_PAGERANK_TEST c_api/mg_pagerank_test.c c_api/mg_test_utils.cpp)
     ConfigureCTestMG(MG_CAPI_BFS_TEST c_api/mg_bfs_test.c c_api/mg_test_utils.cpp)
@@ -610,6 +617,8 @@ endif()
 # - common C API test utils -----------------------------------------------------------------------
 
 add_library(cugraph_c_testutil STATIC
+            utilities/thrust_wrapper.cu
+            utilities/test_utilities_mg.cu
             c_api/test_utils.cpp)
 
 target_compile_options(cugraph_c_testutil
@@ -621,6 +630,7 @@ set_property(TARGET cugraph_c_testutil PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(cugraph_c_testutil
     PUBLIC
+        "${CMAKE_CURRENT_SOURCE_DIR}/../../thirdparty/mmio"
         "${CMAKE_CURRENT_SOURCE_DIR}"
         "${CUGRAPH_SOURCE_DIR}/src"
 )

--- a/cpp/tests/c_api/mg_uniform_neighbor_sample_benchmark.cpp
+++ b/cpp/tests/c_api/mg_uniform_neighbor_sample_benchmark.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mg_test_utils.h"
+
+#include <utilities/cxxopts.hpp>
+#include <utilities/high_res_timer.hpp>
+#include <utilities/test_graphs.hpp>
+
+#include <c_api/graph.hpp>
+
+#include <cugraph_c/algorithms.h>
+#include <cugraph_c/graph.h>
+
+#include <math.h>
+
+#include <sstream>
+#include <vector>
+
+typedef int64_t vertex_t;
+typedef int64_t edge_t;
+typedef float weight_t;
+
+constexpr double a        = 0.57;
+constexpr double b        = 0.19;
+constexpr double c        = 0.19;
+data_type_id_t vertex_tid = INT64;
+data_type_id_t edge_tid   = INT64;
+data_type_id_t weight_tid = FLOAT32;
+constexpr bool store_transposed{FALSE};
+constexpr bool_t with_replacement{FALSE};
+
+int main(int argc, char** argv)
+{
+  // Set up MPI:
+  int comm_rank;
+  int comm_size;
+  int num_gpus_per_node;
+  cudaError_t status;
+  int mpi_status;
+
+  cugraph_resource_handle_t* handle = NULL;
+  cugraph_error_t* ret_error;
+  cugraph_error_code_t ret_code   = CUGRAPH_SUCCESS;
+  cugraph_sample_result_t* result = NULL;
+  int prows{1};
+  size_t scale{24};
+  size_t edge_factor{16};
+  uint64_t seed = std::chrono::system_clock::now().time_since_epoch().count();
+  bool clip_and_flip{false};
+  size_t num_test_iterations{10};
+  std::string fanout_str{"10,25"};
+  vertex_t number_of_start_vertices{100};
+
+  try {
+    cxxopts::Options options(argv[0], " - uniform neighbor sample benchmark command line options");
+    options.allow_unrecognised_options().add_options()(
+      "rmm_mode", "RMM allocation mode", cxxopts::value<std::string>()->default_value("pool"))(
+      "rmat_scale", "specify R-mat scale", cxxopts::value<size_t>()->default_value("24"))(
+      "rmat_edge_factor",
+      "specify R-mat edge factor",
+      cxxopts::value<size_t>()->default_value("16"))(
+      "num_iterations", "number of test iterations", cxxopts::value<size_t>()->default_value("10"))(
+      "fan_out",
+      "comma separate list of fanouts (e.g. 10,25)",
+      cxxopts::value<std::string>()->default_value("10,25"))(
+      "prows", "number of rows in GPU grid", cxxopts::value<int>()->default_value("1"))(
+      "number_start_vertices",
+      "number of starting vertices (batch size)",
+      cxxopts::value<vertex_t>()->default_value("100"));
+
+    auto cmd_opts = options.parse(argc, argv);
+
+    scale                    = cmd_opts["rmat_scale"].as<size_t>();
+    edge_factor              = cmd_opts["rmat_edge_factor"].as<size_t>();
+    prows                    = cmd_opts["prows"].as<int>();
+    num_test_iterations      = cmd_opts["num_iterations"].as<size_t>();
+    fanout_str               = cmd_opts["fan_out"].as<std::string>();
+    number_of_start_vertices = cmd_opts["number_start_vertices"].as<vertex_t>();
+
+  } catch (const cxxopts::OptionException& e) {
+    std::cerr << "Error parsing command line options: " << e.what() << std::endl;
+    exit(1);
+  }
+
+  C_MPI_TRY(MPI_Init(&argc, &argv));
+  C_MPI_TRY(MPI_Comm_rank(MPI_COMM_WORLD, &comm_rank));
+  C_MPI_TRY(MPI_Comm_size(MPI_COMM_WORLD, &comm_size));
+  C_CUDA_TRY(cudaGetDeviceCount(&num_gpus_per_node));
+  C_CUDA_TRY(cudaSetDevice(comm_rank % num_gpus_per_node));
+
+  raft::handle_t* raft_handle = static_cast<raft::handle_t*>(create_raft_handle(prows));
+  handle                      = cugraph_create_resource_handle(raft_handle);
+
+  std::vector<int32_t> fan_out;
+
+  std::stringstream fanout_stream(fanout_str);
+  while (fanout_stream.good()) {
+    std::string value;
+    std::getline(fanout_stream, value, ',');
+    fan_out.push_back(std::stoi(value));
+  }
+
+  cugraph::test::Rmat_Usecase rmat_usecase(
+    scale, edge_factor, a, b, c, seed, false, false, 0, clip_and_flip);
+
+  auto [src, dst, wgt, vertex, undirected] =
+    rmat_usecase.construct_edgelist<vertex_t, weight_t>(*raft_handle, true, store_transposed, true);
+
+  int test_ret_value = 0;
+
+  cugraph_graph_t* graph = NULL;
+
+  cugraph_type_erased_device_array_view_t* d_start_view = NULL;
+  cugraph_type_erased_host_array_view_t* h_fan_out_view = NULL;
+
+  cugraph_graph_properties_t properties;
+
+  properties.is_symmetric  = undirected ? FALSE : TRUE;
+  properties.is_multigraph = TRUE;
+
+  cugraph_type_erased_device_array_view_t* src_view;
+  cugraph_type_erased_device_array_view_t* dst_view;
+  cugraph_type_erased_device_array_view_t* wgt_view;
+
+  src_view = cugraph_type_erased_device_array_view_create(src.data(), src.size(), vertex_tid);
+  dst_view = cugraph_type_erased_device_array_view_create(dst.data(), dst.size(), vertex_tid);
+  wgt_view = cugraph_type_erased_device_array_view_create(wgt->data(), wgt->size(), weight_tid);
+
+  ret_code = cugraph_mg_graph_create(handle,
+                                     &properties,
+                                     src_view,
+                                     dst_view,
+                                     wgt_view,
+                                     NULL,  // need this...
+                                     NULL,  // need this...
+                                     store_transposed ? TRUE : FALSE,
+                                     src.size(),
+                                     FALSE,
+                                     &graph,
+                                     &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "graph creation failed.");
+
+  cugraph_type_erased_device_array_view_free(wgt_view);
+  cugraph_type_erased_device_array_view_free(dst_view);
+  cugraph_type_erased_device_array_view_free(src_view);
+
+  auto graph_view = reinterpret_cast<cugraph::graph_t<vertex_t, edge_t, store_transposed, true>*>(
+                      reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(graph)->graph_)
+                      ->view();
+  auto number_map = reinterpret_cast<rmm::device_uvector<vertex_t>*>(
+    reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(graph)->number_map_);
+
+  h_fan_out_view =
+    cugraph_type_erased_host_array_view_create(fan_out.data(), fan_out.size(), INT32);
+
+  HighResTimer timer;
+
+  for (size_t i = 0; i < num_test_iterations; ++i) {
+    auto start_vertices = cugraph::test::random_ext_vertex_ids<vertex_t, true>(
+      *raft_handle, *number_map, number_of_start_vertices, seed);
+
+    d_start_view = cugraph_type_erased_device_array_view_create(
+      start_vertices.data(), start_vertices.size(), vertex_tid);
+
+    if ((i > 0) && (comm_rank == 0)) timer.start("cugraph_uniform_neighbor_sample");
+
+    ret_code = cugraph_uniform_neighbor_sample(
+      handle, graph, d_start_view, h_fan_out_view, with_replacement, FALSE, &result, &ret_error);
+
+    if ((i > 0) && (comm_rank == 0)) timer.stop();
+
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
+    TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "uniform_neighbor_sample failed.");
+
+    cugraph_sample_result_free(result);
+    cugraph_type_erased_device_array_view_free(d_start_view);
+  }
+
+  if (comm_rank == 0) timer.display(std::cout);
+
+  cugraph_type_erased_host_array_view_free(h_fan_out_view);
+  cugraph_mg_graph_free(graph);
+  cugraph_error_free(ret_error);
+
+  free_raft_handle(raft_handle);
+
+  C_MPI_TRY(MPI_Finalize());
+
+  return ret_code;
+}

--- a/cpp/tests/utilities/test_utilities.hpp
+++ b/cpp/tests/utilities/test_utilities.hpp
@@ -517,5 +517,11 @@ struct device_nearly_equal {
   }
 };
 
+template <typename vertex_t, bool store_transposed>
+rmm::device_uvector<vertex_t> random_ext_vertex_ids(raft::handle_t const& handle,
+                                                    rmm::device_uvector<vertex_t> const& number_map,
+                                                    vertex_t count,
+                                                    uint64_t seed);
+
 }  // namespace test
 }  // namespace cugraph

--- a/cpp/tests/utilities/test_utilities_mg.cu
+++ b/cpp/tests/utilities/test_utilities_mg.cu
@@ -294,5 +294,13 @@ mg_graph_to_sg_graph(
   std::optional<rmm::device_uvector<int64_t>> const& number_map,
   bool renumber);
 
+template rmm::device_uvector<int64_t> random_ext_vertex_ids<int64_t, true>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t> const& number_map,
+  int64_t count,
+  uint64_t seed);
+
+// FIXME: Need more random_ext_vertex_ids
+
 }  // namespace test
 }  // namespace cugraph

--- a/cpp/tests/utilities/test_utilities_sg.cu
+++ b/cpp/tests/utilities/test_utilities_sg.cu
@@ -162,5 +162,13 @@ graph_to_host_csr(
   cugraph::graph_view_t<int64_t, int64_t, true, false> const& graph_view,
   std::optional<cugraph::edge_property_view_t<int64_t, double const*>> edge_weight_view);
 
+template rmm::device_uvector<int64_t> random_ext_vertex_ids<int64_t, false>(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t> const& number_map,
+  int64_t count,
+  uint64_t seed);
+
+// FIXME: Need more random_ext_vertex_ids
+
 }  // namespace test
 }  // namespace cugraph


### PR DESCRIPTION
This PR contains a new benchmarking tool for timing the uniform neighbor sampling algorithm from the C API.

The code is a mix of C/C++ - to take advantage of the C++ test infrastructure that we have built.

This branch contains a hack (adding `rt` to the libraries to work around the problem corrected by #3049).  Once PR 3049 is merged we can undo that hack and this will be ready to review/merge.
