### PR TITLE
Update `cugraph` recipes

### DIFF
--- a/conda/recipes/cugraph-pyg/meta.yaml
+++ b/conda/recipes/cugraph-pyg/meta.yaml
@@ -35,6 +35,9 @@ requirements:
     - numba>=0.56.2
     - numpy
     - pytorch
+    # TODO: Determine if `cudatoolkit` is a necessary runtime dependency for this package.
+    # If so, the version spec may need to be changed to `11.0>=,<12.0` to match the rest of our packages.
+    # If not, we should remove `cudatoolkit` and update the version string above accordingly.
     - cudatoolkit {{ cuda_version }}.*
     # - pyg (uncomment once pyg 2.2 is released)
 

--- a/conda/recipes/cugraph-pyg/meta.yaml
+++ b/conda/recipes/cugraph-pyg/meta.yaml
@@ -35,9 +35,6 @@ requirements:
     - numba>=0.56.2
     - numpy
     - pytorch
-    # TODO: Determine if `cudatoolkit` is a necessary runtime dependency for this package.
-    # If so, the version spec may need to be changed to `11.0>=,<12.0` to match the rest of our packages.
-    # If not, we should remove `cudatoolkit` and update the version string above accordingly.
     - cudatoolkit {{ cuda_version }}.*
     # - pyg (uncomment once pyg 2.2 is released)
 

--- a/conda/recipes/cugraph-pyg/meta.yaml
+++ b/conda/recipes/cugraph-pyg/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - distributed>=2022.12.0
     - numba>=0.56.2
     - numpy
-    - pytorch
+    - pytorch <=1.12
     # - pyg (uncomment once pyg 2.2 is released)
 
 tests:                                 # [linux64]

--- a/conda/recipes/cugraph-pyg/meta.yaml
+++ b/conda/recipes/cugraph-pyg/meta.yaml
@@ -4,9 +4,8 @@
 #   conda build -c rapidsai -c conda-forge -c nvidia .
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
-{% set cuda_version='.'.join(environ.get('CUDA', 'unknown').split('.')[:2]) %}
-{% set cuda_major=cuda_version.split('.')[0] %}
 {% set py_version=environ.get('CONDA_PY', 36) %}
+
 package:
   name: cugraph-pyg
   version: {{ version }}
@@ -16,7 +15,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: cuda{{ cuda_major }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - PARALLEL_LEVEL
   preserve_egg_dir: True
@@ -35,7 +34,6 @@ requirements:
     - numba>=0.56.2
     - numpy
     - pytorch
-    - cudatoolkit {{ cuda_version }}.*
     # - pyg (uncomment once pyg 2.2 is released)
 
 tests:                                 # [linux64]

--- a/conda/recipes/cugraph-service/meta.yaml
+++ b/conda/recipes/cugraph-service/meta.yaml
@@ -50,14 +50,14 @@ outputs:
       run:
         - python x.x
         - thriftpy2 >=0.4.15
-        - {{ pin_compatible('cugraph-service-client', exact=True) }}
-        - {{ pin_compatible('cugraph', exact=True) }}
+        - {{ pin_subpackage('cugraph-service-client', exact=True) }}
         - cupy >=9.5.0,<12.0.0a0
         - numpy
         - ucx-py {{ ucx_py_version }}
         - distributed >=2022.12.0
         - dask-cuda {{ minor_version }}.*
         - cudf {{ minor_version }}.*
+        - cugraph {{ minor_version }}.*
         - dask-cudf {{ minor_version }}.*
 
 tests:                                 # [linux64]

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -44,7 +44,6 @@ requirements:
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
     - cudatoolkit {{ cuda_version }}.*
-    - libraft-headers {{ minor_version }}
     - setuptools
     - versioneer
   run:


### PR DESCRIPTION
This PR includes the following changes:

- Uses `pin_subpackage` to specify the relationship between `cugraph-service-client` and `cugraph-service-server`
- Switches the `cugraph` dependency to use a regular version specifier since `pin_compatible` and `pin_subpackage` aren't applicable since `cugraph` is built in a different recipe
 
These changes are necessary because `pin_compatible` only works with dependencies that are listed in the `build`/`host` section of a given package ([relevant conda docs](https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#extra-jinja2-functions)).

Additionally: 

- the `cudatoolkit` package has been removed from the `run` dependencies since it's not explicitly used in `cugraph-pyg` and comes in transitively through the other dependencies
- a duplicate `libraft-headers` entry has been removed from the `cugraph` recipe