### PR TITLE
Forward-merge branch-24.02 to branch-24.04

### DIFF
--- a/python/cugraph-dgl/pyproject.toml
+++ b/python/cugraph-dgl/pyproject.toml
@@ -53,5 +53,3 @@ version = {file = "cugraph_dgl/VERSION"}
 include = [
     "cugraph_dgl*",
 ]
-exclude = ["*tests*"]
-

--- a/python/cugraph-equivariant/pyproject.toml
+++ b/python/cugraph-equivariant/pyproject.toml
@@ -62,4 +62,3 @@ include = [
     "cugraph_equivariant*",
     "cugraph_equivariant.*",
 ]
-exclude = ["*tests*"]

--- a/python/cugraph-equivariant/setup.py
+++ b/python/cugraph-equivariant/setup.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from setuptools import find_packages, setup
+
+if __name__ == "__main__":
+    packages = find_packages(include=["cugraph_equivariant*"])
+    setup(
+        package_data={key: ["VERSION"] for key in packages},
+    )

--- a/python/cugraph-pyg/pyproject.toml
+++ b/python/cugraph-pyg/pyproject.toml
@@ -57,5 +57,3 @@ include = [
     "cugraph_pyg*",
     "cugraph_pyg.*",
 ]
-exclude = ["*tests*"]
-

--- a/python/cugraph-service/client/pyproject.toml
+++ b/python/cugraph-service/client/pyproject.toml
@@ -42,4 +42,3 @@ version = {file = "cugraph_service_client/VERSION"}
 include = [
     "cugraph_service_client",
 ]
-exclude = ["*tests*"]

--- a/python/cugraph-service/server/pyproject.toml
+++ b/python/cugraph-service/server/pyproject.toml
@@ -71,4 +71,3 @@ include = [
     "cugraph_service_server",
     "cugraph_service_server.*"
 ]
-exclude = ["*tests*"]

--- a/python/cugraph/pyproject.toml
+++ b/python/cugraph/pyproject.toml
@@ -72,7 +72,6 @@ build-dir = "build/{wheel_tag}"
 cmake.build-type = "Release"
 cmake.minimum-version = "3.26.4"
 ninja.make-fallback = true
-sdist.exclude = ["*tests*"]
 sdist.reproducible = true
 wheel.packages = ["cugraph"]
 

--- a/python/nx-cugraph/pyproject.toml
+++ b/python/nx-cugraph/pyproject.toml
@@ -79,7 +79,6 @@ include = [
     "_nx_cugraph*",
     "_nx_cugraph.*",
 ]
-exclude = ["*tests*"]
 
 [tool.black]
 line-length = 88

--- a/python/pylibcugraph/pyproject.toml
+++ b/python/pylibcugraph/pyproject.toml
@@ -59,7 +59,6 @@ build-dir = "build/{wheel_tag}"
 cmake.build-type = "Release"
 cmake.minimum-version = "3.26.4"
 ninja.make-fallback = true
-sdist.exclude = ["*tests*"]
 sdist.reproducible = true
 wheel.packages = ["pylibcugraph"]
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-24.02` that creates a PR to keep `branch-24.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.