### PR TITLE
Update conv layers in `cugraph-dgl` and `-pyg` based on `cugraph-ops` refactoring

### DIFF
--- a/python/cugraph-dgl/cugraph_dgl/nn/conv/transformerconv.py
+++ b/python/cugraph-dgl/cugraph_dgl/nn/conv/transformerconv.py
@@ -15,7 +15,7 @@ from typing import Optional, Tuple, Union
 from cugraph_dgl.nn.conv.base import BaseConv
 from cugraph.utilities.utils import import_optional
 
-from pylibcugraphops.pytorch import BipartiteCSC, StaticCSC
+from pylibcugraphops.pytorch import CSC
 from pylibcugraphops.pytorch.operators import mha_simple_n2n
 
 dgl = import_optional("dgl")
@@ -132,31 +132,34 @@ class TransformerConv(BaseConv):
         efeat: torch.Tensor, optional
             Edge feature tensor. Default: ``None``.
         """
-        bipartite = not isinstance(nfeat, torch.Tensor)
         offsets, indices, _ = g.adj_tensors("csc")
+        graph = CSC(
+            offsets=offsets,
+            indices=indices,
+            num_src_nodes=g.num_src_nodes(),
+            is_bipartite=True,
+        )
 
-        if bipartite:
-            src_feats, dst_feats = nfeat
-            _graph = BipartiteCSC(
-                offsets=offsets, indices=indices, num_src_nodes=g.num_src_nodes()
-            )
-        else:
-            src_feats = dst_feats = nfeat
-            if g.is_block:
-                offsets = self.pad_offsets(offsets, g.num_src_nodes() + 1)
-            _graph = StaticCSC(offsets=offsets, indices=indices)
+        if isinstance(nfeat, torch.Tensor):
+            nfeat = (nfeat, nfeat)
 
-        query = self.lin_query(dst_feats)
-        key = self.lin_key(src_feats)
-        value = self.lin_value(src_feats)
-        if self.lin_edge is not None:
+        query = self.lin_query(nfeat[1][: g.num_dst_nodes()])
+        key = self.lin_key(nfeat[0])
+        value = self.lin_value(nfeat[0])
+
+        if efeat is not None:
+            if self.lin_edge is None:
+                raise RuntimeError(
+                    f"{self.__class__.__name__}.edge_feats must be set to allow "
+                    f"edge features."
+                )
             efeat = self.lin_edge(efeat)
 
         out = mha_simple_n2n(
             key_emb=key,
             query_emb=query,
             value_emb=value,
-            graph=_graph,
+            graph=graph,
             num_heads=self.num_heads,
             concat_heads=self.concat,
             edge_emb=efeat,
@@ -165,7 +168,7 @@ class TransformerConv(BaseConv):
         )[: g.num_dst_nodes()]
 
         if self.root_weight:
-            res = self.lin_skip(dst_feats[: g.num_dst_nodes()])
+            res = self.lin_skip(nfeat[1][: g.num_dst_nodes()])
             if self.lin_beta is not None:
                 beta = self.lin_beta(torch.cat([out, res, out - res], dim=-1))
                 beta = beta.sigmoid()

--- a/python/cugraph-dgl/tests/nn/test_transformerconv.py
+++ b/python/cugraph-dgl/tests/nn/test_transformerconv.py
@@ -26,14 +26,14 @@ dgl = import_optional("dgl")
 
 
 @pytest.mark.parametrize("beta", [False, True])
-@pytest.mark.parametrize("bipartite", [False, True])
+@pytest.mark.parametrize("bipartite_node_feats", [False, True])
 @pytest.mark.parametrize("concat", [False, True])
 @pytest.mark.parametrize("idtype_int", [False, True])
 @pytest.mark.parametrize("num_heads", [1, 2, 3, 4])
 @pytest.mark.parametrize("to_block", [False, True])
 @pytest.mark.parametrize("use_edge_feats", [False, True])
 def test_TransformerConv(
-    beta, bipartite, concat, idtype_int, num_heads, to_block, use_edge_feats
+    beta, bipartite_node_feats, concat, idtype_int, num_heads, to_block, use_edge_feats
 ):
     device = "cuda"
     g = create_graph1().to(device)
@@ -44,7 +44,7 @@ def test_TransformerConv(
     if to_block:
         g = dgl.to_block(g)
 
-    if bipartite:
+    if bipartite_node_feats:
         in_node_feats = (5, 3)
         nfeat = (
             torch.rand(g.num_src_nodes(), in_node_feats[0], device=device),

--- a/python/cugraph-pyg/cugraph_pyg/nn/conv/base.py
+++ b/python/cugraph-pyg/cugraph_pyg/nn/conv/base.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 import warnings
-from typing import Any, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 from cugraph.utilities.utils import import_optional
 
@@ -20,13 +20,7 @@ torch = import_optional("torch")
 torch_geometric = import_optional("torch_geometric")
 
 try:  # pragma: no cover
-    from pylibcugraphops.pytorch import (
-        BipartiteCSC,
-        SampledCSC,
-        SampledHeteroCSC,
-        StaticCSC,
-        StaticHeteroCSC,
-    )
+    from pylibcugraphops.pytorch import CSC, HeteroCSC
 
     HAS_PYLIBCUGRAPHOPS = True
 except ImportError:
@@ -94,7 +88,7 @@ class BaseConv(torch.nn.Module):  # pragma: no cover
         csc: Tuple[torch.Tensor, torch.Tensor, int],
         bipartite: bool = False,
         max_num_neighbors: Optional[int] = None,
-    ) -> Any:
+    ) -> CSC:
         r"""Constructs a :obj:`cugraph-ops` graph object from CSC representation.
         Supports both bipartite and non-bipartite graphs.
 
