### PR TITLE
Remove cublas from the link dependencies

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -459,7 +459,6 @@ endif()
 # - C-API link libraries -------------------------------------------------------
 target_link_libraries(cugraph_c
         PUBLIC
-                CUDA::cublas${_ctk_static_suffix}
                 CUDA::curand${_ctk_static_suffix}
                 CUDA::cusolver${_ctk_static_suffix}
                 CUDA::cusparse${_ctk_static_suffix}


### PR DESCRIPTION
We migrated away from using cuBLAS as we've moved to the primitive implementation.  It is no longer used, not sure how long it hasn't been used.