### PR TITLE
Temporarily disable mg testing

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -63,6 +63,7 @@ pytest \
   tests
 popd
 
+# FIXME: TEMPORARILY disable single-GPU "MG" testing
 rapids-logger "pytest cugraph"
 pushd python/cugraph/cugraph
 DASK_WORKER_DEVICES="0" \
@@ -78,7 +79,7 @@ pytest \
   --cov=cugraph \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cugraph-coverage.xml" \
   --cov-report=term \
-  -k "not test_property_graph_mg" \
+  -k "not _mg" \
   tests
 popd
 

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -21,9 +21,10 @@ arch=$(uname -m)
 if [[ "${arch}" == "aarch64" && ${RAPIDS_BUILD_TYPE} == "pull-request" ]]; then
     python ./ci/wheel_smoke_test_${package_name}.py
 else
+    # FIXME: TEMPORARILY disable single-GPU "MG" testing
     RAPIDS_DATASET_ROOT_DIR=`pwd`/datasets \
     DASK_DISTRIBUTED__SCHEDULER__WORKER_TTL="1000s" \
     DASK_DISTRIBUTED__COMM__TIMEOUTS__CONNECT="1000s" \
     DASK_CUDA_WAIT_WORKERS_MIN_TIMEOUT="1000s" \
-    python -m pytest ./python/${package_name}/${python_package_name}/tests
+    python -m pytest -k "not _mg" ./python/${package_name}/${python_package_name}/tests
 fi


### PR DESCRIPTION
This PR temporarily disables single-GPU "MG" tests in CI until the dask related transient failures are resolved.

The PR to re-enable them, intended to block the 23.12 release, is [here](https://github.com/rapidsai/cugraph/pull/3941).