### PR TITLE
Correct `cugraph-pyg` package name used in wheels and fix test script

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -230,7 +230,6 @@ if [[ "${RAPIDS_CUDA_VERSION}" == "11.8.0" ]]; then
     # rmat is not tested because of multi-GPU testing
     pytest \
       --cache-clear \
-      --ignore=tests/int \
       --ignore=tests/mg \
       --junitxml="${RAPIDS_TESTS_DIR}/junit-cugraph-pyg.xml" \
       --cov-config=../../.coveragerc \

--- a/ci/test_wheel_cugraph-pyg.sh
+++ b/ci/test_wheel_cugraph-pyg.sh
@@ -36,7 +36,6 @@ if [[ "${CUDA_VERSION}" == "11.8.0" ]]; then
   pushd python/cugraph-pyg/cugraph_pyg
   python -m pytest \
     --cache-clear \
-    --ignore=tests/int \
     --ignore=tests/mg \
     tests
   popd

--- a/ci/test_wheel_cugraph-pyg.sh
+++ b/ci/test_wheel_cugraph-pyg.sh
@@ -33,11 +33,13 @@ if [[ "${CUDA_VERSION}" == "11.8.0" ]]; then
     -f https://data.pyg.org/whl/torch-2.1.0+cu118.html
 
   rapids-logger "pytest cugraph-pyg (single GPU)"
+  pushd python/cugraph-pyg/cugraph_pyg
   python -m pytest \
     --cache-clear \
     --ignore=tests/int \
     --ignore=tests/mg \
-    python/cugraph-pyg/cugraph_pyg/tests
+    tests
+  popd
 else
   rapids-logger "skipping cugraph-pyg wheel test on CUDA!=11.8"
 fi

--- a/python/cugraph-pyg/cugraph_pyg/tests/mg/test_mg_cugraph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/mg/test_mg_cugraph_store.py
@@ -385,7 +385,7 @@ def test_get_input_nodes(karate_gnn, dask_client):
 def test_mg_frame_handle(graph, dask_client):
     F, G, N = graph
     cugraph_store = CuGraphStore(F, G, N, multi_gpu=True)
-    assert isinstance(cugraph_store.__graph._plc_graph, dict)
+    assert isinstance(cugraph_store._CuGraphStore__graph._plc_graph, dict)
 
 
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")

--- a/python/cugraph-pyg/cugraph_pyg/tests/mg/test_mg_cugraph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/mg/test_mg_cugraph_store.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph-pyg/cugraph_pyg/tests/mg/test_mg_cugraph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/mg/test_mg_cugraph_store.py
@@ -385,7 +385,7 @@ def test_get_input_nodes(karate_gnn, dask_client):
 def test_mg_frame_handle(graph, dask_client):
     F, G, N = graph
     cugraph_store = CuGraphStore(F, G, N, multi_gpu=True)
-    assert isinstance(cugraph_store._EXPERIMENTAL__CuGraphStore__graph._plc_graph, dict)
+    assert isinstance(cugraph_store.__graph._plc_graph, dict)
 
 
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")

--- a/python/cugraph-pyg/pyproject.toml
+++ b/python/cugraph-pyg/pyproject.toml
@@ -13,7 +13,7 @@ testpaths = ["cugraph_pyg/tests"]
 [project]
 name = "cugraph-pyg"
 dynamic = ["version"]
-description = "cugraph_pyg - PyG support for cuGraph massive-scale, ultra-fast GPU graph analytics."
+description = "cugraph-pyg - PyG support for cuGraph massive-scale, ultra-fast GPU graph analytics."
 authors = [
     { name = "NVIDIA Corporation" },
 ]

--- a/python/cugraph-pyg/pyproject.toml
+++ b/python/cugraph-pyg/pyproject.toml
@@ -11,7 +11,7 @@ requires = [
 testpaths = ["cugraph_pyg/tests"]
 
 [project]
-name = "cugraph_pyg"
+name = "cugraph-pyg"
 dynamic = ["version"]
 description = "cugraph_pyg - PyG support for cuGraph massive-scale, ultra-fast GPU graph analytics."
 authors = [


### PR DESCRIPTION
This is an oversight from #4075. With this fix, the generated wheels should have proper a CUDA suffix (e.g. `cugraph-pyg-cu12`).

Edit: This PR also fixes https://github.com/rapidsai/graph_dl/issues/421 
The mg tests were not skipped as expected due to wrong relative path in `test_wheel_cugraph-pyg.sh`. 