### PR TITLE
Disable mg tests

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -63,6 +63,10 @@ pytest \
   tests
 popd
 
+# FIXME: TEMPORARILY disable single-GPU "MG" testing until
+# https://github.com/rapidsai/cugraph/issues/3790 is closed
+# When closed, replace -k "not _mg" with
+#  -k "not test_property_graph_mg" \
 rapids-logger "pytest cugraph"
 pushd python/cugraph/cugraph
 export DASK_WORKER_DEVICES="0"
@@ -75,7 +79,7 @@ pytest \
   --cov=cugraph \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cugraph-coverage.xml" \
   --cov-report=term \
-  -k "not test_property_graph_mg" \
+  -k "not _mg" \
   tests
 popd
 

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -18,5 +18,7 @@ arch=$(uname -m)
 if [[ "${arch}" == "aarch64" && ${RAPIDS_BUILD_TYPE} == "pull-request" ]]; then
     python ./ci/wheel_smoke_test_${package_name}.py
 else
-    RAPIDS_DATASET_ROOT_DIR=`pwd`/datasets python -m pytest ./python/${package_name}/${package_name}/tests
+    # FIXME: TEMPORARILY disable single-GPU "MG" testing until
+    # https://github.com/rapidsai/cugraph/issues/3790 is closed
+    RAPIDS_DATASET_ROOT_DIR=`pwd`/datasets python -m pytest -k "not _mg" ./python/${package_name}/${package_name}/tests
 fi

--- a/python/cugraph/cugraph/tests/centrality/test_betweenness_centrality_mg.py
+++ b/python/cugraph/cugraph/tests/centrality/test_betweenness_centrality_mg.py
@@ -159,7 +159,7 @@ def input_expected_output(input_combo):
 
 
 @pytest.mark.mg
-def test_dask_betweenness_centrality(dask_client, benchmark, input_expected_output):
+def test_dask_mg_betweenness_centrality(dask_client, benchmark, input_expected_output):
 
     dg = input_expected_output["MGGraph"]
     k = input_expected_output["k"]

--- a/python/cugraph/cugraph/tests/centrality/test_edge_betweenness_centrality_mg.py
+++ b/python/cugraph/cugraph/tests/centrality/test_edge_betweenness_centrality_mg.py
@@ -179,7 +179,7 @@ def input_expected_output(input_combo):
 #    is_single_gpu(), reason="skipping MG testing on Single GPU system"
 # )
 @pytest.mark.mg
