### PR TITLE
[BUG] Unsupported graph for similiarity algos

### DIFF
--- a/python/cugraph/cugraph/link_prediction/jaccard.py
+++ b/python/cugraph/cugraph/link_prediction/jaccard.py
@@ -20,7 +20,7 @@ from cugraph.utilities import (
 )
 
 
-def jaccard(input_graph, vertex_pair=None):
+def jaccard(input_graph, vertex_pair=None, do_expensive_check=True):
     """
     Compute the Jaccard similarity between each pair of vertices connected by
     an edge, or between arbitrary pairs of vertices specified by the user.
@@ -108,6 +108,18 @@ def jaccard(input_graph, vertex_pair=None):
     >>> df = cugraph.jaccard(G)
 
     """
+    if do_expensive_check:
+        if not input_graph.renumbered:
+            input_df = input_graph.edgelist.edgelist_df
+            max_vertex = input_df.max().max()
+            expected_nodes = cudf.Series(range(0, max_vertex + 1 ,1)).astype(
+                input_df.dtypes[0])
+            nodes = cudf.concat(
+                    [input_df["src"], input_df["dst"]]
+                ).unique().sort_values().reset_index(drop=True)
+            if not expected_nodes.equals(nodes):
+                raise RuntimeError("Unrenumbered vertices are not supported.")
+
     if input_graph.is_directed():
         raise ValueError("Input must be an undirected Graph.")
     if type(vertex_pair) == cudf.DataFrame:
@@ -124,7 +136,7 @@ def jaccard(input_graph, vertex_pair=None):
     return df
 
 
-def jaccard_coefficient(G, ebunch=None):
+def jaccard_coefficient(G, ebunch=None, do_expensive_check=True):
     """
     For NetworkX Compatability.  See `jaccard`
 

--- a/python/cugraph/cugraph/link_prediction/jaccard.py
+++ b/python/cugraph/cugraph/link_prediction/jaccard.py
@@ -36,6 +36,10 @@ def jaccard(input_graph, vertex_pair=None):
     of cugraph.jaccard is different from the behavior of
     networkx.jaccard_coefficient.
 
+    This algorithm doesn't currently support datasets with vertices that
+    are not (re)numebred vertices from 0 to V-1 where V is the total number of
+    vertices as this creates isolated vertices.
+
     cugraph.jaccard, in the absence of a specified vertex pair list, will
     use the edges of the graph to construct a vertex pair list and will
     return the jaccard coefficient for those vertex pairs.
@@ -123,6 +127,10 @@ def jaccard(input_graph, vertex_pair=None):
 def jaccard_coefficient(G, ebunch=None):
     """
     For NetworkX Compatability.  See `jaccard`
+
+    NOTE: This algorithm doesn't currently support datasets with vertices that
+    are not (re)numebred vertices from 0 to V-1 where V is the total number of
+    vertices as this creates isolated vertices.
 
     Parameters
     ----------

--- a/python/cugraph/cugraph/link_prediction/overlap.py
+++ b/python/cugraph/cugraph/link_prediction/overlap.py
@@ -24,6 +24,10 @@ def overlap_coefficient(G, ebunch=None):
     """
     For NetworkX Compatability.  See `overlap`
 
+    NOTE: This algorithm doesn't currently support datasets with vertices that
+    are not (re)numebred vertices from 0 to V-1 where V is the total number of
+    vertices as this creates isolated vertices.
+
     """
     vertex_pair = None
 
@@ -53,6 +57,10 @@ def overlap(input_graph, vertex_pair=None):
     connection between vertices based on the relative similarity of their
     neighbors. If first is specified but second is not, or vice versa, an
     exception will be thrown.
+
+    NOTE: This algorithm doesn't currently support datasets with vertices that
+    are not (re)numebred vertices from 0 to V-1 where V is the total number of
+    vertices as this creates isolated vertices.
 
     Parameters
     ----------

--- a/python/cugraph/cugraph/link_prediction/sorensen.py
+++ b/python/cugraph/cugraph/link_prediction/sorensen.py
@@ -30,6 +30,10 @@ def sorensen(input_graph, vertex_pair=None):
     If first is specified but second is not, or vice versa, an exception will
     be thrown.
 
+    NOTE: This algorithm doesn't currently support datasets with vertices that
+    are not (re)numebred vertices from 0 to V-1 where V is the total number of
+    vertices as this creates isolated vertices.
+
     cugraph.sorensen, in the absence of a specified vertex pair list, will
     use the edges of the graph to construct a vertex pair list and will
     return the sorensen coefficient for those vertex pairs.
