### PR TITLE
Remove unused RAFT import causing `ImportError`

### DIFF
--- a/python/cugraph/cugraph/__init__.py
+++ b/python/cugraph/cugraph/__init__.py
@@ -104,7 +104,6 @@ from cugraph.experimental import find_bicliques
 
 from cugraph.linear_assignment import hungarian, dense_hungarian
 from cugraph.layout import force_atlas2
-from raft_dask import raft_include_test
 
 from cugraph.sampling import (
     random_walks,


### PR DESCRIPTION
This PR removes an unused raft import which was causing an `ImportError` due to it being recently relocated in the RAFT namespace.