### PR TITLE
Update recipes to GTest version >=1.13.0

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -23,9 +23,9 @@ dependencies:
 - doxygen
 - fsspec[http]>=0.6.0
 - gcc_linux-64=11.*
-- gmock=1.10.0
+- gmock>=1.13.0
 - graphviz
-- gtest=1.10.0
+- gtest>=1.13.0
 - ipython
 - libcudf=23.6.*
 - libcugraphops=23.6.*

--- a/conda/recipes/libcugraph/conda_build_config.yaml
+++ b/conda/recipes/libcugraph/conda_build_config.yaml
@@ -17,7 +17,7 @@ nccl_version:
   - ">=2.9.9"
 
 gtest_version:
-  - "=1.10.0"
+  - ">=1.13.0"
 
 cuda_profiler_api_version:
   - ">=11.8.86,<12"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -214,8 +214,8 @@ dependencies:
         packages:
           - c-compiler
           - cxx-compiler
-          - gmock=1.10.0
-          - gtest=1.10.0
+          - gmock>=1.13.0
+          - gtest>=1.13.0
           - libcugraphops=23.6.*
           - libraft-headers=23.6.*
           - libraft=23.6.*


### PR DESCRIPTION
This PR updates GTest pinnings to >=1.13.0. This aligns with recent changes in rapids-cmake: https://github.com/rapidsai/rapids-cmake/pull/401.
