### PR TITLE
Forward-merge branch-23.10 to branch-23.12

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -112,3 +112,23 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       package-name: cugraph
+  wheel-build-nx-cugraph:
+    needs: wheel-publish-pylibcugraph
+    secrets: inherit
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-build.yaml@branch-23.10
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
+      script: ci/build_wheel_nx-cugraph.sh
+  wheel-publish-nx-cugraph:
+    needs: wheel-build-nx-cugraph
+    secrets: inherit
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yaml@branch-23.10
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
+      package-name: nx-cugraph

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,6 +23,8 @@ jobs:
       - wheel-tests-pylibcugraph
       - wheel-build-cugraph
       - wheel-tests-cugraph
+      - wheel-build-nx-cugraph
+      - wheel-tests-nx-cugraph
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@branch-23.10
   checks:
@@ -109,3 +111,17 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel_cugraph.sh
+  wheel-build-nx-cugraph:
+    needs: wheel-tests-pylibcugraph
+    secrets: inherit
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-build.yaml@branch-23.10
+    with:
+      build_type: pull-request
+      script: ci/build_wheel_nx-cugraph.sh
+  wheel-tests-nx-cugraph:
+    needs: wheel-build-nx-cugraph
+    secrets: inherit
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yaml@branch-23.10
+    with:
+      build_type: pull-request
+      script: ci/test_wheel_nx-cugraph.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,3 +48,12 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel_cugraph.sh
+  wheel-tests-nx-cugraph:
+    secrets: inherit
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yaml@branch-23.10
+    with:
+      build_type: nightly
+      branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
+      script: ci/test_wheel_nx-cugraph.sh

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -49,7 +49,11 @@ cd "${package_dir}"
 
 python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
 
-mkdir -p final_dist
-python -m auditwheel repair -w final_dist dist/*
-
-RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 final_dist
+# pure-python packages should not have auditwheel run on them.
+if [[ ${package_name} == "nx-cugraph" ]]; then
+    RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 dist
+else
+    mkdir -p final_dist
+    python -m auditwheel repair -w final_dist dist/*
+    RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 final_dist
+fi

--- a/ci/build_wheel_nx-cugraph.sh
+++ b/ci/build_wheel_nx-cugraph.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Copyright (c) 2023, NVIDIA CORPORATION.
+
+set -euo pipefail
+
+./ci/build_wheel.sh nx-cugraph python/nx-cugraph

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -6,17 +6,20 @@ set -eoxu pipefail
 package_name=$1
 package_dir=$2
 
+python_package_name=$(echo ${package_name}|sed 's/-/_/g')
+
 mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
-# echo to expand wildcard before adding `[extra]` requires for pip
+# use 'ls' to expand wildcard before adding `[extra]` requires for pip
 RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
-python -m pip install $(echo ./dist/${package_name}*.whl)[test]
+# pip creates wheels using python package names
+python -m pip install $(ls ./dist/${python_package_name}*.whl)[test]
 
 # Run smoke tests for aarch64 pull requests
 arch=$(uname -m)
 if [[ "${arch}" == "aarch64" && ${RAPIDS_BUILD_TYPE} == "pull-request" ]]; then
     python ./ci/wheel_smoke_test_${package_name}.py
 else
-    RAPIDS_DATASET_ROOT_DIR=`pwd`/datasets python -m pytest ./python/${package_name}/${package_name}/tests
+    RAPIDS_DATASET_ROOT_DIR=`pwd`/datasets python -m pytest ./python/${package_name}/${python_package_name}/tests
 fi

--- a/ci/test_wheel_cugraph.sh
+++ b/ci/test_wheel_cugraph.sh
@@ -11,12 +11,4 @@ python -m pip install --no-deps ./local-pylibcugraph-dep/pylibcugraph*.whl
 # Always install latest dask for testing
 python -m pip install git+https://github.com/dask/dask.git@main git+https://github.com/dask/distributed.git@main
 
-# Only download test data for x86
-arch=$(uname -m)
-if [[ "${arch}" == "x86_64" ]]; then
-    pushd ./datasets
-    bash ./get_test_data.sh
-    popd
-fi
-
 ./ci/test_wheel.sh cugraph python/cugraph

--- a/ci/test_wheel_nx-cugraph.sh
+++ b/ci/test_wheel_nx-cugraph.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Copyright (c) 2023, NVIDIA CORPORATION.
+
+set -eoxu pipefail
+
+./ci/test_wheel.sh nx-cugraph python/nx-cugraph

--- a/ci/wheel_smoke_test_nx-cugraph.py
+++ b/ci/wheel_smoke_test_nx-cugraph.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import networkx as nx
+import nx_cugraph as nxcg
+
+
+if __name__ == "__main__":
+    G = nx.Graph()
+    G.add_edges_from([(0, 1), (1, 2), (2, 3)])
+
+    nx_result = nx.betweenness_centrality(G)
+    # nx_cugraph is intended to be called via the NetworkX dispatcher, like
+    # this:
+    #    nxcu_result = nx.betweenness_centrality(G, backend="cugraph")
+    #
+    # but here it is being called directly since the NetworkX version that
+    # supports the "backend" kwarg may not be available in the testing env.
+    nxcu_result = nxcg.betweenness_centrality(G)
+
+    nx_nodes, nxcu_nodes = nx_result.keys(), nxcu_result.keys()
+    assert nxcu_nodes == nx_nodes
+    for node_id in nx_nodes:
+        nx_bc, nxcu_bc = nx_result[node_id], nxcu_result[node_id]
+        assert math.isclose(nx_bc, nxcu_bc, rel_tol=1e-6), \
+            f"bc for {node_id=} exceeds tolerance: {nx_bc=}, {nxcu_bc=}"


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.10` that creates a PR to keep `branch-23.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.