### PR TITLE
Update UCX Dockerfile to Include Build Packages

### DIFF
--- a/benchmarks/shared/build_cugraph_ucx/cugraph_ucx.dockerfile
+++ b/benchmarks/shared/build_cugraph_ucx/cugraph_ucx.dockerfile
@@ -33,8 +33,13 @@ RUN apt-get update -y \
         curl \
         librdmacm-dev \
         rdma-core \
+        gcc-10 \
+        g++-10 \
     && apt-get autoremove -y \
     && apt-get clean
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
 
 ARG PYTHON_VER=3.9
 ARG RAPIDS_VER=23.02

--- a/benchmarks/shared/build_cugraph_ucx/cugraph_ucx.dockerfile
+++ b/benchmarks/shared/build_cugraph_ucx/cugraph_ucx.dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -54,19 +54,31 @@ RUN gpuci_mamba_retry install -y -c pytorch -c rapidsai-nightly -c rapidsai -c c
     setuptools \
     tqdm
 
+RUN mamba install -c conda-forge -c rapidsai-nightly -c rapidsai -y \
+    ninja \
+    versioneer \
+    scikit-build \
+    cmake=3.23.1 \
+    cython \
+    scikit-build=0.13.1 \
+    pytest \
+    pytest-cov \
+    rapids-pytest-benchmark \
+    py \
+    networkx=2.5.1 \
+    scipy
 
 # Build ucx from source with IB support 
 # on 1.14.x
 RUN conda remove --force -y ucx ucx-proc
 
-ADD build-ucx.sh /root/build-ucx.sh
-RUN chmod 744 /root/build-ucx.sh & bash /root/build-ucx.sh
+ADD build-ucx.sh /home/build-ucx.sh
+RUN chmod 744 ./home/build-ucx.sh & bash ./home/build-ucx.sh
 
-
-ADD test_client_bandwidth.py  /root/test_client_bandwidth.py
-RUN chmod 777 /root/test_client_bandwidth.py
-ADD test_cugraph_sampling.py  /root/test_cugraph_sampling.py
-RUN chmod 777 /root/test_cugraph_sampling.py
+ADD test_client_bandwidth.py  /home/test_client_bandwidth.py
+RUN chmod 777 /home/test_client_bandwidth.py
+ADD test_cugraph_sampling.py  /home/test_cugraph_sampling.py
+RUN chmod 777 /home/test_cugraph_sampling.py
 
 ENV PATH /opt/conda/env/bin:$PATH
-WORKDIR /root/
+WORKDIR /home/


### PR DESCRIPTION
The current UCX Dockerfile does not include packages required for building cugraph, which this version adds.

Closes #3122 