### PR TITLE
Forward-merge branch-23.08 to branch-23.10

### DIFF
--- a/cpp/tests/sampling/mg_uniform_neighbor_sampling.cu
+++ b/cpp/tests/sampling/mg_uniform_neighbor_sampling.cu
@@ -163,7 +163,6 @@ class Tests_MGUniform_Neighbor_Sampling
     EXPECT_THROW(
       cugraph::uniform_neighbor_sample(
         *handle_,
-        handle,
         mg_graph_view,
         mg_edge_weight_view,
         std::optional<cugraph::edge_property_view_t<edge_t, edge_t const*>>{std::nullopt},


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.08` that creates a PR to keep `branch-23.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.