### PR TITLE
Update dgl APIs for v1.1.0

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -124,7 +124,7 @@ if [[ "${RAPIDS_CUDA_VERSION}" == "11.8.0" ]]; then
       pylibcugraphops \
       cugraph \
       cugraph-dgl \
-      'dgl>=1.0' \
+      'dgl>=1.1' \
       'pytorch>=2.0' \
       'pytorch-cuda>=11.8'
 

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -124,7 +124,7 @@ if [[ "${RAPIDS_CUDA_VERSION}" == "11.8.0" ]]; then
       pylibcugraphops \
       cugraph \
       cugraph-dgl \
-      'dgl>=1.1' \
+      'dgl>=1.1.0.dev0' \
       'pytorch>=2.0' \
       'pytorch-cuda>=11.8'
 

--- a/python/cugraph-dgl/cugraph_dgl/nn/conv/gatconv.py
+++ b/python/cugraph-dgl/cugraph_dgl/nn/conv/gatconv.py
@@ -145,7 +145,7 @@ class GATConv(BaseConv):
             :math:`H` is the number of heads, and :math:`D_{out}` is size of
             output feature.
         """
-        offsets, indices, _ = g.adj_sparse("csc")
+        offsets, indices, _ = g.adj_tensors("csc")
 
         if g.is_block:
             if max_in_degree is None:

--- a/python/cugraph-dgl/cugraph_dgl/nn/conv/relgraphconv.py
+++ b/python/cugraph-dgl/cugraph_dgl/nn/conv/relgraphconv.py
@@ -179,7 +179,7 @@ class RelGraphConv(BaseConv):
         torch.Tensor
             New node features. Shape: :math:`(|V|, D_{out})`.
         """
-        offsets, indices, edge_ids = g.adj_sparse("csc")
+        offsets, indices, edge_ids = g.adj_tensors("csc")
         edge_types_perm = etypes[edge_ids.long()].int()
 
         if g.is_block:

--- a/python/cugraph-dgl/cugraph_dgl/nn/conv/sageconv.py
+++ b/python/cugraph-dgl/cugraph_dgl/nn/conv/sageconv.py
@@ -122,7 +122,7 @@ class SAGEConv(BaseConv):
         torch.Tensor
             Output node features. Shape: :math:`(|V|, D_{out})`.
         """
-        offsets, indices, _ = g.adj_sparse("csc")
+        offsets, indices, _ = g.adj_tensors("csc")
 
         if g.is_block:
             if max_in_degree is None:


### PR DESCRIPTION
DGL v1.1.0 introduced a breaking change that renames `adj_sparse` to `adj_tensors`, causing the following error in our CI:
```
nn/test_gatconv.py::test_gatconv_equality[False-None-1-False] - AttributeError: 'DGLGraph' object has no attribute 'adj_sparse'
nn/test_gatconv.py::test_gatconv_equality[False-None-1-True] - AttributeError: 'DGLBlock' object has no attribute 'adj_sparse'
```

 This PR updates the usage in `cugraph-dgl` tests.

CC: @alexbarghi-nv 