### PR TITLE
Use rapids-cmake testing to run tests in parallel

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -41,19 +41,15 @@ EXITCODE=0
 trap "EXITCODE=1" ERR
 set +e
 
+export GTEST_OUTPUT=xml:${RAPIDS_TESTS_DIR}/
+
 # Run libcugraph gtests from libcugraph-tests package
 rapids-logger "Run gtests"
-for gt in "$CONDA_PREFIX"/bin/gtests/libcugraph/* ; do
-    test_name=$(basename ${gt})
-    echo "Running gtest $test_name"
-    ${gt} --gtest_output=xml:${RAPIDS_TESTS_DIR}
-done
+cd "$CONDA_PREFIX"/bin/gtests/libcugraph/
+ctest -j10 --output-on-failure
 
-for ct in "$CONDA_PREFIX"/bin/gtests/libcugraph_c/CAPI_*_TEST ; do
-    test_name=$(basename ${ct})
-    echo "Running C API test $test_name"
-    ${ct}
-done
+cd "$CONDA_PREFIX"/bin/gtests/libcugraph_c/
+ctest -j10 --output-on-failure
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/cpp/src/utilities/cugraph_ops_utils.hpp
+++ b/cpp/src/utilities/cugraph_ops_utils.hpp
@@ -20,33 +20,25 @@
 
 #include <cugraph-ops/graph/format.hpp>
 
-#include <tuple>
-
 namespace cugraph {
 namespace detail {
 
 template <typename NodeTypeT, typename EdgeTypeT>
-ops::graph::fg_csr<EdgeTypeT> get_graph(
+ops::graph::csc<EdgeTypeT, NodeTypeT> get_graph(
   graph_view_t<NodeTypeT, EdgeTypeT, false, false> const& gview)
 {
-  ops::graph::fg_csr<EdgeTypeT> graph;
-  graph.n_nodes   = gview.number_of_vertices();
-  graph.n_indices = gview.number_of_edges();
+  ops::graph::csc<EdgeTypeT, NodeTypeT> graph;
+  graph.n_src_nodes = gview.number_of_vertices();
+  graph.n_dst_nodes = gview.number_of_vertices();
+  graph.n_indices   = gview.number_of_edges();
+  // FIXME this is sufficient for now, but if there is a fast (cached) way
+  // of getting max degree, use that instead
+  graph.dst_max_in_degree = std::numeric_limits<EdgeTypeT>::max();
   // FIXME: this is evil and is just temporary until we have a matching type in cugraph-ops
   // or we change the type accepted by the functions calling into cugraph-ops
   graph.offsets = const_cast<EdgeTypeT*>(gview.local_edge_partition_view().offsets().data());
   graph.indices = const_cast<EdgeTypeT*>(gview.local_edge_partition_view().indices().data());
   return graph;
-}
-
-template <typename NodeTypeT, typename EdgeTypeT>
-std::tuple<ops::graph::fg_csr<EdgeTypeT>, NodeTypeT> get_graph_and_max_degree(
-  graph_view_t<NodeTypeT, EdgeTypeT, false, false> const& gview)
-{
-  // FIXME this is sufficient for now, but if there is a fast (cached) way
-  // of getting max degree, use that instead
-  auto max_degree = std::numeric_limits<NodeTypeT>::max();
-  return std::make_tuple(get_graph(gview), max_degree);
 }
 
 }  // namespace detail

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 #=============================================================================
+enable_testing()
+
+include(rapids-test)
+rapids_test_init()
 
 ###################################################################################################
 # - common test utils -----------------------------------------------------------------------------
@@ -28,7 +32,7 @@ add_library(cugraphtestutil STATIC
             centrality/betweenness_centrality_validate.cu
             community/egonet_validate.cu
             cores/k_core_validate.cu
-	    structure/induced_subgraph_validate.cu
+	        structure/induced_subgraph_validate.cu
             sampling/random_walks_check_sg.cu
             ../../thirdparty/mmio/mmio.c)
 
@@ -59,7 +63,22 @@ target_link_libraries(cugraphtestutil
 # - compiler function -----------------------------------------------------------------------------
 
 function(ConfigureTest CMAKE_TEST_NAME)
-    add_executable(${CMAKE_TEST_NAME} ${ARGN})
+    set(options)
+    set(one_value GPUS PERCENT)
+    set(multi_value)
+    cmake_parse_arguments(_CUGRAPH_TEST "${options}" "${one_value}" "${multi_value}" ${ARGN})
+    if(NOT DEFINED _CUGRAPH_TEST_GPUS AND NOT DEFINED _CUGRAPH_TEST_PERCENT)
+        set(_CUGRAPH_TEST_GPUS 1)
+        set(_CUGRAPH_TEST_PERCENT 25)
+    endif()
+    if(NOT DEFINED _CUGRAPH_TEST_GPUS)
+        set(_CUGRAPH_TEST_GPUS 1)
+    endif()
+    if(NOT DEFINED _CUGRAPH_TEST_PERCENT)
+        set(_CUGRAPH_TEST_PERCENT 100)
+    endif()
+
+    add_executable(${CMAKE_TEST_NAME} ${_CUGRAPH_TEST_UNPARSED_ARGUMENTS})
 
     target_link_libraries(${CMAKE_TEST_NAME}
         PRIVATE
@@ -69,18 +88,18 @@ function(ConfigureTest CMAKE_TEST_NAME)
             GTest::gtest_main
             NCCL::NCCL
     )
-
-    add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
-
     set_target_properties(
         ${CMAKE_TEST_NAME}
             PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib")
 
-    install(
-        TARGETS ${CMAKE_TEST_NAME}
-        COMPONENT testing
-        DESTINATION bin/gtests/libcugraph
-        EXCLUDE_FROM_ALL)
+    rapids_test_add(
+        NAME ${CMAKE_TEST_NAME}
+        COMMAND ${CMAKE_TEST_NAME}
+        GPUS ${_CUGRAPH_TEST_GPUS}
+        PERCENT ${_CUGRAPH_TEST_PERCENT}
+        INSTALL_COMPONENT_SET testing #bin/gtests/libcugraph
+    )
+    set_tests_properties(${CMAKE_TEST_NAME} PROPERTIES LABELS "CUGRAPH")
 endfunction()
 
 function(ConfigureTestMG CMAKE_TEST_NAME)
@@ -96,29 +115,44 @@ function(ConfigureTestMG CMAKE_TEST_NAME)
         NCCL::NCCL
         MPI::MPI_CXX
     )
+    set_target_properties(
+        ${CMAKE_TEST_NAME}
+            PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib")
 
-    add_test(NAME ${CMAKE_TEST_NAME}
-             COMMAND ${MPIEXEC_EXECUTABLE}
+    rapids_test_add(
+        NAME ${CMAKE_TEST_NAME}
+        COMMAND ${MPIEXEC_EXECUTABLE}
              "--noprefix"
              ${MPIEXEC_NUMPROC_FLAG}
              ${GPU_COUNT}
              ${MPIEXEC_PREFLAGS}
              ${CMAKE_TEST_NAME}
-             ${MPIEXEC_POSTFLAGS})
+             ${MPIEXEC_POSTFLAGS}
+        GPUS ${GPU_COUNT}
+        PERCENT 100
+        INSTALL_COMPONENT_SET testing_mg #bin/gtests/libcugraph_mg
+    )
+    set_tests_properties(${CMAKE_TEST_NAME} PROPERTIES LABELS "CUGRAPH_MG")
 
-    set_target_properties(
-        ${CMAKE_TEST_NAME}
-            PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib")
-
-    install(
-        TARGETS ${CMAKE_TEST_NAME}
-        COMPONENT testing
-        DESTINATION bin/gtests/libcugraph_mg
-        EXCLUDE_FROM_ALL)
 endfunction()
 
 function(ConfigureCTest CMAKE_TEST_NAME)
-    add_executable(${CMAKE_TEST_NAME} ${ARGN})
+    set(options)
+    set(one_value GPUS PERCENT)
+    set(multi_value)
+    cmake_parse_arguments(_CUGRAPH_TEST "${options}" "${one_value}" "${multi_value}" ${ARGN})
+    if(NOT DEFINED _CUGRAPH_TEST_GPUS AND NOT DEFINED _CUGRAPH_TEST_PERCENT)
+        set(_CUGRAPH_TEST_GPUS 1)
+        set(_CUGRAPH_TEST_PERCENT 25)
+    endif()
+    if(NOT DEFINED _CUGRAPH_TEST_GPUS)
+        set(_CUGRAPH_TEST_GPUS 1)
+    endif()
+    if(NOT DEFINED _CUGRAPH_TEST_PERCENT)
+        set(_CUGRAPH_TEST_PERCENT 100)
+    endif()
+
+    add_executable(${CMAKE_TEST_NAME} ${_CUGRAPH_TEST_UNPARSED_ARGUMENTS})
 
     target_link_libraries(${CMAKE_TEST_NAME}
         PRIVATE
@@ -127,18 +161,19 @@ function(ConfigureCTest CMAKE_TEST_NAME)
             GTest::gtest
             GTest::gtest_main
     )
-
-    add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
-
     set_target_properties(
         ${CMAKE_TEST_NAME}
             PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib")
 
-    install(
-        TARGETS ${CMAKE_TEST_NAME}
-        COMPONENT testing
-        DESTINATION bin/gtests/libcugraph_c
-        EXCLUDE_FROM_ALL)
+    rapids_test_add(
+        NAME ${CMAKE_TEST_NAME}
+        COMMAND ${CMAKE_TEST_NAME}
+        GPUS ${_CUGRAPH_TEST_GPUS}
+        PERCENT ${_CUGRAPH_TEST_PERCENT}
+        INSTALL_COMPONENT_SET testing_c #bin/gtests/libcugraph_c
+    )
+    set_tests_properties(${CMAKE_TEST_NAME} PROPERTIES LABELS "CUGRAPH_C")
+
 endfunction()
 
 function(ConfigureCTestMG CMAKE_TEST_NAME)
@@ -153,25 +188,26 @@ function(ConfigureCTestMG CMAKE_TEST_NAME)
             NCCL::NCCL
             MPI::MPI_CXX
     )
+    set_target_properties(
+        ${CMAKE_TEST_NAME}
+            PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib")
 
-    add_test(NAME ${CMAKE_TEST_NAME}
-             COMMAND ${MPIEXEC_EXECUTABLE}
+    rapids_test_add(
+        NAME ${CMAKE_TEST_NAME}
+        COMMAND ${MPIEXEC_EXECUTABLE}
              "--noprefix"
              ${MPIEXEC_NUMPROC_FLAG}
              ${GPU_COUNT}
              ${MPIEXEC_PREFLAGS}
              ${CMAKE_TEST_NAME}
-             ${MPIEXEC_POSTFLAGS})
+             ${MPIEXEC_POSTFLAGS}
+        GPUS ${GPU_COUNT}
+        PERCENT 100
+        INSTALL_COMPONENT_SET testing_mg #bin/gtests/libcugraph_mg
+    )
+    set_tests_properties(${CMAKE_TEST_NAME} PROPERTIES LABELS "CUGRAPH_C_MG")
 
-    set_target_properties(
-        ${CMAKE_TEST_NAME}
-            PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib")
 
-    install(
-        TARGETS ${CMAKE_TEST_NAME}
-        COMPONENT testing
-        DESTINATION bin/gtests/libcugraph_c
-        EXCLUDE_FROM_ALL)
 endfunction()
 
 if(NOT USE_CUGRAPH_OPS)
@@ -354,10 +390,7 @@ target_link_libraries(UNIFORM_NEIGHBOR_SAMPLING_TEST PRIVATE cuco::cuco)
 
 ###################################################################################################
 # - Renumber tests --------------------------------------------------------------------------------
-set(RENUMBERING_TEST_SRCS
-    "${CMAKE_CURRENT_SOURCE_DIR}/structure/renumbering_test.cpp")
-
-ConfigureTest(RENUMBERING_TEST "${RENUMBERING_TEST_SRCS}")
+ConfigureTest(RENUMBERING_TEST structure/renumbering_test.cpp)
 
 ###################################################################################################
 # - Core Number tests -----------------------------------------------------------------------------
@@ -374,6 +407,11 @@ ConfigureTest(TRIANGLE_COUNT_TEST community/triangle_count_test.cpp)
 ###################################################################################################
 # - K-hop Neighbors tests -------------------------------------------------------------------------
 ConfigureTest(K_HOP_NBRS_TEST traversal/k_hop_nbrs_test.cpp)
+
+
+###################################################################################################
+# - install tests ---------------------------------------------------------------------------------
+rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing DESTINATION bin/gtests/libcugraph)
 
 ###################################################################################################
 # - MG tests --------------------------------------------------------------------------------------
@@ -619,6 +657,8 @@ if(BUILD_CUGRAPH_MG_TESTS)
     ConfigureCTestMG(MG_CAPI_INDUCED_SUBGRAPH_TEST c_api/mg_induced_subgraph_test.c c_api/mg_test_utils.cpp)
     ConfigureCTestMG(MG_CAPI_EGONET_TEST c_api/mg_egonet_test.c c_api/mg_test_utils.cpp)
     ConfigureCTestMG(MG_CAPI_TWO_HOP_NEIGHBORS_TEST c_api/mg_two_hop_neighbors_test.c c_api/mg_test_utils.cpp)
+
+    rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing_mg DESTINATION bin/gtests/libcugraph_mg)
 endif()
 
 ###################################################################################################
@@ -677,8 +717,4 @@ ConfigureCTest(CAPI_INDUCED_SUBGRAPH_TEST c_api/induced_subgraph_test.c)
 ConfigureCTest(CAPI_EGONET_TEST c_api/egonet_test.c)
 ConfigureCTest(CAPI_TWO_HOP_NEIGHBORS_TEST c_api/two_hop_neighbors_test.c)
 
-###################################################################################################
-### enable testing ################################################################################
-###################################################################################################
-
-enable_testing()
+rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing_c DESTINATION bin/gtests/libcugraph_c)

--- a/cpp/tests/utilities/base_fixture.hpp
+++ b/cpp/tests/utilities/base_fixture.hpp
@@ -69,7 +69,12 @@ inline auto make_managed() { return std::make_shared<rmm::mr::managed_memory_res
 
 inline auto make_pool()
 {
-  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(make_cuda());
+  auto const [free, total] = rmm::detail::available_device_memory();
+  auto min_alloc =
+    rmm::detail::align_down(std::min(free, total / 6), rmm::detail::CUDA_ALLOCATION_ALIGNMENT);
+  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(make_cuda(), min_alloc);
+
+  // return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(make_cuda());
 }
 
 inline auto make_binning()


### PR DESCRIPTION
By switching to rapids-cmake testing infrastructure we can both run all the tests in parallel from the build environment and the test/install env.

Parallel testing performance.
 - serial baseline: 820sec
 - serial + improved memory allocation: 798sec
 - 1 gpu j8: 220sec