### PR TITLE
Pin to minor versions of packages outside the cuGraph repository.

### DIFF
--- a/conda/recipes/cugraph-dgl/meta.yaml
+++ b/conda/recipes/cugraph-dgl/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - dgl >=1.1.0.cu*
     - numba >=0.57
     - numpy >=1.21
-    - pylibcugraphops ={{ version }}
+    - pylibcugraphops ={{ minor_version }}
     - python
     - pytorch
 

--- a/conda/recipes/cugraph-pyg/meta.yaml
+++ b/conda/recipes/cugraph-pyg/meta.yaml
@@ -26,14 +26,14 @@ requirements:
     - python
     - scikit-build >=0.13.1
   run:
-    - rapids-dask-dependency ={{ version }}
+    - rapids-dask-dependency ={{ minor_version }}
     - numba >=0.57
     - numpy >=1.21
     - python
     - pytorch >=2.0
     - cupy >=12.0.0
     - cugraph ={{ version }}
-    - pylibcugraphops ={{ version }}
+    - pylibcugraphops ={{ minor_version }}
     - pyg >=2.3,<2.4
 
 tests:


### PR DESCRIPTION
This PR fixes some pinnings in cuGraph conda recipes. The problem is similar to that handled in https://github.com/rapidsai/cudf/pull/14420. The `{{ version }}` variable can only be used to constrain conda packages built by CI workflows in the _same repository_ because `{{ version }}` includes information about the git commit. We must use `{{ minor_version }}` to constrain other RAPIDS packages. In cuGraph, that means that `pylibcugraphops` (which is built by the cugraph-ops repository) and `rapids-dask-dependency` must pin with `={{ minor_version }}` instead of `={{ version }}`.