@@ -119,16 +113,16 @@ class BaseConv(torch.nn.Module):  # pragma: no cover
                 f"based processing (got CPU tensor)"
             )
 
-        if bipartite:
-            return BipartiteCSC(colptr, row, num_src_nodes)
+        if max_num_neighbors is None:
+            max_num_neighbors = -1
 
-        if num_src_nodes != colptr.numel() - 1:
-            if max_num_neighbors is None:
-                max_num_neighbors = int((colptr[1:] - colptr[:-1]).max())
-
-            return SampledCSC(colptr, row, max_num_neighbors, num_src_nodes)
-
-        return StaticCSC(colptr, row)
+        return CSC(
+            offsets=colptr,
+            indices=row,
+            num_src_nodes=num_src_nodes,
+            dst_max_in_degree=max_num_neighbors,
+            is_bipartite=bipartite,
+        )
 
     def get_typed_cugraph(
         self,
@@ -137,7 +131,7 @@ class BaseConv(torch.nn.Module):  # pragma: no cover
         num_edge_types: Optional[int] = None,
         bipartite: bool = False,
         max_num_neighbors: Optional[int] = None,
-    ) -> Any:
+    ) -> HeteroCSC:
         r"""Constructs a typed :obj:`cugraph` graph object from a CSC
         representation where each edge corresponds to a given edge type.
         Supports both bipartite and non-bipartite graphs.
@@ -162,21 +156,21 @@ class BaseConv(torch.nn.Module):  # pragma: no cover
         if num_edge_types is None:
             num_edge_types = int(edge_type.max()) + 1
 
+        if max_num_neighbors is None:
+            max_num_neighbors = -1
+
         row, colptr, num_src_nodes = csc
         edge_type = edge_type.int()
 
-        if bipartite:
-            raise NotImplementedError
-
-        if num_src_nodes != colptr.numel() - 1:
-            if max_num_neighbors is None:
-                max_num_neighbors = int((colptr[1:] - colptr[:-1]).max())
-
-            return SampledHeteroCSC(
-                colptr, row, edge_type, max_num_neighbors, num_src_nodes, num_edge_types
-            )
-
-        return StaticHeteroCSC(colptr, row, edge_type, num_edge_types)
+        return HeteroCSC(
+            offsets=colptr,
+            indices=row,
+            edge_types=edge_type,
+            num_src_nodes=num_src_nodes,
+            num_edge_types=num_edge_types,
+            dst_max_in_degree=max_num_neighbors,
+            is_bipartite=bipartite,
+        )
 
     def forward(
         self,

--- a/python/cugraph-pyg/cugraph_pyg/nn/conv/gat_conv.py
+++ b/python/cugraph-pyg/cugraph_pyg/nn/conv/gat_conv.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 from typing import Optional, Tuple, Union
 
-from pylibcugraphops.pytorch.operators import mha_gat_n2n, mha_gat_n2n_bipartite
+from pylibcugraphops.pytorch.operators import mha_gat_n2n
 
 from cugraph.utilities.utils import import_optional
 
@@ -203,19 +203,6 @@ class GATConv(BaseConv):
                 )
             x_src = self.lin_src(x[0])
             x_dst = self.lin_dst(x[1])
-
-            out = mha_gat_n2n_bipartite(
-                x_src,
-                x_dst,
-                self.att,
-                graph,
-                num_heads=self.heads,
-                activation="LeakyReLU",
-                negative_slope=self.negative_slope,
-                concat_heads=self.concat,
-                edge_feat=edge_attr,
-            )
-
         else:
             if not hasattr(self, "lin"):
                 raise RuntimeError(
@@ -224,16 +211,16 @@ class GATConv(BaseConv):
                 )
             x = self.lin(x)
 
-            out = mha_gat_n2n(
-                x,
-                self.att,
-                graph,
-                num_heads=self.heads,
-                activation="LeakyReLU",
-                negative_slope=self.negative_slope,
-                concat_heads=self.concat,
-                edge_feat=edge_attr,
-            )
+        out = mha_gat_n2n(
+            (x_src, x_dst) if bipartite else x,
+            self.att,
+            graph,
+            num_heads=self.heads,
+            activation="LeakyReLU",
+            negative_slope=self.negative_slope,
+            concat_heads=self.concat,
+            edge_feat=edge_attr,
+        )
 
         if self.bias is not None:
             out = out + self.bias

--- a/python/cugraph-pyg/cugraph_pyg/nn/conv/gatv2_conv.py
+++ b/python/cugraph-pyg/cugraph_pyg/nn/conv/gatv2_conv.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 from typing import Optional, Tuple, Union
 
-from pylibcugraphops.pytorch.operators import mha_gat_v2_n2n, mha_gat_v2_n2n_bipartite
+from pylibcugraphops.pytorch.operators import mha_gat_v2_n2n
 
 from cugraph.utilities.utils import import_optional
 
@@ -187,8 +187,8 @@ class GATv2Conv(BaseConv):
                 representation to the desired format.
             edge_attr: (torch.Tensor, optional) The edge features.
         """
