### PR TITLE
correct raft-distance definition in dependencies and update-version file

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -59,6 +59,7 @@ for FILE in conda/environments/*.yaml dependencies.yaml; do
    sed_runner "s/cudf=${CURRENT_SHORT_TAG}/cudf=${NEXT_SHORT_TAG}/g" ${FILE};
    sed_runner "s/rmm=${CURRENT_SHORT_TAG}/rmm=${NEXT_SHORT_TAG}/g" ${FILE};
    sed_runner "s/libraft-headers=${CURRENT_SHORT_TAG}/libraft-headers=${NEXT_SHORT_TAG}/g" ${FILE};
+   sed_runner "s/libraft-distance=${CURRENT_SHORT_TAG}/libraft-distance=${NEXT_SHORT_TAG}/g" ${FILE};
    sed_runner "s/pyraft=${CURRENT_SHORT_TAG}/pyraft=${NEXT_SHORT_TAG}/g" ${FILE};
    sed_runner "s/raft-dask=${CURRENT_SHORT_TAG}/raft-dask=${NEXT_SHORT_TAG}/g" ${FILE};
    sed_runner "s/pylibraft=${CURRENT_SHORT_TAG}/pylibraft=${NEXT_SHORT_TAG}/g" ${FILE};

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -26,7 +26,7 @@ dependencies:
 - ipython
 - libcudf=23.04.*
 - libcugraphops=23.04.*
-- libraft-distance=23.02.*
+- libraft-distance=23.04.*
 - libraft-headers=23.04.*
 - librmm=23.04.*
 - nbsphinx

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -87,7 +87,7 @@ dependencies:
           - gtest=1.10.0
           - libcugraphops=23.04.*
           - libraft-headers=23.04.*
-          - libraft-distance=23.02.*
+          - libraft-distance=23.04.*
           - librmm=23.04.*
           - openmpi # Required for building cpp-mgtests (multi-GPU tests)
     specific:


### PR DESCRIPTION
Dependency was added during 23.02 without correcting the update version script.