### PR TITLE
Fix off-by-one in start_dask_client

### DIFF
--- a/python/cugraph/cugraph/dask/common/mg_utils.py
+++ b/python/cugraph/cugraph/dask/common/mg_utils.py
@@ -105,7 +105,7 @@ def start_dask_client():
     n_devices = os.getenv("DASK_NUM_WORKERS", 2)
     n_devices = int(n_devices)
 
-    visible_devices = ",".join([str(i) for i in range(1, n_devices + 1)])
+    visible_devices = ",".join(map(str, range(n_devices)))
 
     cluster = LocalCUDACluster(
         protocol="ucx", rmm_pool_size="25GB", CUDA_VISIBLE_DEVICES=visible_devices


### PR DESCRIPTION
PR #3082 introduced a new version of start_dask_client, but requests devices [1, N], rather than [0, N) as the previous (still extant in testing/mg_utils) version gave us.

Closes #3187.