### PR TITLE
Forward-merge branch-23.12 to branch-24.02

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,6 +31,7 @@ VALIDARGS="
    cugraph-dgl
    nx-cugraph
    cpp-mgtests
+   cpp-mtmgtests
    docs
    all
    -v
@@ -59,6 +60,7 @@ HELP="$0 [<target> ...] [<flag> ...]
    cugraph-dgl                - build the cugraph-dgl extensions for DGL
    nx-cugraph                 - build the nx-cugraph Python package
    cpp-mgtests                - build libcugraph and libcugraph_etl MG tests. Builds MPI communicator, adding MPI as a dependency.
+   cpp-mtmgtests              - build libcugraph MTMG tests. Adds UCX as a dependency (temporary).
    docs                       - build the docs
    all                        - build everything
  and <flag> is:
@@ -105,6 +107,7 @@ BUILD_TYPE=Release
 INSTALL_TARGET="--target install"
 BUILD_CPP_TESTS=ON
 BUILD_CPP_MG_TESTS=OFF
+BUILD_CPP_MTMG_TESTS=OFF
 BUILD_ALL_GPU_ARCH=0
 BUILD_WITH_CUGRAPHOPS=ON
 CMAKE_GENERATOR_OPTION="-G Ninja"
@@ -171,6 +174,9 @@ if hasArg --skip_cpp_tests; then
 fi
 if hasArg --without_cugraphops; then
     BUILD_WITH_CUGRAPHOPS=OFF
+fi
+if hasArg cpp-mtmgtests; then
+    BUILD_CPP_MTMG_TESTS=ON
 fi
 if hasArg cpp-mgtests || hasArg all; then
     BUILD_CPP_MG_TESTS=ON
@@ -264,6 +270,7 @@ if buildDefault || hasArg libcugraph || hasArg all; then
               -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
               -DBUILD_TESTS=${BUILD_CPP_TESTS} \
               -DBUILD_CUGRAPH_MG_TESTS=${BUILD_CPP_MG_TESTS} \
+	      -DBUILD_CUGRAPH_MTMG_TESTS=${BUILD_CPP_MTMG_TESTS} \
 	      -DUSE_CUGRAPH_OPS=${BUILD_WITH_CUGRAPHOPS} \
               ${CMAKE_GENERATOR_OPTION} \
               ${CMAKE_VERBOSE_OPTION}
@@ -294,6 +301,7 @@ if buildDefault || hasArg libcugraph_etl || hasArg all; then
               -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
               -DBUILD_TESTS=${BUILD_CPP_TESTS} \
               -DBUILD_CUGRAPH_MG_TESTS=${BUILD_CPP_MG_TESTS} \
+              -DBUILD_CUGRAPH_MTMG_TESTS=${BUILD_CPP_MTMG_TESTS} \
               -DCMAKE_PREFIX_PATH=${LIBCUGRAPH_BUILD_DIR} \
               ${CMAKE_GENERATOR_OPTION} \
               ${CMAKE_VERBOSE_OPTION} \

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -166,7 +166,10 @@ endif()
 
 include(cmake/thirdparty/get_nccl.cmake)
 include(cmake/thirdparty/get_cuhornet.cmake)
-include(cmake/thirdparty/get_ucp.cmake)
+
+if (BUILD_CUGRAPH_MTMG_TESTS)
+  include(cmake/thirdparty/get_ucp.cmake)
+endif()
 
 if(BUILD_TESTS)
   include(cmake/thirdparty/get_gtest.cmake)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -415,13 +415,6 @@ ConfigureTest(K_HOP_NBRS_TEST traversal/k_hop_nbrs_test.cpp)
 # - install tests ---------------------------------------------------------------------------------
 rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing DESTINATION bin/gtests/libcugraph)
 
-###################################################################################################
-# - MTMG tests -------------------------------------------------------------------------
-ConfigureTest(MTMG_TEST mtmg/threaded_test.cu)
-target_link_libraries(MTMG_TEST
-                      PRIVATE
-                      UCP::UCP
-                    )
 
 ###################################################################################################
 # - MG tests --------------------------------------------------------------------------------------
@@ -681,15 +674,6 @@ if(BUILD_CUGRAPH_MG_TESTS)
 
     rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing_mg DESTINATION bin/gtests/libcugraph_mg)
 