@@ -97,6 +101,10 @@ def sorensen(input_graph, vertex_pair=None):
 def sorensen_coefficient(G, ebunch=None):
     """
     For NetworkX Compatability.  See `sorensen`
+
+    NOTE: This algorithm doesn't currently support datasets with vertices that
+    are not (re)numebred vertices from 0 to V-1 where V is the total number of
+    vertices as this creates isolated vertices.
 
     Parameters
     ----------

--- a/python/cugraph/cugraph/link_prediction/wjaccard.py
+++ b/python/cugraph/cugraph/link_prediction/wjaccard.py
@@ -29,6 +29,10 @@ def jaccard_w(input_graph, weights, vertex_pair=None):
     neighbors. If first is specified but second is not, or vice versa, an
     exception will be thrown.
 
+    NOTE: This algorithm doesn't currently support datasets with vertices that
+    are not (re)numebred vertices from 0 to V-1 where V is the total number of
+    vertices as this creates isolated vertices.
+
     Parameters
     ----------
     input_graph : cugraph.Graph

--- a/python/cugraph/cugraph/link_prediction/woverlap.py
+++ b/python/cugraph/cugraph/link_prediction/woverlap.py
@@ -28,6 +28,10 @@ def overlap_w(input_graph, weights, vertex_pair=None):
     neighbors. If first is specified but second is not, or vice versa, an
     exception will be thrown.
 
+    NOTE: This algorithm doesn't currently support datasets with vertices that
+    are not (re)numebred vertices from 0 to V-1 where V is the total number of
+    vertices as this creates isolated vertices.
+
     Parameters
     ----------
     input_graph : cugraph.Graph

--- a/python/cugraph/cugraph/link_prediction/woverlap.py
+++ b/python/cugraph/cugraph/link_prediction/woverlap.py
@@ -16,7 +16,7 @@ import cudf
 from cugraph.utilities import renumber_vertex_pair
 
 
-def overlap_w(input_graph, weights, vertex_pair=None):
+def overlap_w(input_graph, weights, vertex_pair=None, do_expensive_check=True):
     """
     Compute the weighted Overlap Coefficient between each pair of vertices
     connected by an edge, or between arbitrary pairs of vertices specified by
@@ -92,6 +92,17 @@ def overlap_w(input_graph, weights, vertex_pair=None):
     ...                      len(weights['vertex']))]
     >>> df = cugraph.overlap_w(G, weights)
     """
+    if do_expensive_check:
+        if not input_graph.renumbered:
+            input_df = input_graph.edgelist.edgelist_df
+            max_vertex = input_df.max().max()
+            expected_nodes = cudf.Series(range(0, max_vertex + 1 ,1)).astype(
+                input_df.dtypes[0])
+            nodes = cudf.concat(
+                    [input_df["src"], input_df["dst"]]
+                ).unique().sort_values().reset_index(drop=True)
+            if not expected_nodes.equals(nodes):
+                raise RuntimeError("Unrenumbered vertices are not supported.")
 
     if type(vertex_pair) == cudf.DataFrame:
         vertex_pair = renumber_vertex_pair(input_graph, vertex_pair)

--- a/python/cugraph/cugraph/link_prediction/wsorensen.py
+++ b/python/cugraph/cugraph/link_prediction/wsorensen.py
@@ -24,6 +24,10 @@ def sorensen_w(input_graph, weights, vertex_pair=None):
     the user. Sorensen coefficient is defined between two sets as the ratio of
     twice the volume of their intersection divided by the volume of each set.
 
+    NOTE: This algorithm doesn't currently support datasets with vertices that
+    are not (re)numebred vertices from 0 to V-1 where V is the total number of
+    vertices as this creates isolated vertices.
+
     Parameters
     ----------
     input_graph : cugraph.Graph

--- a/python/cugraph/cugraph/link_prediction/wsorensen.py
+++ b/python/cugraph/cugraph/link_prediction/wsorensen.py
@@ -17,7 +17,7 @@ import cudf
 from cugraph.utilities import renumber_vertex_pair
 
 
-def sorensen_w(input_graph, weights, vertex_pair=None):
+def sorensen_w(input_graph, weights, vertex_pair=None, do_expensive_check=True):
     """
     Compute the weighted Sorensen similarity between each pair of vertices
     connected by an edge, or between arbitrary pairs of vertices specified by
@@ -89,6 +89,18 @@ def sorensen_w(input_graph, weights, vertex_pair=None):
     >>> df = cugraph.sorensen_w(G, weights)
 
     """
+    if do_expensive_check:
+        if not input_graph.renumbered:
+            input_df = input_graph.edgelist.edgelist_df
+            max_vertex = input_df.max().max()
+            expected_nodes = cudf.Series(range(0, max_vertex + 1 ,1)).astype(
+                input_df.dtypes[0])
+            nodes = cudf.concat(
+                    [input_df["src"], input_df["dst"]]
+                ).unique().sort_values().reset_index(drop=True)
+            if not expected_nodes.equals(nodes):
+                raise RuntimeError("Unrenumbered vertices are not supported.")
+
     if type(input_graph) is not Graph:
         raise TypeError("input graph must a Graph")
 


### PR DESCRIPTION
This PR update the docstrings raises an error when running any similarity algos with vertices from a graph that are unrenumbered. 