### PR TITLE
Reorder dependencies.yaml channels

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -4,10 +4,10 @@ channels:
 - rapidsai
 - rapidsai-nightly
 - dask/label/dev
-- conda-forge
-- nvidia
 - pytorch
 - dglteam/label/cu118
+- conda-forge
+- nvidia
 dependencies:
 - aiohttp
 - c-compiler

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -181,10 +181,10 @@ channels:
   - rapidsai
   - rapidsai-nightly
   - dask/label/dev
-  - conda-forge
-  - nvidia
   - pytorch
   - dglteam/label/cu118
+  - conda-forge
+  - nvidia
 dependencies:
   checks:
     common:

--- a/python/cugraph-dgl/conda/cugraph_dgl_dev_cuda-118.yaml
+++ b/python/cugraph-dgl/conda/cugraph_dgl_dev_cuda-118.yaml
@@ -4,10 +4,10 @@ channels:
 - rapidsai
 - rapidsai-nightly
 - dask/label/dev
-- conda-forge
-- nvidia
 - pytorch
 - dglteam/label/cu118
+- conda-forge
+- nvidia
 dependencies:
 - cugraph==23.8.*
 - dgl>=1.1.0.cu*


### PR DESCRIPTION
This PR reorders the channels to be compatible with other RAPIDS libs.

#3693 added two new channels, but they were ordered differently than [other libraries](https://github.com/rapidsai/cudf/blob/branch-23.08/dependencies.yaml#L163-L169). This caused [an error](https://github.com/rapidsai/docker/actions/runs/5591817313/jobs/10223438072?pr=545#step:10:349) in the `conda-merge` script in https://github.com/rapidsai/docker/pull/545.

It's also worth noting that docker overhaul requiring the channel ordering being consistent across libraries' `dependencies.yaml` seems very fragile and will undoubtedly cause more issues down the line. Curious if anyone has thoughts on making this more reliable.