### PR TITLE
Fix issue with latest rapids-make

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -272,7 +272,7 @@ if buildAll || hasArg libcugraph_etl; then
             CUGRAPH_CMAKE_CUDA_ARCHITECTURES="NATIVE"
             echo "Building for the architecture of the GPU in the system..."
         else
-            CUGRAPH_CMAKE_CUDA_ARCHITECTURES="ALL"
+            CUGRAPH_CMAKE_CUDA_ARCHITECTURES="RAPIDS"
             echo "Building for *ALL* supported GPU architectures..."
         fi
         mkdir -p ${LIBCUGRAPH_ETL_BUILD_DIR}


### PR DESCRIPTION
https://github.com/rapidsai/rapids-cmake/commit/fb7033e8860594beb5b0351c204068c12f1d6a0a removed a deprecated feature that we were inadvertently still using.

This PR updates the second reference to `CMAKE_CUDA_ARCHITECTURES` as `ALL`