### PR TITLE
[REVIEW] Fix docs build to be `pydata-sphinx-theme=0.13.0` compatible

### DIFF
--- a/docs/cugraph/source/conf.py
+++ b/docs/cugraph/source/conf.py
@@ -116,6 +116,8 @@ todo_include_todos = False
 #
 html_theme_options = {
     "external_links": [],
+    # https://github.com/pydata/pydata-sphinx-theme/issues/1220
+    "icon_links": [],
     "github_url": "https://github.com/rapidsai/cugraph",
     "twitter_url": "https://twitter.com/rapidsai",
     "show_toc_level": 1,


### PR DESCRIPTION
This PR fixes cugraph docs build to be compatible with `pydata-sphinx-theme=0.13.0` by adding an empty `icon_links` entry.

