### PR TITLE
Remove legacy renumber and shuffle calls from cython.cu

### DIFF
--- a/cpp/include/cugraph/utilities/cython.hpp
+++ b/cpp/include/cugraph/utilities/cython.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,187 +25,9 @@
 namespace cugraph {
 namespace cython {
 
-enum class numberTypeEnum : int { int32Type, int64Type, floatType, doubleType };
-
-// replacement for std::tuple<,,>, since std::tuple is not
-// supported in cython
-//
-template <typename vertex_t, typename edge_t, typename weight_t>
-struct major_minor_weights_t {
-  explicit major_minor_weights_t(raft::handle_t const& handle)
-    : shuffled_major_vertices_(0, handle.get_stream()),
-      shuffled_minor_vertices_(0, handle.get_stream()),
-      shuffled_weights_(0, handle.get_stream())
-  {
-  }
-
-  rmm::device_uvector<vertex_t>& get_major(void) { return shuffled_major_vertices_; }
-
-  rmm::device_uvector<vertex_t>& get_minor(void) { return shuffled_minor_vertices_; }
-
-  rmm::device_uvector<weight_t>& get_weights(void) { return shuffled_weights_; }
-
-  std::vector<edge_t>& get_edge_counts(void) { return edge_counts_; }
-
-  std::pair<std::unique_ptr<rmm::device_buffer>, size_t> get_major_wrap(
-    void)  // const: triggers errors in Cython autogen-ed C++
-  {
-    return std::make_pair(std::make_unique<rmm::device_buffer>(shuffled_major_vertices_.release()),
-                          sizeof(vertex_t));
-  }
-
-  std::pair<std::unique_ptr<rmm::device_buffer>, size_t> get_minor_wrap(void)  // const
-  {
-    return std::make_pair(std::make_unique<rmm::device_buffer>(shuffled_minor_vertices_.release()),
-                          sizeof(vertex_t));
-  }
-
-  std::pair<std::unique_ptr<rmm::device_buffer>, size_t> get_weights_wrap(void)  // const
-  {
-    return std::make_pair(std::make_unique<rmm::device_buffer>(shuffled_weights_.release()),
-                          sizeof(weight_t));
-  }
-
-  std::unique_ptr<std::vector<edge_t>> get_edge_counts_wrap(void)  // const
-  {
-    return std::make_unique<std::vector<edge_t>>(edge_counts_);
-  }
-
- private:
-  rmm::device_uvector<vertex_t> shuffled_major_vertices_;
-  rmm::device_uvector<vertex_t> shuffled_minor_vertices_;
-  rmm::device_uvector<weight_t> shuffled_weights_;
-  std::vector<edge_t> edge_counts_{};
-};
-
 struct graph_generator_t {
   std::unique_ptr<rmm::device_buffer> d_source;
   std::unique_ptr<rmm::device_buffer> d_destination;
-};
-
-// wrapper for renumber_edgelist() return
-// (unrenumbering maps, etc.)
-//
-template <typename vertex_t, typename edge_t>
-struct renum_tuple_t {
-  explicit renum_tuple_t(raft::handle_t const& handle) : dv_(0, handle.get_stream()), part_() {}
-
-  rmm::device_uvector<vertex_t>& get_dv(void) { return dv_; }
-
-  std::pair<std::unique_ptr<rmm::device_buffer>, size_t> get_dv_wrap(
-    void)  // const: see above explanation
-  {
-    return std::make_pair(std::make_unique<rmm::device_buffer>(dv_.release()), sizeof(vertex_t));
-  }
-
-  cugraph::partition_t<vertex_t>& get_partition(void) { return part_; }
-  vertex_t& get_num_vertices(void) { return nv_; }
-  edge_t& get_num_edges(void) { return ne_; }
-
-  std::vector<vertex_t>& get_segment_offsets(void) { return segment_offsets_; }
-
-  std::unique_ptr<std::vector<vertex_t>> get_segment_offsets_wrap()
-  {  // const
-    return std::make_unique<std::vector<vertex_t>>(segment_offsets_);
-  }
-
-  // `partition_t` pass-through getters
-  //
-  int get_part_row_size() const { return part_.row_comm_size(); }
-
-  int get_part_col_size() const { return part_.col_comm_size(); }
-
-  int get_part_comm_rank() const { return part_.comm_rank(); }
-
-  // FIXME: part_.vertex_partition_offsets() returns a std::vector
-  //
-  std::unique_ptr<std::vector<vertex_t>> get_partition_offsets_wrap(void)  // const
-  {
-    return std::make_unique<std::vector<vertex_t>>(part_.vertex_partition_range_offsets());
-  }
-
-  std::pair<vertex_t, vertex_t> get_part_local_vertex_range() const
-  {
-    auto tpl_v = part_.local_vertex_partition_range();
-    return std::make_pair(std::get<0>(tpl_v), std::get<1>(tpl_v));
-  }
-
-  vertex_t get_part_local_vertex_first() const
-  {
-    return part_.local_vertex_partition_range_first();
-  }
-
-  vertex_t get_part_local_vertex_last() const { return part_.local_vertex_partition_range_last(); }
-
-  std::pair<vertex_t, vertex_t> get_part_vertex_partition_range(size_t vertex_partition_idx) const
-  {
-    auto tpl_v = part_.vertex_partition_range(vertex_partition_idx);
-    return std::make_pair(std::get<0>(tpl_v), std::get<1>(tpl_v));
-  }
-
-  vertex_t get_part_vertex_partition_first(size_t vertex_partition_idx) const
-  {
-    return part_.vertex_partition_range_first(vertex_partition_idx);
-  }
-
-  vertex_t get_part_vertex_partition_last(size_t vertex_partition_idx) const
-  {
-    return part_.vertex_partition_range_last(vertex_partition_idx);
-  }
-
-  vertex_t get_part_vertex_partition_size(size_t vertex_partition_idx) const
-  {
-    return part_.vertex_partition_range_size(vertex_partition_idx);
-  }
-
-  size_t get_part_number_of_matrix_partitions() const
-  {
-    return part_.number_of_local_edgex_partitions();
-  }
-
-  std::pair<vertex_t, vertex_t> get_part_matrix_partition_major_range(size_t partition_idx) const
-  {
-    auto tpl_v = part_.local_edgex_partition_major_range(partition_idx);
-    return std::make_pair(std::get<0>(tpl_v), std::get<1>(tpl_v));
-  }
-
-  vertex_t get_part_matrix_partition_major_first(size_t partition_idx) const
-  {
-    return part_.local_edge_partition_major_first(partition_idx);
-  }
-
-  vertex_t get_part_matrix_partition_major_last(size_t partition_idx) const
-  {
-    return part_.local_edge_partition_major_range_last(partition_idx);
-  }
-
-  vertex_t get_part_matrix_partition_major_value_start_offset(size_t partition_idx) const
-  {
-    return part_.local_edge_partition_major_value_start_offset(partition_idx);
-  }
-
-  std::pair<vertex_t, vertex_t> get_part_matrix_partition_minor_range() const
-  {
-    auto tpl_v = part_.local_edge_partition_minor_range();
-    return std::make_pair(std::get<0>(tpl_v), std::get<1>(tpl_v));
-  }
-
-  vertex_t get_part_matrix_partition_minor_first() const
-  {
-    return part_.local_edge_partition_minor_range_first();
-  }
-
-  vertex_t get_part_matrix_partition_minor_last() const
-  {
-    return part_.local_edge_partition_minor_range_last();
-  }
-
- private:
-  rmm::device_uvector<vertex_t> dv_;
-  cugraph::partition_t<vertex_t> part_;
-  vertex_t nv_{0};
-  edge_t ne_{0};
-  std::vector<vertex_t> segment_offsets_;
 };
 
 // Wrapper for calling graph generator
@@ -231,30 +53,6 @@ call_generate_rmat_edgelists(raft::handle_t const& handle,
                              uint64_t seed,
                              bool clip_and_flip,
                              bool scramble_vertex_ids);
-
-// wrapper for shuffling:
-//
-template <typename vertex_t, typename edge_t, typename weight_t>
-std::unique_ptr<major_minor_weights_t<vertex_t, edge_t, weight_t>> call_shuffle(
-  raft::handle_t const& handle,
-  vertex_t*
-    edgelist_major_vertices,  // [IN / OUT]: groupby_gpu_id_and_shuffle_values() sorts in-place
-  vertex_t* edgelist_minor_vertices,  // [IN / OUT]
-  weight_t* edgelist_weights,         // [IN / OUT]
-  edge_t num_edgelist_edges,
-  bool is_weighted);
-
-// Wrapper for calling renumber_edgelist() inplace:
-//
-template <typename vertex_t, typename edge_t>
-std::unique_ptr<renum_tuple_t<vertex_t, edge_t>> call_renumber(
-  raft::handle_t const& handle,
-  vertex_t* shuffled_edgelist_src_vertices /* [INOUT] */,
-  vertex_t* shuffled_edgelist_dst_vertices /* [INOUT] */,
-  std::vector<edge_t> const& edge_counts,
-  bool store_transposed,
-  bool do_expensive_check,
-  bool multi_gpu);
 
 // Helper for setting up subcommunicators, typically called as part of the
 // user-initiated comms initialization in Python.

--- a/cpp/src/utilities/cython.cu
+++ b/cpp/src/utilities/cython.cu
@@ -14,21 +14,14 @@
  * limitations under the License.
  */
 
-#include <detail/graph_partition_utils.cuh>
-
-#include <cugraph/graph_functions.hpp>
 #include <cugraph/graph_generators.hpp>
 #include <cugraph/partition_manager.hpp>
 #include <cugraph/utilities/cython.hpp>
 #include <cugraph/utilities/error.hpp>
-#include <cugraph/utilities/shuffle_comm.cuh>
 
 #include <raft/core/handle.hpp>
 
 #include <rmm/device_uvector.hpp>
-
-#include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
 
 #include <numeric>
 #include <vector>
@@ -112,242 +105,11 @@ call_generate_rmat_edgelists(raft::handle_t const& handle,
   return gg_vec;
 }
 
-// wrapper for shuffling:
-//
-template <typename vertex_t, typename edge_t, typename weight_t>
-std::unique_ptr<major_minor_weights_t<vertex_t, edge_t, weight_t>> call_shuffle(
-  raft::handle_t const& handle,
-  vertex_t*
-    edgelist_major_vertices,  // [IN / OUT]: groupby_gpu_id_and_shuffle_values() sorts in-place
-  vertex_t* edgelist_minor_vertices,  // [IN / OUT]
-  weight_t* edgelist_weights,         // [IN / OUT]
-  edge_t num_edgelist_edges,
-  bool is_weighted)
-{
-  auto& comm                 = handle.get_comms();
-  auto const comm_size       = comm.get_size();
-  auto& major_comm           = handle.get_subcomm(cugraph::partition_manager::major_comm_name());
-  auto const major_comm_size = major_comm.get_size();
-  auto& minor_comm           = handle.get_subcomm(cugraph::partition_manager::minor_comm_name());
-  auto const minor_comm_size = minor_comm.get_size();
-
-  std::unique_ptr<major_minor_weights_t<vertex_t, edge_t, weight_t>> ptr_ret =
-    std::make_unique<major_minor_weights_t<vertex_t, edge_t, weight_t>>(handle);
-
-  if (is_weighted) {
-    auto zip_edge = thrust::make_zip_iterator(
-      thrust::make_tuple(edgelist_major_vertices, edgelist_minor_vertices, edgelist_weights));
-
-    std::forward_as_tuple(
-      std::tie(ptr_ret->get_major(), ptr_ret->get_minor(), ptr_ret->get_weights()),
-      std::ignore) =
-      cugraph::groupby_gpu_id_and_shuffle_values(
-        comm,  // handle.get_comms(),
-        zip_edge,
-        zip_edge + num_edgelist_edges,
-        [key_func =
-           cugraph::detail::compute_gpu_id_from_ext_edge_endpoints_t<vertex_t>{
-             comm_size, major_comm_size, minor_comm_size}] __device__(auto val) {
-          return key_func(thrust::get<0>(val), thrust::get<1>(val));
-        },
-        handle.get_stream());
-  } else {
-    auto zip_edge = thrust::make_zip_iterator(
-      thrust::make_tuple(edgelist_major_vertices, edgelist_minor_vertices));
-
-    std::forward_as_tuple(std::tie(ptr_ret->get_major(), ptr_ret->get_minor()),
-                          std::ignore) =
-      cugraph::groupby_gpu_id_and_shuffle_values(
-        comm,  // handle.get_comms(),
-        zip_edge,
-        zip_edge + num_edgelist_edges,
-        [key_func =
-           cugraph::detail::compute_gpu_id_from_ext_edge_endpoints_t<vertex_t>{
-             comm_size, major_comm_size, minor_comm_size}] __device__(auto val) {
-          return key_func(thrust::get<0>(val), thrust::get<1>(val));
-        },
-        handle.get_stream());
-  }
-
-  auto local_partition_id_op =
-    cugraph::detail::compute_local_edge_partition_id_from_ext_edge_endpoints_t<vertex_t>{
-      comm_size, major_comm_size, minor_comm_size};
-
-  auto pair_first = thrust::make_zip_iterator(
-    thrust::make_tuple(ptr_ret->get_major().data(), ptr_ret->get_minor().data()));
-
-  auto edge_counts = (is_weighted)
-                       ? cugraph::groupby_and_count(pair_first,
-                                                    pair_first + ptr_ret->get_major().size(),
-                                                    ptr_ret->get_weights().data(),
-                                                    local_partition_id_op,
-                                                    minor_comm_size,
-                                                    false,
-                                                    handle.get_stream())
-                       : cugraph::groupby_and_count(pair_first,
-                                                    pair_first + ptr_ret->get_major().size(),
-                                                    local_partition_id_op,
-                                                    minor_comm_size,
-                                                    false,
-                                                    handle.get_stream());
-
-  std::vector<size_t> h_edge_counts(edge_counts.size());
-  raft::update_host(
-    h_edge_counts.data(), edge_counts.data(), edge_counts.size(), handle.get_stream());
-  handle.sync_stream();
-
-  ptr_ret->get_edge_counts().resize(h_edge_counts.size());
-  for (size_t i = 0; i < h_edge_counts.size(); ++i) {
-    ptr_ret->get_edge_counts()[i] = static_cast<edge_t>(h_edge_counts[i]);
-  }
-
-  return ptr_ret;  // RVO-ed
-}
-
-// Wrapper for calling renumber_edeglist() inplace:
-// TODO: check if return type needs further handling...
-//
-template <typename vertex_t, typename edge_t>
-std::unique_ptr<renum_tuple_t<vertex_t, edge_t>> call_renumber(
-  raft::handle_t const& handle,
-  vertex_t* shuffled_edgelist_src_vertices /* [INOUT] */,
-  vertex_t* shuffled_edgelist_dst_vertices /* [INOUT] */,
-  std::vector<edge_t> const& edge_counts,
-  bool store_transposed,
-  bool do_expensive_check,
-  bool multi_gpu)  // bc. cython cannot take non-type template params
-{
-  // caveat: return values have different types on the 2 branches below:
-  //
-  std::unique_ptr<renum_tuple_t<vertex_t, edge_t>> p_ret =
-    std::make_unique<renum_tuple_t<vertex_t, edge_t>>(handle);
-
-  if (multi_gpu) {
-    std::vector<edge_t> displacements(edge_counts.size(), edge_t{0});
-    std::partial_sum(edge_counts.begin(), edge_counts.end() - 1, displacements.begin() + 1);
-    std::vector<vertex_t*> src_ptrs(edge_counts.size());
-    std::vector<vertex_t*> dst_ptrs(src_ptrs.size());
-    for (size_t i = 0; i < edge_counts.size(); ++i) {
-      src_ptrs[i] = shuffled_edgelist_src_vertices + displacements[i];
-      dst_ptrs[i] = shuffled_edgelist_dst_vertices + displacements[i];
-    }
-
-    cugraph::renumber_meta_t<vertex_t, edge_t, true> meta{};
-    std::tie(p_ret->get_dv(), meta) =
-      cugraph::renumber_edgelist<vertex_t, edge_t, true>(handle,
-                                                         std::nullopt,
-                                                         src_ptrs,
-                                                         dst_ptrs,
-                                                         edge_counts,
-                                                         std::nullopt,
-                                                         store_transposed,
-                                                         do_expensive_check);
-    p_ret->get_num_vertices()    = meta.number_of_vertices;
-    p_ret->get_num_edges()       = meta.number_of_edges;
-    p_ret->get_partition()       = meta.partition;
-    p_ret->get_segment_offsets() = meta.edge_partition_segment_offsets;
-  } else {
-    cugraph::renumber_meta_t<vertex_t, edge_t, false> meta{};
-    std::tie(p_ret->get_dv(), meta) =
-      cugraph::renumber_edgelist<vertex_t, edge_t, false>(handle,
-                                                          std::nullopt,
-                                                          shuffled_edgelist_src_vertices,
-                                                          shuffled_edgelist_dst_vertices,
-                                                          edge_counts[0],
-                                                          store_transposed,
-                                                          do_expensive_check);
-
-    p_ret->get_num_vertices()    = static_cast<vertex_t>(p_ret->get_dv().size());
-    p_ret->get_num_edges()       = edge_counts[0];
-    p_ret->get_partition()       = cugraph::partition_t<vertex_t>{};  // dummy
-    p_ret->get_segment_offsets() = meta.segment_offsets;
-  }
-
-  return p_ret;  // RVO-ed (copy ellision)
-}
-
 // Helper for setting up subcommunicators
 void init_subcomms(raft::handle_t& handle, size_t row_comm_size)
 {
   partition_manager::init_subcomm(handle, row_comm_size);
 }
-
-template std::unique_ptr<major_minor_weights_t<int32_t, int32_t, float>> call_shuffle(
-  raft::handle_t const& handle,
-  int32_t* edgelist_major_vertices,
-  int32_t* edgelist_minor_vertices,
-  float* edgelist_weights,
-  int32_t num_edgelist_edges,
-  bool is_weighted);
-
-template std::unique_ptr<major_minor_weights_t<int32_t, int64_t, float>> call_shuffle(
-  raft::handle_t const& handle,
-  int32_t* edgelist_major_vertices,
-  int32_t* edgelist_minor_vertices,
-  float* edgelist_weights,
-  int64_t num_edgelist_edges,
-  bool is_weighted);
-
-template std::unique_ptr<major_minor_weights_t<int32_t, int32_t, double>> call_shuffle(
-  raft::handle_t const& handle,
-  int32_t* edgelist_major_vertices,
-  int32_t* edgelist_minor_vertices,
-  double* edgelist_weights,
-  int32_t num_edgelist_edges,
-  bool is_weighted);
-
-template std::unique_ptr<major_minor_weights_t<int32_t, int64_t, double>> call_shuffle(
-  raft::handle_t const& handle,
-  int32_t* edgelist_major_vertices,
-  int32_t* edgelist_minor_vertices,
-  double* edgelist_weights,
-  int64_t num_edgelist_edges,
-  bool is_weighted);
-
-template std::unique_ptr<major_minor_weights_t<int64_t, int64_t, float>> call_shuffle(
-  raft::handle_t const& handle,
-  int64_t* edgelist_major_vertices,
-  int64_t* edgelist_minor_vertices,
-  float* edgelist_weights,
-  int64_t num_edgelist_edges,
-  bool is_weighted);
-
-template std::unique_ptr<major_minor_weights_t<int64_t, int64_t, double>> call_shuffle(
-  raft::handle_t const& handle,
-  int64_t* edgelist_major_vertices,
-  int64_t* edgelist_minor_vertices,
-  double* edgelist_weights,
-  int64_t num_edgelist_edges,
-  bool is_weighted);
-
-// TODO: add the remaining relevant EIDIr's:
-//
-template std::unique_ptr<renum_tuple_t<int32_t, int32_t>> call_renumber(
-  raft::handle_t const& handle,
-  int32_t* shuffled_edgelist_src_vertices /* [INOUT] */,
-  int32_t* shuffled_edgelist_dst_vertices /* [INOUT] */,
-  std::vector<int32_t> const& edge_counts,
-  bool store_transposed,
-  bool do_expensive_check,
-  bool multi_gpu);
-
-template std::unique_ptr<renum_tuple_t<int32_t, int64_t>> call_renumber(
-  raft::handle_t const& handle,
-  int32_t* shuffled_edgelist_src_vertices /* [INOUT] */,
-  int32_t* shuffled_edgelist_dst_vertices /* [INOUT] */,
-  std::vector<int64_t> const& edge_counts,
-  bool store_transposed,
-  bool do_expensive_check,
-  bool multi_gpu);
-
-template std::unique_ptr<renum_tuple_t<int64_t, int64_t>> call_renumber(
-  raft::handle_t const& handle,
-  int64_t* shuffled_edgelist_src_vertices /* [INOUT] */,
-  int64_t* shuffled_edgelist_dst_vertices /* [INOUT] */,
-  std::vector<int64_t> const& edge_counts,
-  bool store_transposed,
-  bool do_expensive_check,
-  bool multi_gpu);
 
 template std::unique_ptr<graph_generator_t> call_generate_rmat_edgelist<int32_t>(
   raft::handle_t const& handle,

--- a/python/cugraph/cugraph/structure/graph_utilities.pxd
+++ b/python/cugraph/cugraph/structure/graph_utilities.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -28,64 +28,6 @@ from pylibraft.common.handle cimport handle_t
 
 # C++ graph utilities
 cdef extern from "cugraph/utilities/cython.hpp" namespace "cugraph::cython":
-
-    ctypedef enum numberTypeEnum:
-        int32Type "cugraph::cython::numberTypeEnum::int32Type"
-        int64Type "cugraph::cython::numberTypeEnum::int64Type"
-        floatType "cugraph::cython::numberTypeEnum::floatType"
-        doubleType "cugraph::cython::numberTypeEnum::doubleType"
-
-    cdef cppclass graph_container_t:
-       pass
-
-    cdef void populate_graph_container(
-        graph_container_t &graph_container,
-        handle_t &handle,
-        void *src_vertices,
-        void *dst_vertices,
-        void *weights,
-        void *vertex_partition_offsets,
-        void *segment_offsets,
-        size_t num_segments,
-        numberTypeEnum vertexType,
-        numberTypeEnum edgeType,
-        numberTypeEnum weightType,
-        size_t num_local_edges,
-        size_t num_global_vertices,
-        size_t num_global_edges,
-        bool is_weighted,
-        bool is_symmetric,
-        bool transposed,
-        bool multi_gpu) except +
-
-    ctypedef enum graphTypeEnum:
-        LegacyCSR "cugraph::cython::graphTypeEnum::LegacyCSR"
-        LegacyCSC "cugraph::cython::graphTypeEnum::LegacyCSC"
-        LegacyCOO "cugraph::cython::graphTypeEnum::LegacyCOO"
-
-    cdef cppclass cy_multi_edgelists_t:
-        size_t number_of_vertices
-        size_t number_of_edges
-        size_t number_of_subgraph
-        unique_ptr[device_buffer] src_indices
-        unique_ptr[device_buffer] dst_indices
-        unique_ptr[device_buffer] edge_data
-        unique_ptr[device_buffer] subgraph_offsets
-
-    cdef cppclass random_walk_ret_t:
-        size_t coalesced_sz_v_
-        size_t coalesced_sz_w_
-        size_t num_paths_
-        size_t max_depth_
-        unique_ptr[device_buffer] d_coalesced_v_
-        unique_ptr[device_buffer] d_coalesced_w_
-        unique_ptr[device_buffer] d_sizes_
-
-    cdef cppclass random_walk_path_t:
-        unique_ptr[device_buffer] d_v_offsets
-        unique_ptr[device_buffer] d_w_sizes
-        unique_ptr[device_buffer] d_w_offsets
-
     cdef cppclass graph_generator_t:
         unique_ptr[device_buffer] d_source
         unique_ptr[device_buffer] d_destination
@@ -93,91 +35,4 @@ cdef extern from "cugraph/utilities/cython.hpp" namespace "cugraph::cython":
 cdef extern from "<utility>" namespace "std" nogil:
     cdef device_buffer move(device_buffer)
     cdef unique_ptr[device_buffer] move(unique_ptr[device_buffer])
-    cdef cy_multi_edgelists_t move(cy_multi_edgelists_t)
-    cdef unique_ptr[cy_multi_edgelists_t] move(unique_ptr[cy_multi_edgelists_t])
 
-# renumber_edgelist() interface utilities:
-#
-#
-# 1. `cdef extern partition_t`:
-#
-cdef extern from "cugraph/graph_view.hpp" namespace "cugraph":
-
-    cdef cppclass partition_t[vertex_t]:
-        pass
-
-
-# 2. return type for shuffle:
-#
-cdef extern from "cugraph/utilities/cython.hpp" namespace "cugraph::cython":
-
-    cdef cppclass major_minor_weights_t[vertex_t, edge_t, weight_t]:
-        major_minor_weights_t(const handle_t &handle)
-        pair[unique_ptr[device_buffer], size_t] get_major_wrap()
-        pair[unique_ptr[device_buffer], size_t] get_minor_wrap()
-        pair[unique_ptr[device_buffer], size_t] get_weights_wrap()
-        unique_ptr[vector[edge_t]] get_edge_counts_wrap()
-
-
-ctypedef fused shuffled_vertices_t:
-    major_minor_weights_t[int, int, float]
-    major_minor_weights_t[int, int, double]
-    major_minor_weights_t[int, long, float]
-    major_minor_weights_t[int, long, double]
-    major_minor_weights_t[long, long, float]
-    major_minor_weights_t[long, long, double]
-
-# 3. return type for renumber:
-#
-cdef extern from "cugraph/utilities/cython.hpp" namespace "cugraph::cython":
-
-    cdef cppclass renum_tuple_t[vertex_t, edge_t]:
-        renum_tuple_t(const handle_t &handle)
-        pair[unique_ptr[device_buffer], size_t] get_dv_wrap()
-        vertex_t& get_num_vertices()
-        edge_t& get_num_edges()
-        vector[vertex_t]& get_segment_offsets()
-        unique_ptr[vector[vertex_t]] get_segment_offsets_wrap()
-        int get_part_row_size()
-        int get_part_col_size()
-        int get_part_comm_rank()
-        unique_ptr[vector[vertex_t]] get_partition_offsets_wrap()
-        pair[vertex_t, vertex_t] get_part_local_vertex_range()
-        vertex_t get_part_local_vertex_first()
-        vertex_t get_part_local_vertex_last()
-        pair[vertex_t, vertex_t] get_part_vertex_partition_range(size_t vertex_partition_idx)
-        vertex_t get_part_vertex_partition_first(size_t vertex_partition_idx)
-        vertex_t get_part_vertex_partition_last(size_t vertex_partition_idx)
-        vertex_t get_part_vertex_partition_size(size_t vertex_partition_idx)
-        size_t get_part_number_of_matrix_partitions()
-        vertex_t get_part_matrix_partition_major_first(size_t partition_idx)
-        vertex_t get_part_matrix_partition_major_last(size_t partition_idx)
-        vertex_t get_part_matrix_partition_major_value_start_offset(size_t partition_idx)
-        pair[vertex_t, vertex_t] get_part_matrix_partition_minor_range()
-        vertex_t get_part_matrix_partition_minor_first()
-        vertex_t get_part_matrix_partition_minor_last()
-
-# 4. `sort_and_shuffle_values()` wrapper:
-#
-cdef extern from "cugraph/utilities/cython.hpp" namespace "cugraph::cython":
-
-    cdef unique_ptr[major_minor_weights_t[vertex_t, edge_t, weight_t]] call_shuffle[vertex_t, edge_t, weight_t](
-        const handle_t &handle,
-        vertex_t *edgelist_major_vertices,
-        vertex_t *edgelist_minor_vertices,
-        weight_t* edgelist_weights,
-        edge_t num_edges,
-        bool is_weighted) except +
-
-# 5. `renumber_edgelist()` wrapper
-#
-cdef extern from "cugraph/utilities/cython.hpp" namespace "cugraph::cython":
-
-    cdef unique_ptr[renum_tuple_t[vertex_t, edge_t]] call_renumber[vertex_t, edge_t](
-        const handle_t &handle,
-        vertex_t *edgelist_major_vertices,
-        vertex_t *edgelist_minor_vertices,
-        const vector[edge_t]& edge_counts,
-        bool store_transposed,
-        bool do_check,
-        bool multi_gpu) except +


### PR DESCRIPTION
With the merge of PR #2949, we no longer need these calls in `cython.cu`

Closes #3466