### PR TITLE
GH Actions Notebook Testing Fixes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,6 +15,7 @@ jobs:
       - checks
       - conda-cpp-build
       - conda-cpp-tests
+      - conda-notebook-tests
       - conda-python-build
       - conda-python-tests
     secrets: inherit

--- a/conda/environments/all_cuda-115_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-115_arch-x86_64.yaml
@@ -32,7 +32,6 @@ dependencies:
 - nccl>=2.9.9
 - networkx>=2.5.1
 - ninja
-- notebook
 - notebook>=0.5.0
 - numpydoc
 - nvcc_linux-64=11.5

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -127,7 +127,6 @@ dependencies:
           - distributed>=2022.12.0
           - libcudf=23.02.*
           - nccl>=2.9.9
-          - notebook>=0.5.0
           - pylibraft=23.02.*
           - raft-dask=23.02.*
           - rmm=23.02.*
@@ -160,7 +159,7 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - ipython
-          - notebook
+          - notebook>=0.5.0
   test_python:
     common:
       - output_types: [conda, requirements]


### PR DESCRIPTION
This PR contains fixes for some things I missed in #3095.

Specifically:

- Adds the `conda-notebook-tests` job as a dependency of the `pr-builder` job
- Removes a duplicate `notebook` dependency from `dependencies.yaml`