### PR TITLE
Use new `raft::compiled_static` targets

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -364,7 +364,7 @@ if (USE_CUGRAPH_OPS)
             $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:raft::compiled>
         PRIVATE
             $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::raft>
-            $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::compiled>
+            $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::compiled_static>
             cuco::cuco
             cugraph::cuHornet
             NCCL::NCCL
@@ -377,7 +377,7 @@ else()
             $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:raft::compiled>
         PRIVATE
             $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::raft>
-            $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::compiled>
+            $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::compiled_static>
             cuco::cuco
             cugraph::cuHornet
             NCCL::NCCL
@@ -481,12 +481,12 @@ target_link_libraries(cugraph_c
                 CUDA::cusparse${_ctk_static_suffix}
                 rmm::rmm
                 $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:raft::raft>
-                $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:raft::compiled>
+                $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:raft::compiled_static>
         PRIVATE
                 cuco::cuco
                 cugraph::cugraph
                 $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::raft>
-                $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::compiled>
+                $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::compiled_static>
 )
 
 ################################################################################

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -346,11 +346,20 @@ target_include_directories(cugraph
         "$<INSTALL_INTERFACE:include>"
 )
 
+set(COMPILED_RAFT_LIB_STATIC "")
+set(COMPILED_RAFT_LIB "")
 if(CUDA_STATIC_RUNTIME)
   get_target_property(_includes raft::raft INTERFACE_INCLUDE_DIRECTORIES)
   target_include_directories(cugraph PUBLIC ${_includes})
   # Add CTK include paths because we make our CTK library links private below
   target_include_directories(cugraph SYSTEM PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
+  if(CUGRAPH_COMPILE_RAFT_LIB)
+    set(COMPILED_RAFT_LIB_STATIC raft::compiled_static)
+  endif()
+else()
+    if(CUGRAPH_COMPILE_RAFT_LIB)
+        set(COMPILED_RAFT_LIB raft::compiled)
+    endif()
 endif()
 
 ################################################################################
@@ -361,10 +370,10 @@ if (USE_CUGRAPH_OPS)
             rmm::rmm
             cugraph-ops::cugraph-ops++
             $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:raft::raft>
-            $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:raft::compiled>
+            $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:${COMPILED_RAFT_LIB}>
         PRIVATE
             $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::raft>
-            $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::compiled_static>
+            $<$<BOOL:${CUDA_STATIC_RUNTIME}>:${COMPILED_RAFT_LIB_STATIC}>
             cuco::cuco
             cugraph::cuHornet
             NCCL::NCCL
@@ -374,10 +383,10 @@ else()
         PUBLIC
             rmm::rmm
             $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:raft::raft>
-            $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:raft::compiled>
+            $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:${COMPILED_RAFT_LIB}>
         PRIVATE
             $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::raft>
-            $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::compiled_static>
+            $<$<BOOL:${CUDA_STATIC_RUNTIME}>:${COMPILED_RAFT_LIB_STATIC}>
             cuco::cuco
             cugraph::cuHornet
             NCCL::NCCL
@@ -481,12 +490,12 @@ target_link_libraries(cugraph_c
                 CUDA::cusparse${_ctk_static_suffix}
                 rmm::rmm
                 $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:raft::raft>
-                $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:raft::compiled_static>
+                $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:${COMPILED_RAFT_LIB}>
         PRIVATE
                 cuco::cuco
                 cugraph::cugraph
                 $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::raft>
-                $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::compiled_static>
+                $<$<BOOL:${CUDA_STATIC_RUNTIME}>:${COMPILED_RAFT_LIB_STATIC}>
 )
 
 ################################################################################

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -358,7 +358,7 @@ if(CUDA_STATIC_RUNTIME)
   endif()
 else()
   if(CUGRAPH_COMPILE_RAFT_LIB)
-      set(COMPILED_RAFT_LIB raft::compiled)
+    set(COMPILED_RAFT_LIB raft::compiled)
   endif()
 endif()
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -346,7 +346,6 @@ target_include_directories(cugraph
         "$<INSTALL_INTERFACE:include>"
 )
 
-set(COMPILED_RAFT_LIB_STATIC "")
 set(COMPILED_RAFT_LIB "")
 if(CUDA_STATIC_RUNTIME)
   get_target_property(_includes raft::raft INTERFACE_INCLUDE_DIRECTORIES)
@@ -354,7 +353,7 @@ if(CUDA_STATIC_RUNTIME)
   # Add CTK include paths because we make our CTK library links private below
   target_include_directories(cugraph SYSTEM PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
   if(CUGRAPH_COMPILE_RAFT_LIB)
-    set(COMPILED_RAFT_LIB_STATIC raft::compiled_static)
+    set(COMPILED_RAFT_LIB raft::compiled_static)
   endif()
 else()
   if(CUGRAPH_COMPILE_RAFT_LIB)
@@ -373,7 +372,7 @@ if (USE_CUGRAPH_OPS)
             $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:${COMPILED_RAFT_LIB}>
         PRIVATE
             $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::raft>
-            $<$<BOOL:${CUDA_STATIC_RUNTIME}>:${COMPILED_RAFT_LIB_STATIC}>
+            $<$<BOOL:${CUDA_STATIC_RUNTIME}>:${COMPILED_RAFT_LIB}>
             cuco::cuco
             cugraph::cuHornet
             NCCL::NCCL
@@ -386,7 +385,7 @@ else()
             $<$<NOT:$<BOOL:${CUDA_STATIC_RUNTIME}>>:${COMPILED_RAFT_LIB}>
         PRIVATE
             $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::raft>
-            $<$<BOOL:${CUDA_STATIC_RUNTIME}>:${COMPILED_RAFT_LIB_STATIC}>
+            $<$<BOOL:${CUDA_STATIC_RUNTIME}>:${COMPILED_RAFT_LIB}>
             cuco::cuco
             cugraph::cuHornet
             NCCL::NCCL
@@ -495,7 +494,7 @@ target_link_libraries(cugraph_c
                 cuco::cuco
                 cugraph::cugraph
                 $<$<BOOL:${CUDA_STATIC_RUNTIME}>:raft::raft>
-                $<$<BOOL:${CUDA_STATIC_RUNTIME}>:${COMPILED_RAFT_LIB_STATIC}>
+                $<$<BOOL:${CUDA_STATIC_RUNTIME}>:${COMPILED_RAFT_LIB}>
 )
 
 ################################################################################

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -357,9 +357,9 @@ if(CUDA_STATIC_RUNTIME)
     set(COMPILED_RAFT_LIB_STATIC raft::compiled_static)
   endif()
 else()
-    if(CUGRAPH_COMPILE_RAFT_LIB)
-        set(COMPILED_RAFT_LIB raft::compiled)
-    endif()
+  if(CUGRAPH_COMPILE_RAFT_LIB)
+      set(COMPILED_RAFT_LIB raft::compiled)
+  endif()
 endif()
 
 ################################################################################

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -30,7 +30,7 @@ function(find_and_configure_raft)
       set(CPM_DOWNLOAD_raft ON)
     endif()
 
-    if(PKG_COMPILE_LIBRARY)
+    if(PKG_COMPILE_RAFT_LIB)
       if(NOT PKG_USE_RAFT_STATIC)
         string(APPEND RAFT_COMPONENTS " compiled")
       else()

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -30,16 +30,22 @@ function(find_and_configure_raft)
       set(CPM_DOWNLOAD_raft ON)
     endif()
 
-    set(BUILD_RAFT_SHARED ON)
-    if(PKG_USE_RAFT_STATIC)
-      set(BUILD_RAFT_SHARED OFF)
+    if(PKG_COMPILE_LIBRARY)
+      if(NOT PKG_USE_RAFT_STATIC)
+        string(APPEND RAFT_COMPONENTS " compiled")
+      else()
+        string(APPEND RAFT_COMPONENTS " compiled_static")
+      endif()
+      set(RAFT_COMPILE_LIBRARY ON)
+    else()
+      set(RAFT_COMPILE_LIBRARY OFF)
     endif()
 
     rapids_cpm_find(raft ${PKG_VERSION}
       GLOBAL_TARGETS      raft::raft
       BUILD_EXPORT_SET    cugraph-exports
       INSTALL_EXPORT_SET  cugraph-exports
-      COMPONENTS compiled
+      COMPONENTS ${RAFT_COMPONENTS}
         CPM_ARGS
             EXCLUDE_FROM_ALL TRUE
             GIT_REPOSITORY https://github.com/${PKG_FORK}/raft.git
@@ -49,7 +55,6 @@ function(find_and_configure_raft)
                 "RAFT_COMPILE_LIBRARY ${PKG_COMPILE_RAFT_LIB}"
                 "BUILD_TESTS OFF"
                 "BUILD_BENCH OFF"
-                "BUILD_SHARED_LIBS ${BUILD_RAFT_SHARED}"
     )
 
     if(raft_ADDED)

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -36,9 +36,6 @@ function(find_and_configure_raft)
       else()
         string(APPEND RAFT_COMPONENTS " compiled_static")
       endif()
-      set(RAFT_COMPILE_LIBRARY ON)
-    else()
-      set(RAFT_COMPILE_LIBRARY OFF)
     endif()
 
     rapids_cpm_find(raft ${PKG_VERSION}

--- a/python/cugraph/CMakeLists.txt
+++ b/python/cugraph/CMakeLists.txt
@@ -65,7 +65,7 @@ if(NOT cugraph_FOUND)
     # Statically link dependencies if building wheels
     set(CUDA_STATIC_RUNTIME ON)
     set(USE_RAFT_STATIC ON)
-    set(CUGRAPH_COMPILE_RAFT_DIST_LIBS OFF)
+    set(CUGRAPH_COMPILE_RAFT_LIB OFF)
     set(CUGRAPH_USE_CUGRAPH_OPS_STATIC ON)
     set(CUGRAPH_EXCLUDE_CUGRAPH_OPS_FROM_ALL ON)
     set(ALLOW_CLONE_CUGRAPH_OPS ON)

--- a/python/cugraph/CMakeLists.txt
+++ b/python/cugraph/CMakeLists.txt
@@ -65,7 +65,7 @@ if(NOT cugraph_FOUND)
     # Statically link dependencies if building wheels
     set(CUDA_STATIC_RUNTIME ON)
     set(USE_RAFT_STATIC ON)
-    set(CUGRAPH_COMPILE_RAFT_LIB OFF)
+    set(CUGRAPH_COMPILE_RAFT_LIB ON)
     set(CUGRAPH_USE_CUGRAPH_OPS_STATIC ON)
     set(CUGRAPH_EXCLUDE_CUGRAPH_OPS_FROM_ALL ON)
     set(ALLOW_CLONE_CUGRAPH_OPS ON)

--- a/python/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/CMakeLists.txt
@@ -65,7 +65,7 @@ if (NOT cugraph_FOUND)
     # Statically link dependencies if building wheels
     set(CUDA_STATIC_RUNTIME ON)
     set(USE_RAFT_STATIC ON)
-    set(CUGRAPH_COMPILE_RAFT_DIST_LIBS OFF)
+    set(CUGRAPH_COMPILE_RAFT_LIB OFF)
     set(CUGRAPH_USE_CUGRAPH_OPS_STATIC ON)
     set(CUGRAPH_EXCLUDE_CUGRAPH_OPS_FROM_ALL ON)
     set(ALLOW_CLONE_CUGRAPH_OPS ON)

--- a/python/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/CMakeLists.txt
@@ -65,7 +65,7 @@ if (NOT cugraph_FOUND)
     # Statically link dependencies if building wheels
     set(CUDA_STATIC_RUNTIME ON)
     set(USE_RAFT_STATIC ON)
-    set(CUGRAPH_COMPILE_RAFT_LIB OFF)
+    set(CUGRAPH_COMPILE_RAFT_LIB ON)
     set(CUGRAPH_USE_CUGRAPH_OPS_STATIC ON)
     set(CUGRAPH_EXCLUDE_CUGRAPH_OPS_FROM_ALL ON)
     set(ALLOW_CLONE_CUGRAPH_OPS ON)


### PR DESCRIPTION
https://github.com/rapidsai/raft/pull/1746 added static targets for RAFT that can be used directly now instead of building RAFT static explicitly