### PR TITLE
Removes (unintentional?) runtime dependency on `packaging` from nx-cugraph

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
         types: [python]
         language: python
         pass_filenames: false
-        additional_dependencies: ["networkx>=3.2", "packaging>=21"]
+        additional_dependencies: ["networkx>=3.2"]
   - repo: local
     hooks:
       - id: nx-cugraph-readme-update
@@ -82,4 +82,4 @@ repos:
         types_or: [python, markdown]
         language: python
         pass_filenames: false
-        additional_dependencies: ["networkx>=3.2", "packaging>=21"]
+        additional_dependencies: ["networkx>=3.2"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
         types: [python]
         language: python
         pass_filenames: false
-        additional_dependencies: ["networkx>=3.2"]
+        additional_dependencies: ["networkx>=3.2", "packaging>=21"]
   - repo: local
     hooks:
       - id: nx-cugraph-readme-update
@@ -82,4 +82,4 @@ repos:
         types_or: [python, markdown]
         language: python
         pass_filenames: false
-        additional_dependencies: ["networkx>=3.2"]
+        additional_dependencies: ["networkx>=3.2", "packaging>=21"]

--- a/python/nx-cugraph/_nx_cugraph/__init__.py
+++ b/python/nx-cugraph/_nx_cugraph/__init__.py
@@ -35,7 +35,7 @@ _info = {
     "backend_name": "cugraph",
     "project": "nx-cugraph",
     "package": "nx_cugraph",
-    "url": f"https://github.com/rapidsai/cugraph/tree/branch-{_version_major:02}.{_version_minor:02}/python/nx-cugraph",
+    "url": f"https://github.com/rapidsai/cugraph/tree/branch-{_version_major:0>2}.{_version_minor:0>2}/python/nx-cugraph",
     "short_summary": "GPU-accelerated backend.",
     # "description": "TODO",
     "functions": {

--- a/python/nx-cugraph/_nx_cugraph/__init__.py
+++ b/python/nx-cugraph/_nx_cugraph/__init__.py
@@ -23,18 +23,19 @@ or
 $ python _nx_cugraph/__init__.py
 """
 
-from packaging.version import Version
-
 from _nx_cugraph._version import __version__
 
-_nx_cugraph_version = Version(__version__)
+# This is normally handled by packaging.version.Version, but instead of adding
+# an additional runtime dependency on "packaging", assume __version__ will
+# always be in <major>.<minor>.<build> format.
+(_version_major, _version_minor) = __version__.split(".")[:2]
 
 # Entries between BEGIN and END are automatically generated
 _info = {
     "backend_name": "cugraph",
     "project": "nx-cugraph",
     "package": "nx_cugraph",
-    "url": f"https://github.com/rapidsai/cugraph/tree/branch-{_nx_cugraph_version.major:02}.{_nx_cugraph_version.minor:02}/python/nx-cugraph",
+    "url": f"https://github.com/rapidsai/cugraph/tree/branch-{_version_major:02}.{_version_minor:02}/python/nx-cugraph",
     "short_summary": "GPU-accelerated backend.",
     # "description": "TODO",
     "functions": {


### PR DESCRIPTION
A [recent PR](https://github.com/rapidsai/cugraph/pull/4217) was merged that added `packaging` as a runtime dependency to nx-cugraph.  This PR removes that dependency and manually extracts the `major` and `minor` version numbers instead.