### PR TITLE
Remove RAFT specialization.

### DIFF
--- a/cpp/src/community/legacy/spectral_clustering.cu
+++ b/cpp/src/community/legacy/spectral_clustering.cu
@@ -24,9 +24,6 @@
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
 
-#if defined RAFT_COMPILED
-#include <raft/distance/specializations.cuh>
-#endif
 #include <raft/spectral/modularity_maximization.cuh>
 #include <raft/spectral/partition.cuh>
 


### PR DESCRIPTION
This PR removes a deprecation warning coming from RAFT. Including the specializations header no longer has an effect, so it can be safely removed.