### PR TITLE
CuGraph compatibility fixes

### DIFF
--- a/python/cugraph/cugraph/structure/graph_classes.py
+++ b/python/cugraph/cugraph/structure/graph_classes.py
@@ -469,8 +469,7 @@ class Graph:
         nodes: array-like or None, optional (default=None)
             A list of column names, acting as labels for nodes
         """
-        if not isinstance(np_array, np.ndarray):
-            raise TypeError("np_array input is not a Numpy array")
+        np_array = np.asarray(np_array)
         if len(np_array.shape) != 2:
             raise ValueError("np_array is not a 2D matrix")
 

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -1288,7 +1288,7 @@ class simpleGraphImpl:
             else:
                 return cudf.concat(
                     [df[simpleGraphImpl.srcCol], df[simpleGraphImpl.dstCol]]
-                ).unique()
+                ).drop_duplicates()
         if self.adjlist is not None:
             return cudf.Series(np.arange(0, self.number_of_nodes()))
 

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -1288,7 +1288,7 @@ class simpleGraphImpl:
             else:
                 return cudf.concat(
                     [df[simpleGraphImpl.srcCol], df[simpleGraphImpl.dstCol]]
-                ).drop_duplicates()
+                ).drop_duplicates().reset_index(drop=True)
         if self.adjlist is not None:
             return cudf.Series(np.arange(0, self.number_of_nodes()))
 

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -1286,9 +1286,13 @@ class simpleGraphImpl:
                 else:
                     return df[df.columns[0]]
             else:
-                return cudf.concat(
-                    [df[simpleGraphImpl.srcCol], df[simpleGraphImpl.dstCol]]
-                ).drop_duplicates().reset_index(drop=True)
+                return (
+                    cudf.concat(
+                        [df[simpleGraphImpl.srcCol], df[simpleGraphImpl.dstCol]]
+                    )
+                    .drop_duplicates()
+                    .reset_index(drop=True)
+                )
         if self.adjlist is not None:
             return cudf.Series(np.arange(0, self.number_of_nodes()))
 


### PR DESCRIPTION
This PR contains two changes.
- A change that defers to `numpy.asarray` to process array objects that `cugraph` consumes
- An update from using `unique` to use `drop_duplicates` in `simpleGraph.py`, which always always returns a Series to preserve pandas compatibility. 