### PR TITLE
Update to support NetworkX 3.0 (and handle other deprecations)

### DIFF
--- a/conda/environments/all_cuda-115_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-115_arch-x86_64.yaml
@@ -30,7 +30,7 @@ dependencies:
 - librmm=23.02.*
 - nbsphinx
 - nccl>=2.9.9
-- networkx>=2.5.1,<3.0
+- networkx>=2.5.1
 - ninja
 - notebook>=0.5.0
 - numpydoc

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -151,7 +151,7 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - aiohttp
-          - networkx>=2.5.1,<3.0
+          - networkx>=2.5.1
           - requests
           - scipy
   test_notebook:

--- a/python/cugraph/cugraph/tests/generators/test_rmat.py
+++ b/python/cugraph/cugraph/tests/generators/test_rmat.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -74,6 +74,7 @@ def teardown_module():
 
 
 ###############################################################################
+@pytest.mark.filterwarnings("ignore:make_current is deprecated:DeprecationWarning")
 @pytest.mark.parametrize("scale", _scale_values, ids=_scale_test_ids)
 @pytest.mark.parametrize("mg", _mg_values, ids=_mg_test_ids)
 def test_rmat_edgelist(scale, mg):
@@ -97,6 +98,7 @@ def test_rmat_edgelist(scale, mg):
     assert len(df_to_check) == num_edges
 
 
+@pytest.mark.filterwarnings("ignore:make_current is deprecated:DeprecationWarning")
 @pytest.mark.parametrize("graph_type", _graph_types, ids=_graph_test_ids)
 @pytest.mark.parametrize("mg", _mg_values, ids=_mg_test_ids)
 def test_rmat_return_type(graph_type, mg):

