### PR TITLE
Fixes `KeyError` for `get_two_hop_neighbors` when called with a small start vertices list

### DIFF
--- a/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
@@ -819,6 +819,7 @@ class simpleDistributedGraphImpl:
 
         _client = default_client()
         if start_vertices is not None:
+            # breakpoint()
             result = [
                 _client.submit(
                     _call_plc_two_hop_neighbors,


### PR DESCRIPTION
closes #3745 

This PR adds updates to replace the `get_distributed_data()` call with `persist_dask_df_equal_parts_per_worker()` and `get_persisted_df_worker_map()` to avoid a problem where `get_distributed_data()` does not distribute data properly across all workers.  This resulted in a `KeyError` when the data was accessed via worker, when that worker was not a key in the map.

More details are in the [linked issue](https://github.com/rapidsai/cugraph/issues/3745).

This PR also does minor refactoring in `get_two_hop_neighbors()` and reorganizes the imports according to [PEP 8](https://peps.python.org/pep-0008/#imports).

Tested manually on a 4-GPU system, where the problem described in #3745 was reproduced, the change in the PR applied and re-run, and the error no longer occurring.