### PR TITLE
Forward-merge branch-24.02 to branch-24.04

### DIFF
--- a/cpp/include/cugraph_c/community_algorithms.h
+++ b/cpp/include/cugraph_c/community_algorithms.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@
 #include <cugraph_c/resource_handle.h>
 
 /** @defgroup community Community algorithms
- *  @{
  */
 
 #ifdef __cplusplus
@@ -60,18 +59,21 @@ cugraph_error_code_t cugraph_triangle_count(const cugraph_resource_handle_t* han
                                             cugraph_error_t** error);
 
 /**
+ * @ingroup community
  * @brief     Get triangle counting vertices
  */
 cugraph_type_erased_device_array_view_t* cugraph_triangle_count_result_get_vertices(
   cugraph_triangle_count_result_t* result);
 
 /**
+ * @ingroup community
  * @brief     Get triangle counting counts
  */
 cugraph_type_erased_device_array_view_t* cugraph_triangle_count_result_get_counts(
   cugraph_triangle_count_result_t* result);
 
 /**
+ * @ingroup community
  * @brief     Free a triangle count result
  *
  * @param [in] result     The result from a sampling algorithm
@@ -147,24 +149,28 @@ cugraph_error_code_t cugraph_leiden(const cugraph_resource_handle_t* handle,
                                     cugraph_error_t** error);
 
 /**
+ * @ingroup community
  * @brief     Get hierarchical clustering vertices
  */
 cugraph_type_erased_device_array_view_t* cugraph_hierarchical_clustering_result_get_vertices(
   cugraph_hierarchical_clustering_result_t* result);
 
 /**
+ * @ingroup community
  * @brief     Get hierarchical clustering clusters
  */
 cugraph_type_erased_device_array_view_t* cugraph_hierarchical_clustering_result_get_clusters(
   cugraph_hierarchical_clustering_result_t* result);
 
 /**
+ * @ingroup community
  * @brief     Get modularity
  */
 double cugraph_hierarchical_clustering_result_get_modularity(
   cugraph_hierarchical_clustering_result_t* result);
 
 /**
+ * @ingroup community
  * @brief     Free a hierarchical clustering result
  *
  * @param [in] result     The result from a sampling algorithm
@@ -423,7 +429,3 @@ void cugraph_clustering_result_free(cugraph_clustering_result_t* result);
 #ifdef __cplusplus
 }
 #endif
-
-/**
- *  @}
- */

--- a/cpp/include/cugraph_c/sampling_algorithms.h
+++ b/cpp/include/cugraph_c/sampling_algorithms.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@
 #include <cugraph_c/resource_handle.h>
 
 /** @defgroup samplingC Sampling algorithms
- *  @{
  */
 
 #ifdef __cplusplus
