### PR TITLE
Refactor and Fix `test_induced_subgraph_mg`

### DIFF
--- a/python/cugraph/cugraph/community/induced_subgraph.py
+++ b/python/cugraph/cugraph/community/induced_subgraph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -35,7 +35,7 @@ networkx = import_optional("networkx")
 # FIXME: Move this function to the utility module so that it can be
 # shared by other algos
 def ensure_valid_dtype(input_graph: Graph, input: cudf.Series, input_name: str):
-    vertex_dtype = input_graph.edgelist.edgelist_df.dtypes[0]
+    vertex_dtype = input_graph.edgelist.edgelist_df.dtypes.iloc[0]
     input_dtype = input.dtype
     if input_dtype != vertex_dtype:
         warning_msg = (


### PR DESCRIPTION
Addresses [#459](https://github.com/rapidsai/graph_dl/issues/459)

Changes:
 - Updates `cugraph/community/induced_subgraph.py` to use `Series.iloc` to avoid a `DeprecationWarning` when calling the function
 - This PR fixes a bug in `test_mg_induced_subgraph` where it would break when passed an `ndarray` object while trying to construct an MG induced sub-graph. 
 - This unit test has been cleaned up to use the `cugraph.datasets` API to construct SG and MG graph objects, as well as the `sample_random_vertices` function to construct sub-graphs the proper way.

Notes:
 - The `offsets` parameter is not ready for testing yet.
 - There is no one-hop neighbor check in place to verify if the sub-graphs are actually generated correctly.
 - This test will be updates once those are available. 