### PR TITLE
Forward-merge branch-23.10 to branch-23.12

### DIFF
--- a/python/cugraph-dgl/tests/nn/test_gatconv.py
+++ b/python/cugraph-dgl/tests/nn/test_gatconv.py
@@ -35,6 +35,7 @@ def test_gatconv_equality(
 ):
     from dgl.nn.pytorch import GATConv
 
+    torch.manual_seed(12345)
     g = create_graph1().to("cuda")
 
     if idtype_int:
@@ -121,6 +122,7 @@ def test_gatconv_equality(
 def test_gatconv_edge_feats(
     bias, bipartite, concat, max_in_degree, num_heads, to_block, use_edge_feats
 ):
+    torch.manual_seed(12345)
     g = create_graph1().to("cuda")
 
     if to_block:

--- a/python/cugraph-dgl/tests/nn/test_gatv2conv.py
+++ b/python/cugraph-dgl/tests/nn/test_gatv2conv.py
@@ -35,6 +35,7 @@ def test_gatv2conv_equality(
 ):
     from dgl.nn.pytorch import GATv2Conv
 
+    torch.manual_seed(12345)
     g = create_graph1().to("cuda")
 
     if idtype_int:
@@ -109,6 +110,7 @@ def test_gatv2conv_equality(
 def test_gatv2conv_edge_feats(
     bias, bipartite, concat, max_in_degree, num_heads, to_block, use_edge_feats
 ):
+    torch.manual_seed(12345)
     g = create_graph1().to("cuda")
 
     if to_block:

--- a/python/cugraph-dgl/tests/nn/test_sageconv.py
+++ b/python/cugraph-dgl/tests/nn/test_sageconv.py
@@ -35,6 +35,7 @@ def test_sageconv_equality(
 ):
     from dgl.nn.pytorch import SAGEConv
 
+    torch.manual_seed(12345)
     kwargs = {"aggregator_type": aggr, "bias": bias}
     g = create_graph1().to("cuda")
 

--- a/python/cugraph-dgl/tests/nn/test_transformerconv.py
+++ b/python/cugraph-dgl/tests/nn/test_transformerconv.py
@@ -41,6 +41,7 @@ def test_transformerconv(
     use_edge_feats,
     sparse_format,
 ):
+    torch.manual_seed(12345)
     device = "cuda"
     g = create_graph1().to(device)
 

--- a/python/cugraph-pyg/cugraph_pyg/tests/nn/test_gat_conv.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/nn/test_gat_conv.py
@@ -32,6 +32,7 @@ def test_gat_conv_equality(
     import torch
     from torch_geometric.nn import GATConv
 
+    torch.manual_seed(12345)
     edge_index, size = request.getfixturevalue(graph)
     edge_index = edge_index.cuda()
 

--- a/python/cugraph-pyg/cugraph_pyg/tests/nn/test_gatv2_conv.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/nn/test_gatv2_conv.py
@@ -28,6 +28,7 @@ def test_gatv2_conv_equality(bipartite, concat, heads, use_edge_attr, graph, req
     import torch
     from torch_geometric.nn import GATv2Conv
 
+    torch.manual_seed(12345)
     edge_index, size = request.getfixturevalue(graph)
     edge_index = edge_index.cuda()
 

--- a/python/cugraph-pyg/cugraph_pyg/tests/nn/test_rgcn_conv.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/nn/test_rgcn_conv.py
@@ -31,6 +31,7 @@ def test_rgcn_conv_equality(
     import torch
     from torch_geometric.nn import FastRGCNConv as RGCNConv
 
+    torch.manual_seed(12345)
     in_channels, out_channels, num_relations = (4, 2, 3)
     kwargs = dict(aggr=aggr, bias=bias, num_bases=num_bases, root_weight=root_weight)
 

--- a/python/cugraph-pyg/cugraph_pyg/tests/nn/test_sage_conv.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/nn/test_sage_conv.py
@@ -32,6 +32,7 @@ def test_sage_conv_equality(
     import torch
     from torch_geometric.nn import SAGEConv
 
+    torch.manual_seed(12345)
     edge_index, size = request.getfixturevalue(graph)
     edge_index = edge_index.cuda()
     csc = CuGraphSAGEConv.to_csc(edge_index, size)

--- a/python/cugraph-pyg/cugraph_pyg/tests/nn/test_transformer_conv.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/nn/test_transformer_conv.py
@@ -27,6 +27,7 @@ def test_transformer_conv_equality(bipartite, concat, heads, graph, request):
     import torch
     from torch_geometric.nn import TransformerConv
 
+    torch.manual_seed(12345)
     edge_index, size = request.getfixturevalue(graph)
     edge_index = edge_index.cuda()
     csc = CuGraphTransformerConv.to_csc(edge_index, size)


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.10` that creates a PR to keep `branch-23.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.