### PR TITLE
[BUG] Reindex Start Vertices and Batch Ids Prior to Sampling Call

### DIFF
--- a/python/cugraph/cugraph/gnn/data_loading/bulk_sampler.py
+++ b/python/cugraph/cugraph/gnn/data_loading/bulk_sampler.py
@@ -179,11 +179,19 @@ class EXPERIMENTAL__BulkSampler:
             else cugraph.dask.uniform_neighbor_sample
         )
 
+        start_list = (
+            self.__batches[self.start_col_name][batch_id_filter]
+        ).reset_index(drop=True)
+        
+        batch_id_list = (
+            self.__batches[self.batch_col_name][batch_id_filter]
+        ).reset_index(drop=True)
+
         samples = sample_fn(
             self.__graph,
             **self.__sample_call_args,
-            start_list=self.__batches[self.start_col_name][batch_id_filter],
-            batch_id_list=self.__batches[self.batch_col_name][batch_id_filter],
+            start_list=start_list,
+            batch_id_list=batch_id_list,
             with_edge_properties=True,
         )
 


### PR DESCRIPTION
This fixes a bug where output sample batch ids do not match those expected when using the bulk sampler, causing subgraphs that are larger than expected and incorrect.  Without reindexing, the wrong batch ids are assigned to the start vertices.  Reindexing ensures that the same order is preserved for batch ids and start vertices.