--- a/python/cugraph/cugraph/tests/test_betweenness_centrality.py
+++ b/python/cugraph/cugraph/tests/test_betweenness_centrality.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.:
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.:
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -160,7 +160,7 @@ def _calc_bc_subset(G, Gnx, normalized, weight, endpoints, k, seed, result_dtype
     # And the sampling is operated on Gnx.nodes() directly
     # We first mimic acquisition of the nodes to compare with same sources
     random.seed(seed)  # It will be called again in nx's call
-    sources = random.sample(Gnx.nodes(), k)
+    sources = random.sample(list(Gnx.nodes()), k)
     df = cugraph.betweenness_centrality(
         G,
         k=sources,

--- a/python/cugraph/cugraph/tests/test_bfs.py
+++ b/python/cugraph/cugraph/tests/test_bfs.py
@@ -277,7 +277,7 @@ def get_cu_graph_nx_results_and_params(seed, depth_limit, G, dataset, directed, 
     Helper for fixtures returning Nx results and params.
     """
     random.seed(seed)
-    start_vertex = random.sample(Gnx.nodes(), 1)[0]
+    start_vertex = random.sample(list(Gnx.nodes()), 1)[0]
 
     nx_values = nx.single_source_shortest_path_length(
         Gnx, start_vertex, cutoff=depth_limit

--- a/python/cugraph/cugraph/tests/test_convert_matrix.py
+++ b/python/cugraph/cugraph/tests/test_convert_matrix.py
@@ -107,8 +107,8 @@ def test_from_to_numpy(graph_file):
     # convert graphs to numpy array
     nparray_nx = nx.to_numpy_array(nxG, nodelist=cuG.nodes().values_host)
     nparray_cu = cugraph.to_numpy_array(cuG)
-    npmatrix_nx = nx.to_numpy_matrix(nxG, nodelist=cuG.nodes().values_host)
-    npmatrix_cu = cugraph.to_numpy_matrix(cuG)
+    npmatrix_nx = nx.to_numpy_array(nxG, nodelist=cuG.nodes().values_host)
+    npmatrix_cu = cugraph.to_numpy_array(cuG)
 
     # Compare arrays and matrices
     assert np.array_equal(nparray_nx, nparray_cu)
@@ -135,8 +135,8 @@ def test_from_to_numpy(graph_file):
     assert exp_pdf.equals(res_pdf)
 
     # Create graphs from numpy matrix
-    new_nxG = nx.from_numpy_matrix(npmatrix_nx, create_using=nx.DiGraph)
-    new_cuG = cugraph.from_numpy_matrix(
+    new_nxG = nx.from_numpy_array(npmatrix_nx, create_using=nx.DiGraph)
+    new_cuG = cugraph.from_numpy_array(
         npmatrix_cu, create_using=cugraph.Graph(directed=True)
     )
 

--- a/python/cugraph/cugraph/tests/test_edge_betweenness_centrality.py
+++ b/python/cugraph/cugraph/tests/test_edge_betweenness_centrality.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.:
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.:
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -162,7 +162,7 @@ def _calc_bc_subset(G, Gnx, normalized, weight, k, seed, result_dtype):
     # And the sampling is operated on Gnx.nodes() directly
     # We first mimic acquisition of the nodes to compare with same sources
     random.seed(seed)  # It will be called again in nx's call
-    sources = random.sample(Gnx.nodes(), k)
+    sources = random.sample(list(Gnx.nodes()), k)
 
     # NOTE: Since we sampled the Networkx graph, the sources are already
     # external ids, so we don't need to translate to external ids for

--- a/python/cugraph/cugraph/tests/test_graph.py
+++ b/python/cugraph/cugraph/tests/test_graph.py
@@ -372,6 +372,7 @@ def test_view_edge_list_for_Graph(graph_file):
 
 
 # Test
+@pytest.mark.filterwarnings("ignore:make_current is deprecated:DeprecationWarning")
 @pytest.mark.parametrize("graph_file", utils.DATASETS)
 def test_consolidation(graph_file):
     cluster = LocalCUDACluster()

--- a/python/cugraph/cugraph/tests/test_hungarian.py
+++ b/python/cugraph/cugraph/tests/test_hungarian.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -60,7 +60,7 @@ def setup_function():
 
 @pytest.mark.parametrize("v1_size, v2_size, weight_limit", SPARSE_SIZES)
 def test_hungarian(v1_size, v2_size, weight_limit):
-    v1, g, m = create_random_bipartite(v1_size, v2_size, weight_limit, np.float)
+    v1, g, m = create_random_bipartite(v1_size, v2_size, weight_limit, np.float64)
 
     start = timer()
     cugraph_cost, matching = cugraph.hungarian(g, v1)

--- a/python/cugraph/cugraph/tests/test_paths.py
+++ b/python/cugraph/cugraph/tests/test_paths.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -16,7 +16,7 @@ from tempfile import NamedTemporaryFile
 import math
 
 import cudf
-from cupy.sparse import coo_matrix as cupy_coo_matrix
+from cupyx.scipy.sparse import coo_matrix as cupy_coo_matrix
 import cupy
 import networkx as nx
 import pytest

--- a/python/cugraph/cugraph/traversal/sssp.py
+++ b/python/cugraph/cugraph/traversal/sssp.py
@@ -109,8 +109,8 @@ def _convert_df_to_output_type(df, input_type, return_predecessors):
         if return_predecessors:
             if is_cp_matrix_type(input_type):
                 return (
-                    cp.fromDlpack(sorted_df["distance"].to_dlpack()),
-                    cp.fromDlpack(sorted_df["predecessor"].to_dlpack()),
+                    cp.from_dlpack(sorted_df["distance"].to_dlpack()),
+                    cp.from_dlpack(sorted_df["predecessor"].to_dlpack()),
                 )
             else:
                 return (
@@ -119,7 +119,7 @@ def _convert_df_to_output_type(df, input_type, return_predecessors):
                 )
         else:
             if is_cp_matrix_type(input_type):
-                return cp.fromDlpack(sorted_df["distance"].to_dlpack())
+                return cp.from_dlpack(sorted_df["distance"].to_dlpack())
             else:
                 return sorted_df["distance"].to_numpy()
     else:


### PR DESCRIPTION
Closes #3084 and mostly takes care of #3068 (I didn't update `PendingDeprecationWarning`s that originate from `cugraph`).

Old versions of NetworkX should continue to work.

I ran the tests (and many--but not all--of the notebooks) with `-Werror::DeprecationWarning` to uncover issues.

`tornado` warns `DeprecationWarning: make_current is deprecated; start the event loop first`, which originate from their code. They deprecated it, but didn't update their code yet, so I updated the tests to ignore it.