### PR TITLE
[WIP] Make graph objects serializable

### DIFF
--- a/python/cugraph/cugraph/dask/centrality/eigenvector_centrality.py
+++ b/python/cugraph/cugraph/dask/centrality/eigenvector_centrality.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from dask.distributed import wait
+from dask.distributed import wait, default_client
 
 from pylibcugraph import (
     eigenvector_centrality as pylib_eigen,
@@ -112,7 +112,7 @@ def eigenvector_centrality(input_graph, max_iter=100, tol=1.0e-6):
     >>> ec = dcg.eigenvector_centrality(dg)
 
     """
-    client = input_graph._client
+    client = default_client()
 
     if input_graph.store_transposed is False:
         warning_msg = (

--- a/python/cugraph/cugraph/dask/centrality/katz_centrality.py
+++ b/python/cugraph/cugraph/dask/centrality/katz_centrality.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from dask.distributed import wait
+from dask.distributed import wait, default_client
 from pylibcugraph import ResourceHandle, katz_centrality as pylibcugraph_katz
 import cugraph.dask.comms.comms as Comms
 import dask_cudf
@@ -141,7 +141,7 @@ def katz_centrality(
     >>> pr = dcg.katz_centrality(dg)
 
     """
-    client = input_graph._client
+    client = default_client()
 
     if input_graph.store_transposed is False:
         warning_msg = (

--- a/python/cugraph/cugraph/dask/community/egonet.py
+++ b/python/cugraph/cugraph/dask/community/egonet.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from dask.distributed import wait
+from dask.distributed import wait, default_client
 
 import cugraph.dask.comms.comms as Comms
 import dask_cudf
@@ -108,7 +108,7 @@ def ego_graph(input_graph, n, radius=1, center=True):
     """
 
     # Initialize dask client
-    client = input_graph._client
+    client = default_client()
 
     if isinstance(n, (int, list)):
         n = cudf.Series(n)

--- a/python/cugraph/cugraph/dask/community/louvain.py
+++ b/python/cugraph/cugraph/dask/community/louvain.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from dask.distributed import wait
+from dask.distributed import wait, default_client
 import cugraph.dask.comms.comms as Comms
 import dask_cudf
 import cudf
@@ -102,7 +102,7 @@ def louvain(input_graph, max_iter=100, resolution=1.0):
         raise ValueError("input graph must be undirected")
 
     # Initialize dask client
-    client = input_graph._client
+    client = default_client()
 
     do_expensive_check = False
 

--- a/python/cugraph/cugraph/dask/community/triangle_count.py
+++ b/python/cugraph/cugraph/dask/community/triangle_count.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from dask.distributed import wait
+from dask.distributed import wait, default_client
 
 import cugraph.dask.comms.comms as Comms
 import dask_cudf
@@ -79,7 +79,7 @@ def triangle_count(input_graph, start_list=None):
     if input_graph.is_directed():
         raise ValueError("input graph must be undirected")
     # Initialize dask client
-    client = input_graph._client
+    client = default_client()
 
     if start_list is not None:
         if isinstance(start_list, int):

--- a/python/cugraph/cugraph/dask/components/connectivity.py
+++ b/python/cugraph/cugraph/dask/components/connectivity.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from dask.distributed import wait
+from dask.distributed import wait, default_client
 import cugraph.dask.comms.comms as Comms
 import dask_cudf
 import cudf
@@ -92,7 +92,7 @@ def weakly_connected_components(input_graph):
         raise ValueError("input graph must be undirected")
 
     # Initialize dask client
-    client = input_graph._client
+    client = default_client()
 
     do_expensive_check = False
 

--- a/python/cugraph/cugraph/dask/cores/core_number.py
+++ b/python/cugraph/cugraph/dask/cores/core_number.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from dask.distributed import wait
+from dask.distributed import wait, default_client
 import cugraph.dask.comms.comms as Comms
 import dask_cudf
 import cudf
@@ -84,7 +84,7 @@ def core_number(input_graph, degree_type="bidirectional"):
         )
 
     # Initialize dask client
-    client = input_graph._client
+    client = default_client()
 
     do_expensive_check = False
 

--- a/python/cugraph/cugraph/dask/cores/k_core.py
+++ b/python/cugraph/cugraph/dask/cores/k_core.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from dask.distributed import wait
+from dask.distributed import wait, default_client
 import cugraph.dask.comms.comms as Comms
 from cugraph.dask.common.input_utils import get_distributed_data
 import dask_cudf
@@ -160,7 +160,7 @@ def k_core(input_graph, k=None, core_number=None, degree_type="bidirectional"):
     wait(core_number)
     core_number = core_number.worker_to_parts
 
-    client = input_graph._client
+    client = default_client()
 
     do_expensive_check = False
 

--- a/python/cugraph/cugraph/dask/link_analysis/hits.py
+++ b/python/cugraph/cugraph/dask/link_analysis/hits.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from dask.distributed import wait
+from dask.distributed import wait, default_client
 
 import cugraph.dask.comms.comms as Comms
 import dask_cudf
@@ -128,7 +128,7 @@ def hits(input_graph, tol=1.0e-5, max_iter=100, nstart=None, normalized=True):
 
     """
 
-    client = input_graph._client
+    client = default_client()
 
     if input_graph.store_transposed is False:
         warning_msg = (

--- a/python/cugraph/cugraph/dask/link_analysis/pagerank.py
+++ b/python/cugraph/cugraph/dask/link_analysis/pagerank.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from dask.distributed import wait
+from dask.distributed import wait, default_client
 import cugraph.dask.comms.comms as Comms
 import dask_cudf
 import cudf
@@ -239,7 +239,7 @@ def pagerank(
     """
 
     # Initialize dask client
-    client = input_graph._client
+    client = default_client()
 
     if input_graph.store_transposed is False:
         warning_msg = (

--- a/python/cugraph/cugraph/dask/link_prediction/jaccard.py
+++ b/python/cugraph/cugraph/dask/link_prediction/jaccard.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from dask.distributed import wait
+from dask.distributed import wait, default_client
 import cugraph.dask.comms.comms as Comms
 import dask_cudf
 import cudf
@@ -165,7 +165,7 @@ def jaccard(input_graph, vertex_pair=None, use_weight=False):
     vertex_pair = vertex_pair.worker_to_parts
 
     # Initialize dask client
-    client = input_graph._client
+    client = default_client()
 
     do_expensive_check = False
 

--- a/python/cugraph/cugraph/dask/link_prediction/overlap.py
+++ b/python/cugraph/cugraph/dask/link_prediction/overlap.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from dask.distributed import wait
+from dask.distributed import wait, default_client
 import cugraph.dask.comms.comms as Comms
 import dask_cudf
 import cudf
@@ -143,7 +143,7 @@ def overlap(input_graph, vertex_pair=None, use_weight=False):
     vertex_pair = vertex_pair.worker_to_parts
 
     # Initialize dask client
-    client = input_graph._client
+    client = default_client()
 
     do_expensive_check = False
 

--- a/python/cugraph/cugraph/dask/link_prediction/sorensen.py
+++ b/python/cugraph/cugraph/dask/link_prediction/sorensen.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from dask.distributed import wait
+from dask.distributed import wait, default_client
 import cugraph.dask.comms.comms as Comms
 import dask_cudf
 import cudf
@@ -139,7 +139,7 @@ def sorensen(input_graph, vertex_pair=None, use_weight=False):
     vertex_pair = vertex_pair.worker_to_parts
 
     # Initialize dask client
-    client = input_graph._client
+    client = default_client()
 
     do_expensive_check = False
 

--- a/python/cugraph/cugraph/dask/sampling/random_walks.py
+++ b/python/cugraph/cugraph/dask/sampling/random_walks.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dask.distributed import wait
-
+from dask.distributed import wait, default_client
 import dask_cudf
 import cudf
 import operator as op
@@ -131,7 +130,7 @@ def random_walks(
     wait(start_vertices)
     start_vertices = start_vertices.worker_to_parts
 
-    client = input_graph._client
+    client = default_client()
 
     result = [
         client.submit(

--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -156,7 +156,8 @@ def uniform_neighbor_sample(
         Random seed to use when making sampling calls.
 
     _multiple_clients: bool, optional (default=False)
-        internal flag to ensure sampling works with multiple clients
+        internal flag to ensure sampling works with multiple dask clients
+        set to True to prevent hangs in multi-client environment
 
     Returns
     -------
@@ -189,6 +190,9 @@ def uniform_neighbor_sample(
                 Contains the hop ids from the sampling result
     """
     if _multiple_clients:
+        # Distributed centralized lock to allow
+        # two disconnected processes to coordinate a lock
+        # https://docs.dask.org/en/stable/futures.html?highlight=lock#distributed.Lock
         lock = Lock("sampling_mg_lock")
         lock.acquire(timeout=1)
 

--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import numpy
-from dask.distributed import wait, Lock
+from dask.distributed import wait, Lock, default_client
 from cugraph.dask.common.input_utils import get_distributed_data
 
 
@@ -247,7 +247,7 @@ def uniform_neighbor_sample(
         wait(ddf)
         ddf = ddf.worker_to_parts
 
-    client = input_graph._client
+    client = default_client()
 
     session_id = Comms.get_session_id()
     result = [

--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -191,7 +191,7 @@ def uniform_neighbor_sample(
     """
     if _multiple_clients:
         # Distributed centralized lock to allow
-        # two disconnected processes to coordinate a lock
+        # two disconnected processes (clients) to coordinate a lock
         # https://docs.dask.org/en/stable/futures.html?highlight=lock#distributed.Lock
         lock = Lock("sampling_mg_lock")
         lock.acquire(timeout=1)
@@ -250,7 +250,6 @@ def uniform_neighbor_sample(
     client = input_graph._client
 
     session_id = Comms.get_session_id()
-    random_state = hash(None)
     result = [
         client.submit(
             _call_plc_uniform_neighbor_sample,

--- a/python/cugraph/cugraph/dask/traversal/bfs.py
+++ b/python/cugraph/cugraph/dask/traversal/bfs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 
 from pylibcugraph import ResourceHandle, bfs as pylibcugraph_bfs
 
-from dask.distributed import wait
+from dask.distributed import wait, default_client
 from cugraph.dask.common.input_utils import get_distributed_data
 import cugraph.dask.comms.comms as Comms
 import cudf
@@ -117,7 +117,7 @@ def bfs(input_graph, start, depth_limit=None, return_distances=True, check_start
 
     """
 
-    client = input_graph._client
+    client = default_client()
     invalid_dtype = False
 
     if not isinstance(start, (dask_cudf.DataFrame, dask_cudf.Series)):

--- a/python/cugraph/cugraph/dask/traversal/sssp.py
+++ b/python/cugraph/cugraph/dask/traversal/sssp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 #
 
 
-from dask.distributed import wait
+from dask.distributed import wait, default_client
 import cugraph.dask.comms.comms as Comms
 import cupy
 import cudf
@@ -109,7 +109,7 @@ def sssp(input_graph, source, cutoff=None, check_source=True):
         )
         warnings.warn(warning_msg, PendingDeprecationWarning)
 
-    client = input_graph._client
+    client = default_client()
 
     def check_valid_vertex(G, source):
         is_valid_vertex = G.has_node(source)

--- a/python/cugraph/cugraph/structure/graph_classes.py
+++ b/python/cugraph/cugraph/structure/graph_classes.py
@@ -81,7 +81,9 @@ class Graph:
                 )
 
     def __getattr__(self, name):
-        if self._Impl is None:
+        # TODO: This leads to recursion
+        # Find out betterway
+        if name == "_Impl":
             raise AttributeError(name)
         if hasattr(self._Impl, name):
             return getattr(self._Impl, name)

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
@@ -257,9 +257,9 @@ class simpleDistributedGraphImpl:
             is_symmetric=not self.properties.directed,
         )
 
-        self._client = default_client()
+        _client = default_client()
         self._plc_graph = {
-            w: self._client.submit(
+            w: _client.submit(
                 simpleDistributedGraphImpl._make_plc_graph,
                 Comms.get_session_id(),
                 edata,
@@ -705,9 +705,10 @@ class simpleDistributedGraphImpl:
                 do_expensive_check=False,
             )
 
+        _client = default_client()
         if start_vertices is not None:
             result = [
-                self._client.submit(
+                _client.submit(
                     _call_plc_two_hop_neighbors,
                     Comms.get_session_id(),
                     self._plc_graph[w],
@@ -719,7 +720,7 @@ class simpleDistributedGraphImpl:
             ]
         else:
             result = [
-                self._client.submit(
+                _client.submit(
                     _call_plc_two_hop_neighbors,
                     Comms.get_session_id(),
                     self._plc_graph[w],
@@ -742,8 +743,9 @@ class simpleDistributedGraphImpl:
             df["second"] = second
             return df
 
+        _client = default_client()
         cudf_result = [
-            self._client.submit(convert_to_cudf, cp_arrays) for cp_arrays in result
+            _client.submit(convert_to_cudf, cp_arrays) for cp_arrays in result
         ]
 
         wait(cudf_result)

--- a/python/cugraph/cugraph/tests/test_uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/tests/test_uniform_neighbor_sample.py
@@ -443,3 +443,8 @@ def test_uniform_neighbor_sample_empty_start_list():
     )
 
     assert sampling_results.empty
+
+
+@pytest.mark.skip(reason="needs to be written!")
+def test_multi_client_sampling():
+    pass

--- a/python/cugraph/cugraph/tests/test_uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/tests/test_uniform_neighbor_sample.py
@@ -449,4 +449,4 @@ def test_uniform_neighbor_sample_empty_start_list():
 def test_multi_client_sampling():
     # See gist for example test to write
     # https://gist.github.com/VibhuJawa/1b705427f7a0c5a2a4f58e0a3e71ef21
-    pass
+    raise NotImplementedError

--- a/python/cugraph/cugraph/tests/test_uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/tests/test_uniform_neighbor_sample.py
@@ -447,4 +447,6 @@ def test_uniform_neighbor_sample_empty_start_list():
 
 @pytest.mark.skip(reason="needs to be written!")
 def test_multi_client_sampling():
+    # See gist for example test to write
+    # https://gist.github.com/VibhuJawa/1b705427f7a0c5a2a4f58e0a3e71ef21
     pass


### PR DESCRIPTION
This PR makes `cugraph.structure.graph_classes` dask serializable and de-serializable.  This means that we can cleanly use dask to transmit graph objects b/w different clients without much work and using all ready supported API. 

See docs here: https://distributed.dask.org/en/stable/publish.html


**On client 0**
```python3
print(type(g))
client.publish_dataset(mg_graph_for_sampling=g)
```
```
<class 'cugraph.structure.graph_classes.MultiGraph'>
```

**On client 1** 
```python3
g = client_worker_1.get_dataset('mg_graph_for_sampling')
type(g)
```
```
cugraph.structure.graph_classes.MultiGraph
```


CC: @rlratzel 
