### PR TITLE
Use `minor_version` instead of full version for `rapids-dask-dependency`

### DIFF
--- a/conda/recipes/cugraph-pyg/meta.yaml
+++ b/conda/recipes/cugraph-pyg/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - python
     - scikit-build >=0.13.1
   run:
-    - rapids-dask-dependency ={{ version }}
+    - rapids-dask-dependency ={{ minor_version }}
     - numba >=0.57
     - numpy >=1.21
     - python


### PR DESCRIPTION
I previously added a dask dependency to cugraph, but it added too tight of a pinning by requiring the exact same version. This is not valid because rapids-dask-dependency won't release a new version corresponding to each new cugraph release, so pinning to the exact same version up to the alpha creates an unsatisfiable constraint.

