### PR TITLE
Python Build Dependency Issues

### DIFF
--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -58,7 +58,7 @@ requirements:
     - cython >=3.0.0
     - libcugraph ={{ version }}
     - pylibraft ={{ minor_version }}
-    - python
+    - python >=3.9,<3.10.0a0
     - raft-dask ={{ minor_version }}
     - rmm ={{ minor_version }}
     - scikit-build >=0.13.1

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -83,7 +83,7 @@ requirements:
     - libcugraph ={{ version }}
     - pylibcugraph ={{ version }}
     - pylibraft ={{ minor_version }}
-    - python
+    - python >=3.9,<3.10.0a0
     - raft-dask ={{ minor_version }}
     - requests
     - ucx-proc=*=gpu


### PR DESCRIPTION
Attempting to resolve [ucx version error](https://github.com/rapidsai/cugraph/actions/runs/6621722770/job/18010826156?pr=3550#step:7:1206) to unblock CI python builds