### PR TITLE
Remove Usage of Experimental Datasets Package

### DIFF
--- a/benchmarks/cugraph/pytest-based/bench_cugraph_uniform_neighbor_sample.py
+++ b/benchmarks/cugraph/pytest-based/bench_cugraph_uniform_neighbor_sample.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ from cugraph import (
     uniform_neighbor_sample,
 )
 from cugraph.generators import rmat
-from cugraph.experimental import datasets
+from cugraph import datasets
 from cugraph.dask import uniform_neighbor_sample as uniform_neighbor_sample_mg
 
 from cugraph_benchmarking import params


### PR DESCRIPTION
This PR addresses one of the nightly benchmark algo failures that was calling the previous (experimental) version of the Datasets API.

Relevant Logs: https://mg-test-results.s3.us-east-2.amazonaws.com/cugraph/20240306_101219_UTC/benchmarks/2-GPU/pytest-results.html