-    ###############################################################################################
-    # - Multi-node MTMG tests ---------------------------------------------------------------------
-    ConfigureTest(MTMG_MULTINODE_TEST mtmg/multi_node_threaded_test.cu utilities/mg_utilities.cpp)
-    target_link_libraries(MTMG_MULTINODE_TEST
-                          PRIVATE
-                          cugraphmgtestutil
-                          UCP::UCP
-                         )
-
 endif()
 
 ###################################################################################################
@@ -748,5 +732,26 @@ ConfigureCTest(CAPI_INDUCED_SUBGRAPH_TEST c_api/induced_subgraph_test.c)
 ConfigureCTest(CAPI_EGONET_TEST c_api/egonet_test.c)
 ConfigureCTest(CAPI_TWO_HOP_NEIGHBORS_TEST c_api/two_hop_neighbors_test.c)
 ConfigureCTest(CAPI_LEGACY_K_TRUSS_TEST c_api/legacy_k_truss_test.c)
+
+if (BUILD_CUGRAPH_MTMG_TESTS)
+    ###################################################################################################
+    # - MTMG tests -------------------------------------------------------------------------
+    ConfigureTest(MTMG_TEST mtmg/threaded_test.cu)
+    target_link_libraries(MTMG_TEST
+                        PRIVATE
+                        UCP::UCP
+                        )
+
+    if(BUILD_CUGRAPH_MG_TESTS)
+        ###############################################################################################
+        # - Multi-node MTMG tests ---------------------------------------------------------------------
+        ConfigureTest(MTMG_MULTINODE_TEST mtmg/multi_node_threaded_test.cu utilities/mg_utilities.cpp)
+        target_link_libraries(MTMG_MULTINODE_TEST
+                              PRIVATE
+                              cugraphmgtestutil
+                              UCP::UCP
+                             )
+    endif(BUILD_CUGRAPH_MG_TESTS)
+endif(BUILD_CUGRAPH_MTMG_TESTS)
 
 rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing_c DESTINATION bin/gtests/libcugraph_c)

--- a/python/cugraph/cugraph/structure/property_graph.py
+++ b/python/cugraph/cugraph/structure/property_graph.py
@@ -800,15 +800,9 @@ class EXPERIMENTAL__PropertyGraph:
             tmp_df.index = tmp_df.index.rename(self.vertex_col_name)
 
         # FIXME: handle case of a type_name column already being in tmp_df
-        if self.__series_type is cudf.Series:
-            # cudf does not yet support initialization with a scalar
-            tmp_df[TCN] = cudf.Series(
-                cudf.Series([type_name], dtype=cat_dtype).repeat(len(tmp_df)),
-                index=tmp_df.index,
-            )
-        else:
-            # pandas is oddly slow if dtype is passed to the constructor here
-            tmp_df[TCN] = pd.Series(type_name, index=tmp_df.index).astype(cat_dtype)
+        tmp_df[TCN] = self.__series_type(type_name, index=tmp_df.index).astype(
+            cat_dtype
+        )
 
         if property_columns:
             # all columns
@@ -1207,15 +1201,9 @@ class EXPERIMENTAL__PropertyGraph:
         tmp_df[self.src_col_name] = tmp_df[vertex_col_names[0]]
         tmp_df[self.dst_col_name] = tmp_df[vertex_col_names[1]]
 
-        if self.__series_type is cudf.Series:
-            # cudf does not yet support initialization with a scalar
-            tmp_df[TCN] = cudf.Series(
-                cudf.Series([type_name], dtype=cat_dtype).repeat(len(tmp_df)),
-                index=tmp_df.index,
-            )
-        else:
-            # pandas is oddly slow if dtype is passed to the constructor here
-            tmp_df[TCN] = pd.Series(type_name, index=tmp_df.index).astype(cat_dtype)
+        tmp_df[TCN] = self.__series_type(type_name, index=tmp_df.index).astype(
+            cat_dtype
+        )
 
         # Add unique edge IDs to the new rows. This is just a count for each
         # row starting from the last edge ID value, with initial edge ID 0.


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.12` that creates a PR to keep `branch-24.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.