-def test_dask_edge_betweenness_centrality(
+def test_dask_mg_edge_betweenness_centrality(
     dask_client, benchmark, input_expected_output
 ):
     if input_expected_output is not None:

--- a/python/cugraph/cugraph/tests/centrality/test_eigenvector_centrality_mg.py
+++ b/python/cugraph/cugraph/tests/centrality/test_eigenvector_centrality_mg.py
@@ -39,7 +39,7 @@ IS_DIRECTED = [True, False]
 @pytest.mark.skipif(is_single_gpu(), reason="skipping MG testing on Single GPU system")
 @pytest.mark.parametrize("directed", IS_DIRECTED)
 @pytest.mark.parametrize("input_data_path", DATASETS)
-def test_dask_eigenvector_centrality(dask_client, directed, input_data_path):
+def test_dask_mg_eigenvector_centrality(dask_client, directed, input_data_path):
     input_data_path = input_data_path.as_posix()
     print(f"dataset={input_data_path}")
     chunksize = dcg.get_chunksize(input_data_path)
@@ -86,7 +86,7 @@ def test_dask_eigenvector_centrality(dask_client, directed, input_data_path):
 
 
 @pytest.mark.mg
-def test_dask_eigenvector_centrality_transposed_false(dask_client):
+def test_dask_mg_eigenvector_centrality_transposed_false(dask_client):
     input_data_path = DATASETS[0]
 
     chunksize = dcg.get_chunksize(input_data_path)

--- a/python/cugraph/cugraph/tests/centrality/test_katz_centrality_mg.py
+++ b/python/cugraph/cugraph/tests/centrality/test_katz_centrality_mg.py
@@ -38,7 +38,7 @@ IS_DIRECTED = [True, False]
 @pytest.mark.mg
 @pytest.mark.skipif(is_single_gpu(), reason="skipping MG testing on Single GPU system")
 @pytest.mark.parametrize("directed", IS_DIRECTED)
-def test_dask_katz_centrality(dask_client, directed):
+def test_dask_mg_katz_centrality(dask_client, directed):
 
     input_data_path = (RAPIDS_DATASET_ROOT_DIR_PATH / "karate.csv").as_posix()
     print(f"dataset={input_data_path}")
@@ -96,7 +96,7 @@ def test_dask_katz_centrality(dask_client, directed):
 @pytest.mark.mg
 @pytest.mark.skipif(is_single_gpu(), reason="skipping MG testing on Single GPU system")
 @pytest.mark.parametrize("directed", IS_DIRECTED)
-def test_dask_katz_centrality_nstart(dask_client, directed):
+def test_dask_mg_katz_centrality_nstart(dask_client, directed):
     input_data_path = (RAPIDS_DATASET_ROOT_DIR_PATH / "karate.csv").as_posix()
     print(f"dataset={input_data_path}")
     chunksize = dcg.get_chunksize(input_data_path)
@@ -141,7 +141,7 @@ def test_dask_katz_centrality_nstart(dask_client, directed):
 
 
 @pytest.mark.mg
-def test_dask_katz_centrality_transposed_false(dask_client):
+def test_dask_mg_katz_centrality_transposed_false(dask_client):
     input_data_path = (RAPIDS_DATASET_ROOT_DIR_PATH / "karate.csv").as_posix()
 
     chunksize = dcg.get_chunksize(input_data_path)

--- a/python/cugraph/cugraph/tests/comms/test_comms_mg.py
+++ b/python/cugraph/cugraph/tests/comms/test_comms_mg.py
@@ -38,7 +38,7 @@ IS_DIRECTED = [True, False]
 # )
 @pytest.mark.mg
 @pytest.mark.parametrize("directed", IS_DIRECTED)
-def test_dask_pagerank(dask_client, directed):
+def test_dask_mg_pagerank(dask_client, directed):
 
     # Initialize and run pagerank on two distributed graphs
     # with same communicator

--- a/python/cugraph/cugraph/tests/components/test_connectivity_mg.py
+++ b/python/cugraph/cugraph/tests/components/test_connectivity_mg.py
@@ -40,7 +40,7 @@ IS_DIRECTED = [False, True]
 # )
 @pytest.mark.mg
 @pytest.mark.parametrize("directed", IS_DIRECTED)
-def test_dask_wcc(dask_client, directed):
+def test_dask_mg_wcc(dask_client, directed):
 
     input_data_path = (RAPIDS_DATASET_ROOT_DIR_PATH / "netscience.csv").as_posix()
     print(f"dataset={input_data_path}")

--- a/python/cugraph/cugraph/tests/core/test_k_core_mg.py
+++ b/python/cugraph/cugraph/tests/core/test_k_core_mg.py
@@ -137,7 +137,7 @@ def test_sg_k_core(dask_client, benchmark, input_expected_output):
 
 
 @pytest.mark.mg
-def test_dask_k_core(dask_client, benchmark, input_expected_output):
+def test_dask_mg_k_core(dask_client, benchmark, input_expected_output):
 
     dg = input_expected_output["MGGraph"]
     core_number = input_expected_output["core_number"]
@@ -159,7 +159,7 @@ def test_dask_k_core(dask_client, benchmark, input_expected_output):
 
 
 @pytest.mark.mg
-def test_dask_k_core_invalid_input(dask_client):
+def test_dask_mg_k_core_invalid_input(dask_client):
     input_data_path = datasets[0]
     chunksize = dcg.get_chunksize(input_data_path)
     ddf = dask_cudf.read_csv(

--- a/python/cugraph/cugraph/tests/internals/test_renumber_mg.py
+++ b/python/cugraph/cugraph/tests/internals/test_renumber_mg.py
@@ -132,7 +132,7 @@ def test_mg_renumber_add_internal_vertex_id(graph_file, dask_client):
 @pytest.mark.mg
 @pytest.mark.skipif(is_single_gpu(), reason="skipping MG testing on Single GPU system")
 @pytest.mark.parametrize("directed", IS_DIRECTED)
-def test_dask_pagerank(dask_client, directed):
+def test_dask_mg_pagerank(dask_client, directed):
     pandas.set_option("display.max_rows", 10000)
 
     input_data_path = (RAPIDS_DATASET_ROOT_DIR_PATH / "karate.csv").as_posix()

--- a/python/cugraph/cugraph/tests/link_analysis/test_hits_mg.py
+++ b/python/cugraph/cugraph/tests/link_analysis/test_hits_mg.py
@@ -111,7 +111,7 @@ def input_expected_output(input_combo):
 #    is_single_gpu(), reason="skipping MG testing on Single GPU system"
 # )
 @pytest.mark.mg
-def test_dask_hits(dask_client, benchmark, input_expected_output):
+def test_dask_mg_hits(dask_client, benchmark, input_expected_output):
 
     dg = input_expected_output["MGGraph"]
 
@@ -155,7 +155,7 @@ def test_dask_hits(dask_client, benchmark, input_expected_output):
 
 
 @pytest.mark.mg
-def test_dask_hits_transposed_false(dask_client):
+def test_dask_mg_hits_transposed_false(dask_client):
     input_data_path = (utils.RAPIDS_DATASET_ROOT_DIR_PATH / "karate.csv").as_posix()
 
     chunksize = dcg.get_chunksize(input_data_path)

--- a/python/cugraph/cugraph/tests/link_analysis/test_pagerank_mg.py
+++ b/python/cugraph/cugraph/tests/link_analysis/test_pagerank_mg.py
@@ -89,7 +89,7 @@ def setup_function():
 @pytest.mark.parametrize("directed", IS_DIRECTED)
 @pytest.mark.parametrize("has_precomputed_vertex_out_weight", HAS_PRECOMPUTED)
 @pytest.mark.parametrize("has_guess", HAS_GUESS)
-def test_dask_pagerank(
+def test_dask_mg_pagerank(
     dask_client,
     personalization_perc,
     directed,
@@ -215,7 +215,7 @@ def test_pagerank_invalid_personalization_dtype(dask_client):
 
 
 @pytest.mark.mg
-def test_dask_pagerank_transposed_false(dask_client):
+def test_dask_mg_pagerank_transposed_false(dask_client):
     dg = create_distributed_karate_graph(store_transposed=False)
 
     warning_msg = (

--- a/python/cugraph/cugraph/tests/link_prediction/test_jaccard_mg.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_jaccard_mg.py
@@ -119,7 +119,7 @@ def input_expected_output(input_combo):
 
 
 @pytest.mark.mg
-def test_dask_jaccard(dask_client, benchmark, input_expected_output):
+def test_dask_mg_jaccard(dask_client, benchmark, input_expected_output):
 
     dg = input_expected_output["MGGraph"]
 
@@ -154,7 +154,7 @@ def test_dask_jaccard(dask_client, benchmark, input_expected_output):
 
 
 @pytest.mark.mg
-def test_dask_weighted_jaccard(dask_client):
+def test_dask_mg_weighted_jaccard(dask_client):
     input_data_path = datasets[0]
     chunksize = dcg.get_chunksize(input_data_path)
     ddf = dask_cudf.read_csv(

--- a/python/cugraph/cugraph/tests/link_prediction/test_overlap_mg.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_overlap_mg.py
@@ -122,7 +122,7 @@ def input_expected_output(input_combo):
 #    is_single_gpu(), reason="skipping MG testing on Single GPU system"
 # )
 @pytest.mark.mg
-def test_dask_overlap(dask_client, benchmark, input_expected_output):
+def test_dask_mg_overlap(dask_client, benchmark, input_expected_output):
 
     dg = input_expected_output["MGGraph"]
 
@@ -157,7 +157,7 @@ def test_dask_overlap(dask_client, benchmark, input_expected_output):
 
 
 @pytest.mark.mg
-def test_dask_weighted_overlap():
+def test_dask_mg_weighted_overlap():
     input_data_path = datasets[0]
     chunksize = dcg.get_chunksize(input_data_path)
     ddf = dask_cudf.read_csv(

--- a/python/cugraph/cugraph/tests/link_prediction/test_sorensen_mg.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_sorensen_mg.py
@@ -121,7 +121,7 @@ def input_expected_output(input_combo):
 
 @pytest.mark.mg
 @pytest.mark.skipif(is_single_gpu(), reason="skipping MG testing on Single GPU system")
-def test_dask_sorensen(dask_client, benchmark, input_expected_output):
+def test_dask_mg_sorensen(dask_client, benchmark, input_expected_output):
 
     dg = input_expected_output["MGGraph"]
 
@@ -156,7 +156,7 @@ def test_dask_sorensen(dask_client, benchmark, input_expected_output):
 
 
 @pytest.mark.mg
-def test_dask_weighted_sorensen(dask_client):
+def test_dask_mg_weighted_sorensen(dask_client):
     input_data_path = datasets[0]
     chunksize = dcg.get_chunksize(input_data_path)
     ddf = dask_cudf.read_csv(

--- a/python/cugraph/cugraph/tests/sampling/test_egonet_mg.py
+++ b/python/cugraph/cugraph/tests/sampling/test_egonet_mg.py
@@ -118,7 +118,7 @@ def input_expected_output(input_combo):
 
 @pytest.mark.mg
 @pytest.mark.skipif(is_single_gpu(), reason="skipping MG testing on Single GPU system")
-def test_dask_ego_graphs(dask_client, benchmark, input_expected_output):
+def test_dask_mg_ego_graphs(dask_client, benchmark, input_expected_output):
 
     dg = input_expected_output["MGGraph"]
 

--- a/python/cugraph/cugraph/tests/sampling/test_random_walks_mg.py
+++ b/python/cugraph/cugraph/tests/sampling/test_random_walks_mg.py
@@ -202,7 +202,7 @@ def input_graph(request):
 
 @pytest.mark.mg
 @pytest.mark.cugraph_ops
-def test_dask_random_walks(dask_client, benchmark, input_graph):
+def test_dask_mg_random_walks(dask_client, benchmark, input_graph):
     path_data, seeds, max_depth = calc_random_walks(input_graph)
     df_G = input_graph.input_df.compute().reset_index(drop=True)
     check_random_walks(input_graph, path_data, seeds, max_depth, df_G)

--- a/python/cugraph/cugraph/tests/traversal/test_bfs_mg.py
+++ b/python/cugraph/cugraph/tests/traversal/test_bfs_mg.py
@@ -38,7 +38,7 @@ IS_DIRECTED = [True, False]
 # )
 @pytest.mark.mg
 @pytest.mark.parametrize("directed", IS_DIRECTED)
-def test_dask_bfs(dask_client, directed):
+def test_dask_mg_bfs(dask_client, directed):
 
     input_data_path = (RAPIDS_DATASET_ROOT_DIR_PATH / "netscience.csv").as_posix()
 
@@ -102,7 +102,7 @@ def test_dask_bfs(dask_client, directed):
 # )
 @pytest.mark.mg
 @pytest.mark.parametrize("directed", IS_DIRECTED)
-def test_dask_bfs_invalid_start(dask_client, directed):
+def test_dask_mg_bfs_invalid_start(dask_client, directed):
     source_vertex = 10
     input_data_path = (RAPIDS_DATASET_ROOT_DIR_PATH / "netscience.csv").as_posix()
 
@@ -138,7 +138,7 @@ def test_dask_bfs_invalid_start(dask_client, directed):
 # )
 @pytest.mark.mg
 @pytest.mark.parametrize("directed", IS_DIRECTED)
-def test_dask_bfs_multi_column_depthlimit(dask_client, directed):
+def test_dask_mg_bfs_multi_column_depthlimit(dask_client, directed):
     gc.collect()
 
     input_data_path = (RAPIDS_DATASET_ROOT_DIR_PATH / "netscience.csv").as_posix()

--- a/python/cugraph/cugraph/tests/traversal/test_sssp_mg.py
+++ b/python/cugraph/cugraph/tests/traversal/test_sssp_mg.py
@@ -39,7 +39,7 @@ IS_DIRECTED = [True, False]
 # )
 @pytest.mark.mg
 @pytest.mark.parametrize("directed", IS_DIRECTED)
-def test_dask_sssp(dask_client, directed):
+def test_dask_mg_sssp(dask_client, directed):
 
     input_data_path = (RAPIDS_DATASET_ROOT_DIR_PATH / "netscience.csv").as_posix()
     print(f"dataset={input_data_path}")


### PR DESCRIPTION
This PR is on top off the changes from #3831. 

Temporarily disables single-GPU "MG" tests in CI until https://github.com/rapidsai/cugraph/issues/3790 is closed.
This will unblock CI for PRs unrelated to the issue in https://github.com/rapidsai/cugraph/issues/3790 at the risk of removed coverage for MG code paths. Hopefully nightly MG testing will minimize the risk.
A followup PR will be submitted that re-enables the tests and must be merged prior to 23.10 burndown.