### PR TITLE
[FEA] Enable using cugraph uniform sampling in multi client environments

### DIFF
--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -156,7 +156,8 @@ def uniform_neighbor_sample(
         Random seed to use when making sampling calls.
 
     _multiple_clients: bool, optional (default=False)
-        internal flag to ensure sampling works with multiple clients
+        internal flag to ensure sampling works with multiple dask clients
+        set to True to prevent hangs in multi-client environment
 
     Returns
     -------
@@ -189,6 +190,9 @@ def uniform_neighbor_sample(
                 Contains the hop ids from the sampling result
     """
     if _multiple_clients:
+        # Distributed centralized lock to allow
+        # two disconnected processes to coordinate a lock
+        # https://docs.dask.org/en/stable/futures.html?highlight=lock#distributed.Lock
         lock = Lock("sampling_mg_lock")
         lock.acquire(timeout=1)
 

--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -111,6 +111,45 @@ def _call_plc_uniform_neighbor_sample(
     return convert_to_cudf(cp_arrays, weight_t, with_edge_properties)
 
 
+def _mg_call_plc_uniform_neighbor_sample(
+    client,
+    session_id,
+    input_graph,
+    ddf,
+    fanout_vals,
+    with_replacement,
+    weight_t,
+    indices_t,
+    with_edge_properties,
+    random_state,
+):
+    result = [
+        client.submit(
+            _call_plc_uniform_neighbor_sample,
+            session_id,
+            input_graph._plc_graph[w],
+            ddf[w][0],
+            fanout_vals,
+            with_replacement,
+            weight_t=weight_t,
+            with_edge_properties=with_edge_properties,
+            # FIXME accept and properly transmute a numpy/cupy random state.
+            random_state=hash((random_state, i)),
+            workers=[w],
+            allow_other_workers=False,
+            pure=False,
+        )
+        for i, w in enumerate(Comms.get_workers())
+    ]
+
+    ddf = dask_cudf.from_delayed(
+        result, meta=create_empty_df(indices_t, weight_t), verify_meta=False
+    ).persist()
+    wait(ddf)
+    wait([r.release() for r in result])
+    return ddf
+
+
 def uniform_neighbor_sample(
     input_graph,
     start_list,
@@ -189,12 +228,6 @@ def uniform_neighbor_sample(
             df['hop_id']: dask_cudf.Series
                 Contains the hop ids from the sampling result
     """
-    if _multiple_clients:
-        # Distributed centralized lock to allow
-        # two disconnected processes (clients) to coordinate a lock
-        # https://docs.dask.org/en/stable/futures.html?highlight=lock#distributed.Lock
-        lock = Lock("sampling_mg_lock")
-        lock.acquire(timeout=1)
 
     if isinstance(start_list, int):
         start_list = [start_list]
@@ -248,32 +281,45 @@ def uniform_neighbor_sample(
         ddf = ddf.worker_to_parts
 
     client = input_graph._client
-
     session_id = Comms.get_session_id()
-    result = [
-        client.submit(
-            _call_plc_uniform_neighbor_sample,
-            session_id,
-            input_graph._plc_graph[w],
-            ddf[w][0],
-            fanout_vals,
-            with_replacement,
+    if _multiple_clients:
+        # Distributed centralized lock to allow
+        # two disconnected processes (clients) to coordinate a lock
+        # https://docs.dask.org/en/stable/futures.html?highlight=lock#distributed.Lock
+        lock = Lock("plc_graph_access")
+        if lock.acquire(timeout=100):
+            try:
+                ddf = _mg_call_plc_uniform_neighbor_sample(
+                    client=client,
+                    session_id=session_id,
+                    input_graph=input_graph,
+                    ddf=ddf,
+                    fanout_vals=fanout_vals,
+                    with_replacement=with_replacement,
+                    weight_t=weight_t,
+                    indices_t=indices_t,
+                    with_edge_properties=with_edge_properties,
+                    random_state=random_state,
+                )
+            finally:
+                lock.release()
+        else:
+            raise RuntimeError(
+                "Failed to acquire lock(plc_graph_access) while trying to sampling"
+            )
+    else:
+        ddf = _mg_call_plc_uniform_neighbor_sample(
+            client=client,
+            session_id=session_id,
+            input_graph=input_graph,
+            ddf=ddf,
+            fanout_vals=fanout_vals,
+            with_replacement=with_replacement,
             weight_t=weight_t,
+            indices_t=indices_t,
             with_edge_properties=with_edge_properties,
-            # FIXME accept and properly transmute a numpy/cupy random state.
-            random_state=hash((random_state, i)),
-            workers=[w],
-            allow_other_workers=False,
-            pure=False,
+            random_state=random_state,
         )
-        for i, w in enumerate(Comms.get_workers())
-    ]
-
-    ddf = dask_cudf.from_delayed(
-        result, meta=create_empty_df(indices_t, weight_t), verify_meta=False
-    ).persist()
-    wait(ddf)
-    wait([r.release() for r in result])
 
     if input_graph.renumbered:
         ddf = input_graph.unrenumber(ddf, "sources", preserve_order=True)

--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -191,7 +191,7 @@ def uniform_neighbor_sample(
     """
     if _multiple_clients:
         # Distributed centralized lock to allow
-        # two disconnected processes to coordinate a lock
+        # two disconnected processes (clients) to coordinate a lock
         # https://docs.dask.org/en/stable/futures.html?highlight=lock#distributed.Lock
         lock = Lock("sampling_mg_lock")
         lock.acquire(timeout=1)
@@ -250,7 +250,6 @@ def uniform_neighbor_sample(
     client = input_graph._client
 
     session_id = Comms.get_session_id()
-    random_state = hash(None)
     result = [
         client.submit(
             _call_plc_uniform_neighbor_sample,

--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -325,7 +325,4 @@ def uniform_neighbor_sample(
         ddf = input_graph.unrenumber(ddf, "sources", preserve_order=True)
         ddf = input_graph.unrenumber(ddf, "destinations", preserve_order=True)
 
-    if _multiple_clients:
-        lock.release()
-
     return ddf

--- a/python/cugraph/cugraph/tests/test_uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/tests/test_uniform_neighbor_sample.py
@@ -443,3 +443,8 @@ def test_uniform_neighbor_sample_empty_start_list():
     )
 
     assert sampling_results.empty
+
+
+@pytest.mark.skip(reason="needs to be written!")
+def test_multi_client_sampling():
+    pass

--- a/python/cugraph/cugraph/tests/test_uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/tests/test_uniform_neighbor_sample.py
@@ -449,4 +449,4 @@ def test_uniform_neighbor_sample_empty_start_list():
 def test_multi_client_sampling():
     # See gist for example test to write
     # https://gist.github.com/VibhuJawa/1b705427f7a0c5a2a4f58e0a3e71ef21
-    pass
+    raise NotImplementedError

--- a/python/cugraph/cugraph/tests/test_uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/tests/test_uniform_neighbor_sample.py
@@ -447,4 +447,6 @@ def test_uniform_neighbor_sample_empty_start_list():
 
 @pytest.mark.skip(reason="needs to be written!")
 def test_multi_client_sampling():
+    # See gist for example test to write
+    # https://gist.github.com/VibhuJawa/1b705427f7a0c5a2a4f58e0a3e71ef21
     pass


### PR DESCRIPTION
In multi client environments our sampling algorithms tend to hang, this PR adds a lock to prevent that from happening.  This PR closes https://github.com/rapidsai/cugraph/issues/3186

See [notebooks](https://gist.github.com/VibhuJawa/1b705427f7a0c5a2a4f58e0a3e71ef21) here with MRE to reproduce. 


Before PR (HANG): 
<img width="1721" alt="Screen Shot 2023-01-25 at 9 01 39 PM" src="https://user-images.githubusercontent.com/4837571/214762758-0ad9b45b-b089-49b6-a0f5-cb08b4597e4f.png">
After PR (NO HANG): 
<img width="1721" alt="Screen Shot 2023-01-25 at 9 07 02 PM" src="https://user-images.githubusercontent.com/4837571/214762771-031e57e4-e657-40a6-95ba-c9b72f963b6a.png">


I have not added tests for this here because mocking dask with multi client environment is not possible in CI yet so we will do this as future work. 

Also includes a bug fix in our sampling code path.  