### PR TITLE
Experimenting with `ruff --fix`

### DIFF
--- a/python/cugraph-dgl/cugraph_dgl/cugraph_storage.py
+++ b/python/cugraph-dgl/cugraph_dgl/cugraph_storage.py
@@ -61,13 +61,13 @@ class CuGraphStorage:
 
         Parameters
         ----------
-         data_dict:
+        data_dict:
             The dictionary data for constructing a heterogeneous graph.
             The keys are in the form of string triplets (src_type, edge_type, dst_type),
             specifying the source node, edge, and destination node types.
-            The values are graph data is a dataframe with 2 columns form of (𝑈,𝑉),
-            where (𝑈[𝑖],𝑉[𝑖]) forms the edge with ID 𝑖.
-         num_nodes_dict: dict[str, int]
+            The values are graph data is a dataframe with 2 columns form of (U,V),
+            where (U[i],V[i]) forms the edge with ID i.
+        num_nodes_dict: dict[str, int]
             The number of nodes for some node types, which is a
             dictionary mapping a node type T to the number of T-typed nodes.
         single_gpu: bool
@@ -84,9 +84,9 @@ class CuGraphStorage:
             for PyTorch.
             Defaults to ``torch.int64`` if pytorch is installed
 
-         Examples
-         --------
-         The following example uses `CuGraphStorage` :
+        Examples
+        --------
+        The following example uses `CuGraphStorage` :
             >>> from cugraph_dgl.cugraph_storage import CuGraphStorage
             >>> import cudf
             >>> import torch
@@ -136,7 +136,7 @@ class CuGraphStorage:
         # do this first before cuda work
         # Create cuda context on the right gpu,
         # defaults to gpu-0
-        import numba.cuda as cuda
+        from numba import cuda
 
         cuda.select_device(device_id)
 
@@ -184,6 +184,7 @@ class CuGraphStorage:
             might be "users".
         feat_name : str
             The name of the feature being stored
+
         Returns
         -------
         None
@@ -210,6 +211,7 @@ class CuGraphStorage:
         canonical_etype : Tuple[(str, str, str)]
             The edge type to be added
         feat_name : string
+
         Returns
         -------
         None
@@ -236,6 +238,7 @@ class CuGraphStorage:
         Return a DGLGraph which is a subgraph induced by sampling neighboring
         edges of the given nodes.
         See ``dgl.sampling.sample_neighbors`` for detailed semantics.
+
         Parameters
         ----------
         nodes : Tensor or dict[str, Tensor]
@@ -270,6 +273,7 @@ class CuGraphStorage:
             If True, sample with replacement.
         output_device : Framework-specific device context object, optional
             The output device.  Default is the same as the input graph.
+
         Returns
         -------
         DGLGraph
@@ -350,6 +354,7 @@ class CuGraphStorage:
     def subgraph(self, nodes, relabel_nodes=False, output_device=None):
         """Return a subgraph induced on given nodes.
         This has the same semantics as ``dgl.node_subgraph``.
+
         Parameters
         ----------
         nodes : nodes or dict[str, nodes]
@@ -367,6 +372,7 @@ class CuGraphStorage:
             specified node set and it will relabel the nodes in order.
         output_device : Framework-specific device context object, optional
             The output device.  Default is the same as the input graph.
+
         Returns
         -------
         DGLGraph
@@ -381,6 +387,7 @@ class CuGraphStorage:
         """
         Return a subgraph induced on given edges.
         This has the same semantics as ``dgl.edge_subgraph``.
+
         Parameters
         ----------
         edges : edges or dict[(str, str, str), edges]
@@ -398,6 +405,7 @@ class CuGraphStorage:
             specified node set and it will relabel the nodes in order.
         output_device : Framework-specific device context object, optional
             The output device.  Default is the same as the input graph.
+
         Returns
         -------
         DGLGraph
@@ -492,6 +500,7 @@ class CuGraphStorage:
     def num_nodes(self, ntype: str = None) -> int:
         """
         Return the number of nodes in the graph.
+
         Parameters
         ----------
         ntype : str, optional
@@ -558,6 +567,7 @@ class CuGraphStorage:
     def num_edges(self, etype: Optional[str] = None) -> int:
         """
         Return the number of edges in the graph.
+
         Parameters
         ----------
         etype:
@@ -594,6 +604,7 @@ class CuGraphStorage:
     def device(self):
         """
         Get the device of the graph.
+
         Returns
         -------
         device context

--- a/python/cugraph-dgl/cugraph_dgl/dataloading/neighbor_sampler.py
+++ b/python/cugraph-dgl/cugraph_dgl/dataloading/neighbor_sampler.py
@@ -19,6 +19,7 @@ class NeighborSampler:
     neighbor sampling for multilayer GNN.
     This sampler will make every node gather messages from a fixed number of neighbors
     per edge type.  The neighbors are picked uniformly.
+
     Parameters
     ----------
     fanouts_per_layer : int

--- a/python/cugraph-dgl/cugraph_dgl/nn/conv/gatconv.py
+++ b/python/cugraph-dgl/cugraph_dgl/nn/conv/gatconv.py
@@ -11,7 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Torch Module for graph attention network layer using the aggregation
-primitives in cugraph-ops"""
+primitives in cugraph-ops
+"""
 # pylint: disable=no-member, arguments-differ, invalid-name, too-many-arguments
 from __future__ import annotations
 from typing import Optional

--- a/python/cugraph-dgl/cugraph_dgl/nn/conv/relgraphconv.py
+++ b/python/cugraph-dgl/cugraph_dgl/nn/conv/relgraphconv.py
@@ -11,7 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Torch Module for Relational graph convolution layer using the aggregation
-primitives in cugraph-ops"""
+primitives in cugraph-ops
+"""
 # pylint: disable=no-member, arguments-differ, invalid-name, too-many-arguments
 from __future__ import annotations
 import math

--- a/python/cugraph-dgl/cugraph_dgl/nn/conv/sageconv.py
+++ b/python/cugraph-dgl/cugraph_dgl/nn/conv/sageconv.py
@@ -11,7 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Torch Module for GraphSAGE layer using the aggregation primitives in
-cugraph-ops"""
+cugraph-ops
+"""
 # pylint: disable=no-member, arguments-differ, invalid-name, too-many-arguments
 from __future__ import annotations
 from typing import Optional

--- a/python/cugraph-dgl/cugraph_dgl/utils/cugraph_storage_utils.py
+++ b/python/cugraph-dgl/cugraph_dgl/utils/cugraph_storage_utils.py
@@ -35,10 +35,7 @@ def _is_valid_canonical_etype(canonical_etype):
     if len(canonical_etype) != 3:
         return False
 
-    for t in canonical_etype:
-        if not isinstance(t, str):
-            return False
-    return True
+    return all(isinstance(t, str) for t in canonical_etype)
 
 
 def add_edge_ids_to_edges_dict(edge_data_dict, edge_id_offset_d, id_dtype):

--- a/python/cugraph-dgl/cugraph_dgl/utils/feature_storage.py
+++ b/python/cugraph-dgl/cugraph_dgl/utils/feature_storage.py
@@ -30,6 +30,7 @@ class dgl_FeatureStorage:
     def fetch(self, indices, device=None, pin_memory=False, **kwargs):
         """Fetch the features of the given node/edge IDs to the
         given device.
+
         Parameters
         ----------
         indices : Tensor

--- a/python/cugraph-dgl/tests/test_cugraph_storage.py
+++ b/python/cugraph-dgl/tests/test_cugraph_storage.py
@@ -28,7 +28,7 @@ th = import_optional("torch")
 dgl = import_optional("dgl")
 
 
