### PR TITLE
Add support in C API for handling unweighted graphs in algorithms that expect weights

### DIFF
--- a/cpp/include/cugraph/edge_property.hpp
+++ b/cpp/include/cugraph/edge_property.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/utilities/dataframe_buffer.hpp>
 #include <cugraph/utilities/thrust_tuple_utils.hpp>
 
@@ -124,6 +125,26 @@ class edge_dummy_property_t {
 
   auto view() const { return edge_dummy_property_view_t{}; }
 };
+
+template <typename GraphViewType, typename T>
+auto create_constant_edge_property(raft::handle_t const& handle,
+                                   GraphViewType const& graph_view,
+                                   T constant_value)
+{
+  edge_property_t<GraphViewType, T> edge_property(handle, graph_view);
+
+  auto mutable_view = edge_property.mutable_view();
+
+  std::for_each(
+    thrust::make_zip_iterator(mutable_view.value_firsts().begin(),
+                              mutable_view.edge_counts().begin()),
+    thrust::make_zip_iterator(mutable_view.value_firsts().end(), mutable_view.edge_counts().end()),
+    [&handle, constant_value](auto tuple) {
+      detail::scalar_fill(handle, thrust::get<0>(tuple), thrust::get<1>(tuple), constant_value);
+    });
+
+  return edge_property;
+}
 
 template <typename edge_t, typename... Ts>
 auto view_concat(edge_property_view_t<edge_t, Ts> const&... views)

--- a/cpp/src/c_api/core_result.cpp
+++ b/cpp/src/c_api/core_result.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,8 +95,10 @@ cugraph_type_erased_device_array_view_t* cugraph_k_core_result_get_weights(
   cugraph_k_core_result_t* result)
 {
   auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_k_core_result_t*>(result);
-  return reinterpret_cast<cugraph_type_erased_device_array_view_t*>(
-    internal_pointer->weights_->view());
+  return (internal_pointer->weights_ == nullptr)
+           ? NULL
+           : reinterpret_cast<cugraph_type_erased_device_array_view_t*>(
+               internal_pointer->weights_->view());
 }
 
 void cugraph_k_core_result_free(cugraph_k_core_result_t* result)

