### PR TITLE
Ensure that `ctest` is called with `--no-tests=error`.

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -47,11 +47,11 @@ export GTEST_OUTPUT=xml:${RAPIDS_TESTS_DIR}/
 # Run libcugraph gtests from libcugraph-tests package
 rapids-logger "Run gtests"
 cd "$CONDA_PREFIX"/bin/gtests/libcugraph/
-ctest -j10 --output-on-failure
+ctest -j10 --output-on-failure --no-tests=error
 
 if [ -d "$CONDA_PREFIX"/bin/gtests/libcugraph_c/ ]; then
   cd "$CONDA_PREFIX"/bin/gtests/libcugraph_c/
-  ctest -j10 --output-on-failure
+  ctest -j10 --output-on-failure --no-tests=error
 fi
 
 rapids-logger "Test script exiting with value: $EXITCODE"

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 


### PR DESCRIPTION
This PR ensures that all calls to `ctest` include the flag `--no-tests=error`. See https://github.com/rapidsai/build-planning/issues/18.
