### PR TITLE
[HOTFIX] Updates cudf usage for compatibility with cudf>=23.10.1

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -130,8 +130,9 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/build-in-devcontainer.yaml@branch-23.10
     with:
+      node_type: cpu32
       extra-repo-deploy-key: CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY
       build_command: |
         sccache -z;
-        build-all --verbose;
+        build-all --verbose -j$(nproc --ignore=1);
         sccache -s;

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -33,7 +33,7 @@ rapids-mamba-retry install \
   --channel "${PYTHON_CHANNEL}" \
   libcugraph \
   pylibcugraph \
-  cugraph \
+  "${PYTHON_CHANNEL}"::cugraph \
   nx-cugraph \
   cugraph-service-server \
   cugraph-service-client

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -33,7 +33,7 @@ rapids-mamba-retry install \
   --channel "${PYTHON_CHANNEL}" \
   libcugraph \
   pylibcugraph \
-  "${PYTHON_CHANNEL}"::cugraph \
+  cugraph \
   nx-cugraph \
   cugraph-service-server \
   cugraph-service-client

--- a/ci/test_wheel_nx-cugraph.sh
+++ b/ci/test_wheel_nx-cugraph.sh
@@ -3,4 +3,9 @@
 
 set -eoxu pipefail
 
+# Download the pylibcugraph built in the previous step
+RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
+RAPIDS_PY_WHEEL_NAME="pylibcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./local-pylibcugraph-dep
+python -m pip install --no-deps ./local-pylibcugraph-dep/pylibcugraph*.whl
+
 ./ci/test_wheel.sh nx-cugraph python/nx-cugraph

--- a/python/cugraph/cugraph/structure/property_graph.py
+++ b/python/cugraph/cugraph/structure/property_graph.py
@@ -800,15 +800,9 @@ class EXPERIMENTAL__PropertyGraph:
             tmp_df.index = tmp_df.index.rename(self.vertex_col_name)
 
         # FIXME: handle case of a type_name column already being in tmp_df
-        if self.__series_type is cudf.Series:
-            # cudf does not yet support initialization with a scalar
-            tmp_df[TCN] = cudf.Series(
-                cudf.Series([type_name], dtype=cat_dtype).repeat(len(tmp_df)),
-                index=tmp_df.index,
-            )
-        else:
-            # pandas is oddly slow if dtype is passed to the constructor here
-            tmp_df[TCN] = pd.Series(type_name, index=tmp_df.index).astype(cat_dtype)
+        tmp_df[TCN] = self.__series_type(type_name, index=tmp_df.index).astype(
+            cat_dtype
+        )
 
         if property_columns:
             # all columns
@@ -1207,15 +1201,9 @@ class EXPERIMENTAL__PropertyGraph:
         tmp_df[self.src_col_name] = tmp_df[vertex_col_names[0]]
         tmp_df[self.dst_col_name] = tmp_df[vertex_col_names[1]]
 
-        if self.__series_type is cudf.Series:
-            # cudf does not yet support initialization with a scalar
-            tmp_df[TCN] = cudf.Series(
-                cudf.Series([type_name], dtype=cat_dtype).repeat(len(tmp_df)),
-                index=tmp_df.index,
-            )
-        else:
-            # pandas is oddly slow if dtype is passed to the constructor here
-            tmp_df[TCN] = pd.Series(type_name, index=tmp_df.index).astype(cat_dtype)
+        tmp_df[TCN] = self.__series_type(type_name, index=tmp_df.index).astype(
+            cat_dtype
+        )
 
         # Add unique edge IDs to the new rows. This is just a count for each
         # row starting from the last edge ID value, with initial edge ID 0.


### PR DESCRIPTION
`cudf>=23.10.1` has been updated to have behavior matching `pandas` for some APIs that are used by `PropertyGraph`. 

This PR updates `PropertyGraph` so those API calls are compatible with `cudf>=23.10.1`.

These changes were tested with `cudf=23.10.0` and `cudf=23.10.1`


