### PR TITLE
Fix `build.yaml` workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,6 @@ concurrency:
 
 jobs:
   cpp-build:
-    node_type: cpu32
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-build.yaml@branch-23.08
     with:
@@ -35,6 +34,7 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
+      node_type: cpu32
   python-build:
     needs: [cpp-build]
     secrets: inherit


### PR DESCRIPTION
This PR fixes the `build.yaml` workflow. The `node_type` reusable workflow input was placed incorrectly in #3712.

Skipping CI since this file isn't tested in PRs.