### PR TITLE
[REVIEW] Optimize bulk sampling

### DIFF
--- a/python/cugraph/cugraph/gnn/data_loading/bulk_sampler.py
+++ b/python/cugraph/cugraph/gnn/data_loading/bulk_sampler.py
@@ -172,6 +172,8 @@ class EXPERIMENTAL__BulkSampler:
         if self.size == 0:
             return
         self.__batches.reset_index(drop=True)
+        if isinstance(self.__batches, dask_cudf.DataFrame): 
+            self.__batches = self.__batches.persist()
 
         min_batch_id = self.__batches[self.batch_col_name].min()
         if isinstance(self.__batches, dask_cudf.DataFrame):
@@ -213,6 +215,9 @@ class EXPERIMENTAL__BulkSampler:
         )
 
         self.__batches = self.__batches[~batch_id_filter]
+        if isinstance(self.__batches, dask_cudf.DataFrame): 
+            self.__batches = self.__batches.persist()
+
         self.__write(samples, offsets)
 
         if self.size > 0:

--- a/python/cugraph/cugraph/gnn/data_loading/bulk_sampler.py
+++ b/python/cugraph/cugraph/gnn/data_loading/bulk_sampler.py
@@ -172,7 +172,7 @@ class EXPERIMENTAL__BulkSampler:
         if self.size == 0:
             return
         self.__batches.reset_index(drop=True)
-        if isinstance(self.__batches, dask_cudf.DataFrame): 
+        if isinstance(self.__batches, dask_cudf.DataFrame):
             self.__batches = self.__batches.persist()
 
         min_batch_id = self.__batches[self.batch_col_name].min()
@@ -215,7 +215,7 @@ class EXPERIMENTAL__BulkSampler:
         )
 
         self.__batches = self.__batches[~batch_id_filter]
-        if isinstance(self.__batches, dask_cudf.DataFrame): 
+        if isinstance(self.__batches, dask_cudf.DataFrame):
             self.__batches = self.__batches.persist()
 
         self.__write(samples, offsets)


### PR DESCRIPTION
This PR optimizes bulk sampling by persisting the samples to prevent redundant computations . 

I see a 50% boost and consistent perf with this PR on `13.5 s` vs `9s`  on https://github.com/rapidsai/cugraph/pull/3628