### PR TITLE
Forward-merge branch-24.02 to branch-24.04

### DIFF
--- a/python/nx-cugraph/_nx_cugraph/__init__.py
+++ b/python/nx-cugraph/_nx_cugraph/__init__.py
@@ -12,7 +12,11 @@
 # limitations under the License.
 """Tell NetworkX about the cugraph backend. This file can update itself:
 
-$ make plugin-info  # Recommended method for development
+$ make plugin-info
+
+or
+
+$ make all  # Recommended - runs 'plugin-info' followed by 'lint'
 
 or
 
@@ -78,7 +82,6 @@ _info = {
         "is_connected",
         "is_forest",
         "is_isolate",
-        "is_strongly_connected",
         "is_tree",
         "is_weakly_connected",
         "isolates",
@@ -96,7 +99,6 @@ _info = {
         "number_connected_components",
         "number_of_isolates",
         "number_of_selfloops",
-        "number_strongly_connected_components",
         "number_weakly_connected_components",
         "octahedral_graph",
         "out_degree_centrality",
@@ -111,7 +113,6 @@ _info = {
         "single_source_shortest_path_length",
         "single_target_shortest_path_length",
         "star_graph",
-        "strongly_connected_components",
         "tadpole_graph",
         "tetrahedral_graph",
         "transitivity",

--- a/python/nx-cugraph/nx_cugraph/algorithms/components/strongly_connected.py
+++ b/python/nx-cugraph/nx_cugraph/algorithms/components/strongly_connected.py
@@ -15,12 +15,7 @@ import networkx as nx
 import pylibcugraph as plc
 
 from nx_cugraph.convert import _to_directed_graph
-from nx_cugraph.utils import (
-    _groupby,
-    index_dtype,
-    networkx_algorithm,
-    not_implemented_for,
-)
+from nx_cugraph.utils import _groupby, index_dtype, not_implemented_for
 
 __all__ = [
     "number_strongly_connected_components",
@@ -50,8 +45,19 @@ def _strongly_connected_components(G):
     return labels
 
 
+# The networkx_algorithm decorator is (temporarily) removed to disable
+# dispatching for this function. The current cugraph
+# strongly_connected_components is a legacy implementation with known issues,
+# and in most cases should not be used until the cugraph team can provide an
+# update.
+#
+# Users can still call this via the nx_cugraph module directly:
+# >>> import nx_cugraph as nxcg
+# >>> nxcg.strongly_connected_components(...)
+
+
 @not_implemented_for("undirected")
-@networkx_algorithm(version_added="24.02", _plc="strongly_connected_components")
+# @networkx_algorithm(version_added="24.02", _plc="strongly_connected_components")
 def strongly_connected_components(G):
     G = _to_directed_graph(G)
     if G.src_indices.size == 0:
@@ -62,7 +68,7 @@ def strongly_connected_components(G):
 
 
 @not_implemented_for("undirected")
-@networkx_algorithm(version_added="24.02", _plc="strongly_connected_components")
+# @networkx_algorithm(version_added="24.02", _plc="strongly_connected_components")
 def number_strongly_connected_components(G):
     G = _to_directed_graph(G)
     if G.src_indices.size == 0:
@@ -72,7 +78,7 @@ def number_strongly_connected_components(G):
 
 
 @not_implemented_for("undirected")
-@networkx_algorithm(version_added="24.02", _plc="strongly_connected_components")
+# @networkx_algorithm(version_added="24.02", _plc="strongly_connected_components")
 def is_strongly_connected(G):
     G = _to_directed_graph(G)
     if len(G) == 0:

--- a/python/nx-cugraph/nx_cugraph/interface.py
+++ b/python/nx-cugraph/nx_cugraph/interface.py
@@ -69,10 +69,14 @@ class BackendInterface:
         no_string_dtype = "string edge values not currently supported"
 
         xfail = {
-            key(
-                "test_strongly_connected.py:"
-                "TestStronglyConnected.test_condensation_mapping_and_members"
-            ): "Strongly connected groups in different iteration order",
+            # This is removed while strongly_connected_components() is not
+            # dispatchable. See algorithms/components/strongly_connected.py for
+            # details.
+            #
+            # key(
+            #     "test_strongly_connected.py:"
+            #     "TestStronglyConnected.test_condensation_mapping_and_members"
+            # ): "Strongly connected groups in different iteration order",
         }
 
         from packaging.version import parse


### PR DESCRIPTION
Forward-merge triggered by push to `branch-24.02` that creates a PR to keep `branch-24.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.