### PR TITLE
Fix subtle memory leak in nbr_intersection primitive

### DIFF
--- a/cpp/src/prims/detail/nbr_intersection.cuh
+++ b/cpp/src/prims/detail/nbr_intersection.cuh
@@ -1023,7 +1023,7 @@ nbr_intersection(raft::handle_t const& handle,
                                (*major_nbr_offsets).begin() + 1);
       }
 
-      std::tie(*major_nbr_indices, std::ignore) = shuffle_values(
+      std::tie(major_nbr_indices, std::ignore) = shuffle_values(
         major_comm, local_nbrs_for_rx_majors.begin(), local_nbr_counts, handle.get_stream());
 
       if constexpr (!std::is_same_v<edge_property_value_t, thrust::nullopt_t>) {


### PR DESCRIPTION
Closes https://github.com/rapidsai/graph_dl/issues/259

A customer found a subtle memory leak in Jaccard similarity.  Tracked it down to this subtle error.

`major_nbr_indices` is an `std::optional` that is initialized to `std::nullopt`.  Overwriting the dereferenced entry replaces the value but does not mark the optional as containing a value.  So the resulting value is never destroyed.