### PR TITLE
Prevent automatic labeler from adding `Label Checker` labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,17 +9,6 @@ python:
 benchmarks:
   - 'benchmarks/**'
 
-doc:
-  - 'docs/**'
-  - '**/*.md'
-  - 'datasets/**'
-  - 'notebooks/**'
-  - '**/*.txt'
-  - '**/*.rst'
-  - '**/*.ipynb'
-  - '**/*.pdf'
-  - '**/*.png'
-
 datasets:
   - 'datasets/**'
 


### PR DESCRIPTION
This PR prevents the `doc` label from being automatically added to PRs since it can interfere with the [Label Checker](https://docs.rapids.ai/resources/label-checker/) check.

Skipping CI since these changes aren't tested there.