### PR TITLE
Add cuda-nvtx-dev, add missing CUDA library dependencies.

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -14,6 +14,7 @@ dependencies:
 - breathe
 - c-compiler
 - cmake>=3.26.4
+- cuda-nvtx
 - cuda-version=11.8
 - cudatoolkit
 - cudf==24.4.*

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -14,7 +14,10 @@ dependencies:
 - breathe
 - c-compiler
 - cmake>=3.26.4
+- cuda-cudart-dev
 - cuda-nvcc
+- cuda-nvtx-dev
+- cuda-profiler-api
 - cuda-version=12.0
 - cudf==24.4.*
 - cupy>=12.0.0
@@ -29,8 +32,12 @@ dependencies:
 - graphviz
 - gtest>=1.13.0
 - ipython
+- libcublas-dev
 - libcudf==24.4.*
 - libcugraphops==24.4.*
+- libcurand-dev
+- libcusolver-dev
+- libcusparse-dev
 - libraft-headers==24.4.*
 - libraft==24.4.*
 - librmm==24.4.*

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -327,10 +327,18 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
+              - cuda-cudart-dev
+              - cuda-nvtx-dev
+              - cuda-profiler-api
+              - libcublas-dev
+              - libcurand-dev
+              - libcusolver-dev
+              - libcusparse-dev
           - matrix:
               cuda: "11.*"
             packages:
               - cudatoolkit
+              - cuda-nvtx
   common_build:
     common:
       - output_types: [conda, pyproject]
@@ -345,6 +353,7 @@ dependencies:
           - cxx-compiler
           - gmock>=1.13.0
           - gtest>=1.13.0
+          - libcudf==24.4.*
           - libcugraphops==24.4.*
           - libraft-headers==24.4.*
           - libraft==24.4.*
@@ -438,7 +447,6 @@ dependencies:
         packages:
           - aiohttp
           - fsspec>=0.6.0
-          - libcudf==24.4.*
           - requests
           - nccl>=2.9.9
           - ucx-proc=*=gpu


### PR DESCRIPTION
This PR fixes issues with devcontainer builds where `cuda-nvtx-dev` was missing when building `libcugraph_etl`.