### PR TITLE
Adds `update-version.sh` support for recently added files containing RAPIDS versions

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -90,8 +90,9 @@ DEPENDENCIES=(
   ucx-py
 )
 for DEP in "${DEPENDENCIES[@]}"; do
-  for FILE in dependencies.yaml conda/environments/*.yaml; do
+  for FILE in dependencies.yaml conda/environments/*.yaml python/cugraph-{pyg,dgl}/conda/*.yaml; do
     sed_runner "/-.* ${DEP}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}.*/g" ${FILE}
+    sed_runner "/-.* ${DEP}-cu[0-9][0-9]==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}.*/g" ${FILE}
     sed_runner "/-.* ucx-py==/ s/==.*/==${NEXT_UCX_PY_VERSION}.*/g" ${FILE}
   done
   for FILE in python/**/pyproject.toml python/**/**/pyproject.toml; do
@@ -107,6 +108,11 @@ sed_runner "s|PROJECT_NUMBER[[:space:]]*=.*|PROJECT_NUMBER=${NEXT_SHORT_TAG}|" c
 sed_runner "/^ucx_py_version:$/ {n;s/.*/  - \"${NEXT_UCX_PY_VERSION}.*\"/}" conda/recipes/cugraph/conda_build_config.yaml
 sed_runner "/^ucx_py_version:$/ {n;s/.*/  - \"${NEXT_UCX_PY_VERSION}.*\"/}" conda/recipes/cugraph-service/conda_build_config.yaml
 sed_runner "/^ucx_py_version:$/ {n;s/.*/  - \"${NEXT_UCX_PY_VERSION}.*\"/}" conda/recipes/pylibcugraph/conda_build_config.yaml
+
+# nx-cugraph NetworkX entry-point meta-data
+sed_runner "s@branch-[0-9][0-9].[0-9][0-9]@branch-${NEXT_SHORT_TAG}@g" python/nx-cugraph/_nx_cugraph/__init__.py
+# FIXME: can this use the standard VERSION file and update mechanism?
+sed_runner "s/__version__ = .*/__version__ = \"${NEXT_FULL_TAG}\"/g" python/nx-cugraph/_nx_cugraph/__init__.py
 
 # CI files
 for FILE in .github/workflows/*.yaml; do

--- a/python/nx-cugraph/_nx_cugraph/__init__.py
+++ b/python/nx-cugraph/_nx_cugraph/__init__.py
@@ -136,6 +136,7 @@ def get_info():
     return d
 
 
+# FIXME: can this use the standard VERSION file and update mechanism?
 __version__ = "23.12.00"
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds `update-version.sh` support for:
* nx-cugraph meta-data files
* `cugraph-pyg`, `cugraph-dgl` env yaml files
* `*-cu11`, `*-cu12` wheel dependencies in dependencies.yaml