-        bipartite = not isinstance(x, torch.Tensor)
-        graph = self.get_cugraph(csc, bipartite=bipartite or not self.share_weights)
+        bipartite = not isinstance(x, torch.Tensor) or not self.share_weights
+        graph = self.get_cugraph(csc, bipartite=bipartite)
 
         if edge_attr is not None:
             if self.lin_edge is None:
@@ -200,38 +200,24 @@ class GATv2Conv(BaseConv):
                 edge_attr = edge_attr.view(-1, 1)
             edge_attr = self.lin_edge(edge_attr)
 
-        if not bipartite and self.share_weights:
+        if bipartite:
+            if isinstance(x, torch.Tensor):
+                x = (x, x)
+            x_src = self.lin_src(x[0])
+            x_dst = self.lin_dst(x[1])
+        else:
             x = self.lin_src(x)
 
-            out = mha_gat_v2_n2n(
-                x,
-                self.att,
-                graph,
-                num_heads=self.heads,
-                activation="LeakyReLU",
-                negative_slope=self.negative_slope,
-                concat_heads=self.concat,
-                edge_feat=edge_attr,
-            )
-        else:
-            if bipartite:
-                x_src = self.lin_src(x[0])
-                x_dst = self.lin_dst(x[1])
-            else:
-                x_src = self.lin_src(x)
-                x_dst = self.lin_dst(x)
-
-            out = mha_gat_v2_n2n_bipartite(
-                x_src,
-                x_dst,
-                self.att,
-                graph,
-                num_heads=self.heads,
-                activation="LeakyReLU",
-                negative_slope=self.negative_slope,
-                concat_heads=self.concat,
-                edge_feat=edge_attr,
-            )
+        out = mha_gat_v2_n2n(
+            (x_src, x_dst) if bipartite else x,
+            self.att,
+            graph,
+            num_heads=self.heads,
+            activation="LeakyReLU",
+            negative_slope=self.negative_slope,
+            concat_heads=self.concat,
+            edge_feat=edge_attr,
+        )
 
         if self.bias is not None:
             out = out + self.bias

--- a/python/cugraph-pyg/cugraph_pyg/nn/conv/transformer_conv.py
+++ b/python/cugraph-pyg/cugraph_pyg/nn/conv/transformer_conv.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 from typing import Optional, Tuple, Union
 
-from pylibcugraphops.pytorch.operators import mha_simple_n2n as TransformerConvAgg
+from pylibcugraphops.pytorch.operators import mha_simple_n2n
 
 from cugraph.utilities.utils import import_optional
 
@@ -168,10 +168,10 @@ class TransformerConv(BaseConv):
                 representation to the desired format.
             edge_attr: (torch.Tensor, optional) The edge features.
         """
-        bipartite = not isinstance(x, torch.Tensor)
+        bipartite = True
         graph = self.get_cugraph(csc, bipartite=bipartite)
 
-        if not bipartite:
+        if isinstance(x, torch.Tensor):
             x = (x, x)
 
         query = self.lin_query(x[1])
@@ -186,7 +186,7 @@ class TransformerConv(BaseConv):
                 )
             edge_attr = self.lin_edge(edge_attr)
 
-        out = TransformerConvAgg(
+        out = mha_simple_n2n(
             key,
             query,
             value,


### PR DESCRIPTION
This PR address the breaking changes in `pylibcugraphops` pytorch APIs. It should fix the [pytest error](https://github.com/rapidsai/cugraph/actions/runs/5425211493/jobs/9890754410?pr=3683) in the CI for `cugraph-dgl` and `-pyg` in https://github.com/rapidsai/cugraph/pull/3683.

@MatthiasKohl We need both your PR and this one to pass CI. Please feel free to consolidate them. 