@@ -134,6 +133,7 @@ cugraph_error_code_t cugraph_node2vec(const cugraph_resource_handle_t* handle,
                                       cugraph_error_t** error);
 
 /**
+ * @ingroup samplingC
  * @brief     Get the max path length from random walk result
  *
  * @param [in]   result   The result from random walks
@@ -145,6 +145,7 @@ size_t cugraph_random_walk_result_get_max_path_length(cugraph_random_walk_result
 //         difference at the moment is that RW results contain weights
 //         and extract_paths results don't.  But that's probably wrong.
 /**
+ * @ingroup samplingC
  * @brief     Get the matrix (row major order) of vertices in the paths
  *
  * @param [in]   result   The result from a random walk algorithm
@@ -154,6 +155,7 @@ cugraph_type_erased_device_array_view_t* cugraph_random_walk_result_get_paths(
   cugraph_random_walk_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Get the matrix (row major order) of edge weights in the paths
  *
  * @param [in]   result   The result from a random walk algorithm
@@ -163,6 +165,7 @@ cugraph_type_erased_device_array_view_t* cugraph_random_walk_result_get_weights(
   cugraph_random_walk_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     If the random walk result is compressed, get the path sizes
  * @deprecated This call will no longer be relevant once the new node2vec are called
  *
@@ -173,6 +176,7 @@ cugraph_type_erased_device_array_view_t* cugraph_random_walk_result_get_path_siz
   cugraph_random_walk_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Free random walks result
  *
  * @param [in]   result   The result from random walks
@@ -220,6 +224,7 @@ typedef enum cugraph_compression_type_t {
 } cugraph_compression_type_t;
 
 /**
+ * @ingroup samplingC
  * @brief   Create sampling options object
  *
  * All sampling options set to FALSE
@@ -232,6 +237,7 @@ cugraph_error_code_t cugraph_sampling_options_create(cugraph_sampling_options_t*
                                                      cugraph_error_t** error);
 
 /**
+ * @ingroup samplingC
  * @brief   Set flag to renumber results
  *
  * @param options - opaque pointer to the sampling options
@@ -240,6 +246,7 @@ cugraph_error_code_t cugraph_sampling_options_create(cugraph_sampling_options_t*
 void cugraph_sampling_set_renumber_results(cugraph_sampling_options_t* options, bool_t value);
 
 /**
+ * @ingroup samplingC
  * @brief   Set whether to compress per-hop (True) or globally (False)
  *
  * @param options - opaque pointer to the sampling options
@@ -248,6 +255,7 @@ void cugraph_sampling_set_renumber_results(cugraph_sampling_options_t* options, 
 void cugraph_sampling_set_compress_per_hop(cugraph_sampling_options_t* options, bool_t value);
 
 /**
+ * @ingroup samplingC
  * @brief   Set flag to sample with_replacement
  *
  * @param options - opaque pointer to the sampling options
@@ -256,6 +264,7 @@ void cugraph_sampling_set_compress_per_hop(cugraph_sampling_options_t* options, 
 void cugraph_sampling_set_with_replacement(cugraph_sampling_options_t* options, bool_t value);
 
 /**
+ * @ingroup samplingC
  * @brief   Set flag to sample return_hops
  *
  * @param options - opaque pointer to the sampling options
@@ -264,6 +273,7 @@ void cugraph_sampling_set_with_replacement(cugraph_sampling_options_t* options, 
 void cugraph_sampling_set_return_hops(cugraph_sampling_options_t* options, bool_t value);
 
 /**
+ * @ingroup samplingC
  * @brief   Set compression type
  *
  * @param options - opaque pointer to the sampling options
@@ -273,6 +283,7 @@ void cugraph_sampling_set_compression_type(cugraph_sampling_options_t* options,
                                            cugraph_compression_type_t value);
 
 /**
+ * @ingroup samplingC
  * @brief   Set prior sources behavior
  *
  * @param options - opaque pointer to the sampling options
@@ -282,6 +293,7 @@ void cugraph_sampling_set_prior_sources_behavior(cugraph_sampling_options_t* opt
                                                  cugraph_prior_sources_behavior_t value);
 
 /**
+ * @ingroup samplingC
  * @brief   Set flag to sample dedupe_sources prior to sampling
  *
  * @param options - opaque pointer to the sampling options
@@ -290,6 +302,7 @@ void cugraph_sampling_set_prior_sources_behavior(cugraph_sampling_options_t* opt
 void cugraph_sampling_set_dedupe_sources(cugraph_sampling_options_t* options, bool_t value);
 
 /**
+ * @ingroup samplingC
  * @brief     Free sampling options object
  *
  * @param [in]   options   Opaque pointer to sampling object
@@ -369,6 +382,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_destinations(
   const cugraph_sample_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Get the major vertices from the sampling algorithm result
  *
  * @param [in]   result   The result from a sampling algorithm
@@ -378,6 +392,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_majors(
   const cugraph_sample_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Get the minor vertices from the sampling algorithm result
  *
  * @param [in]   result   The result from a sampling algorithm
@@ -387,6 +402,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_minors(
   const cugraph_sample_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Get the major offsets from the sampling algorithm result
  *
  * @param [in]   result   The result from a sampling algorithm
@@ -396,6 +412,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_major_offsets
   const cugraph_sample_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Get the start labels from the sampling algorithm result
  *
  * @param [in]   result   The result from a sampling algorithm
@@ -405,6 +422,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_start_labels(
   const cugraph_sample_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Get the edge_id from the sampling algorithm result
  *
  * @param [in]   result   The result from a sampling algorithm
@@ -414,6 +432,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_edge_id(
   const cugraph_sample_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Get the edge_type from the sampling algorithm result
  *
  * @param [in]   result   The result from a sampling algorithm
@@ -423,6 +442,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_edge_type(
   const cugraph_sample_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Get the edge_weight from the sampling algorithm result
  *
  * @param [in]   result   The result from a sampling algorithm
@@ -432,6 +452,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_edge_weight(
   const cugraph_sample_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Get the hop from the sampling algorithm result
  *
  * @param [in]   result   The result from a sampling algorithm
@@ -441,6 +462,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_hop(
   const cugraph_sample_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Get the label-hop offsets from the sampling algorithm result
  *
  * @param [in]   result   The result from a sampling algorithm
@@ -450,6 +472,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_label_hop_off
   const cugraph_sample_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Get the index from the sampling algorithm result
  *
  * @param [in]   result   The result from a sampling algorithm
@@ -469,6 +492,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_offsets(
   const cugraph_sample_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Get the renumber map
  *
  * @param [in]   result   The result from a sampling algorithm
@@ -478,6 +502,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_renumber_map(
   const cugraph_sample_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Get the renumber map offsets
  *
  * @param [in]   result   The result from a sampling algorithm
@@ -487,6 +512,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_renumber_map_
   const cugraph_sample_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Free a sampling result
  *
  * @param [in]   result   The result from a sampling algorithm
@@ -494,6 +520,7 @@ cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_renumber_map_
 void cugraph_sample_result_free(cugraph_sample_result_t* result);
 
 /**
+ * @ingroup samplingC
  * @brief     Create a sampling result (testing API)
  *
  * @param [in]   handle         Handle for accessing resources
@@ -524,6 +551,7 @@ cugraph_error_code_t cugraph_test_sample_result_create(
   cugraph_error_t** error);
 
 /**
+ * @ingroup samplingC
  * @brief     Create a sampling result (testing API)
  *
  * @param [in]   handle         Handle for accessing resources
@@ -554,6 +582,7 @@ cugraph_error_code_t cugraph_test_uniform_neighborhood_sample_result_create(
   cugraph_error_t** error);
 
 /**
+ * @ingroup samplingC
  * @brief Select random vertices from the graph
  *
  * @param [in]      handle        Handle for accessing resources
@@ -576,7 +605,3 @@ cugraph_error_code_t cugraph_select_random_vertices(const cugraph_resource_handl
 #ifdef __cplusplus
 }
 #endif
-
-/**
- *  @}
- */

