### PR TITLE
Find rmm before cuco

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -155,6 +155,7 @@ rapids_cpm_init()
 
 # Need to make sure rmm is found before cuco so that rmm patches the libcudacxx
 # directory to be found by cuco.
+include(${rapids-cmake-dir}/cpm/rmm.cmake)
 rapids_cpm_rmm(BUILD_EXPORT_SET cugraph-exports
                INSTALL_EXPORT_SET  cugraph-exports)
 # Putting this before raft to override RAFT from pulling them in.

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -153,6 +153,10 @@ rapids_cpm_init()
 # lags behind.
 ###
 
+# Need to make sure rmm is found before cuco so that rmm patches the libcudacxx
+# directory to be found by cuco.
+rapids_cpm_rmm(BUILD_EXPORT_SET cugraph-exports
+               INSTALL_EXPORT_SET  cugraph-exports)
 # Putting this before raft to override RAFT from pulling them in.
 include(cmake/thirdparty/get_libcudacxx.cmake)
 include(${rapids-cmake-dir}/cpm/cuco.cmake)


### PR DESCRIPTION
RAPIDS currently relies on copies of CCCL headers bundled into rmm. This dependency is centralized by virtue of rmm installing these into the package and everything else finding those installed packages. To do this, however, rmm must be loaded first so that the libcudacxx install location is patched into CMake's search paths. cugraph also uses cuco, which requires libcudacxx but does not bundle its own, so rmm must be found first so that cuco can find libcudacxx where rmm installed it.