### PR TITLE
nx-cugraph: xfail test_louvain.py:test_threshold in Python 3.9

### DIFF
--- a/python/nx-cugraph/nx_cugraph/interface.py
+++ b/python/nx-cugraph/nx_cugraph/interface.py
@@ -176,6 +176,10 @@ class BackendInterface:
                     ): louvain_different,
                     key("test_louvain.py:test_none_weight_param"): louvain_different,
                     key("test_louvain.py:test_multigraph"): louvain_different,
+                    # See networkx#6630
+                    key(
+                        "test_louvain.py:test_undirected_selfloops"
+                    ): "self-loops not handled in Louvain",
                 }
             )
             if sys.version_info[:2] == (3, 9):

--- a/python/nx-cugraph/nx_cugraph/interface.py
+++ b/python/nx-cugraph/nx_cugraph/interface.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 from __future__ import annotations
 
+import sys
+
 import networkx as nx
 
 import nx_cugraph as nxcg
@@ -174,12 +176,13 @@ class BackendInterface:
                     ): louvain_different,
                     key("test_louvain.py:test_none_weight_param"): louvain_different,
                     key("test_louvain.py:test_multigraph"): louvain_different,
-                    # See networkx#6630
-                    key(
-                        "test_louvain.py:test_undirected_selfloops"
-                    ): "self-loops not handled in Louvain",
                 }
             )
+            if sys.version_info[:2] == (3, 9):
+                # This test is sensitive to RNG, which depends on Python version
+                xfail[
+                    key("test_louvain.py:test_threshold")
+                ] = "Louvain does not support seed parameter"
 
         for item in items:
             kset = set(item.keywords)


### PR DESCRIPTION
This test is flaky b/c Louvain in PLC does not have a seed or random state parameter. This test holds the seed fixed and changes the threshold, but clearly this may not work if we can't set the seed.