### PR TITLE
Fix Double `degree` Values for Symmetric MG Graphs

### DIFF
--- a/python/cugraph/cugraph/tests/centrality/test_degree_centrality_mg.py
+++ b/python/cugraph/cugraph/tests/centrality/test_degree_centrality_mg.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023, NVIDIA CORPORATION.
+# Copyright (c) 2018-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -18,7 +18,6 @@ import pytest
 import cudf
 import dask_cudf
 import cugraph
-from cugraph.dask.common.mg_utils import is_single_gpu
 from cugraph.testing.utils import RAPIDS_DATASET_ROOT_DIR_PATH
 from cudf.testing import assert_series_equal
 
@@ -41,7 +40,6 @@ DATA_PATH = [
 
 
 @pytest.mark.mg
-@pytest.mark.skipif(is_single_gpu(), reason="skipping MG testing on Single GPU system")
 @pytest.mark.parametrize("directed", IS_DIRECTED)
 @pytest.mark.parametrize("data_file", DATA_PATH)
 def test_dask_mg_degree(dask_client, directed, data_file):


### PR DESCRIPTION
Closes #4171 

This PR fixes a bug where `degree` would return values that are double when creating an undirected MG graph from a symmetric and directed dataset. 