### PR TITLE
Fix sampling call parameters if compiled with -DNO_CUGRAPH_OPS

### DIFF
--- a/cpp/tests/sampling/mg_uniform_neighbor_sampling.cu
+++ b/cpp/tests/sampling/mg_uniform_neighbor_sampling.cu
@@ -163,7 +163,6 @@ class Tests_MGUniform_Neighbor_Sampling
     EXPECT_THROW(
       cugraph::uniform_neighbor_sample(
         *handle_,
-        handle,
         mg_graph_view,
         mg_edge_weight_view,
         std::optional<cugraph::edge_property_view_t<edge_t, edge_t const*>>{std::nullopt},


### PR DESCRIPTION
Updated sampling call in the `#ifdef NO_CUGRAPH_OPS` branch of the SG unit test.  The MG unit test was correctly updated previously.

Fixes #3726 