### PR TITLE
[BUG] Restore the original default order of CSR, which does not reverse edges in cuGraph-PyG

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/data/cugraph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/cugraph_store.py
@@ -214,7 +214,7 @@ class EXPERIMENTAL__CuGraphStore:
         num_nodes_dict: Dict[str, int],
         *,
         multi_gpu: bool = False,
-        order: str = "CSC",
+        order: str = "CSR",
     ):
         """
         Constructs a new CuGraphStore from the provided
@@ -260,11 +260,11 @@ class EXPERIMENTAL__CuGraphStore:
             Whether the store should be backed by a multi-GPU graph.
             Requires dask to have been set up.
 
-        order: str (Optional ["CSR", "CSC"], default = CSC)
-            The order to use for sampling.  Should nearly always be CSC
-            unless there is a specific expectation of "reverse" sampling.
-            It is also not uncommon to use CSR order for correctness
-            testing, which some cuGraph-PyG tests do.
+        order: str (Optional ["CSR", "CSC"], default = CSR)
+            The order to use for sampling.  CSR corresponds to the
+            standard OGB dataset order that is usually used in PyG.
+            CSC order constructs the same graph as CSR, but with
+            edges in the opposite direction.
         """
 
         if None in G:


### PR DESCRIPTION
OGB and many other datasets express the edge index in CSR order, but in release 23.10, the default order was changed to CSC, which broke downstream workflows.  This PR restores the original default, which should be acceptable for the most common datasets, and familiar to most PyG users.

Closes #3969 