--- a/cpp/include/cugraph_c/traversal_algorithms.h
+++ b/cpp/include/cugraph_c/traversal_algorithms.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@
 
 /** @defgroup traversal Traversal Algorithms
  *  @ingroup c_api
- *  @{
  */
 
 #ifdef __cplusplus
@@ -40,6 +39,7 @@ typedef struct {
 } cugraph_paths_result_t;
 
 /**
+ * @ingroup traversal
  * @brief     Get the vertex ids from the paths result
  *
  * @param [in]   result   The result from bfs or sssp
@@ -49,6 +49,7 @@ cugraph_type_erased_device_array_view_t* cugraph_paths_result_get_vertices(
   cugraph_paths_result_t* result);
 
 /**
+ * @ingroup traversal
  * @brief     Get the distances from the paths result
  *
  * @param [in]   result   The result from bfs or sssp
@@ -58,6 +59,7 @@ cugraph_type_erased_device_array_view_t* cugraph_paths_result_get_distances(
   cugraph_paths_result_t* result);
 
 /**
+ * @ingroup traversal
  * @brief     Get the predecessors from the paths result
  *
  * @param [in]   result   The result from bfs or sssp
@@ -69,6 +71,7 @@ cugraph_type_erased_device_array_view_t* cugraph_paths_result_get_predecessors(
   cugraph_paths_result_t* result);
 
 /**
+ * @ingroup traversal
  * @brief     Free paths result
  *
  * @param [in]   result   The result from bfs or sssp
@@ -188,6 +191,7 @@ cugraph_error_code_t cugraph_extract_paths(
 size_t cugraph_extract_paths_result_get_max_path_length(cugraph_extract_paths_result_t* result);
 
 /**
+ * @ingroup traversal
  * @brief     Get the matrix (row major order) of paths
  *
  * @param [in]   result   The result from extract_paths
@@ -197,6 +201,7 @@ cugraph_type_erased_device_array_view_t* cugraph_extract_paths_result_get_paths(
   cugraph_extract_paths_result_t* result);
 
 /**
+ * @ingroup traversal
  * @brief     Free extract_paths result
  *
  * @param [in]   result   The result from extract_paths
@@ -206,7 +211,3 @@ void cugraph_extract_paths_result_free(cugraph_extract_paths_result_t* result);
 #ifdef __cplusplus
 }
 #endif
-
-/**
- *  @}
- */