--- a/cpp/src/c_api/induced_subgraph_result.cpp
+++ b/cpp/src/c_api/induced_subgraph_result.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,10 @@ extern "C" cugraph_type_erased_device_array_view_t* cugraph_induced_subgraph_get
 {
   auto internal_pointer =
     reinterpret_cast<cugraph::c_api::cugraph_induced_subgraph_result_t*>(induced_subgraph);
-  return reinterpret_cast<cugraph_type_erased_device_array_view_t*>(internal_pointer->wgt_->view());
+  return (internal_pointer->wgt_ == nullptr)
+           ? NULL
+           : reinterpret_cast<cugraph_type_erased_device_array_view_t*>(
+               internal_pointer->wgt_->view());
 }
 
 extern "C" cugraph_type_erased_device_array_view_t* cugraph_induced_subgraph_get_subgraph_offsets(

--- a/cpp/src/c_api/legacy_spectral.cpp
+++ b/cpp/src/c_api/legacy_spectral.cpp
@@ -110,10 +110,18 @@ struct balanced_cut_clustering_functor : public cugraph::c_api::abstract_functor
       auto graph_view          = graph->view();
       auto edge_partition_view = graph_view.local_edge_partition_view();
 
+      rmm::device_uvector<weight_t> tmp_weights(0, handle_.get_stream());
+      if (edge_weights == nullptr) {
+        tmp_weights.resize(edge_partition_view.indices().size(), handle_.get_stream());
+        cugraph::detail::scalar_fill(handle_, tmp_weights.data(), tmp_weights.size(), weight_t{1});
+      }
+
       cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> legacy_graph_view(
         const_cast<edge_t*>(edge_partition_view.offsets().data()),
         const_cast<vertex_t*>(edge_partition_view.indices().data()),
-        const_cast<weight_t*>(edge_weights->view().value_firsts().front()),
+        (edge_weights == nullptr)
+          ? tmp_weights.data()
+          : const_cast<weight_t*>(edge_weights->view().value_firsts().front()),
         edge_partition_view.offsets().size() - 1,
         edge_partition_view.indices().size());
 
@@ -209,10 +217,18 @@ struct spectral_clustering_functor : public cugraph::c_api::abstract_functor {
       auto graph_view          = graph->view();
       auto edge_partition_view = graph_view.local_edge_partition_view();
 
+      rmm::device_uvector<weight_t> tmp_weights(0, handle_.get_stream());
+      if (edge_weights == nullptr) {
+        tmp_weights.resize(edge_partition_view.indices().size(), handle_.get_stream());
+        cugraph::detail::scalar_fill(handle_, tmp_weights.data(), tmp_weights.size(), weight_t{1});
+      }
+
       cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> legacy_graph_view(
         const_cast<edge_t*>(edge_partition_view.offsets().data()),
         const_cast<vertex_t*>(edge_partition_view.indices().data()),
-        const_cast<weight_t*>(edge_weights->view().value_firsts().front()),
+        (edge_weights == nullptr)
+          ? tmp_weights.data()
+          : const_cast<weight_t*>(edge_weights->view().value_firsts().front()),
         edge_partition_view.offsets().size() - 1,
         edge_partition_view.indices().size());
 
@@ -298,10 +314,18 @@ struct analyze_clustering_ratio_cut_functor : public cugraph::c_api::abstract_fu
       auto graph_view          = graph->view();
       auto edge_partition_view = graph_view.local_edge_partition_view();
 
+      rmm::device_uvector<weight_t> tmp_weights(0, handle_.get_stream());
+      if (edge_weights == nullptr) {
+        tmp_weights.resize(edge_partition_view.indices().size(), handle_.get_stream());
+        cugraph::detail::scalar_fill(handle_, tmp_weights.data(), tmp_weights.size(), weight_t{1});
+      }
+
       cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> legacy_graph_view(
         const_cast<edge_t*>(edge_partition_view.offsets().data()),
         const_cast<vertex_t*>(edge_partition_view.indices().data()),
-        const_cast<weight_t*>(edge_weights->view().value_firsts().front()),
+        (edge_weights == nullptr)
+          ? tmp_weights.data()
+          : const_cast<weight_t*>(edge_weights->view().value_firsts().front()),
         edge_partition_view.offsets().size() - 1,
         edge_partition_view.indices().size());
 
@@ -405,10 +429,18 @@ struct analyze_clustering_edge_cut_functor : public cugraph::c_api::abstract_fun
       auto graph_view          = graph->view();
       auto edge_partition_view = graph_view.local_edge_partition_view();
 
+      rmm::device_uvector<weight_t> tmp_weights(0, handle_.get_stream());
+      if (edge_weights == nullptr) {
+        tmp_weights.resize(edge_partition_view.indices().size(), handle_.get_stream());
+        cugraph::detail::scalar_fill(handle_, tmp_weights.data(), tmp_weights.size(), weight_t{1});
+      }
+
       cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> legacy_graph_view(
         const_cast<edge_t*>(edge_partition_view.offsets().data()),
         const_cast<vertex_t*>(edge_partition_view.indices().data()),
-        const_cast<weight_t*>(edge_weights->view().value_firsts().front()),
+        (edge_weights == nullptr)
+          ? tmp_weights.data()
+          : const_cast<weight_t*>(edge_weights->view().value_firsts().front()),
         edge_partition_view.offsets().size() - 1,
         edge_partition_view.indices().size());
 
@@ -512,10 +544,18 @@ struct analyze_clustering_modularity_functor : public cugraph::c_api::abstract_f
       auto graph_view          = graph->view();
       auto edge_partition_view = graph_view.local_edge_partition_view();
 
+      rmm::device_uvector<weight_t> tmp_weights(0, handle_.get_stream());
+      if (edge_weights == nullptr) {
+        tmp_weights.resize(edge_partition_view.indices().size(), handle_.get_stream());
+        cugraph::detail::scalar_fill(handle_, tmp_weights.data(), tmp_weights.size(), weight_t{1});
+      }
+
       cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> legacy_graph_view(
         const_cast<edge_t*>(edge_partition_view.offsets().data()),
         const_cast<vertex_t*>(edge_partition_view.indices().data()),
-        const_cast<weight_t*>(edge_weights->view().value_firsts().front()),
+        (edge_weights == nullptr)
+          ? tmp_weights.data()
+          : const_cast<weight_t*>(edge_weights->view().value_firsts().front()),
         edge_partition_view.offsets().size() - 1,
         edge_partition_view.indices().size());
 

--- a/cpp/src/c_api/louvain.cpp
+++ b/cpp/src/c_api/louvain.cpp
@@ -86,10 +86,18 @@ struct louvain_functor : public cugraph::c_api::abstract_functor {
       rmm::device_uvector<vertex_t> clusters(graph_view.local_vertex_partition_range_size(),
                                              handle_.get_stream());
 
+      // FIXME: Revisit the constant edge property idea.  We could consider an alternate
+      // implementation (perhaps involving the thrust::constant_iterator), or we
+      // could add support in Louvain for std::nullopt as the edge weights behaving
+      // as desired and only instantiating a real edge_property_view_t for the
+      // coarsened graphs.
       auto [level, modularity] = cugraph::louvain(
         handle_,
         graph_view,
-        (edge_weights != nullptr) ? std::make_optional(edge_weights->view()) : std::nullopt,
+        (edge_weights != nullptr)
+          ? std::make_optional(edge_weights->view())
+          : std::make_optional(
+              cugraph::create_constant_edge_property(handle_, graph_view, weight_t{1}).view()),
         clusters.data(),
         max_level_,
         static_cast<weight_t>(resolution_));

--- a/cpp/tests/c_api/egonet_test.c
+++ b/cpp/tests/c_api/egonet_test.c
@@ -43,6 +43,12 @@ int generic_egonet_test(vertex_t* h_src,
   cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
   cugraph_error_t* ret_error;
 
+  data_type_id_t vertex_tid = INT32;
+  data_type_id_t edge_tid   = INT32;
+  data_type_id_t weight_tid = FLOAT32;
+  data_type_id_t edge_id_tid   = INT32;
+  data_type_id_t edge_type_tid = INT32;
+
   cugraph_resource_handle_t* resource_handle          = NULL;
   cugraph_graph_t* graph                              = NULL;
   cugraph_type_erased_device_array_t* seeds           = NULL;
@@ -52,16 +58,7 @@ int generic_egonet_test(vertex_t* h_src,
   resource_handle = cugraph_create_resource_handle(NULL);
   TEST_ASSERT(test_ret_value, resource_handle != NULL, "resource handle creation failed.");
 
-  ret_code = create_test_graph(resource_handle,
-                               h_src,
-                               h_dst,
-                               h_wgt,
-                               num_edges,
-                               store_transposed,
-                               FALSE,
-                               FALSE,
-                               &graph,
-                               &ret_error);
+  ret_code = create_sg_test_graph(resource_handle, vertex_tid, edge_tid, h_src, h_dst, weight_tid, h_wgt, edge_type_tid, NULL, edge_id_tid, NULL, num_edges, store_transposed, FALSE, FALSE, FALSE, &graph, &ret_error);
 
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "create_test_graph failed.");
   TEST_ALWAYS_ASSERT(ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
@@ -109,9 +106,11 @@ int generic_egonet_test(vertex_t* h_src,
       resource_handle, (byte_t*)h_result_dst, dst, &ret_error);
     TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
 
+#if 0
     ret_code = cugraph_type_erased_device_array_view_copy_to_host(
       resource_handle, (byte_t*)h_result_wgt, wgt, &ret_error);
     TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+#endif
 
     ret_code = cugraph_type_erased_device_array_view_copy_to_host(
       resource_handle, (byte_t*)h_result_offsets, offsets, &ret_error);
@@ -185,11 +184,42 @@ int test_egonet()
                              FALSE);
 }
 
+int test_egonet_no_weights()
+{
+  size_t num_edges    = 9;
+  size_t num_vertices = 6;
+  size_t radius       = 2;
+  size_t num_seeds    = 2;
+
+  vertex_t h_src[]   = {0, 1, 1, 2, 2, 2, 3, 3, 4};
+  vertex_t h_dst[]   = {1, 3, 4, 0, 1, 3, 4, 5, 5};
+  vertex_t h_seeds[] = {0, 1};
+
+  vertex_t h_result_src[]   = {0, 1, 1, 3, 1, 1, 3, 3, 4};
+  vertex_t h_result_dst[]   = {1, 3, 4, 4, 3, 4, 4, 5, 5};
+  size_t h_result_offsets[] = {0, 4, 9};
+
+  // Egonet wants store_transposed = FALSE
+  return generic_egonet_test(h_src,
+                             h_dst,
+                             NULL,
+                             h_seeds,
+                             h_result_src,
+                             h_result_dst,
+                             h_result_offsets,
+                             num_vertices,
+                             num_edges,
+                             num_seeds,
+                             radius,
+                             FALSE);
+}
+
 /******************************************************************************/
 
 int main(int argc, char** argv)
 {
   int result = 0;
   result |= RUN_TEST(test_egonet);
+  result |= RUN_TEST(test_egonet_no_weights);
   return result;
 }

--- a/cpp/tests/c_api/leiden_test.c
+++ b/cpp/tests/c_api/leiden_test.c
@@ -45,20 +45,22 @@ int generic_leiden_test(vertex_t* h_src,
   cugraph_graph_t* p_graph                           = NULL;
   cugraph_hierarchical_clustering_result_t* p_result = NULL;
 
+  data_type_id_t vertex_tid = INT32;
+  data_type_id_t edge_tid   = INT32;
+  data_type_id_t weight_tid = FLOAT32;
+  data_type_id_t edge_id_tid   = INT32;
+  data_type_id_t edge_type_tid = INT32;
+
   p_handle = cugraph_create_resource_handle(NULL);
   TEST_ASSERT(test_ret_value, p_handle != NULL, "resource handle creation failed.");
 
-  ret_code = create_test_graph(
-    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, FALSE, FALSE, &p_graph, &ret_error);
+  ret_code = create_sg_test_graph(p_handle, vertex_tid, edge_tid, h_src, h_dst, weight_tid, h_wgt, edge_type_tid, NULL, edge_id_tid, NULL, num_edges, store_transposed, FALSE, FALSE, FALSE, &p_graph, &ret_error);
 
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "create_test_graph failed.");
   TEST_ALWAYS_ASSERT(ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
 
   ret_code = cugraph_leiden(p_handle, p_graph, max_level, resolution, FALSE, &p_result, &ret_error);
 
-#if 0
-  TEST_ASSERT(test_ret_value, ret_code != CUGRAPH_SUCCESS, "cugraph_leiden should have failed");
-#else
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
   TEST_ALWAYS_ASSERT(ret_code == CUGRAPH_SUCCESS, "cugraph_leiden failed.");
 
@@ -87,7 +89,6 @@ int generic_leiden_test(vertex_t* h_src,
 
     cugraph_hierarchical_clustering_result_free(p_result);
   }
-#endif
 
   cugraph_sg_graph_free(p_graph);
   cugraph_free_resource_handle(p_handle);
@@ -123,11 +124,37 @@ int test_leiden()
                              FALSE);
 }
 
+int test_leiden_no_weights()
+{
+  size_t num_edges    = 16;
+  size_t num_vertices = 6;
+  size_t max_level    = 10;
+  weight_t resolution = 1.0;
+
+  vertex_t h_src[] = {0, 1, 1, 2, 2, 2, 3, 4, 1, 3, 4, 0, 1, 3, 5, 5};
+  vertex_t h_dst[] = {1, 3, 4, 0, 1, 3, 5, 5, 0, 1, 1, 2, 2, 2, 3, 4};
+  vertex_t h_result[]          = {1, 1, 1, 2, 0, 0};
+  weight_t expected_modularity = 0.0859375;
+
+  // Louvain wants store_transposed = FALSE
+  return generic_leiden_test(h_src,
+                             h_dst,
+                             NULL,
+                             h_result,
+                             expected_modularity,
+                             num_vertices,
+                             num_edges,
+                             max_level,
+                             resolution,
+                             FALSE);
+}
+
 /******************************************************************************/
 
 int main(int argc, char** argv)
 {
   int result = 0;
   result |= RUN_TEST(test_leiden);
+  result |= RUN_TEST(test_leiden_no_weights);
   return result;
 }

--- a/cpp/tests/c_api/louvain_test.c
+++ b/cpp/tests/c_api/louvain_test.c
@@ -45,11 +45,16 @@ int generic_louvain_test(vertex_t* h_src,
   cugraph_graph_t* p_graph                           = NULL;
   cugraph_hierarchical_clustering_result_t* p_result = NULL;
 
+  data_type_id_t vertex_tid = INT32;
+  data_type_id_t edge_tid   = INT32;
+  data_type_id_t weight_tid = FLOAT32;
+  data_type_id_t edge_id_tid   = INT32;
+  data_type_id_t edge_type_tid = INT32;
+
   p_handle = cugraph_create_resource_handle(NULL);
   TEST_ASSERT(test_ret_value, p_handle != NULL, "resource handle creation failed.");
 
-  ret_code = create_test_graph(
-    p_handle, h_src, h_dst, h_wgt, num_edges, store_transposed, FALSE, FALSE, &p_graph, &ret_error);
+  ret_code = create_sg_test_graph(p_handle, vertex_tid, edge_tid, h_src, h_dst, weight_tid, h_wgt, edge_type_tid, NULL, edge_id_tid, NULL, num_edges, store_transposed, FALSE, FALSE, FALSE, &p_graph, &ret_error);
 
   TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "create_test_graph failed.");
   TEST_ALWAYS_ASSERT(ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
@@ -125,11 +130,37 @@ int test_louvain()
                               FALSE);
 }
 
+int test_louvain_no_weight()
+{
+  size_t num_edges    = 16;
+  size_t num_vertices = 6;
+  size_t max_level    = 10;
+  weight_t resolution = 1.0;
+
+  vertex_t h_src[] = {0, 1, 1, 2, 2, 2, 3, 4, 1, 3, 4, 0, 1, 3, 5, 5};
+  vertex_t h_dst[] = {1, 3, 4, 0, 1, 3, 5, 5, 0, 1, 1, 2, 2, 2, 3, 4};
+  vertex_t h_result[]          = {1, 1, 1, 2, 0, 0};
+  weight_t expected_modularity = 0.0859375;
+
+  // Louvain wants store_transposed = FALSE
+  return generic_louvain_test(h_src,
+                              h_dst,
+                              NULL,
+                              h_result,
+                              expected_modularity,
+                              num_vertices,
+                              num_edges,
+                              max_level,
+                              resolution,
+                              FALSE);
+}
+
 /******************************************************************************/
 
 int main(int argc, char** argv)
 {
   int result = 0;
   result |= RUN_TEST(test_louvain);
+  result |= RUN_TEST(test_louvain_no_weight);
   return result;
 }


### PR DESCRIPTION
Closes #3499 

Some of our C++ algorithms require a graph to be weighted.  The python layer will add "fake" edge weights of 1 to every edge in order to call these algorithms.  This adds a persisted constant value for every edge that will continue to exist for the life span of the python graph object, even though it is only necessary for a handful of algorithms.

This PR addresses these concerns.

Many of the C++ algorithms already actually support the graph not having weights.  A few should support it and had bugs that were corrected (induced subgraph, k-core, egonet).  A few can easily support it but did not (legacy spectral algorithms).

The Louvain and Leiden algorithms need to have a weighted graph because they will coarsen the weights as the graph is coarsened, and the weights will eventually not be one while the algorithm is running.  These require a slightly different approach.

This PR also added C API tests for unweighted graphs for these algorithms.