### PR TITLE
Update to Cython 3.0.0

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cudf==23.10.*
 - cupy>=12.0.0
 - cxx-compiler
-- cython>=0.29,<0.30
+- cython>=3.0.0
 - dask-core>=2023.5.1
 - dask-cuda==23.10.*
 - dask-cudf==23.10.*

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cudf==23.10.*
 - cupy>=12.0.0
 - cxx-compiler
-- cython>=0.29,<0.30
+- cython>=3.0.0
 - dask-core>=2023.5.1
 - dask-cuda==23.10.*
 - dask-cudf==23.10.*

--- a/conda/recipes/cugraph-pyg/meta.yaml
+++ b/conda/recipes/cugraph-pyg/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   build:
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
-    - cython >=0.29,<0.30
+    - cython >=3.0.0
     - python
     - scikit-build >=0.13.1
   run:

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - cudatoolkit
     {% endif %}
     - cudf ={{ minor_version }}
-    - cython >=0.29,<0.30
+    - cython >=3.0.0
     - libcugraph ={{ version }}
     - pylibraft ={{ minor_version }}
     - python

--- a/conda/recipes/pylibcugraph/meta.yaml
+++ b/conda/recipes/pylibcugraph/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     {% if cuda_major == "11" %}
     - cudatoolkit
     {% endif %}
-    - cython >=0.29,<0.30
+    - cython >=3.0.0
     - libcugraph ={{ version }}
     - pylibraft ={{ minor_version }}
     - python

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -308,7 +308,7 @@ dependencies:
     common:
       - output_types: [conda, pyproject]
         packages:
-          - cython>=0.29,<0.30
+          - cython>=3.0.0
           - &pylibraft pylibraft==23.10.*
           - &rmm rmm==23.10.*
           - scikit-build>=0.13.1

--- a/python/cugraph/cugraph/community/ktruss_subgraph_wrapper.pyx
+++ b/python/cugraph/cugraph/community/ktruss_subgraph_wrapper.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -23,12 +23,12 @@ import numpy as np
 
 
 def ktruss_subgraph_float(input_graph, k, use_weights):
-    cdef GraphCOOViewFloat in_graph = get_graph_view[GraphCOOViewFloat](input_graph, use_weights)
+    cdef GraphCOOViewFloat in_graph = get_coo_float_graph_view(input_graph, use_weights)
     return coo_to_df(move(k_truss_subgraph[int,int,float](in_graph, k)))
 
 
 def ktruss_subgraph_double(input_graph, k, use_weights):
-    cdef GraphCOOViewDouble in_graph = get_graph_view[GraphCOOViewDouble](input_graph, use_weights)
+    cdef GraphCOOViewDouble in_graph = get_coo_double_graph_view(input_graph, use_weights)
     return coo_to_df(move(k_truss_subgraph[int,int,double](in_graph, k)))
 
 

--- a/python/cugraph/cugraph/structure/graph_primtypes.pxd
+++ b/python/cugraph/cugraph/structure/graph_primtypes.pxd
@@ -154,22 +154,9 @@ ctypedef GraphCOOView[int,int,double] GraphCOOViewDouble
 ctypedef GraphCSRView[int,int,float] GraphCSRViewFloat
 ctypedef GraphCSRView[int,int,double] GraphCSRViewDouble
 
-ctypedef fused GraphCOOViewType:
-    GraphCOOViewFloat
-    GraphCOOViewDouble
-
-ctypedef fused GraphCSRViewType:
-    GraphCSRViewFloat
-    GraphCSRViewDouble
-
-ctypedef fused GraphViewType:
-    GraphCOOViewFloat
-    GraphCOOViewDouble
-    GraphCSRViewFloat
-    GraphCSRViewDouble
-
 cdef move_device_buffer_to_column(unique_ptr[device_buffer] device_buffer_unique_ptr, dtype)
 cdef move_device_buffer_to_series(unique_ptr[device_buffer] device_buffer_unique_ptr, dtype, series_name)
 cdef coo_to_df(GraphCOOPtrType graph)
 cdef csr_to_series(GraphCSRPtrType graph)
