### PR TITLE
Bump pinned pip wheel deps to 23.4

### DIFF
--- a/python/cugraph/_custom_build/backend.py
+++ b/python/cugraph/_custom_build/backend.py
@@ -21,9 +21,9 @@ def replace_requirements(func):
         orig_list = getattr(_orig, func.__name__)(config_settings)
         cuda_suffix = os.getenv("RAPIDS_PY_WHEEL_CUDA_SUFFIX", default="")
         append_list = [
-            f"rmm{cuda_suffix}==23.2.*",
-            f"raft-dask{cuda_suffix}==23.2.*",
-            f"pylibcugraph{cuda_suffix}==23.2.*",
+            f"rmm{cuda_suffix}==23.4.*",
+            f"raft-dask{cuda_suffix}==23.4.*",
+            f"pylibcugraph{cuda_suffix}==23.4.*",
         ]
         return orig_list + append_list
 

--- a/python/cugraph/setup.py
+++ b/python/cugraph/setup.py
@@ -24,11 +24,11 @@ cuda_suffix = os.getenv("RAPIDS_PY_WHEEL_CUDA_SUFFIX", default="")
 INSTALL_REQUIRES = [
     "numba",
     "dask-cuda",
-    f"rmm{cuda_suffix}==23.2.*",
-    f"cudf{cuda_suffix}==23.2.*",
-    f"raft-dask{cuda_suffix}==23.2.*",
-    f"dask-cudf{cuda_suffix}==23.2.*",
-    f"pylibcugraph{cuda_suffix}==23.2.*",
+    f"rmm{cuda_suffix}==23.4.*",
+    f"cudf{cuda_suffix}==23.4.*",
+    f"raft-dask{cuda_suffix}==23.4.*",
+    f"dask-cudf{cuda_suffix}==23.4.*",
+    f"pylibcugraph{cuda_suffix}==23.4.*",
     "cupy-cuda11x",
 ]
 

--- a/python/pylibcugraph/_custom_build/backend.py
+++ b/python/pylibcugraph/_custom_build/backend.py
@@ -21,8 +21,8 @@ def replace_requirements(func):
         orig_list = getattr(_orig, func.__name__)(config_settings)
         cuda_suffix = os.getenv("RAPIDS_PY_WHEEL_CUDA_SUFFIX", default="")
         append_list = [
-            f"rmm{cuda_suffix}==23.2.*",
-            f"pylibraft{cuda_suffix}==23.2.*",
+            f"rmm{cuda_suffix}==23.4.*",
+            f"pylibraft{cuda_suffix}==23.4.*",
         ]
         return orig_list + append_list
 

--- a/python/pylibcugraph/setup.py
+++ b/python/pylibcugraph/setup.py
@@ -93,8 +93,8 @@ setup(
     package_data={key: ["*.pxd"] for key in find_packages(include=["pylibcugraph*"])},
     include_package_data=True,
     install_requires=[
-        f"pylibraft{cuda_suffix}==23.2.*",
-        f"rmm{cuda_suffix}==23.2.*",
+        f"pylibraft{cuda_suffix}==23.4.*",
+        f"rmm{cuda_suffix}==23.4.*",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
We introduced a change to pin RAPIDS wheel dependencies to the same release version. However, branch 23.04 was created before that last PR was merged, so as of now cugraph's 23.4 wheels are installing 23.2 RAPIDS dependencies. This PR updates those pins to the current release.

This should solve the error in #3160 (where the old pylibcugraph-cu11==23.2 is being pulled in the test step as opposed to the desired 23.4 version).