--- a/docs/cugraph/source/api_docs/cugraph_c/community.rst
+++ b/docs/cugraph/source/api_docs/cugraph_c/community.rst
@@ -1,12 +1,6 @@
 Community
 =========
 
-.. role:: py(code)
-   :language: c
-   :class: highlight
-
-``#include <cugraph_c/community_algorithms.h>``
-
 Triangle Counting
 -----------------
 .. doxygenfunction:: cugraph_triangle_count
@@ -45,8 +39,8 @@ Spectral Clustering - Modularity Maximization
 .. doxygenfunction:: cugraph_analyze_clustering_modularity
     :project: libcugraph
 
-Spectral Clusteriong - Edge Cut
--------------------------------
+Spectral Clustering - Edge Cut
+------------------------------
 .. doxygenfunction:: cugraph_analyze_clustering_edge_cut
     :project: libcugraph
 

--- a/docs/cugraph/source/api_docs/cugraph_c/labeling.rst
+++ b/docs/cugraph/source/api_docs/cugraph_c/labeling.rst
@@ -12,8 +12,8 @@ Strongly Connected Components
 .. doxygenfunction:: cugraph_strongly_connected_components
     :project: libcugraph
 
-Support
--------
+Labeling Support Functions
+--------------------------
  .. doxygengroup:: labeling
      :project: libcugraph
      :members:

--- a/docs/cugraph/source/api_docs/cugraph_c/sampling.rst
+++ b/docs/cugraph/source/api_docs/cugraph_c/sampling.rst
@@ -7,7 +7,7 @@ Uniform Random Walks
     :project: libcugraph
 
 Biased Random Walks
---------------------
+-------------------
 .. doxygenfunction:: cugraph_biased_random_walks
     :project: libcugraph
 
@@ -21,16 +21,13 @@ Node2Vec
 .. doxygenfunction:: cugraph_node2vec
     :project: libcugraph
 
-Uniform Neighborhood Sampling
------------------------------
-.. doxygenfunction:: cugraph_uniform_neighbor_sample_with_edge_properties
-    :project: libcugraph
-
+Uniform Neighbor Sampling
+-------------------------
 .. doxygenfunction:: cugraph_uniform_neighbor_sample
     :project: libcugraph
 
-Support
--------
+Sampling Support Functions
+--------------------------
 .. doxygengroup:: samplingC
      :project: libcugraph
      :members:

--- a/docs/cugraph/source/api_docs/cugraph_c/similarity.rst
+++ b/docs/cugraph/source/api_docs/cugraph_c/similarity.rst
@@ -17,8 +17,8 @@ Overlap
 .. doxygenfunction:: cugraph_overlap_coefficients
     :project: libcugraph
 
-Support
--------
+Similarty Support Functions
+---------------------------
 .. doxygengroup:: similarity
      :project: libcugraph
      :members:

--- a/docs/cugraph/source/api_docs/cugraph_c/traversal.rst
+++ b/docs/cugraph/source/api_docs/cugraph_c/traversal.rst
@@ -22,8 +22,8 @@ Extract Max Path Length
 .. doxygenfunction:: cugraph_extract_paths_result_get_max_path_length
     :project: libcugraph
 
-Support
--------
+Traversal Support Functions
+---------------------------
 .. doxygengroup:: traversal
      :project: libcugraph
      :members:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-24.02` that creates a PR to keep `branch-24.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.