-cdef GraphViewType get_graph_view(input_graph, bool weightless=*, GraphViewType* dummy=*)
+cdef GraphCOOViewFloat get_coo_float_graph_view(input_graph, bool weighted=*)
+cdef GraphCOOViewDouble get_coo_double_graph_view(input_graph, bool weighted=*)

--- a/python/cugraph/pyproject.toml
+++ b/python/cugraph/pyproject.toml
@@ -4,7 +4,7 @@
 
 requires = [
     "cmake>=3.26.4",
-    "cython>=0.29,<0.30",
+    "cython>=3.0.0",
     "ninja",
     "pylibcugraph==23.10.*",
     "pylibraft==23.10.*",

--- a/python/pylibcugraph/pylibcugraph/uniform_neighbor_sample.pyx
+++ b/python/pylibcugraph/pylibcugraph/uniform_neighbor_sample.pyx
@@ -82,14 +82,14 @@ def uniform_neighbor_sample(ResourceHandle resource_handle,
                             *,
                             bool_t with_replacement,
                             bool_t do_expensive_check,
-                            bool_t with_edge_properties=<bool_t>False,
+                            with_edge_properties=False,
                             batch_id_list=None,
                             label_list=None,
                             label_to_output_comm_rank=None,
                             prior_sources_behavior=None,
-                            bool_t deduplicate_sources=<bool_t>False,
-                            bool_t return_hops=<bool_t>False,
-                            bool_t renumber=<bool_t>False,
+                            deduplicate_sources=False,
+                            return_hops=False,
+                            renumber=False,
                             random_state=None):
     """
     Does neighborhood sampling, which samples nodes from a graph based on the
@@ -176,6 +176,10 @@ def uniform_neighbor_sample(ResourceHandle resource_handle,
     cdef cugraph_resource_handle_t* c_resource_handle_ptr = \
         resource_handle.c_resource_handle_ptr
     cdef cugraph_graph_t* c_graph_ptr = input_graph.c_graph_ptr
+
+    cdef bool_t c_deduplicate_sources = deduplicate_sources
+    cdef bool_t c_return_hops = return_hops
+    cdef bool_t c_renumber = renumber
 
     assert_CAI_type(start_list, "start_list")
     assert_CAI_type(batch_id_list, "batch_id_list", True)
@@ -271,10 +275,10 @@ def uniform_neighbor_sample(ResourceHandle resource_handle,
     assert_success(error_code, error_ptr, "cugraph_sampling_options_create")
 
     cugraph_sampling_set_with_replacement(sampling_options, with_replacement)
-    cugraph_sampling_set_return_hops(sampling_options, return_hops)
-    cugraph_sampling_set_dedupe_sources(sampling_options, deduplicate_sources)
+    cugraph_sampling_set_return_hops(sampling_options, c_return_hops)
+    cugraph_sampling_set_dedupe_sources(sampling_options, c_deduplicate_sources)
     cugraph_sampling_set_prior_sources_behavior(sampling_options, prior_sources_behavior_e)
-    cugraph_sampling_set_renumber_results(sampling_options, renumber)
+    cugraph_sampling_set_renumber_results(sampling_options, c_renumber)
 
     error_code = cugraph_uniform_neighbor_sample(
         c_resource_handle_ptr,

--- a/python/pylibcugraph/pyproject.toml
+++ b/python/pylibcugraph/pyproject.toml
@@ -4,7 +4,7 @@
 
 requires = [
     "cmake>=3.26.4",
-    "cython>=0.29,<0.30",
+    "cython>=3.0.0",
     "ninja",
     "pylibraft==23.10.*",
     "rmm==23.10.*",


### PR DESCRIPTION
This PR contains the minimal set of changes to compile using Cython 3 without warnings. Future PRs can be made to take advantage of new or improved features.

The main change is that a the graph_primtypes module runs into https://github.com/cython/cython/issues/5554. I was able to work around that issue by removing all the fused type logic and instead just duplicate one function. There were multiple functions present that were not used at all corresponding to fused type specializations that were never instantiated, so the changes still ended up being a net reduction in code. 