### PR TITLE
[BUG] Critical: Force cudf.concat when passing in a cudf Series to MG Uniform Neighbor Sample

### DIFF
--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -396,17 +396,15 @@ def uniform_neighbor_sample(
     else:
         indices_t = numpy.int32
 
-    start_list = start_list.rename(start_col_name)
+    start_list = start_list.rename(start_col_name).to_frame()
     if batch_id_list is not None:
-        batch_id_list = batch_id_list.rename(batch_col_name)
-        if isinstance(start_list, cudf.Series):
-            concat_fn = cudf.concat
-        else:
-            concat_fn = dask_cudf.concat
-        ddf = concat_fn([
-            start_list,
-            batch_id_list   
-        ], axis=1, names=[start_col_name, batch_col_name])
+        batch_id_list = batch_id_list.rename(batch_col_name).to_frame()
+        ddf = start_list.merge(
+            batch_id_list,
+            how='left',
+            left_index=True,
+            right_index=True,
+        )
     else:
         ddf = start_list.to_frame()
     

--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -294,7 +294,7 @@ def uniform_neighbor_sample(
         List of unique batch id labels.  Used along with
         label_to_output_comm_rank to assign batch ids to GPUs.
 
-    label_to_out_comm_rank: cudf.Series or dask_cudf.Series (int32), 
+    label_to_out_comm_rank: cudf.Series or dask_cudf.Series (int32),
     optional (default=None)
         List of output GPUs (by rank) corresponding to batch
         id labels in the label list.  Used to assign each batch

--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -294,7 +294,8 @@ def uniform_neighbor_sample(
         List of unique batch id labels.  Used along with
         label_to_output_comm_rank to assign batch ids to GPUs.
 
-    label_to_out_comm_rank: cudf.Series or dask_cudf.Series (int32), optional (default=None)
+    label_to_out_comm_rank: cudf.Series or dask_cudf.Series (int32), 
+    optional (default=None)
         List of output GPUs (by rank) corresponding to batch
         id labels in the label list.  Used to assign each batch
         id to a GPU.

--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -424,7 +424,7 @@ def uniform_neighbor_sample(
     if input_graph.renumbered:
         ddf = input_graph.lookup_internal_vertex_id(ddf, column_name=start_col_name)
 
-    if hasattr(ddf, 'compute'):
+    if hasattr(ddf, "compute"):
         ddf = get_distributed_data(ddf)
         wait(ddf)
         ddf = ddf.worker_to_parts

--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -399,33 +399,33 @@ def uniform_neighbor_sample(
     start_list = start_list.rename(start_col_name)
     if batch_id_list is not None:
         batch_id_list = batch_id_list.rename(batch_col_name)
-        if hasattr(start_list, 'compute'):
+        if hasattr(start_list, "compute"):
             # mg input
             start_list = start_list.to_frame()
             batch_id_list = batch_id_list.to_frame()
             ddf = start_list.merge(
                 batch_id_list,
-                how='left',
+                how="left",
                 left_index=True,
                 right_index=True,
             )
         else:
             # sg input
-            ddf = cudf.concat([
-                start_list,
-                batch_id_list,
-            ], axis=1)
+            ddf = cudf.concat(
+                [
+                    start_list,
+                    batch_id_list,
+                ],
+                axis=1,
+            )
     else:
         ddf = start_list.to_frame()
-    
+
     if input_graph.renumbered:
         ddf = input_graph.lookup_internal_vertex_id(ddf, column_name=start_col_name)
 
     if isinstance(ddf, cudf.DataFrame):
-        ddf = dask_cudf.from_cudf(
-            ddf,
-            npartitions=len(Comms.get_workers())
-        )
+        ddf = dask_cudf.from_cudf(ddf, npartitions=len(Comms.get_workers()))
 
     ddf = get_distributed_data(ddf)
     wait(ddf)

--- a/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
+++ b/python/cugraph/cugraph/dask/sampling/uniform_neighbor_sample.py
@@ -272,10 +272,10 @@ def uniform_neighbor_sample(
         cuGraph graph, which contains connectivity information as dask cudf
         edge list dataframe
 
-    start_list : list or cudf.Series (int32)
+    start_list : int, list, cudf.Series, or dask_cudf.Series (int32 or int64)
         a list of starting vertices for sampling
 
-    fanout_vals : list (int32)
+    fanout_vals : list
         List of branching out (fan-out) degrees per starting vertex for each
         hop level.
 
@@ -286,15 +286,15 @@ def uniform_neighbor_sample(
         Flag to specify whether to return edge properties (weight, edge id,
         edge type, batch id, hop id) with the sampled edges.
 
-    batch_id_list: list (int32), optional (default=None)
+    batch_id_list: cudf.Series or dask_cudf.Series (int32), optional (default=None)
         List of batch ids that will be returned with the sampled edges if
         with_edge_properties is set to True.
 
-    label_list: list (int32), optional (default=None)
+    label_list: cudf.Series or dask_cudf.Series (int32), optional (default=None)
         List of unique batch id labels.  Used along with
         label_to_output_comm_rank to assign batch ids to GPUs.
 
-    label_to_out_comm_rank (int32), optional (default=None)
+    label_to_out_comm_rank: cudf.Series or dask_cudf.Series (int32), optional (default=None)
         List of output GPUs (by rank) corresponding to batch
         id labels in the label list.  Used to assign each batch
         id to a GPU.

--- a/python/cugraph/cugraph/tests/sampling/test_uniform_neighbor_sample_mg.py
+++ b/python/cugraph/cugraph/tests/sampling/test_uniform_neighbor_sample_mg.py
@@ -485,7 +485,9 @@ def test_uniform_neighbor_sample_edge_properties_self_loops(dask_client):
 @pytest.mark.skipif(
     int(os.getenv("DASK_NUM_WORKERS", 2)) < 2, reason="too few workers to test"
 )
-def test_uniform_neighbor_edge_properties_sample_small_start_list(dask_client, with_replacement):
+def test_uniform_neighbor_edge_properties_sample_small_start_list(
+    dask_client, with_replacement
+):
     df = dask_cudf.from_cudf(
         cudf.DataFrame(
             {
@@ -575,32 +577,40 @@ def test_uniform_neighbor_sample_without_dask_inputs(dask_client):
 
 
 @pytest.mark.mg
-@pytest.mark.parametrize('dataset', datasets)
-@pytest.mark.parametrize('input_df', [cudf.DataFrame, dask_cudf.DataFrame])
-@pytest.mark.parametrize('max_batches', [2, 8, 16, 32])
+@pytest.mark.parametrize("dataset", datasets)
+@pytest.mark.parametrize("input_df", [cudf.DataFrame, dask_cudf.DataFrame])
+@pytest.mark.parametrize("max_batches", [2, 8, 16, 32])
 def test_uniform_neighbor_sample_batched(dask_client, dataset, input_df, max_batches):
-    num_workers = len(dask_client.scheduler_info()['workers'])
+    num_workers = len(dask_client.scheduler_info()["workers"])
 
     df = dataset.get_edgelist()
-    df['eid'] = cupy.arange(len(df), dtype=df['src'].dtype)
-    df['etp'] = cupy.zeros_like(df['eid'].to_cupy())
+    df["eid"] = cupy.arange(len(df), dtype=df["src"].dtype)
+    df["etp"] = cupy.zeros_like(df["eid"].to_cupy())
     ddf = dask_cudf.from_cudf(df, npartitions=num_workers)
 
     G = cugraph.Graph(directed=True)
-    G.from_dask_cudf_edgelist(ddf, source='src', destination='dst', edge_attr=['wgt', 'eid', 'etp'], legacy_renum_only=True)
+    G.from_dask_cudf_edgelist(
+        ddf,
+        source="src",
+        destination="dst",
+        edge_attr=["wgt", "eid", "etp"],
+        legacy_renum_only=True,
+    )
 
     input_vertices = dask_cudf.concat([df.src, df.dst]).unique().compute()
     assert isinstance(input_vertices, cudf.Series)
 
     input_vertices.index = cupy.random.permutation(len(input_vertices))
 
-    input_batch = cudf.Series(cupy.random.randint(0, max_batches, len(input_vertices)), dtype='int32')
+    input_batch = cudf.Series(
+        cupy.random.randint(0, max_batches, len(input_vertices)), dtype="int32"
+    )
     input_batch.index = cupy.random.permutation(len(input_vertices))
 
     if input_df == dask_cudf.DataFrame:
         input_batch = dask_cudf.from_cudf(input_batch, npartitions=num_workers)
         input_vertices = dask_cudf.from_cudf(input_vertices, npartitions=num_workers)
-    
+
     sampling_results = cugraph.dask.uniform_neighbor_sample(
         G,
         start_list=input_vertices,
@@ -611,13 +621,20 @@ def test_uniform_neighbor_sample_batched(dask_client, dataset, input_df, max_bat
     )
 
     for batch_id in range(max_batches):
-        output_starts_per_batch = sampling_results[(sampling_results.batch_id==batch_id) & (sampling_results.hop_id==0)].sources.nunique().compute()
+        output_starts_per_batch = (
+            sampling_results[
+                (sampling_results.batch_id == batch_id) & (sampling_results.hop_id == 0)
+            ]
+            .sources.nunique()
+            .compute()
+        )
         print(output_starts_per_batch)
 
-        input_starts_per_batch = len(input_batch[input_batch==batch_id])
+        input_starts_per_batch = len(input_batch[input_batch == batch_id])
         print(input_starts_per_batch)
         # Should be <= to account for starts without outgoing edges
         assert output_starts_per_batch <= input_starts_per_batch
+
 
 # =============================================================================
 # Benchmarks

--- a/python/cugraph/cugraph/tests/sampling/test_uniform_neighbor_sample_mg.py
+++ b/python/cugraph/cugraph/tests/sampling/test_uniform_neighbor_sample_mg.py
@@ -485,7 +485,7 @@ def test_uniform_neighbor_sample_edge_properties_self_loops(dask_client):
 @pytest.mark.skipif(
     int(os.getenv("DASK_NUM_WORKERS", 2)) < 2, reason="too few workers to test"
 )
-def test_uniform_neighbor_edge_properties_sample_small_start_list(dsak_client, with_replacement):
+def test_uniform_neighbor_edge_properties_sample_small_start_list(dask_client, with_replacement):
     df = dask_cudf.from_cudf(
         cudf.DataFrame(
             {
@@ -578,7 +578,6 @@ def test_uniform_neighbor_sample_without_dask_inputs(dask_client):
 @pytest.mark.parametrize('dataset', datasets)
 @pytest.mark.parametrize('input_df', [cudf.DataFrame, dask_cudf.DataFrame])
 @pytest.mark.parametrize('max_batches', [2, 8, 16, 32])
-@pytest.mark.tags('runme')
 def test_uniform_neighbor_sample_batched(dask_client, dataset, input_df, max_batches):
     num_workers = len(dask_client.scheduler_info()['workers'])
 


### PR DESCRIPTION
Currently, cudf does not merge series properly when they already share an index.  I'm not sure if this is a bug in cudf, or intentional behavior.  This issue does not occur with dask_cudf.  The resolution is to use `cudf.concat` when passing a `cudf.Series` for start vertices and batch ids, and `df.to_frame().merge` when passing in a `dask_cudf.Series` for start vertices and batch ids.

This PR also adds an additional test which tests both cudf and dask_cudf inputs to catch these sort of problems in the future.