-@pytest.fixture()
+@pytest.fixture
 def dgl_graph():
     graph_data = {
         ("nt.a", "connects", "nt.b"): (

--- a/python/cugraph-dgl/tests/utils.py
+++ b/python/cugraph-dgl/tests/utils.py
@@ -18,7 +18,7 @@ th = import_optional("torch")
 def assert_same_node_feats(gs, g):
     set(gs.ndata.keys()) == set(g.ndata.keys())
 
-    for key in g.ndata.keys():
+    for key in g.ndata:
         for ntype in g.ntypes:
             indices = th.arange(0, g.num_nodes(ntype), dtype=g.idtype).cuda()
             if len(g.ntypes) <= 1 or ntype in g.ndata[key]:
@@ -47,7 +47,7 @@ def assert_same_num_edges_etypes(gs, g):
 
 def assert_same_edge_feats(gs, g):
     set(gs.edata.keys()) == set(g.edata.keys())
-    for key in g.edata.keys():
+    for key in g.edata:
         for etype in g.canonical_etypes:
             indices = th.arange(0, g.num_edges(etype), dtype=g.idtype).cuda()
             if len(g.etypes) <= 1 or etype in g.edata[key]:

--- a/python/cugraph-pyg/cugraph_pyg/data/cugraph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/cugraph_store.py
@@ -140,7 +140,7 @@ class CuGraphTensorAttr:
 
     def is_fully_specified(self):
         r"""Whether the :obj:`TensorAttr` has no unset fields."""
-        return all([self.is_set(key) for key in self.__dataclass_fields__])
+        return all(self.is_set(key) for key in self.__dataclass_fields__)
 
     def fully_specify(self):
         r"""Sets all :obj:`UNSET` fields to :obj:`None`."""
@@ -151,7 +151,8 @@ class CuGraphTensorAttr:
 
     def update(self, attr):
         r"""Updates an :class:`TensorAttr` with set attributes from another
-        :class:`TensorAttr`."""
+        :class:`TensorAttr`.
+        """
         for key in self.__dataclass_fields__:
             if attr.is_set(key):
                 setattr(self, key, getattr(attr, key))
@@ -160,6 +161,7 @@ class CuGraphTensorAttr:
     def cast(cls, *args, **kwargs):
         """
         Casts to a CuGraphTensorAttr from a tuple, list, or dict
+
         Returns
         -------
         CuGraphTensorAttr
@@ -193,6 +195,7 @@ class EXPERIMENTAL__CuGraphStore:
         """
         Constructs a new CuGraphStore from the provided
         arguments.
+
         Parameters
         ----------
         F : cugraph.gnn.FeatureStore (Required)
@@ -226,16 +229,16 @@ class EXPERIMENTAL__CuGraphStore:
             asarray = _torch_as_array
             from torch import int64 as vertex_dtype
             from torch import float32 as property_dtype
-            from torch import searchsorted as searchsorted
-            from torch import concatenate as concatenate
-            from torch import arange as arange
+            from torch import searchsorted
+            from torch import concatenate
+            from torch import arange
         elif backend == "cupy":
             from cupy import asarray
             from cupy import int64 as vertex_dtype
             from cupy import float32 as property_dtype
-            from cupy import searchsorted as searchsorted
-            from cupy import concatenate as concatenate
-            from cupy import arange as arange
+            from cupy import searchsorted
+            from cupy import concatenate
+            from cupy import arange
         else:
             raise ValueError(f"Invalid backend {backend}.")
 
@@ -321,6 +324,7 @@ class EXPERIMENTAL__CuGraphStore:
         multi_gpu: bool (Optional, default=False)
             Whether to construct a single-GPU or multi-GPU cugraph Graph.
             Defaults to a single-GPU graph.
+
         Returns
         -------
         A newly-constructed directed cugraph.MultiGraph object.
@@ -568,11 +572,13 @@ class EXPERIMENTAL__CuGraphStore:
         Args:
             **attr(EdgeAttr): the edge attributes.
 
-        Returns:
+        Returns
+        -------
             EdgeTensorType: an edge_index tensor corresonding to the provided
             attributes, or None if there is no such tensor.
 
-        Raises:
+        Raises
+        ------
             KeyError: if the edge index corresponding to attr was not found.
         """
 

--- a/python/cugraph-pyg/cugraph_pyg/tests/int/test_int_cugraph.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/int/test_int_cugraph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph-pyg/cugraph_pyg/tests/int/test_int_cugraph.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/int/test_int_cugraph.py
@@ -62,7 +62,7 @@ def loader_hetero_mag():
         pG.add_vertex_data(blank_df, vertex_col_name="id", type_name=node_type)
 
     # Add the remaining vertex features
-    for i, (node_type, node_features) in enumerate(data[0]["node_feat_dict"].items()):
+    for _i, (node_type, node_features) in enumerate(data[0]["node_feat_dict"].items()):
         vertex_offset = vertex_offsets[node_type]
 
         feature_df = cudf.DataFrame(node_features)
@@ -76,7 +76,7 @@ def loader_hetero_mag():
     pG.fillna(0.0)
 
     # Add the edges
-    for i, (edge_key, eidx) in enumerate(data[0]["edge_index_dict"].items()):
+    for _i, (edge_key, eidx) in enumerate(data[0]["edge_index_dict"].items()):
         node_type_src, edge_type, node_type_dst = edge_key
         print(node_type_src, edge_type, node_type_dst)
         vertex_offset_src = vertex_offsets[node_type_src]
@@ -152,7 +152,7 @@ def loader_hetero_mag_multi_gpu(rmmc):
         pG.add_vertex_data(blank_df, vertex_col_name="id", type_name=node_type)
 
     # Add the remaining vertex features
-    for i, (node_type, node_features) in enumerate(data[0]["node_feat_dict"].items()):
+    for _i, (node_type, node_features) in enumerate(data[0]["node_feat_dict"].items()):
         vertex_offset = vertex_offsets[node_type]
 
         feature_df = cudf.DataFrame(node_features)
@@ -167,7 +167,7 @@ def loader_hetero_mag_multi_gpu(rmmc):
     pG.fillna(0.0)
 
     # Add the edges
-    for i, (edge_key, eidx) in enumerate(data[0]["edge_index_dict"].items()):
+    for _i, (edge_key, eidx) in enumerate(data[0]["edge_index_dict"].items()):
         node_type_src, edge_type, node_type_dst = edge_key
         print(node_type_src, edge_type, node_type_dst)
         vertex_offset_src = vertex_offsets[node_type_src]

--- a/python/cugraph-pyg/cugraph_pyg/tests/mg/test_mg_cugraph_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/mg/test_mg_cugraph_loader.py
@@ -34,7 +34,7 @@ def test_cugraph_loader_basic(dask_client, karate_gnn):
 
     assert isinstance(cugraph_store._subgraph()._plc_graph, dict)
 
-    samples = [s for s in loader]
+    samples = list(loader)
 
     assert len(samples) == 3
     for sample in samples:

--- a/python/cugraph-pyg/cugraph_pyg/tests/mg/test_mg_cugraph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/mg/test_mg_cugraph_store.py
@@ -120,7 +120,7 @@ def test_get_subgraph(graph, dask_client):
     cugraph_store = CuGraphStore(F, G, N, backend="cupy", multi_gpu=True)
 
     if len(G.keys()) > 1:
-        for edge_type in G.keys():
+        for edge_type in G:
             # Subgraphing is not implemented yet and should raise an error
             with pytest.raises(ValueError):
                 sg = cugraph_store._subgraph([edge_type])

--- a/python/cugraph-pyg/cugraph_pyg/tests/test_cugraph_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/test_cugraph_loader.py
@@ -32,7 +32,7 @@ def test_cugraph_loader_basic(karate_gnn):
         replace=False,
     )
 
-    samples = [s for s in loader]
+    samples = list(loader)
 
     assert len(samples) == 3
     for sample in samples:

--- a/python/cugraph-pyg/cugraph_pyg/tests/test_cugraph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/test_cugraph_store.py
@@ -120,7 +120,7 @@ def test_get_subgraph(graph):
     cugraph_store = CuGraphStore(F, G, N, backend="cupy")
 
     if len(G.keys()) > 1:
-        for edge_type in G.keys():
+        for edge_type in G:
             # Subgraphing is not implemented yet and should raise an error
             with pytest.raises(ValueError):
                 sg = cugraph_store._subgraph([edge_type])

--- a/python/cugraph-service/client/cugraph_service_client/client.py
+++ b/python/cugraph-service/client/cugraph_service_client/client.py
@@ -315,7 +315,7 @@ class CugraphServiceClient:
         server_info = self.__client.get_server_info()
         # server_info is a dictionary of Value objects ("union" types returned
         # from the server), so convert them to simple py types.
-        return dict((k, ValueWrapper(server_info[k]).get_py_obj()) for k in server_info)
+        return {k: ValueWrapper(server_info[k]).get_py_obj() for k in server_info}
 
     @__server_connection
     def load_graph_creation_extensions(self, extension_dir_path):
@@ -673,7 +673,7 @@ class CugraphServiceClient:
 
         # graph_info is a dictionary of Value objects ("union" types returned
         # from the graph), so convert them to simple py types.
-        return dict((k, ValueWrapper(graph_info[k]).get_py_obj()) for k in graph_info)
+        return {k: ValueWrapper(graph_info[k]).get_py_obj() for k in graph_info}
 
     @__server_connection
     def load_csv_as_vertex_data(
@@ -688,7 +688,6 @@ class CugraphServiceClient:
         graph_id=defaults.graph_id,
         names=None,
     ):
-
         """
         Reads csv_file_name and applies it as vertex data to the graph
         identified as graph_id (or the default graph if not specified).
@@ -1276,7 +1275,8 @@ class CugraphServiceClient:
         """
         Samples the graph and returns a UniformNeighborSampleResult instance.
 
-        Parameters:
+        Parameters
+        ----------
         start_list : list[int]
 
         fanout_vals : list[int]
@@ -1369,7 +1369,6 @@ class CugraphServiceClient:
 
     @__server_connection
     def _get_graph_type(self, graph_id=defaults.graph_id):
-
         """
         Test/debug API for returning a string repr of the graph_id instance.
         """

--- a/python/cugraph-service/client/cugraph_service_client/remote_graph.py
+++ b/python/cugraph-service/client/cugraph_service_client/remote_graph.py
@@ -379,7 +379,7 @@ class RemoteGraph:
             columns.remove(self.type_col_name)
         if self.vertex_col_name in columns:
             columns.remove(self.vertex_col_name)
-        column_names = [self.vertex_col_name, self.type_col_name] + list(columns)
+        column_names = [self.vertex_col_name, self.type_col_name, *list(columns)]
 
         return _transform_to_backend_dtype(
             vertex_data,
@@ -701,6 +701,7 @@ class RemoteGraph:
             Defaults to cudf if available, otherwise falls back to numpy.
 
         Returns
+        -------
         A DataFrame or dict (depending on backend) with the start and stop IDs for
         each edge type.
         Stop is *inclusive*.

--- a/python/cugraph-service/client/cugraph_service_client/types.py
+++ b/python/cugraph-service/client/cugraph_service_client/types.py
@@ -40,7 +40,7 @@ class UnionWrapper:
     unions to Thrift unions/py objects.
     """
 
-    non_attrs = set(["default_spec", "thrift_spec", "read", "write"])
+    non_attrs = {"default_spec", "thrift_spec", "read", "write"}
 
 
 class ValueWrapper(UnionWrapper):

--- a/python/cugraph-service/server/cugraph_service_server/cugraph_handler.py
+++ b/python/cugraph-service/server/cugraph_service_server/cugraph_handler.py
@@ -472,16 +472,14 @@ class CugraphHandler:
         Dictionary items are string:union_objs, where union_objs are Value
         "unions" used for RPC serialization.
         """
-        valid_keys = set(
-            [
-                "num_vertices",
-                "num_vertices_from_vertex_data",
-                "num_edges",
-                "num_vertex_properties",
-                "num_edge_properties",
-                "is_multi_gpu",
-            ]
-        )
+        valid_keys = {
+            "num_vertices",
+            "num_vertices_from_vertex_data",
+            "num_edges",
+            "num_vertex_properties",
+            "num_edge_properties",
+            "is_multi_gpu",
+        }
         if len(keys) == 0:
             keys = valid_keys
         else:
@@ -1279,7 +1277,6 @@ class CugraphHandler:
         await ep.close()
 
     def __get_dataframe_from_csv(self, csv_file_name, delimiter, dtypes, header, names):
-
         """
         Read a CSV into a DataFrame and return it. This will use either a cuDF
         DataFrame or a dask_cudf DataFrame based on if the handler is

--- a/python/cugraph-service/tests/client1_script.py
+++ b/python/cugraph-service/tests/client1_script.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph-service/tests/client1_script.py
+++ b/python/cugraph-service/tests/client1_script.py
@@ -46,7 +46,7 @@ n = int(random.random() * 1000)
 
 # print(f"---> starting {n}", flush=True)
 
-for i in range(1000000):
+for _i in range(1000000):
     extracted_gid = client.extract_subgraph(allow_multi_edges=False)
     # client.delete_graph(extracted_gid)
     # print(f"---> {n}: extracted {extracted_gid}", flush=True)

--- a/python/cugraph-service/tests/client2_script.py
+++ b/python/cugraph-service/tests/client2_script.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph-service/tests/client2_script.py
+++ b/python/cugraph-service/tests/client2_script.py
@@ -26,7 +26,7 @@ n = int(random.random() * 1000)
 
 # print(f"---> starting {n}", flush=True)
 
-for i in range(1000000):
+for _i in range(1000000):
     extracted_gid = client.extract_subgraph(allow_multi_edges=False)
     # client.delete_graph(extracted_gid)
     # print(f"---> {n}: extracted {extracted_gid}", flush=True)

--- a/python/cugraph-service/tests/conftest.py
+++ b/python/cugraph-service/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cugraph-service/tests/conftest.py
+++ b/python/cugraph-service/tests/conftest.py
@@ -374,7 +374,7 @@ def extension_adds_graph():
 # function scope fixtures
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def client(server):
     """
     Creates a client instance to the running server, closes the client when the

--- a/python/cugraph-service/tests/test_cugraph_handler.py
+++ b/python/cugraph-service/tests/test_cugraph_handler.py
@@ -299,7 +299,6 @@ def test_load_call_unload_extensions_python_module_path(extension1):
 
 
 def test_load_call_unload_graph_creation_extension_no_args(graph_creation_extension1):
-
     """
     Test graph_creation_extension1 which contains an extension with no args.
     """

--- a/python/cugraph-service/tests/test_e2e.py
+++ b/python/cugraph-service/tests/test_e2e.py
@@ -25,7 +25,7 @@ from . import data
 # The fixtures used in these tests are defined here and in conftest.py
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def client_with_graph_creation_extension_loaded(client, graph_creation_extension1):
     """
     Loads the extension defined in graph_creation_extension1, unloads upon completion.
@@ -41,7 +41,7 @@ def client_with_graph_creation_extension_loaded(client, graph_creation_extension
         client.unload_extension_module(modname)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def client_with_edgelist_csv_loaded(client):
     """
     Loads the karate CSV into the default graph on the server.
@@ -57,7 +57,7 @@ def client_with_edgelist_csv_loaded(client):
     return (client, test_data)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def client_with_property_csvs_loaded(client):
     """
     Loads each of the vertex and edge property CSVs into the default graph on
@@ -187,9 +187,12 @@ def test_node2vec(client_with_edgelist_csv_loaded):
         start_vertices, max_depth, extracted_gid
     )
     # FIXME: consider a more thorough test
-    assert isinstance(vertex_paths, list) and len(vertex_paths)
-    assert isinstance(edge_weights, list) and len(edge_weights)
-    assert isinstance(path_sizes, list) and len(path_sizes)
+    assert isinstance(vertex_paths, list)
+    assert len(vertex_paths)
+    assert isinstance(edge_weights, list)
+    assert len(edge_weights)
+    assert isinstance(path_sizes, list)
+    assert len(path_sizes)
 
 
 def test_extract_subgraph(client_with_edgelist_csv_loaded):

--- a/python/cugraph-service/tests/test_mg_cugraph_handler.py
+++ b/python/cugraph-service/tests/test_mg_cugraph_handler.py
@@ -54,7 +54,7 @@ def mg_handler():
 
 # Make this a function-level fixture so it cleans up the mg_handler after each
 # test, allowing other tests to use mg_handler without graphs loaded.
-@pytest.fixture(scope="function")
+@pytest.fixture
 def handler_with_karate_edgelist_loaded(mg_handler):
     """
     Loads the karate CSV into the default graph in the handler.

--- a/python/cugraph-service/tests/test_mg_e2e.py
+++ b/python/cugraph-service/tests/test_mg_e2e.py
@@ -135,7 +135,7 @@ def client_of_mg_server(mg_server):
     client.close()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def client_of_mg_server_with_edgelist_csv_loaded(client_of_mg_server):
     """
     Loads the karate CSV into the default graph on the server.
@@ -199,7 +199,7 @@ def client_of_sg_server_on_device_1_with_test_array(
     client._delete_test_array(test_array_id)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def client_of_sg_server_on_device_1_large_property_graph_loaded(
     client_of_sg_server_on_device_1,
     graph_creation_extension_large_property_graph,

--- a/python/cugraph-service/tests/test_remote_graph.py
+++ b/python/cugraph-service/tests/test_remote_graph.py
@@ -39,7 +39,7 @@ pytest.skip(
 # The fixtures used in these tests are defined here and in conftest.py
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def client_with_property_csvs_loaded(client):
     """
     Loads each of the vertex and edge property CSVs into the default graph on
@@ -93,7 +93,7 @@ def client_with_property_csvs_loaded(client):
     return client
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def pG_with_property_csvs_loaded():
     """
     Loads each of the vertex and edge property CSVs into a
@@ -323,13 +323,13 @@ def test_get_edge_data(client_with_property_csvs_loaded, pG_with_property_csvs_l
 def test_add_vertex_data(
     client_with_property_csvs_loaded, pG_with_property_csvs_loaded
 ):
-    raise NotImplementedError()
+    raise NotImplementedError
 
 
 @pytest.mark.skip(reason="not yet implemented")
 def test_add_edge_data(client_with_property_csvs_loaded, pG_with_property_csvs_loaded):
 
-    raise NotImplementedError()
+    raise NotImplementedError
 
 
 def test_get_vertices(client_with_property_csvs_loaded, pG_with_property_csvs_loaded):
@@ -345,7 +345,7 @@ def test_get_vertices(client_with_property_csvs_loaded, pG_with_property_csvs_lo
 def test_get_vertices_with_selection(
     client_with_property_csvs_loaded, pG_with_property_csvs_loaded
 ):
-    raise NotImplementedError()
+    raise NotImplementedError
 
 
 @pytest.mark.parametrize(
@@ -454,7 +454,7 @@ def test_backend_pandas(client_with_property_csvs_loaded, pG_with_property_csvs_
     rpg_vertex_data = rpG.get_vertex_data(backend="pandas")
     pg_vertex_data = pG.get_vertex_data().fillna(0)
     assert isinstance(rpg_vertex_data, pd.DataFrame)
-    assert sorted(list(rpg_vertex_data.columns)) == sorted(list(pg_vertex_data.columns))
+    assert sorted(rpg_vertex_data.columns) == sorted(pg_vertex_data.columns)
     for col in rpg_vertex_data.columns:
         assert rpg_vertex_data[col].tolist() == pg_vertex_data[col].values_host.tolist()
 
@@ -462,7 +462,7 @@ def test_backend_pandas(client_with_property_csvs_loaded, pG_with_property_csvs_
     rpg_edge_data = rpG.get_edge_data(backend="pandas")
     pg_edge_data = pG.get_edge_data().fillna(0)
     assert isinstance(rpg_edge_data, pd.DataFrame)
-    assert sorted(list(rpg_edge_data.columns)) == sorted(list(pg_edge_data.columns))
+    assert sorted(rpg_edge_data.columns) == sorted(pg_edge_data.columns)
     for col in rpg_edge_data.columns:
         assert rpg_edge_data[col].tolist() == pg_edge_data[col].values_host.tolist()
 

--- a/python/cugraph/cugraph/community/ktruss_subgraph.py
+++ b/python/cugraph/cugraph/community/ktruss_subgraph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/community/ktruss_subgraph.py
+++ b/python/cugraph/cugraph/community/ktruss_subgraph.py
@@ -46,7 +46,7 @@ def k_truss(G, k):
     NOTE: this function is currently not available on CUDA 11.4 systems.
 
     The k-truss of a graph is a subgraph where each edge is part of at least
-    (k−2) triangles. K-trusses are used for finding tighlty knit groups of
+    (k-2) triangles. K-trusses are used for finding tighlty knit groups of
     vertices in a graph. A k-truss is a relaxation of a k-clique in the graph
     and was define in [1]. Finding cliques is computationally demanding and
     finding the maximal k-clique is known to be NP-Hard.
@@ -97,7 +97,7 @@ def ktruss_subgraph(G, k, use_weights=True):
     NOTE: this function is currently not available on CUDA 11.4 systems.
 
     The k-truss of a graph is a subgraph where each edge is part of at least
-    (k−2) triangles. K-trusses are used for finding tighlty knit groups of
+    (k-2) triangles. K-trusses are used for finding tighlty knit groups of
     vertices in a graph. A k-truss is a relaxation of a k-clique in the graph
     and was define in [1]. Finding cliques is computationally demanding and
     finding the maximal k-clique is known to be NP-Hard.
@@ -114,7 +114,6 @@ def ktruss_subgraph(G, k, use_weights=True):
 
     References
     ----------
-
     [1] Cohen, J.,
     "Trusses: Cohesive subgraphs for social network analysis"
     National security agency technical report, 2008

--- a/python/cugraph/cugraph/components/connectivity.py
+++ b/python/cugraph/cugraph/components/connectivity.py
@@ -144,8 +144,8 @@ def weakly_connected_components(G, directed=None, connection=None, return_labels
 
     Returns
     -------
-    Return value type is based on the input type.  If G is a cugraph.Graph,
-    returns:
+    Return value type is based on the input type.
+    If G is a cugraph.Graph, returns:
 
        cudf.DataFrame
            GPU data frame containing two cudf.Series of size V: the vertex
@@ -253,8 +253,8 @@ def strongly_connected_components(
 
     Returns
     -------
-    Return value type is based on the input type.  If G is a cugraph.Graph,
-    returns:
+    Return value type is based on the input type.
+    If G is a cugraph.Graph, returns:
 
        cudf.DataFrame
            GPU data frame containing two cudf.Series of size V: the vertex
@@ -334,7 +334,7 @@ def connected_components(G, directed=None, connection="weak", return_labels=None
             For Graph-type values of G, weak components are only
             supported for undirected graphs.
 
-        [‘weak’|’strong’]. Return either weakly or strongly connected
+        [`weak`|`strong`]. Return either weakly or strongly connected
         components.
 
     return_labels : bool, optional (default=True)
@@ -348,8 +348,8 @@ def connected_components(G, directed=None, connection="weak", return_labels=None
 
     Returns
     -------
-    Return value type is based on the input type.  If G is a cugraph.Graph,
-    returns:
+    Return value type is based on the input type.
+    If G is a cugraph.Graph, returns:
 
        cudf.DataFrame
            GPU data frame containing two cudf.Series of size V: the vertex

--- a/python/cugraph/cugraph/dask/common/input_utils.py
+++ b/python/cugraph/cugraph/dask/common/input_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cugraph/cugraph/dask/common/part_utils.py
+++ b/python/cugraph/cugraph/dask/common/part_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cugraph/cugraph/dask/comms/comms.py
+++ b/python/cugraph/cugraph/dask/comms/comms.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/dask/comms/comms.py
+++ b/python/cugraph/cugraph/dask/comms/comms.py
@@ -163,10 +163,7 @@ def is_initialized():
     Returns True if comms was initialized, False otherwise.
     """
     global __instance
-    if __instance is not None:
-        return True
-    else:
-        return False
+    return __instance is not None
 
 
 def get_comms():

--- a/python/cugraph/cugraph/dask/link_analysis/hits.py
+++ b/python/cugraph/cugraph/dask/link_analysis/hits.py
@@ -70,7 +70,6 @@ def hits(input_graph, tol=1.0e-5, max_iter=100, nstart=None, normalized=True):
 
     Parameters
     ----------
-
     input_graph : cugraph.Graph
         cuGraph graph descriptor, should contain the connectivity information
         as an edge list (edge weights are not used for this algorithm).

--- a/python/cugraph/cugraph/dask/sampling/random_walks.py
+++ b/python/cugraph/cugraph/dask/sampling/random_walks.py
@@ -69,7 +69,7 @@ def random_walks(
     padded result along with the maximum path length. Vertices with no outgoing
     edges will be padded with -1.
 
-    parameters
+    Parameters
     ----------
     input_graph : cuGraph.Graph
         The graph can be either directed or undirected.

--- a/python/cugraph/cugraph/dask/structure/mg_property_graph.py
+++ b/python/cugraph/cugraph/dask/structure/mg_property_graph.py
@@ -564,7 +564,7 @@ class EXPERIMENTAL__MGPropertyGraph:
             column_names_to_drop = set(tmp_df.columns)
             # remove the ones to keep
             column_names_to_drop.difference_update(
-                property_columns + [self.vertex_col_name, TCN]
+                [*property_columns, self.vertex_col_name, TCN]
             )
         else:
             column_names_to_drop = {vertex_col_name}
@@ -663,7 +663,7 @@ class EXPERIMENTAL__MGPropertyGraph:
             if columns is not None:
                 # FIXME: invalid columns will result in a KeyError, should a
                 # check be done here and a more PG-specific error raised?
-                df = df[[self.type_col_name] + columns]
+                df = df[[self.type_col_name, *columns]]
             df_out = df.reset_index()
 
             # Preserve the dtype (vertex id type) to avoid cugraph algorithms
@@ -918,7 +918,7 @@ class EXPERIMENTAL__MGPropertyGraph:
             column_names_to_drop = set(tmp_df.columns)
             # remove the ones to keep
             column_names_to_drop.difference_update(
-                property_columns + [self.src_col_name, self.dst_col_name, TCN]
+                [*property_columns, self.src_col_name, self.dst_col_name, TCN]
             )
         else:
             column_names_to_drop = {vertex_col_names[0], vertex_col_names[1]}
@@ -972,12 +972,9 @@ class EXPERIMENTAL__MGPropertyGraph:
             self.__edge_prop_dataframe = df
 
         # Update the edge eval dict with the latest column instances
-        latest = dict(
-            [
-                (n, self.__edge_prop_dataframe[n])
-                for n in self.__edge_prop_dataframe.columns
-            ]
-        )
+        latest = {
+            n: self.__edge_prop_dataframe[n] for n in self.__edge_prop_dataframe.columns
+        }
         self.__edge_prop_eval_dict.update(latest)
         self.__edge_prop_eval_dict[
             self.edge_id_col_name
@@ -1020,7 +1017,7 @@ class EXPERIMENTAL__MGPropertyGraph:
                 # FIXME: invalid columns will result in a KeyError, should a
                 # check be done here and a more PG-specific error raised?
                 df = df[
-                    [self.src_col_name, self.dst_col_name, self.type_col_name] + columns
+                    [self.src_col_name, self.dst_col_name, self.type_col_name, *columns]
                 ]
 
             df_out = df.reset_index()
@@ -1230,7 +1227,7 @@ class EXPERIMENTAL__MGPropertyGraph:
         )
 
     def annotate_dataframe(self, df, G, edge_vertex_col_names):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def edge_props_to_graph(
         self,

--- a/python/cugraph/cugraph/experimental/compat/nx/algorithms/link_analysis/pagerank_alg.py
+++ b/python/cugraph/cugraph/experimental/compat/nx/algorithms/link_analysis/pagerank_alg.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/experimental/compat/nx/algorithms/link_analysis/pagerank_alg.py
+++ b/python/cugraph/cugraph/experimental/compat/nx/algorithms/link_analysis/pagerank_alg.py
@@ -50,7 +50,6 @@ def pagerank(
     weight="weight",
     dangling=None,
 ):
-
     """
     Calls the cugraph pagerank algorithm taking in a networkX object.
     In future releases it will maintain compatibility but will migrate more

--- a/python/cugraph/cugraph/experimental/datasets/dataset.py
+++ b/python/cugraph/cugraph/experimental/datasets/dataset.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/experimental/datasets/dataset.py
+++ b/python/cugraph/cugraph/experimental/datasets/dataset.py
@@ -71,7 +71,7 @@ class Dataset:
     """
 
     def __init__(self, meta_data_file_name):
-        with open(meta_data_file_name, "r") as file:
+        with open(meta_data_file_name) as file:
             self.metadata = yaml.safe_load(file)
 
         self._dl_path = default_download_dir
@@ -198,6 +198,7 @@ def load_all(force=False):
     provided in each YAML file.
 
     Parameters
+    ----------
     force : Boolean (default=False)
         Overwrite any existing copies of datafiles.
     """
@@ -207,7 +208,7 @@ def load_all(force=False):
     for file in meta_path.iterdir():
         meta = None
         if file.suffix == ".yaml":
-            with open(meta_path / file, "r") as metafile:
+            with open(meta_path / file) as metafile:
                 meta = yaml.safe_load(metafile)
 
             if "url" in meta:
@@ -227,7 +228,7 @@ def set_config(cfgpath):
     cfgfile : String
         Read the custom config file given its path, and override the default
     """
-    with open(Path(cfgpath), "r") as file:
+    with open(Path(cfgpath)) as file:
         cfg = yaml.safe_load(file)
         default_download_dir.path = Path(cfg["download_dir"])
 

--- a/python/cugraph/cugraph/experimental/structure/bicliques.py
+++ b/python/cugraph/cugraph/experimental/structure/bicliques.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/experimental/structure/bicliques.py
+++ b/python/cugraph/cugraph/experimental/structure/bicliques.py
@@ -60,7 +60,7 @@ def EXPERIMENTAL__find_bicliques(
     # must be factor of 10
     PART_SIZE = int(1000)
 
-    x = [col for col in df.columns]
+    x = list(df.columns)
     if "src" not in x:
         raise NameError("src column not found")
     if "dst" not in x:

--- a/python/cugraph/cugraph/gnn/dgl_extensions/dgl_uniform_sampler.py
+++ b/python/cugraph/cugraph/gnn/dgl_extensions/dgl_uniform_sampler.py
@@ -62,6 +62,7 @@ class DGLUniformSampler:
             the result will be undefined. If not specified, sample uniformly.
         replace : bool
             If True, sample with replacement.
+
         Returns
         -------
         [src, dst, eids] or {etype1:[src, dst, eids],...,}

--- a/python/cugraph/cugraph/gnn/dgl_extensions/utils/sampling.py
+++ b/python/cugraph/cugraph/gnn/dgl_extensions/utils/sampling.py
@@ -154,7 +154,7 @@ def _convert_can_etype_s_to_tup(canonical_etype_s):
 
 def create_cp_result_ls(d):
     cupy_result_ls = []
-    for k, df in d.items():
+    for _k, df in d.items():
         if len(df) == 0:
             cupy_result_ls.append(cp.empty(shape=0, dtype=cp.int32))
             cupy_result_ls.append(cp.empty(shape=0, dtype=cp.int32))

--- a/python/cugraph/cugraph/gnn/feature_storage/feat_storage.py
+++ b/python/cugraph/cugraph/gnn/feature_storage/feat_storage.py
@@ -61,8 +61,8 @@ class FeatureStore:
         """
         Retrieve the feature data corresponding to the indices, type and feature name
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         indices: np.ndarray or torch.Tensor
             The indices of the values to extract.
         type_name : str
@@ -70,8 +70,8 @@ class FeatureStore:
         feat_name:
             The feature name to retrieve data for
 
-        Returns:
-        --------
+        Returns
+        -------
         np.ndarray or torch.Tensor
             Array object of the backend type
         """

--- a/python/cugraph/cugraph/layout/force_atlas2.py
+++ b/python/cugraph/cugraph/layout/force_atlas2.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/layout/force_atlas2.py
+++ b/python/cugraph/cugraph/layout/force_atlas2.py
@@ -32,7 +32,6 @@ def force_atlas2(
     verbose=False,
     callback=None,
 ):
-
     """
     ForceAtlas2 is a continuous graph layout algorithm for handy network
     visualization.

--- a/python/cugraph/cugraph/sampling/node2vec.py
+++ b/python/cugraph/cugraph/sampling/node2vec.py
@@ -30,7 +30,6 @@ def node2vec(G, start_vertices, max_depth=1, compress_result=True, p=1.0, q=1.0)
 
     References
     ----------
-
     A Grover, J Leskovec: node2vec: Scalable Feature Learning for Networks,
     Proceedings of the 22nd ACM SIGKDD International Conference on Knowledge
     Discovery and Data Mining, https://arxiv.org/abs/1607.00653

--- a/python/cugraph/cugraph/sampling/random_walks.py
+++ b/python/cugraph/cugraph/sampling/random_walks.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cugraph/cugraph/sampling/random_walks.py
+++ b/python/cugraph/cugraph/sampling/random_walks.py
@@ -47,7 +47,7 @@ def random_walks(
     either a padded or a coalesced result. For the padded case, vertices
     with no outgoing edges will be padded with NA
 
-    parameters
+    Parameters
     ----------
     G : cuGraph.Graph or networkx.Graph
         The graph can be either directed or undirected.
@@ -159,7 +159,7 @@ def random_walks(
         )
         warnings.warn(warning_msg, PendingDeprecationWarning)
 
-        drop_vertex = [i for i in range(max_depth, len(vertex_paths), max_depth + 1)]
+        drop_vertex = list(range(max_depth, len(vertex_paths), max_depth + 1))
         drop_edge_wgt = [
             i - 1 for i in range(max_depth, len(edge_wgt_paths), max_depth)
         ]
@@ -213,7 +213,7 @@ def rw_path(num_paths, sizes):
     Retrieve more information on the obtained paths in case use_padding
     is False.
 
-    parameters
+    Parameters
     ----------
     num_paths: int
         Number of paths in the random walk output.

--- a/python/cugraph/cugraph/structure/graph_classes.py
+++ b/python/cugraph/cugraph/structure/graph_classes.py
@@ -493,7 +493,7 @@ class Graph:
             Name of the column containing the external vertex ids
 
         Returns
-        ---------
+        -------
         series : cudf.Series or dask_cudf.Series
             The internal vertex identifiers
         """
@@ -532,7 +532,7 @@ class Graph:
             Preserve the order of the data frame (requires an extra sort)
 
         Returns
-        ---------
+        -------
         df : cudf.DataFrame or dask_cudf.DataFrame
             Original DataFrame with new column containing internal vertex
             id
@@ -732,7 +732,7 @@ class MultiGraph(Graph):
     """
 
     def __init__(self, directed=False):
-        super(MultiGraph, self).__init__(directed=directed)
+        super().__init__(directed=directed)
         self.graph_properties.multi_edge = True
 
     def is_multigraph(self):
@@ -762,13 +762,13 @@ class Tree(Graph):
     """
 
     def __init__(self, directed=False):
-        super(Tree, self).__init__(directed=directed)
+        super().__init__(directed=directed)
         self.graph_properties.tree = True
 
 
 class NPartiteGraph(Graph):
     def __init__(self, bipartite=False, directed=False):
-        super(NPartiteGraph, self).__init__(directed=directed)
+        super().__init__(directed=directed)
         self.graph_properties.bipartite = bipartite
         self.graph_properties.multipartite = True
 
@@ -902,7 +902,6 @@ class NPartiteGraph(Graph):
 
         Parameters
         ----------
-
         nodes : list or cudf.Series
             The nodes of the graph to be stored. If bipartite and multipartite
             arguments are not passed, the nodes are considered to be a list of
@@ -941,7 +940,7 @@ class BiPartiteGraph(NPartiteGraph):
     """
 
     def __init__(self, directed=False):
-        super(BiPartiteGraph, self).__init__(directed=directed, bipartite=True)
+        super().__init__(directed=directed, bipartite=True)
 
     def is_bipartite(self):
         """

--- a/python/cugraph/cugraph/structure/graph_implementation/npartiteGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/npartiteGraph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/structure/graph_implementation/npartiteGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/npartiteGraph.py
@@ -17,7 +17,7 @@ import cudf
 
 class npartiteGraphImpl(simpleGraphImpl):
     def __init__(self, properties):
-        super(npartiteGraphImpl, self).__init__(properties)
+        super().__init__(properties)
         self.properties.bipartite = properties.bipartite
 
     # API may change in future
@@ -46,7 +46,7 @@ class npartiteGraphImpl(simpleGraphImpl):
         graph is not bipartite.
         """
         # TO DO: Call coloring algorithm
-        set_names = [i for i in self._nodes.keys() if i != "all_nodes"]
+        set_names = [i for i in self._nodes if i != "all_nodes"]
         if self.properties.bipartite:
             top = self._nodes[set_names[0]]
             if len(set_names) == 2:
@@ -80,7 +80,7 @@ class npartiteGraphImpl(simpleGraphImpl):
         if bipartite is None and multipartite is None:
             raise Exception("Partition not provided")
         else:
-            set_names = [i for i in self._nodes.keys() if i != "all_nodes"]
+            set_names = [i for i in self._nodes if i != "all_nodes"]
             if multipartite is not None:
                 if self.properties.bipartite:
                     raise Exception(

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
@@ -402,6 +402,7 @@ class simpleDistributedGraphImpl:
                 specified).
             df[degree] : dask_cudf.Series
                 The computed in-degree of the corresponding vertex.
+
         Examples
         --------
         >>> M = dask_cudf.read_csv(datasets_path / 'karate.csv', delimiter=' ',
@@ -492,6 +493,7 @@ class simpleDistributedGraphImpl:
                 specified).
             df[degree] : dask_cudf.Series
                 The computed out-degree of the corresponding vertex.
+
         Examples
         --------
         >>> M = dask_cudf.read_csv(datasets_path / 'karate.csv', delimiter=' ',
@@ -570,6 +572,7 @@ class simpleDistributedGraphImpl:
             opt. (default=None)
             a container of vertices for displaying corresponding degree. If not
             set, degrees are computed for the entire set of vertices.
+
         Returns
         -------
         df : dask_cudf.DataFrame
@@ -582,6 +585,7 @@ class simpleDistributedGraphImpl:
                 specified).
             df['degree'] : dask_cudf.Series
                 The computed degree of the corresponding vertex.
+
         Examples
         --------
         >>> M = dask_cudf.read_csv(datasets_path / 'karate.csv', delimiter=' ',
@@ -809,6 +813,7 @@ class simpleDistributedGraphImpl:
         """
 
         Returns True if the graph contains the node(s) n.
+
         Examples
         --------
         >>> M = dask_cudf.read_csv(datasets_path / 'karate.csv', delimiter=' ',

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -15,7 +15,7 @@ from cugraph.structure import graph_primtypes_wrapper
 from cugraph.structure.graph_primtypes_wrapper import Direction
 from cugraph.structure.symmetrize import symmetrize
 from cugraph.structure.number_map import NumberMap
-import cugraph.dask.common.mg_utils as mg_utils
+from cugraph.dask.common import mg_utils
 import cupy
 import cudf
 import dask_cudf
@@ -967,10 +967,7 @@ class simpleGraphImpl:
         DiG.adjlist = self.adjlist
         DiG.transposedadjlist = self.transposedadjlist
 
-        if simpleGraphImpl.edgeWeightCol in self.edgelist.edgelist_df:
-            value_col = self.edgelist.edgelist_df[simpleGraphImpl.edgeWeightCol]
-        else:
-            value_col = None
+        value_col = self.edgelist.edgelist_df.get(simpleGraphImpl.edgeWeightCol, None)
 
         DiG._make_plc_graph(value_col, store_transposed)
 
@@ -1003,10 +1000,7 @@ class simpleGraphImpl:
                 value_col = None
             G.edgelist = simpleGraphImpl.EdgeList(source_col, dest_col, value_col)
 
-        if simpleGraphImpl.edgeWeightCol in self.edgelist.edgelist_df:
-            value_col = self.edgelist.edgelist_df[simpleGraphImpl.edgeWeightCol]
-        else:
-            value_col = None
+        value_col = self.edgelist.edgelist_df.get(simpleGraphImpl.edgeWeightCol, None)
 
         G._make_plc_graph(value_col, store_transposed)
 

--- a/python/cugraph/cugraph/structure/hypergraph.py
+++ b/python/cugraph/cugraph/structure/hypergraph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/structure/hypergraph.py
+++ b/python/cugraph/cugraph/structure/hypergraph.py
@@ -45,7 +45,7 @@ def hypergraph(
     dropna=True,
     direct=False,
     graph_class=Graph,
-    categories=dict(),
+    categories={},
     drop_edge_attrs=False,
     categorical_metadata=True,
     SKIP=None,
@@ -85,7 +85,6 @@ def hypergraph(
 
     Parameters
     ----------
-
     values : cudf.DataFrame
         The input Dataframe to transform into a hypergraph.
 
@@ -177,9 +176,7 @@ def hypergraph(
     """
 
     columns = values.columns if columns is None else columns
-    columns = sorted(
-        list(columns if SKIP is None else [x for x in columns if x not in SKIP])
-    )
+    columns = sorted(columns if SKIP is None else [x for x in columns if x not in SKIP])
 
     events = values.copy(deep=False)
     events.reset_index(drop=True, inplace=True)
@@ -291,7 +288,7 @@ def _create_entity_nodes(
     columns,
     dropna=True,
     categorical_metadata=False,
-    categories=dict(),
+    categories={},
     DELIM="::",
     NODEID="node_id",
     CATEGORY="category",
@@ -346,7 +343,7 @@ def _create_entity_nodes(
 
     nodes = cudf.concat(nodes)
     nodes = nodes.drop_duplicates(subset=[NODEID])
-    nodes = nodes[[NODEID, NODETYPE, CATEGORY] + list(columns)]
+    nodes = nodes[[NODEID, NODETYPE, CATEGORY, *list(columns)]]
     nodes.reset_index(drop=True, inplace=True)
     return nodes
 
@@ -385,7 +382,7 @@ def _create_hyper_edges(
     events,
     columns,
     dropna=True,
-    categories=dict(),
+    categories={},
     drop_edge_attrs=False,
     categorical_metadata=False,
     DELIM="::",
@@ -473,7 +470,7 @@ def _create_direct_edges(
     events,
     columns,
     dropna=True,
-    categories=dict(),
+    categories={},
     edge_shape=None,
     drop_edge_attrs=False,
     categorical_metadata=False,

--- a/python/cugraph/cugraph/structure/number_map.py
+++ b/python/cugraph/cugraph/structure/number_map.py
@@ -320,7 +320,7 @@ class NumberMap:
             vertex identifier
 
         Returns
-        ---------
+        -------
         vertex_ids : cudf.Series or dask_cudf.Series
             The vertex identifiers.  Note that to_internal_vertex_id
             does not guarantee order or partitioning (in the case of
@@ -376,7 +376,7 @@ class NumberMap:
             of the input DataFrame.
 
         Returns
-        ---------
+        -------
         df : cudf.DataFrame or dask_cudf.DataFrame
             A DataFrame containing the input data (DataFrame or series)
             with an additional column containing the internal vertex id.
@@ -441,7 +441,7 @@ class NumberMap:
             DataFrame.
 
         Returns
-        ---------
+        -------
         df : cudf.DataFrame or dask_cudf.DataFrame
             The original DataFrame columns exist unmodified.  Columns
             are added to the DataFrame to identify the external vertex
@@ -752,7 +752,7 @@ class NumberMap:
             If True, the unrenumbered column names are returned.
 
         Returns
-        ---------
+        -------
         df : cudf.DataFrame or dask_cudf.DataFrame
             The original DataFrame columns exist unmodified.  The external
             vertex identifiers are added to the DataFrame, the internal

--- a/python/cugraph/cugraph/structure/property_graph.py
+++ b/python/cugraph/cugraph/structure/property_graph.py
@@ -763,7 +763,7 @@ class EXPERIMENTAL__PropertyGraph:
             column_names_to_drop = set(tmp_df.columns)
             # remove the ones to keep
             column_names_to_drop.difference_update(
-                property_columns + [self.vertex_col_name, TCN]
+                [*property_columns, self.vertex_col_name, TCN]
             )
         else:
             column_names_to_drop = {vertex_col_name}
@@ -903,7 +903,7 @@ class EXPERIMENTAL__PropertyGraph:
             if columns is not None:
                 # FIXME: invalid columns will result in a KeyError, should a
                 # check be done here and a more PG-specific error raised?
-                df = df[[self.type_col_name] + columns]
+                df = df[[self.type_col_name, *columns]]
 
             # Should not drop to ensure vertex ids are returned as a column.
             df_out = df.reset_index(drop=False)
@@ -1183,7 +1183,7 @@ class EXPERIMENTAL__PropertyGraph:
             column_names_to_drop = set(tmp_df.columns)
             # remove the ones to keep
             column_names_to_drop.difference_update(
-                property_columns + [self.src_col_name, self.dst_col_name, TCN]
+                [*property_columns, self.src_col_name, self.dst_col_name, TCN]
             )
         else:
             column_names_to_drop = {vertex_col_names[0], vertex_col_names[1]}
@@ -1316,7 +1316,7 @@ class EXPERIMENTAL__PropertyGraph:
                 # FIXME: invalid columns will result in a KeyError, should a
                 # check be done here and a more PG-specific error raised?
                 df = df[
-                    [self.src_col_name, self.dst_col_name, self.type_col_name] + columns
+                    [self.src_col_name, self.dst_col_name, self.type_col_name, *columns]
                 ]
 
             # Should not drop so the edge ids are returned as a column.
@@ -1421,7 +1421,7 @@ class EXPERIMENTAL__PropertyGraph:
                 previously_selected_rows.index
             ]
 
-            locals = dict([(n, rows_to_eval[n]) for n in rows_to_eval.columns])
+            locals = {n: rows_to_eval[n] for n in rows_to_eval.columns}
             locals[self.vertex_col_name] = rows_to_eval.index
         else:
             locals = self.__vertex_prop_eval_dict

--- a/python/cugraph/cugraph/testing/utils.py
+++ b/python/cugraph/cugraph/testing/utils.py
@@ -366,7 +366,7 @@ def random_edgelist(
     >>>    #df.to_parquet('files_parquet/df'+str(x), index=False)
     """
     state = np.random.RandomState(seed)
-    columns = dict((k, make[dt](e // ef, e, state)) for k, dt in dtypes.items())
+    columns = {k: make[dt](e // ef, e, state) for k, dt in dtypes.items()}
 
     df = pd.DataFrame(columns)
     if drop_duplicates:

--- a/python/cugraph/cugraph/tests/centrality/test_betweenness_centrality.py
+++ b/python/cugraph/cugraph/tests/centrality/test_betweenness_centrality.py
@@ -96,6 +96,7 @@ def calc_betweenness_centrality(
     edgevals: bool
         When True, enable tests with weighted graph, should be ignored
         during computation.
+
     Returns
     -------
     sorted_df : cudf.DataFrame
@@ -128,7 +129,8 @@ def calc_betweenness_centrality(
         create_using=(nx.DiGraph() if directed else nx.Graph()),
     )
 
-    assert G is not None and Gnx is not None
+    assert G is not None
+    assert Gnx is not None
     if multi_gpu_batch:
         G.enable_batch()
 
@@ -362,7 +364,8 @@ def test_betweenness_centrality_k_full(
     edgevals,
 ):
     """Tests full betweenness centrality by using k = G.number_of_vertices()
-    instead of k=None, checks that k scales properly"""
+    instead of k=None, checks that k scales properly
+    """
     sorted_df = calc_betweenness_centrality(
         graph_file,
         directed=directed,

--- a/python/cugraph/cugraph/tests/centrality/test_edge_betweenness_centrality.py
+++ b/python/cugraph/cugraph/tests/centrality/test_edge_betweenness_centrality.py
@@ -114,7 +114,6 @@ def calc_edge_betweenness_centrality(
 
     Returns
     -------
-
     sorted_df : cudf.DataFrame
         Contains 'src', 'dst', 'cu_bc' and 'ref_bc' columns,  where 'cu_bc'
         and 'ref_bc' are the two betweenness centrality scores to compare.
@@ -132,7 +131,8 @@ def calc_edge_betweenness_centrality(
         create_using=cugraph.Graph(directed=directed), ignore_weights=not edgevals
     )
 
-    assert G is not None and Gnx is not None
+    assert G is not None
+    assert Gnx is not None
     if multi_gpu_batch:
         G.enable_batch()
 
@@ -365,7 +365,8 @@ def test_edge_betweenness_centrality_k_full(
     edgevals,
 ):
     """Tests full edge betweenness centrality by using k = G.number_of_vertices()
-    instead of k=None, checks that k scales properly"""
+    instead of k=None, checks that k scales properly
+    """
     sorted_df = calc_edge_betweenness_centrality(
         graph_file,
         directed=directed,

--- a/python/cugraph/cugraph/tests/community/test_balanced_cut.py
+++ b/python/cugraph/cugraph/tests/community/test_balanced_cut.py
@@ -36,9 +36,9 @@ def random_call(G, partitions):
     num_verts = G.number_of_vertices()
 
     score = 0.0
-    for repeat in range(20):
+    for _repeat in range(20):
         assignment = []
-        for i in range(num_verts):
+        for _i in range(num_verts):
             assignment.append(random.randint(0, partitions - 1))
 
         assign_cu = cudf.DataFrame(assignment, columns=["cluster"])

--- a/python/cugraph/cugraph/tests/community/test_k_truss_subgraph.py
+++ b/python/cugraph/cugraph/tests/community/test_k_truss_subgraph.py
@@ -33,7 +33,7 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import networkx as nx
 
-print("Networkx version : {} ".format(nx.__version__))
+print(f"Networkx version : {nx.__version__} ")
 
 
 # =============================================================================
@@ -105,7 +105,7 @@ def test_unsupported_cuda_version():
     (__cuda_version == __unsupported_cuda_version),
     reason="skipping on unsupported CUDA " f"{__unsupported_cuda_version} environment.",
 )
-@pytest.mark.parametrize("graph_file, nx_ground_truth", utils.DATASETS_KTRUSS)
+@pytest.mark.parametrize(("graph_file", "nx_ground_truth"), utils.DATASETS_KTRUSS)
 def test_ktruss_subgraph_Graph(graph_file, nx_ground_truth):
 
     k = 5
@@ -122,7 +122,7 @@ def test_ktruss_subgraph_Graph(graph_file, nx_ground_truth):
     (__cuda_version == __unsupported_cuda_version),
     reason="skipping on unsupported CUDA " f"{__unsupported_cuda_version} environment.",
 )
-@pytest.mark.parametrize("graph_file, nx_ground_truth", DATASETS_KTRUSS)
+@pytest.mark.parametrize(("graph_file", "nx_ground_truth"), DATASETS_KTRUSS)
 def test_ktruss_subgraph_Graph_nx(graph_file, nx_ground_truth):
 
     k = 5

--- a/python/cugraph/cugraph/tests/community/test_louvain.py
+++ b/python/cugraph/cugraph/tests/community/test_louvain.py
@@ -43,7 +43,7 @@ except ModuleNotFoundError:
     )
 
 
-print("Networkx version : {} ".format(nx.__version__))
+print(f"Networkx version : {nx.__version__} ")
 
 
 # =============================================================================

--- a/python/cugraph/cugraph/tests/community/test_modularity.py
+++ b/python/cugraph/cugraph/tests/community/test_modularity.py
@@ -37,7 +37,7 @@ def random_call(G, partitions):
     random.seed(0)
     num_verts = G.number_of_vertices()
     assignment = []
-    for i in range(num_verts):
+    for _i in range(num_verts):
         assignment.append(random.randint(0, partitions - 1))
 
     assignment_cu = cudf.DataFrame(assignment, columns=["cluster"])

--- a/python/cugraph/cugraph/tests/components/test_connectivity.py
+++ b/python/cugraph/cugraph/tests/components/test_connectivity.py
@@ -43,7 +43,7 @@ with warnings.catch_warnings():
     import networkx as nx
 
 
-print("Networkx version : {} ".format(nx.__version__))
+print(f"Networkx version : {nx.__version__} ")
 
 # Map of cuGraph input types to the expected output type for cuGraph
 # connected_components calls.
@@ -156,7 +156,7 @@ def cugraph_call(
         else:
             assert type(result[1]) is np.ndarray
 
-        unique_labels = set([n.item() for n in result[1]])
+        unique_labels = {n.item() for n in result[1]}
         assert len(unique_labels) == result[0]
 
         # The returned dict used in the tests for checking correctness needs
@@ -202,6 +202,7 @@ def assert_scipy_api_compat(G, dataset_path, api_type):
                                               directed=True,
                                               connection='weak',
                                               return_labels=True)
+
     Parameters
     ----------
         csgraph : array_like or sparse matrix
@@ -213,7 +214,7 @@ def assert_scipy_api_compat(G, dataset_path, api_type):
             the shortest path on an undirected graph: the algorithm can
             progress from point i to j along csgraph[i, j] or csgraph[j, i].
         connection : str, optional
-            [‘weak’|’strong’]. For directed graphs, the type of connection to
+            [`weak`|`strong`]. For directed graphs, the type of connection to
             use. Nodes i and j are strongly connected if a path exists both
             from i to j and from j to i. A directed graph is weakly connected
             if replacing all of its directed edges with undirected edges

--- a/python/cugraph/cugraph/tests/core/test_k_core.py
+++ b/python/cugraph/cugraph/tests/core/test_k_core.py
@@ -31,7 +31,7 @@ with warnings.catch_warnings():
     import networkx as nx
 
 
-print("Networkx version : {} ".format(nx.__version__))
+print(f"Networkx version : {nx.__version__} ")
 
 
 # =============================================================================

--- a/python/cugraph/cugraph/tests/data_store/test_property_graph.py
+++ b/python/cugraph/cugraph/tests/data_store/test_property_graph.py
@@ -201,7 +201,7 @@ def setup_function():
 # =============================================================================
 # Pytest fixtures
 # =============================================================================
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def raise_on_pandas_warning():
     """Raise when pandas gives SettingWithCopyWarning warning"""
     # Perhaps we should put this in pytest.ini, pyproject.toml, or conftest.py
@@ -231,7 +231,7 @@ def df_type_id(dataframe_type):
 df_types_fixture_params = gen_fixture_params_product((df_types, df_type_id))
 
 
-@pytest.fixture(scope="function", params=df_types_fixture_params)
+@pytest.fixture(params=df_types_fixture_params)
 def dataset1_PropertyGraph(request):
     """
     Fixture which returns an instance of a PropertyGraph with vertex and edge
@@ -504,8 +504,8 @@ def test_type_names(df_type):
         }
     )
     pG.add_edge_data(df, vertex_col_names=("src", "dst"))
-    assert pG.edge_types == set([""])
-    assert pG.vertex_types == set([""])
+    assert pG.edge_types == {""}
+    assert pG.vertex_types == {""}
 
     df = df_type(
         {
@@ -514,8 +514,8 @@ def test_type_names(df_type):
         }
     )
     pG.add_vertex_data(df, type_name="vtype", vertex_col_name="vertex")
-    assert pG.edge_types == set([""])
-    assert pG.vertex_types == set(["", "vtype"])
+    assert pG.edge_types == {""}
+    assert pG.vertex_types == {"", "vtype"}
 
     df = df_type(
         {
@@ -525,8 +525,8 @@ def test_type_names(df_type):
         }
     )
     pG.add_edge_data(df, type_name="etype", vertex_col_names=("src", "dst"))
-    assert pG.edge_types == set(["", "etype"])
-    assert pG.vertex_types == set(["", "vtype"])
+    assert pG.edge_types == {"", "etype"}
+    assert pG.vertex_types == {"", "vtype"}
     assert type_is_categorical(pG)
 
 
@@ -674,7 +674,7 @@ def test_get_vertex_data(dataset1_PropertyGraph):
         vert_ids = vert_ids.values_host
     assert sorted(actual_vertex_ids) == sorted(vert_ids)
 
-    expected_columns = set([pG.vertex_col_name, pG.type_col_name])
+    expected_columns = {pG.vertex_col_name, pG.type_col_name}
     for d in ["merchants", "users"]:
         for name in data[d][0]:
             expected_columns.add(name)
@@ -760,9 +760,12 @@ def test_get_edge_data(dataset1_PropertyGraph):
     assert sorted(actual_edge_ids) == sorted(edge_ids)
 
     # Create a list of expected column names from the three input tables
-    expected_columns = set(
-        [pG.src_col_name, pG.dst_col_name, pG.edge_id_col_name, pG.type_col_name]
-    )
+    expected_columns = {
+        pG.src_col_name,
+        pG.dst_col_name,
+        pG.edge_id_col_name,
+        pG.type_col_name,
+    }
     for d in ["transactions", "relationships", "referrals"]:
         for name in data[d][0]:
             expected_columns.add(name)

--- a/python/cugraph/cugraph/tests/data_store/test_property_graph_mg.py
+++ b/python/cugraph/cugraph/tests/data_store/test_property_graph_mg.py
@@ -256,7 +256,7 @@ def dataset1_PropertyGraph(request):
     return (pG, dataset1)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def dataset1_MGPropertyGraph(dask_client):
     """
     Fixture which returns an instance of a PropertyGraph with vertex and edge
@@ -772,9 +772,12 @@ def test_get_edge_data(dataset1_MGPropertyGraph):
     assert some_edge_data.dtypes["_TYPE_"] == "category"
 
     # Create a list of expected column names from the three input tables
-    expected_columns = set(
-        [pG.src_col_name, pG.dst_col_name, pG.edge_id_col_name, pG.type_col_name]
-    )
+    expected_columns = {
+        pG.src_col_name,
+        pG.dst_col_name,
+        pG.edge_id_col_name,
+        pG.type_col_name,
+    }
     for d in ["transactions", "relationships", "referrals"]:
         for name in data[d][0]:
             expected_columns.add(name)

--- a/python/cugraph/cugraph/tests/docs/test_doctests.py
+++ b/python/cugraph/cugraph/tests/docs/test_doctests.py
@@ -62,6 +62,7 @@ def _find_modules_in_obj(finder, obj, obj_name, criteria=None):
 
 def _find_doctests_in_obj(finder, obj, obj_name, criteria=None):
     """Find all doctests in a module or class.
+
     Parameters
     ----------
     finder : doctest.DocTestFinder
@@ -165,14 +166,14 @@ class TestDoctests:
         optionflags = doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
         runner = doctest.DocTestRunner(optionflags=optionflags)
         np.random.seed(6)
-        globs = dict(
-            cudf=cudf,
-            np=np,
-            cugraph=cugraph,
-            datasets_path=self.abs_datasets_path,
-            scipy=scipy,
-            pd=pd,
-        )
+        globs = {
+            "cudf": cudf,
+            "np": np,
+            "cugraph": cugraph,
+            "datasets_path": self.abs_datasets_path,
+            "scipy": scipy,
+            "pd": pd,
+        }
         docstring.globs = globs
 
         # Capture stdout and include failing outputs in the traceback.

--- a/python/cugraph/cugraph/tests/docs/test_doctests_mg.py
+++ b/python/cugraph/cugraph/tests/docs/test_doctests_mg.py
@@ -50,6 +50,7 @@ def _find_doctests_in_docstring(finder, member):
 
 def _find_doctests_in_obj(finder, obj, obj_name, criteria=None):
     """Find all doctests in a module or class.
+
     Parameters
     ----------
     finder : doctest.DocTestFinder
@@ -114,14 +115,14 @@ class TestDoctests:
         optionflags = doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
         runner = doctest.DocTestRunner(optionflags=optionflags)
         np.random.seed(6)
-        globs = dict(
-            cudf=cudf,
-            np=np,
-            cugraph=cugraph,
-            datasets_path=self.abs_datasets_path,
-            scipy=scipy,
-            pd=pd,
-        )
+        globs = {
+            "cudf": cudf,
+            "np": np,
+            "cugraph": cugraph,
+            "datasets_path": self.abs_datasets_path,
+            "scipy": scipy,
+            "pd": pd,
+        }
         docstring.globs = globs
 
         # Capture stdout and include failing outputs in the traceback.

--- a/python/cugraph/cugraph/tests/gnn/test_dgl_uniform_sampler.py
+++ b/python/cugraph/cugraph/tests/gnn/test_dgl_uniform_sampler.py
@@ -67,7 +67,7 @@ def test_sampling_homogeneous_gs_out_dir():
         4: ([], []),
     }
 
-    for seed in expected_out.keys():
+    for seed in expected_out:
         seed_cap = cudf.Series([seed]).to_dlpack()
         sample_src, sample_dst, sample_eid = sampler.sample_neighbors(
             seed_cap, fanout=9, edge_dir="out"
@@ -112,7 +112,7 @@ def test_sampling_homogeneous_gs_in_dir():
         4: ([1, 2], [4, 4]),
     }
 
-    for seed in expected_in.keys():
+    for seed in expected_in:
         seed_cap = cudf.Series([seed]).to_dlpack()
         sample_src, sample_dst, sample_eid = sampler.sample_neighbors(
             seed_cap, fanout=9, edge_dir="in"
@@ -211,7 +211,7 @@ def test_sampling_gs_heterogeneous_out_dir():
         },
     }
 
-    for seed in expeced_val_d.keys():
+    for seed in expeced_val_d:
         fanout = 4
         sampled_node_p = cudf.Series(seed).astype(np.int32).to_dlpack()
         sampled_g = sampler.sample_neighbors(
@@ -270,7 +270,7 @@ def test_sampling_gs_heterogeneous_in_dir():
         },
     }
 
-    for seed in expeced_val_d.keys():
+    for seed in expeced_val_d:
         fanout = 4
         sampled_node_p = cudf.Series(seed).astype(np.int32).to_dlpack()
         sampled_g = sampler.sample_neighbors(

--- a/python/cugraph/cugraph/tests/gnn/test_dgl_uniform_sampler_mg.py
+++ b/python/cugraph/cugraph/tests/gnn/test_dgl_uniform_sampler_mg.py
@@ -67,7 +67,7 @@ def test_sampling_homogeneous_gs_out_dir(dask_client):
         4: ([], []),
     }
 
-    for seed in expected_out.keys():
+    for seed in expected_out:
         seed_cap = cudf.Series([seed]).to_dlpack()
         sample_src, sample_dst, sample_eid = sampler.sample_neighbors(
             seed_cap, fanout=9, edge_dir="out"
@@ -113,7 +113,7 @@ def test_sampling_homogeneous_gs_in_dir(dask_client):
         4: ([1, 2], [4, 4]),
     }
 
-    for seed in expected_in.keys():
+    for seed in expected_in:
         seed_cap = cudf.Series([seed]).to_dlpack()
         sample_src, sample_dst, sample_eid = sampler.sample_neighbors(
             seed_cap, fanout=9, edge_dir="in"
@@ -212,7 +212,7 @@ def test_sampling_gs_heterogeneous_out_dir(dask_client):
         },
     }
 
-    for seed in expeced_val_d.keys():
+    for seed in expeced_val_d:
         fanout = 4
         sampled_node_p = cudf.Series(seed).astype(np.int32).to_dlpack()
         sampled_g = sampler.sample_neighbors(
@@ -271,7 +271,7 @@ def test_sampling_gs_heterogeneous_in_dir(dask_client):
         },
     }
 
-    for seed in expeced_val_d.keys():
+    for seed in expeced_val_d:
         fanout = 4
         sampled_node_p = cudf.Series(seed).astype(np.int32).to_dlpack()
         sampled_g = sampler.sample_neighbors(

--- a/python/cugraph/cugraph/tests/internals/test_renumber_mg.py
+++ b/python/cugraph/cugraph/tests/internals/test_renumber_mg.py
@@ -17,7 +17,6 @@ import gc
 import pytest
 
 import pandas
-import numpy as np
 import dask_cudf
 import dask
 import cudf
@@ -113,7 +112,7 @@ def test_mg_renumber_add_internal_vertex_id(graph_file, dask_client):
     gdf["dst_old"] = destinations
     gdf["src"] = sources + translate
     gdf["dst"] = destinations + translate
-    gdf["weight"] = gdf.index.astype(np.float)
+    gdf["weight"] = gdf.index.astype(float)
 
     ddf = dask.dataframe.from_pandas(
         gdf, npartitions=len(dask_client.scheduler_info()["workers"])
@@ -335,7 +334,7 @@ def test_pagerank_string_vertex_ids(dask_client):
 @pytest.mark.parametrize("dtype", ["int32", "int64"])
 def test_mg_renumber_multi_column(dtype, dask_client):
     df = cudf.DataFrame(
-        {"src_a": [i for i in range(0, 10)], "dst_a": [i for i in range(10, 20)]}
+        {"src_a": list(range(0, 10)), "dst_a": list(range(10, 20))}
     ).astype(dtype)
 
     df["src_b"] = df["src_a"] + 10

--- a/python/cugraph/cugraph/tests/internals/test_symmetrize_mg.py
+++ b/python/cugraph/cugraph/tests/internals/test_symmetrize_mg.py
@@ -145,8 +145,9 @@ def compare(ddf1, ddf2, src_col_name, dst_col_name, val_col_name):
 
 
 input_data_path = [
-    utils.RAPIDS_DATASET_ROOT_DIR_PATH / "karate-asymmetric.csv"
-] + utils.DATASETS_UNDIRECTED
+    utils.RAPIDS_DATASET_ROOT_DIR_PATH / "karate-asymmetric.csv",
+    *utils.DATASETS_UNDIRECTED,
+]
 datasets = [pytest.param(d.as_posix()) for d in input_data_path]
 
 fixture_params = gen_fixture_params_product(

--- a/python/cugraph/cugraph/tests/layout/test_force_atlas2.py
+++ b/python/cugraph/cugraph/tests/layout/test_force_atlas2.py
@@ -81,7 +81,7 @@ BARNES_HUT_OPTIMIZE = [False, True]
 
 class TestCallback(GraphBasedDimRedCallback):
     def __init__(self):
-        super(TestCallback, self).__init__()
+        super().__init__()
         self.on_preprocess_end_called_count = 0
         self.on_epoch_end_called_count = 0
         self.on_train_end_called_count = 0
@@ -97,7 +97,7 @@ class TestCallback(GraphBasedDimRedCallback):
 
 
 @pytest.mark.sg
-@pytest.mark.parametrize("graph_file, score", DATASETS)
+@pytest.mark.parametrize(("graph_file", "score"), DATASETS)
 @pytest.mark.parametrize("max_iter", MAX_ITERATIONS)
 @pytest.mark.parametrize("barnes_hut_optimize", BARNES_HUT_OPTIMIZE)
 def test_force_atlas2(graph_file, score, max_iter, barnes_hut_optimize):
@@ -150,7 +150,7 @@ def test_force_atlas2(graph_file, score, max_iter, barnes_hut_optimize):
 # need to revisit ASAP
 @pytest.mark.sg
 @pytest.mark.skip(reason="non-deterministric - needs fixing!")
-@pytest.mark.parametrize("graph_file, score", DATASETS[:-1])
+@pytest.mark.parametrize(("graph_file", "score"), DATASETS[:-1])
 @pytest.mark.parametrize("max_iter", MAX_ITERATIONS)
 @pytest.mark.parametrize("barnes_hut_optimize", BARNES_HUT_OPTIMIZE)
 def test_force_atlas2_multi_column_pos_list(

--- a/python/cugraph/cugraph/tests/linear/test_hungarian.py
+++ b/python/cugraph/cugraph/tests/linear/test_hungarian.py
@@ -59,7 +59,7 @@ def setup_function():
 
 
 @pytest.mark.sg
-@pytest.mark.parametrize("v1_size, v2_size, weight_limit", SPARSE_SIZES)
+@pytest.mark.parametrize(("v1_size", "v2_size", "weight_limit"), SPARSE_SIZES)
 def test_hungarian(v1_size, v2_size, weight_limit):
     v1, g, m = create_random_bipartite(v1_size, v2_size, weight_limit, np.float64)
 
@@ -81,7 +81,7 @@ def test_hungarian(v1_size, v2_size, weight_limit):
 
 
 @pytest.mark.sg
-@pytest.mark.parametrize("n, weight_limit", DENSE_SIZES)
+@pytest.mark.parametrize(("n", "weight_limit"), DENSE_SIZES)
 def test_dense_hungarian(n, weight_limit):
     C = np.random.uniform(0, weight_limit, size=(n, n)).round().astype(np.float32)
 

--- a/python/cugraph/cugraph/tests/link_analysis/test_hits.py
+++ b/python/cugraph/cugraph/tests/link_analysis/test_hits.py
@@ -34,7 +34,7 @@ def setup_function():
 # =============================================================================
 # Pytest fixtures
 # =============================================================================
-datasets = DATASETS_UNDIRECTED + [email_Eu_core]
+datasets = [*DATASETS_UNDIRECTED, email_Eu_core]
 fixture_params = gen_fixture_params_product(
     (datasets, "graph_file"),
     ([50], "max_iter"),

--- a/python/cugraph/cugraph/tests/link_analysis/test_hits_mg.py
+++ b/python/cugraph/cugraph/tests/link_analysis/test_hits_mg.py
@@ -40,8 +40,9 @@ IS_DIRECTED = [True, False]
 # Pytest fixtures
 # =============================================================================
 
-datasets = utils.DATASETS_UNDIRECTED + [
-    utils.RAPIDS_DATASET_ROOT_DIR_PATH / "email-Eu-core.csv"
+datasets = [
+    *utils.DATASETS_UNDIRECTED,
+    utils.RAPIDS_DATASET_ROOT_DIR_PATH / "email-Eu-core.csv",
 ]
 
 fixture_params = gen_fixture_params_product(

--- a/python/cugraph/cugraph/tests/link_analysis/test_pagerank.py
+++ b/python/cugraph/cugraph/tests/link_analysis/test_pagerank.py
@@ -35,7 +35,7 @@ with warnings.catch_warnings():
     import networkx as nx
 
 
-print("Networkx version : {} ".format(nx.__version__))
+print(f"Networkx version : {nx.__version__} ")
 
 
 def cudify(d):

--- a/python/cugraph/cugraph/tests/link_prediction/test_jaccard.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_jaccard.py
@@ -35,7 +35,7 @@ with warnings.catch_warnings():
     import networkx as nx
 
 
-print("Networkx version : {} ".format(nx.__version__))
+print(f"Networkx version : {nx.__version__} ")
 
 
 # =============================================================================
@@ -62,7 +62,7 @@ def compare_jaccard_two_hop(G, Gnx, edgevals=True):
     nx_pairs = list(pairs.to_records(index=False))
     preds = nx.jaccard_coefficient(Gnx, nx_pairs)
     nx_coeff = []
-    for u, v, p in preds:
+    for _u, _v, p in preds:
         # print(u, " ", v, " ", p)
         nx_coeff.append(p)
     df = cugraph.jaccard(G, pairs)

--- a/python/cugraph/cugraph/tests/link_prediction/test_jaccard_mg.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_jaccard_mg.py
@@ -40,8 +40,9 @@ HAS_VERTEX_PAIR = [True, False]
 # Pytest fixtures
 # =============================================================================
 
-datasets = utils.DATASETS_UNDIRECTED + [
-    utils.RAPIDS_DATASET_ROOT_DIR_PATH / "email-Eu-core.csv"
+datasets = [
+    *utils.DATASETS_UNDIRECTED,
+    utils.RAPIDS_DATASET_ROOT_DIR_PATH / "email-Eu-core.csv",
 ]
 
 fixture_params = gen_fixture_params_product(

--- a/python/cugraph/cugraph/tests/link_prediction/test_overlap_mg.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_overlap_mg.py
@@ -40,8 +40,9 @@ HAS_VERTEX_PAIR = [True, False]
 # Pytest fixtures
 # =============================================================================
 
-datasets = utils.DATASETS_UNDIRECTED + [
-    utils.RAPIDS_DATASET_ROOT_DIR_PATH / "email-Eu-core.csv"
+datasets = [
+    *utils.DATASETS_UNDIRECTED,
+    utils.RAPIDS_DATASET_ROOT_DIR_PATH / "email-Eu-core.csv",
 ]
 
 fixture_params = gen_fixture_params_product(

--- a/python/cugraph/cugraph/tests/link_prediction/test_sorensen.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_sorensen.py
@@ -34,7 +34,7 @@ with warnings.catch_warnings():
     import networkx as nx
 
 
-print("Networkx version : {} ".format(nx.__version__))
+print(f"Networkx version : {nx.__version__} ")
 
 
 # =============================================================================
@@ -61,7 +61,7 @@ def compare_sorensen_two_hop(G, Gnx, edgevals=False):
     nx_pairs = list(pairs.to_records(index=False))
     preds = nx.jaccard_coefficient(Gnx, nx_pairs)
     nx_coeff = []
-    for u, v, p in preds:
+    for _u, _v, p in preds:
         # FIXME: Use known correct values of Sorensen for few graphs,
         # hardcode it and compare to Cugraph Sorensen to get a more robust test
 

--- a/python/cugraph/cugraph/tests/link_prediction/test_sorensen_mg.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_sorensen_mg.py
@@ -41,8 +41,9 @@ HAS_VERTEX_PAIR = [True, False]
 # Pytest fixtures
 # =============================================================================
 
-datasets = utils.DATASETS_UNDIRECTED + [
-    utils.RAPIDS_DATASET_ROOT_DIR_PATH / "email-Eu-core.csv"
+datasets = [
+    *utils.DATASETS_UNDIRECTED,
+    utils.RAPIDS_DATASET_ROOT_DIR_PATH / "email-Eu-core.csv",
 ]
 
 fixture_params = gen_fixture_params_product(

--- a/python/cugraph/cugraph/tests/link_prediction/test_wjaccard.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_wjaccard.py
@@ -35,7 +35,7 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import networkx as nx
 
-print("Networkx version : {} ".format(nx.__version__))
+print(f"Networkx version : {nx.__version__} ")
 
 
 # =============================================================================
@@ -89,7 +89,7 @@ def networkx_call(M, benchmark_callable=None):
         preds = nx.jaccard_coefficient(Gnx, edges)
 
     coeff = []
-    for u, v, p in preds:
+    for _u, _v, p in preds:
         coeff.append(p)
     return coeff
 

--- a/python/cugraph/cugraph/tests/link_prediction/test_wsorensen.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_wsorensen.py
@@ -35,7 +35,7 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import networkx as nx
 
-print("Networkx version : {} ".format(nx.__version__))
+print(f"Networkx version : {nx.__version__} ")
 
 
 # =============================================================================
@@ -88,7 +88,7 @@ def networkx_call(M, benchmark_callable=None):
     else:
         preds = nx.jaccard_coefficient(Gnx, edges)
     coeff = []
-    for u, v, p in preds:
+    for _u, _v, p in preds:
         # FIXME: Use known correct values of WSorensen for few graphs,
         # hardcode it and compare to Cugraph WSorensen
         # to get a more robust test

--- a/python/cugraph/cugraph/tests/nx/test_compat_algo.py
+++ b/python/cugraph/cugraph/tests/nx/test_compat_algo.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cugraph.experimental.compat.nx as nx
+from cugraph.experimental.compat import nx
 import pytest
 
 

--- a/python/cugraph/cugraph/tests/nx/test_compat_pr.py
+++ b/python/cugraph/cugraph/tests/nx/test_compat_pr.py
@@ -241,4 +241,4 @@ def test_fixture_data(input_expected_output, which_import):
     )
     actual = sorted(pr.items())
     expected = sorted(input_expected_output["nx_pr_rankings"].items())
-    assert all([a == pytest.approx(b, abs=1.0e-04) for a, b in zip(actual, expected)])
+    assert all(a == pytest.approx(b, abs=1.0e-04) for a, b in zip(actual, expected))

--- a/python/cugraph/cugraph/tests/sampling/test_egonet.py
+++ b/python/cugraph/cugraph/tests/sampling/test_egonet.py
@@ -30,7 +30,7 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import networkx as nx
 
-print("Networkx version : {} ".format(nx.__version__))
+print(f"Networkx version : {nx.__version__} ")
 
 SEEDS = [0, 5, 13]
 RADIUS = [1, 2, 3]

--- a/python/cugraph/cugraph/tests/sampling/test_egonet_mg.py
+++ b/python/cugraph/cugraph/tests/sampling/test_egonet_mg.py
@@ -42,8 +42,9 @@ RADIUS = [1, 2, 3]
 # Pytest fixtures
 # =============================================================================
 
-datasets = utils.DATASETS_UNDIRECTED + [
-    utils.RAPIDS_DATASET_ROOT_DIR_PATH / "email-Eu-core.csv"
+datasets = [
+    *utils.DATASETS_UNDIRECTED,
+    utils.RAPIDS_DATASET_ROOT_DIR_PATH / "email-Eu-core.csv",
 ]
 
 fixture_params = gen_fixture_params_product(

--- a/python/cugraph/cugraph/tests/sampling/test_node2vec.py
+++ b/python/cugraph/cugraph/tests/sampling/test_node2vec.py
@@ -185,10 +185,10 @@ def test_node2vec(
                     u = vertex_paths[idx + path_idx]
                     v = vertex_paths[idx + path_idx + 1]
                     # Corresponding weight to edge is not correct
-                    expr = "(src == {} and dst == {})".format(u, v)
+                    expr = f"(src == {u} and dst == {v})"
                     edge_query = G.edgelist.edgelist_df.query(expr)
                     if edge_query.empty:
-                        raise ValueError("edge_query didn't find:({},{})".format(u, v))
+                        raise ValueError(f"edge_query didn't find:({u},{v})")
                     else:
                         if edge_query["weights"].values[0] != weight:
                             raise ValueError("edge_query weight incorrect")
@@ -206,10 +206,10 @@ def test_node2vec(
                     u = vertex_paths[path_idx * max_depth + idx]
                     v = vertex_paths[path_idx * max_depth + idx + 1]
                     # Corresponding weight to edge is not correct
-                    expr = "(src == {} and dst == {})".format(u, v)
+                    expr = f"(src == {u} and dst == {v})"
                     edge_query = G.edgelist.edgelist_df.query(expr)
                     if edge_query.empty:
-                        raise ValueError("edge_query didn't find:({},{})".format(u, v))
+                        raise ValueError(f"edge_query didn't find:({u},{v})")
                     else:
                         if edge_query["weights"].values[0] != weight:
                             raise ValueError("edge_query weight incorrect")
@@ -238,10 +238,10 @@ def test_node2vec(
                 u = vertex_paths[src_idx]
                 v = vertex_paths[dst_idx]
                 # Corresponding weight to edge is not correct
-                expr = "(src == {} and dst == {})".format(u, v)
+                expr = f"(src == {u} and dst == {v})"
                 edge_query = G.edgelist.edgelist_df.query(expr)
                 if edge_query.empty:
-                    raise ValueError("edge_query didn't find:({},{})".format(u, v))
+                    raise ValueError(f"edge_query didn't find:({u},{v})")
                 else:
                     if edge_query["weights"].values[0] != weight:
                         raise ValueError("edge_query weight incorrect")

--- a/python/cugraph/cugraph/tests/sampling/test_random_walks.py
+++ b/python/cugraph/cugraph/tests/sampling/test_random_walks.py
@@ -40,7 +40,7 @@ def calc_random_walks(graph_file, directed=False, max_depth=None, use_padding=Fa
     """
     compute random walks for each nodes in 'start_vertices'
 
-    parameters
+    Parameters
     ----------
     G : cuGraph.Graph or networkx.Graph
         The graph can be either directed or undirected.
@@ -107,7 +107,7 @@ def check_random_walks(path_data, seeds, df_G=None):
             (df_G["src"] == (src)) & (df_G["dst"] == (dst))
         ].reset_index(drop=True)
 
-        if not (exp_edge["src"].loc[0], exp_edge["dst"].loc[0]) == (src, dst):
+        if (exp_edge["src"].loc[0], exp_edge["dst"].loc[0]) != (src, dst):
             print(
                 "[ERR] Invalid edge: " "There is no edge src {} dst {}".format(src, dst)
             )
@@ -140,8 +140,8 @@ def test_random_walks_coalesced(graph_file, directed):
 
     # Check path query output
     df = cugraph.rw_path(len(seeds), path_data[2])
-    v_offsets = [0] + path_data[2].cumsum()[:-1].to_numpy().tolist()
-    w_offsets = [0] + (path_data[2] - 1).cumsum()[:-1].to_numpy().tolist()
+    v_offsets = [0, *path_data[2].cumsum()[:-1].to_numpy().tolist()]
+    w_offsets = [0, *(path_data[2] - 1).cumsum()[:-1].to_numpy().tolist()]
 
     assert_series_equal(df["weight_sizes"], path_data[2] - 1, check_names=False)
     assert df["vertex_offsets"].to_numpy().tolist() == v_offsets

--- a/python/cugraph/cugraph/tests/sampling/test_random_walks_mg.py
+++ b/python/cugraph/cugraph/tests/sampling/test_random_walks_mg.py
@@ -41,7 +41,7 @@ IS_DIRECTED = [True, False]
 # Pytest fixtures
 # =============================================================================
 
-datasets = DATASETS_SMALL + [karate_asymmetric]
+datasets = [*DATASETS_SMALL, karate_asymmetric]
 
 fixture_params = gen_fixture_params_product(
     (datasets, "graph_file"),
@@ -53,7 +53,7 @@ def calc_random_walks(G):
     """
     compute random walks
 
-    parameters
+    Parameters
     ----------
     G : cuGraph.Graph or networkx.Graph
         The graph can be either directed (DiGraph) or undirected (Graph).

--- a/python/cugraph/cugraph/tests/sampling/test_uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/tests/sampling/test_uniform_neighbor_sample.py
@@ -34,7 +34,7 @@ def setup_function():
 # =============================================================================
 IS_DIRECTED = [True, False]
 
-datasets = DATASETS_UNDIRECTED + [email_Eu_core]
+datasets = [*DATASETS_UNDIRECTED, email_Eu_core]
 
 fixture_params = gen_fixture_params_product(
     (datasets, "graph_file"),

--- a/python/cugraph/cugraph/tests/sampling/test_uniform_neighbor_sample_mg.py
+++ b/python/cugraph/cugraph/tests/sampling/test_uniform_neighbor_sample_mg.py
@@ -51,7 +51,7 @@ def setup_function():
 # =============================================================================
 IS_DIRECTED = [True, False]
 
-datasets = DATASETS_UNDIRECTED + [email_Eu_core]
+datasets = [*DATASETS_UNDIRECTED, email_Eu_core]
 
 fixture_params = gen_fixture_params_product(
     (datasets, "graph_file"),

--- a/python/cugraph/cugraph/tests/structure/test_graph.py
+++ b/python/cugraph/cugraph/tests/structure/test_graph.py
@@ -549,7 +549,7 @@ def test_to_directed(graph_file):
     assert DiG.number_of_edges() == DiGnx.number_of_edges()
     assert DiG._plc_graph is not None
 
-    for index, row in cu_M.to_pandas().iterrows():
+    for _index, row in cu_M.to_pandas().iterrows():
         assert G.has_edge(row["0"], row["1"])
         assert G.has_edge(row["1"], row["0"])
 
@@ -574,7 +574,7 @@ def test_to_undirected(graph_file):
         M, source="0", target="1", create_using=nx.DiGraph()
     )
 
-    for index, row in cu_M.to_pandas().iterrows():
+    for _index, row in cu_M.to_pandas().iterrows():
         assert DiG.has_edge(row["0"], row["1"])
         assert not DiG.has_edge(row["1"], row["0"])
 
@@ -586,7 +586,7 @@ def test_to_undirected(graph_file):
     assert G.number_of_edges() == Gnx.number_of_edges()
     assert G._plc_graph is not None
 
-    for index, row in cu_M.to_pandas().iterrows():
+    for _index, row in cu_M.to_pandas().iterrows():
         assert G.has_edge(row["0"], row["1"])
         assert G.has_edge(row["1"], row["0"])
 
@@ -602,7 +602,7 @@ def test_has_edge(graph_file):
     G = cugraph.Graph()
     G.from_cudf_edgelist(cu_M, source="0", destination="1")
 
-    for index, row in cu_M.to_pandas().iterrows():
+    for _index, row in cu_M.to_pandas().iterrows():
         assert G.has_edge(row["0"], row["1"])
         assert G.has_edge(row["1"], row["0"])
 
@@ -674,7 +674,7 @@ def test_neighbors(graph_file):
     Gnx = nx.from_pandas_edgelist(M, source="0", target="1", create_using=nx.Graph())
     for n in nodes.values_host:
         cu_neighbors = G.neighbors(n).to_arrow().to_pylist()
-        nx_neighbors = [i for i in Gnx.neighbors(n)]
+        nx_neighbors = list(Gnx.neighbors(n))
         cu_neighbors.sort()
         nx_neighbors.sort()
         assert cu_neighbors == nx_neighbors

--- a/python/cugraph/cugraph/tests/traversal/test_bfs.py
+++ b/python/cugraph/cugraph/tests/traversal/test_bfs.py
@@ -242,7 +242,7 @@ def _compare_bfs(cugraph_df, nx_distances, source):
                 else:
                     # The graph is unweighted thus, predecessors are 1 away
                     if vertex != source and (
-                        (nx_distances[pred] + 1 != cu_distances[vertex])
+                        nx_distances[pred] + 1 != cu_distances[vertex]
                     ):
                         print(
                             "[ERR] Invalid on predecessors: "
@@ -365,7 +365,7 @@ def dataset_nxresults_allstartvertices_spc(small_dataset_nx_graph):
     dataset, directed, Gnx = small_dataset_nx_graph
     use_spc = True
 
-    start_vertices = [start_vertex for start_vertex in Gnx]
+    start_vertices = list(Gnx)
 
     all_nx_values = []
     for start_vertex in start_vertices:

--- a/python/cugraph/cugraph/tests/traversal/test_filter_unreachable.py
+++ b/python/cugraph/cugraph/tests/traversal/test_filter_unreachable.py
@@ -39,7 +39,7 @@ with warnings.catch_warnings():
     import networkx as nx
 
 
-print("Networkx version : {} ".format(nx.__version__))
+print(f"Networkx version : {nx.__version__} ")
 
 SOURCES = [1]
 

--- a/python/cugraph/cugraph/tests/traversal/test_sssp.py
+++ b/python/cugraph/cugraph/tests/traversal/test_sssp.py
@@ -43,7 +43,7 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import networkx as nx
 
-print("Networkx version : {} ".format(nx.__version__))
+print(f"Networkx version : {nx.__version__} ")
 
 
 # Map of cuGraph input types to the expected output type for cuGraph
@@ -247,7 +247,7 @@ def test_sssp(gpubenchmark, dataset_source_nxresults, cugraph_input_type):
             if vid != source and cu_paths[pred][0] + 1 != cu_paths[vid][0]:
                 err = err + 1
         else:
-            if vid in nx_paths.keys():
+            if vid in nx_paths:
                 err = err + 1
 
     assert err == 0
@@ -305,7 +305,7 @@ def test_sssp_edgevals(
                 if cu_paths[pred][0] + edge_weight != cu_paths[vid][0]:
                     err = err + 1
         else:
-            if vid in nx_paths.keys():
+            if vid in nx_paths:
                 err = err + 1
 
     assert err == 0
@@ -373,7 +373,7 @@ def test_sssp_data_type_conversion(graph_file, source):
                 if cu_paths[pred][0] + edge_weight != cu_paths[vid][0]:
                     err = err + 1
         else:
-            if vid in nx_paths.keys():
+            if vid in nx_paths:
                 err = err + 1
 
     assert err == 0

--- a/python/cugraph/cugraph/tests/tree/test_maximum_spanning_tree.py
+++ b/python/cugraph/cugraph/tests/tree/test_maximum_spanning_tree.py
@@ -35,7 +35,7 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import networkx as nx
 
-print("Networkx version : {} ".format(nx.__version__))
+print(f"Networkx version : {nx.__version__} ")
 
 
 # =============================================================================

--- a/python/cugraph/cugraph/tests/tree/test_minimum_spanning_tree.py
+++ b/python/cugraph/cugraph/tests/tree/test_minimum_spanning_tree.py
@@ -34,7 +34,7 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import networkx as nx
 
-print("Networkx version : {} ".format(nx.__version__))
+print(f"Networkx version : {nx.__version__} ")
 
 
 # =============================================================================

--- a/python/cugraph/cugraph/tests/utils/mg_context.py
+++ b/python/cugraph/cugraph/tests/utils/mg_context.py
@@ -113,4 +113,4 @@ def enforce_rescale(
         time.sleep(wait_time)
         ready = len(cluster.workers) == scale
         attempt += 1
-    assert ready, "Unable to rescale cluster to {}".format(scale)
+    assert ready, f"Unable to rescale cluster to {scale}"

--- a/python/cugraph/cugraph/tests/utils/test_replication_mg.py
+++ b/python/cugraph/cugraph/tests/utils/test_replication_mg.py
@@ -18,9 +18,9 @@ import cudf
 from cudf.testing import assert_series_equal, assert_frame_equal
 
 import cugraph
-import cugraph.dask.structure.replication as replication
+from cugraph.dask.structure import replication
 from cugraph.dask.common.mg_utils import is_single_gpu
-import cugraph.testing.utils as utils
+from cugraph.testing import utils
 
 DATASETS_OPTIONS = utils.DATASETS_SMALL
 DIRECTED_GRAPH_OPTIONS = [False, True]
@@ -259,4 +259,5 @@ def test_enable_batch_adjlist_replication_no_weights(graph_file, directed, dask_
         (rep_offsets, rep_indices, rep_weights) = G.batch_adjlists[worker]
         assert_series_equal(offsets, rep_offsets.result(), check_names=False)
         assert_series_equal(indices, rep_indices.result(), check_names=False)
-        assert weights is None and rep_weights is None
+        assert weights is None
+        assert rep_weights is None

--- a/python/cugraph/cugraph/traversal/bfs.py
+++ b/python/cugraph/cugraph/traversal/bfs.py
@@ -165,8 +165,8 @@ def bfs(
 
     Returns
     -------
-    Return value type is based on the input type.  If G is a cugraph.Graph,
-    returns:
+    Return value type is based on the input type.
+    If G is a cugraph.Graph, returns:
 
        cudf.DataFrame
           df['vertex'] vertex IDs
@@ -214,9 +214,7 @@ def bfs(
 
     # The BFS C++ extension assumes the start vertex is a cudf.Series object,
     # and operates on internal vertex IDs if renumbered.
-    is_dataframe = isinstance(start, cudf.DataFrame) or isinstance(
-        start, dask_cudf.DataFrame
-    )
+    is_dataframe = isinstance(start, (cudf.DataFrame, dask_cudf.DataFrame))
     if G.renumbered is True:
         if is_dataframe:
             start = G.lookup_internal_vertex_id(start, start.columns)
@@ -283,8 +281,8 @@ def bfs_edges(G, source, reverse=False, depth_limit=None, sort_neighbors=None):
 
     Returns
     -------
-    Return value type is based on the input type.  If G is a cugraph.Graph,
-    returns:
+    Return value type is based on the input type.
+    If G is a cugraph.Graph, returns:
 
        cudf.DataFrame
           df['vertex'] vertex IDs

--- a/python/cugraph/cugraph/traversal/sssp.py
+++ b/python/cugraph/cugraph/traversal/sssp.py
@@ -166,8 +166,8 @@ def sssp(
 
     Returns
     -------
-    Return value type is based on the input type.  If G is a cugraph.Graph,
-    returns:
+    Return value type is based on the input type.
+    If G is a cugraph.Graph, returns:
 
        cudf.DataFrame
           df['vertex']

--- a/python/cugraph/cugraph/utilities/api_tools.py
+++ b/python/cugraph/cugraph/utilities/api_tools.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/utilities/api_tools.py
+++ b/python/cugraph/cugraph/utilities/api_tools.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pylibcugraph.utilities.api_tools as api_tools
+from pylibcugraph.utilities import api_tools
 
 experimental_prefix = "EXPERIMENTAL"
 

--- a/python/cugraph/cugraph/utilities/path_retrieval.py
+++ b/python/cugraph/cugraph/utilities/path_retrieval.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/utilities/path_retrieval.py
+++ b/python/cugraph/cugraph/utilities/path_retrieval.py
@@ -46,7 +46,7 @@ def get_traversed_cost(df, source, source_col, dest_col, value_col):
         Weight should be a floating type.
 
     Returns
-    ---------
+    -------
     df : cudf.DataFrame
         DataFrame containing two columns 'vertex' and 'info'.
         Unreachable vertices will have value the max value of the weight type.

--- a/python/cugraph/cugraph/utilities/utils.py
+++ b/python/cugraph/cugraph/utilities/utils.py
@@ -78,7 +78,7 @@ def get_traversed_path(df, id):
         most be the same data types as what is in the dataframe
 
     Returns
-    ---------
+    -------
     df : cudf.DataFrame
         a dataframe containing the path steps
 
@@ -151,7 +151,7 @@ def get_traversed_path_list(df, id):
         The vertex ID
 
     Returns
-    ---------
+    -------
     a : Python array
         a ordered array containing the steps from id to root
 
@@ -254,7 +254,6 @@ def get_device_memory_info():
 # |      Many NetworkX algorithms designed for weighted graphs use
 # |      an edge attribute (by default `weight`) to hold a numerical value.
 def ensure_cugraph_obj(obj, nx_weight_attr=None, matrix_graph_type=None):
-
     """
     Convert the input obj - if possible - to a cuGraph Graph-type obj (Graph,
     etc.) and return a tuple of (cugraph Graph-type obj, original

--- a/python/pylibcugraph/pylibcugraph/testing/utils.py
+++ b/python/pylibcugraph/pylibcugraph/testing/utils.py
@@ -124,7 +124,7 @@ def gen_fixture_params_product(*args):
         for (p, paramId) in zip(paramCombo, ids):
             # Assume paramId is either a string or a callable
             if isinstance(paramId, str):
-                id_strings.append("%s=%s" % (paramId, p.values[0]))
+                id_strings.append(f"{paramId}={p.values[0]}")
             else:
                 id_strings.append(paramId(p.values[0]))
         comboid = ",".join(id_strings)

--- a/python/pylibcugraph/pylibcugraph/tests/conftest.py
+++ b/python/pylibcugraph/pylibcugraph/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/pylibcugraph/pylibcugraph/tests/conftest.py
+++ b/python/pylibcugraph/pylibcugraph/tests/conftest.py
@@ -82,10 +82,7 @@ valid_datasets = [
     Simple_1,
     Simple_2,
 ]
-all_datasets = valid_datasets + [
-    InvalidNumWeights_1,
-    InvalidNumVerts_1,
-]
+all_datasets = [*valid_datasets, InvalidNumWeights_1, InvalidNumVerts_1]
 
 
 # =============================================================================

--- a/python/pylibcugraph/pylibcugraph/utilities/api_tools.py
+++ b/python/pylibcugraph/pylibcugraph/utilities/api_tools.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/pylibcugraph/pylibcugraph/utilities/api_tools.py
+++ b/python/pylibcugraph/pylibcugraph/utilities/api_tools.py
@@ -69,9 +69,9 @@ def experimental_warning_wrapper(obj):
                 # not have a standard callable __init__ and assigning to self
                 # works instead.
                 if isinstance(obj.__init__, types.FunctionType):
-                    super(WarningWrapperClass, self).__init__(*args, **kwargs)
+                    super().__init__(*args, **kwargs)
                 else:
-                    self = obj(*args, **kwargs)
+                    obj(*args, **kwargs)
 
         WarningWrapperClass.__module__ = ns_name
         WarningWrapperClass.__qualname__ = obj_name
@@ -135,9 +135,9 @@ def promoted_experimental_warning_wrapper(obj):
                 # not have a standard callable __init__ and assigning to self
                 # works instead.
                 if isinstance(obj.__init__, types.FunctionType):
-                    super(WarningWrapperClass, self).__init__(*args, **kwargs)
+                    super().__init__(*args, **kwargs)
                 else:
-                    self = obj(*args, **kwargs)
+                    obj(*args, **kwargs)
 
         WarningWrapperClass.__module__ = ns_name
         WarningWrapperClass.__qualname__ = obj_name
@@ -188,9 +188,9 @@ def deprecated_warning_wrapper(obj):
                 # not have a standard callable __init__ and assigning to self
                 # works instead.
                 if isinstance(obj.__init__, types.FunctionType):
-                    super(WarningWrapperClass, self).__init__(*args, **kwargs)
+                    super().__init__(*args, **kwargs)
                 else:
-                    self = obj(*args, **kwargs)
+                    obj(*args, **kwargs)
 
         WarningWrapperClass.__module__ = ns_name
         WarningWrapperClass.__qualname__ = obj_name

--- a/python/pylibcugraph/setup.py
+++ b/python/pylibcugraph/setup.py
@@ -45,9 +45,7 @@ class CleanCommand(Command):
 
 def exclude_libcxx_symlink(cmake_manifest):
     return list(
-        filter(
-            lambda name: not ("include/rapids/libcxx/include" in name), cmake_manifest
-        )
+        filter(lambda name: "include/rapids/libcxx/include" not in name, cmake_manifest)
     )
 
 

--- a/python/utils/asv_report.py
+++ b/python/utils/asv_report.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/utils/asv_report.py
+++ b/python/utils/asv_report.py
@@ -40,21 +40,21 @@ def cugraph_update_asv(
 
     uname = platform.uname()
 
-    prefixDict = dict(
-        maxGpuUtil="gpuutil",
-        maxGpuMemUsed="gpumem",
-        exeTime="time",
-    )
-    unitsDict = dict(
-        maxGpuUtil="percent",
-        maxGpuMemUsed="bytes",
-        exeTime="seconds",
-    )
+    prefixDict = {
+        "maxGpuUtil": "gpuutil",
+        "maxGpuMemUsed": "gpumem",
+        "exeTime": "time",
+    }
+    unitsDict = {
+        "maxGpuUtil": "percent",
+        "maxGpuMemUsed": "bytes",
+        "exeTime": "seconds",
+    }
 
     bInfo = BenchmarkInfo(
         machineName=machineName or uname.machine,
         cudaVer=cudaVer or "unknown",
-        osType=osType or "%s %s" % (uname.system, uname.release),
+        osType=osType or f"{uname.system} {uname.release}",
         pythonVer=pythonVer or platform.python_version(),
         commitHash=commitHash,
         commitTime=commitTime,
@@ -72,7 +72,7 @@ def cugraph_update_asv(
             # run error), skip
             if metricName in validKeys:
                 bResult = BenchmarkResult(
-                    funcName="%s_%s" % (funcName, prefixDict[metricName]),
+                    funcName=f"{funcName}_{prefixDict[metricName]}",
                     argNameValuePairs=[("dataset", datasetName)],
                     result=val,
                 )

--- a/python/utils/gpu_metric_poller.py
+++ b/python/utils/gpu_metric_poller.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/utils/gpu_metric_poller.py
+++ b/python/utils/gpu_metric_poller.py
@@ -70,7 +70,7 @@ class GPUMetricPoller(threading.Thread):
         gpuMetricsStr = self.__waitForInput(parentReadPipe)
         while True:
             # FIXME: this assumes the input received is perfect!
-            (memUsed, gpuUtil) = [int(x) for x in gpuMetricsStr.strip().split()]
+            (memUsed, gpuUtil) = (int(x) for x in gpuMetricsStr.strip().split())
 
             if memUsed > self.maxGpuMemUsed:
                 self.maxGpuMemUsed = memUsed
@@ -108,7 +108,7 @@ class GPUMetricPoller(threading.Thread):
             gpuUtil = utilObj.gpu - initialGpuUtil
 
             if controlStr.strip() == "1":
-                self.__writeToPipe(childWritePipe, "%s %s\n" % (memUsed, gpuUtil))
+                self.__writeToPipe(childWritePipe, f"{memUsed} {gpuUtil}\n")
             elif controlStr.strip() == "0":
                 break
             controlStr = self.__waitForInput(childReadPipe)

--- a/python/utils/mtx2csv.py
+++ b/python/utils/mtx2csv.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/utils/mtx2csv.py
+++ b/python/utils/mtx2csv.py
@@ -63,7 +63,7 @@ t1 = time.time()
 os.path.splitext(os.path.basename(args.file.name))[0] + ".csv"
 csv_file = open(os.path.splitext(os.path.basename(args.file.name))[0] + ".csv", "w")
 for item in range(M.getnnz()):
-    csv_file.write("{}{}{}\n".format(M.row[item], separator, M.col[item]))
+    csv_file.write(f"{M.row[item]}{separator}{M.col[item]}\n")
 csv_file.close()
 write_time = time.time() - t1
 print("Time (s) : " + str(round(write_time, 3)))

--- a/python/utils/run_benchmarks.py
+++ b/python/utils/run_benchmarks.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/utils/run_benchmarks.py
+++ b/python/utils/run_benchmarks.py
@@ -95,7 +95,7 @@ def getBenchmarks(G, edgelist_gdf, args):
         Benchmark(name="cugraph.graph.degrees", func=G.degrees),
     ]
     # Return a dictionary of Benchmark name to Benchmark obj mappings
-    return dict([(b.name, b) for b in benches])
+    return {b.name: b for b in benches}
 
 
 ########################################
@@ -109,7 +109,7 @@ def loadDataFile(file_name, csv_delimiter=" "):
         edgelist_gdf = read_csv(file_name, csv_delimiter)
     else:
         raise ValueError(
-            "bad file type: '%s', %s " % (file_type, file_name)
+            f"bad file type: '{file_type}', {file_name} "
             + "must have a .csv or .mtx extension"
         )
     return edgelist_gdf
@@ -305,7 +305,7 @@ if __name__ == "__main__":
     # set algosToRun based on the command line args
     allPossibleAlgos = getAllPossibleAlgos()
     if args.algo and ("ALL" not in args.algo):
-        allowedAlgoNames = allPossibleAlgos + ["ALL"]
+        allowedAlgoNames = [*allPossibleAlgos, "ALL"]
         if (set(args.algo) - set(allowedAlgoNames)) != set():
             raise ValueError(
                 "bad algo(s): '%s', must be in set of %s"

--- a/python/utils/utils.py
+++ b/python/utils/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/utils/utils.py
+++ b/python/utils/utils.py
@@ -22,16 +22,14 @@ def getRepoInfo():
 
 
 def getCommandOutput(cmd):
-    result = subprocess.run(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
-    )
+    result = subprocess.run(cmd, capture_output=True, shell=True)
     stdout = result.stdout.decode().strip()
     if result.returncode == 0:
         return stdout
 
     stderr = result.stderr.decode().strip()
     raise RuntimeError(
-        "Problem running '%s' (STDOUT: '%s' STDERR: '%s')" % (cmd, stdout, stderr)
+        f"Problem running '{cmd}' (STDOUT: '{stdout}' STDERR: '{stderr}')"
     )
 
 


### PR DESCRIPTION
The next time we update `black`, we should also consider adding `ruff` for auto-linting and lint checking.

I was curious what `ruff` would do to `cugraph`, so I spent a few minutes of my idle time trying it out. Check it out!

These are the ruff codes that were automatically fixed in this PR:
```
     13 B007 (unused-loop-control-variable)
      2 C402 (unnecessary-generator-dict)
      1 C403 (unnecessary-list-comprehension-set)
      4 C404 (unnecessary-list-comprehension-dict)
      4 C405 (unnecessary-literal-set)
      5 C408 (unnecessary-collection-call)
      1 C409 (unnecessary-literal-within-tuple-call)
      2 C414 (unnecessary-double-cast-or-process)
      8 C416 (unnecessary-comprehension)
      2 C417 (unnecessary-map)
      6 D201 (no-blank-line-before-function)
      6 D209 (new-line-after-last-paragraph)
      1 D214 (section-not-over-indented)
      1 D215 (section-underline-not-over-indented)
      7 D405 (capitalize-section-name)
      6 D406 (new-line-after-section-name)
      7 D407 (dashed-underline-after-section)
      6 D409 (section-underline-matches-section-length)
      7 D410 (blank-line-after-section)
     13 D411 (blank-line-before-section)
     10 D412 (no-blank-lines-between-header-and-content)
      1 E713 (not-in-test)
      1 F401 (unused-import)
      1 F841 (unused-variable)
      1 NPY001 (numpy-deprecated-type-alias)
      2 PIE802 (unnecessary-comprehension-any-all)
      1 PLC0414 (useless-import-alias)
      5 PLR0402 (consider-using-from-import)
      7 PT001 (incorrect-fixture-parentheses-style)
      7 PT003 (extraneous-scope-function)
      3 PT006 (parametrize-names-wrong-type)
      4 PT018 (composite-assertion)
      2 RSE102 (unnecessary-paren-on-raise-exception)
      4 RUF002 (ambiguous-unicode-character-docstring)
     17 RUF005 (unpack-instead-of-concatenating-to-collection-literal)
      1 SIM101 (duplicate-isinstance-call)
      1 SIM103 (needless-bool)
      1 SIM110 (reimplemented-builtin)
      7 SIM118 (key-in-dict)
      1 SIM201 (negate-equal-op)
      1 SIM401 (dict-get-with-default)
      4 UP008 (super-call-with-parameters)
      1 UP015 (redundant-open-modes)
      1 UP022 (replace-stdout-stderr)
      1 UP027 (rewrite-list-comprehension)
      5 UP031 (printf-string-formatting)
     22 UP032 (f-string)
      2 UP034 (extraneous-parentheses)
```
And these are the codes that _could_ be automatically fixed, but were skipped for various reasons:
```
     37 ANN204 (missing-return-type-special-method)
    214 COM812 (trailing-comma-missing)
     63 D200 (fits-on-one-line)
     73 D202 (no-blank-line-after-function)
     46 ERA001 (commented-out-code)
      9 F401 (unused-import)
    261 I001 (unsorted-imports)
     24 PD002 (use-of-inplace-argument)
      3 PIE790 (unnecessary-pass)
      1 PT022 (useless-yield-fixture)
      3 RET502 (implicit-return-value)
      5 RET503 (implicit-return)
      9 SIM102 (collapsible-if)
     16 SIM108 (use-ternary-operator)
      1 SIM210 (if-expr-with-true-false)
      2 SIM300 (yoda-conditions)
      5 UP006 (deprecated-collection-type)
      7 UP007 (typing-union)
```