### PR TITLE
Add back deleted version attribute

### DIFF
--- a/python/pylibcugraph/pylibcugraph/__init__.py
+++ b/python/pylibcugraph/pylibcugraph/__init__.py
@@ -62,3 +62,5 @@ from pylibcugraph.betweenness_centrality import betweenness_centrality
 from pylibcugraph.random import CuGraphRandomState
 
 from pylibcugraph.select_random_vertices import select_random_vertices
+
+__version__ = "23.04.00"


### PR DESCRIPTION
The `__version__` attribute appears to have been accidentally deleted in #2971.