### PR TITLE
Add dfg as a pre-commit hook.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,6 +27,8 @@ jobs:
   checks:
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@branch-23.04
+    with:
+      enable_check_generated_files: false
   conda-cpp-build:
     needs: checks
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,7 @@ repos:
         language: python
         pass_filenames: false
         additional_dependencies: [gitpython]
+  - repo: https://github.com/rapidsai/dependency-file-generator
+    rev: v1.2.0
+    hooks:
+        - id: rapids-dependency-file-generator

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,7 @@ repos:
         pass_filenames: false
         additional_dependencies: [gitpython]
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.2.0
+    rev: v1.4.0
     hooks:
         - id: rapids-dependency-file-generator
+          args: ["--clean"]


### PR DESCRIPTION
This change allows local and remote runs to handle calls to dfg identically, and removes the need for a separate CI check.
