### PR TITLE
Enable FutureWarnings and Deprecations as errors in cugraph

### DIFF
--- a/python/cugraph/cugraph/community/egonet.py
+++ b/python/cugraph/cugraph/community/egonet.py
@@ -199,10 +199,10 @@ def batched_ego_graphs(G, seeds, radius=1, center=True, undirected=None, distanc
     --------
     >>> from cugraph.datasets import karate
     >>> G = karate.get_graph(download=True)
-    >>> b_ego_graph, offsets = cugraph.batched_ego_graphs(G, seeds=[1,5],
+    >>> b_ego_graph, offsets = cugraph.batched_ego_graphs(G, seeds=[1,5],  # doctest: +SKIP
     ...                                                   radius=2)
 
-    """
+    """  # noqa:E501
     warning_msg = "This function is deprecated. Batched support for multiple vertices \
          will be added to `ego_graph`"
     warnings.warn(warning_msg, DeprecationWarning)

--- a/python/cugraph/cugraph/community/ktruss_subgraph.py
+++ b/python/cugraph/cugraph/community/ktruss_subgraph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -95,11 +95,11 @@ def k_truss(
     G, isNx = ensure_cugraph_obj_for_nx(G)
 
     if isNx is True:
-        k_sub = ktruss_subgraph(G, k)
+        k_sub = ktruss_subgraph(G, k, use_weights=False)
         S = cugraph_to_nx(k_sub)
         return S
     else:
-        return ktruss_subgraph(G, k)
+        return ktruss_subgraph(G, k, use_weights=False)
 
 
 # FIXME: merge this function with k_truss
@@ -174,7 +174,7 @@ def ktruss_subgraph(
     --------
     >>> from cugraph.datasets import karate
     >>> G = karate.get_graph(download=True)
-    >>> k_subgraph = cugraph.ktruss_subgraph(G, 3)
+    >>> k_subgraph = cugraph.ktruss_subgraph(G, 3, use_weights=False)
 
     """
 

--- a/python/cugraph/cugraph/gnn/data_loading/bulk_sampler.py
+++ b/python/cugraph/cugraph/gnn/data_loading/bulk_sampler.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -259,18 +259,24 @@ class BulkSampler:
         start_time_sample_call = time.perf_counter()
 
         # Call uniform neighbor sample
-        output = sample_fn(
-            self.__graph,
-            **self.__sample_call_args,
-            start_list=self.__batches[[self.start_col_name, self.batch_col_name]][
-                batch_id_filter
-            ],
-            with_batch_ids=True,
-            with_edge_properties=True,
-            return_offsets=True,
-            renumber=self.__renumber,
-            # use_legacy_names=False,
-        )
+        with warnings.catch_warnings():
+            # TODO: Address the following uniform_neighbor_sample deprecations
+            # with_edge_properties
+            # include_hop_column
+            # use_legacy_names
+            warnings.simplefilter("ignore", FutureWarning)
+            output = sample_fn(
+                self.__graph,
+                **self.__sample_call_args,
+                start_list=self.__batches[[self.start_col_name, self.batch_col_name]][
+                    batch_id_filter
+                ],
+                with_batch_ids=True,
+                with_edge_properties=True,
+                return_offsets=True,
+                renumber=self.__renumber,
+                # use_legacy_names=False,
+            )
 
         if self.__renumber:
             samples, offsets, renumber_map = output

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -131,7 +131,7 @@ class simpleGraphImpl:
         edge_id=None,
         edge_type=None,
         renumber=True,
-        legacy_renum_only=True,
+        legacy_renum_only=False,
         store_transposed=False,
     ):
         if legacy_renum_only:
@@ -261,14 +261,16 @@ class simpleGraphImpl:
         # will be dropped unless the graph is a MultiGraph(Not Implemented yet)
         # TODO: Update Symmetrize to work on Graph and/or DataFrame
         if edge_attr is not None:
-            source_col, dest_col, value_col = symmetrize(
-                elist,
-                source,
-                destination,
-                edge_attr,
-                multi=self.properties.multi_edge,  # Deprecated parameter
-                symmetrize=not self.properties.directed,
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", "Multi is deprecated", FutureWarning)
+                source_col, dest_col, value_col = symmetrize(
+                    elist,
+                    source,
+                    destination,
+                    edge_attr,
+                    multi=self.properties.multi_edge,  # Deprecated parameter
+                    symmetrize=not self.properties.directed,
+                )
 
             if isinstance(value_col, cudf.DataFrame):
                 value_dict = {}
@@ -277,13 +279,15 @@ class simpleGraphImpl:
                 value_col = value_dict
         else:
             value_col = None
-            source_col, dest_col = symmetrize(
-                elist,
-                source,
-                destination,
-                multi=self.properties.multi_edge,  # Deprecated parameter
-                symmetrize=not self.properties.directed,
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", "Multi is deprecated", FutureWarning)
+                source_col, dest_col = symmetrize(
+                    elist,
+                    source,
+                    destination,
+                    multi=self.properties.multi_edge,  # Deprecated parameter
+                    symmetrize=not self.properties.directed,
+                )
 
         if isinstance(value_col, dict):
             value_col = {

--- a/python/cugraph/cugraph/tests/community/test_k_truss_subgraph.py
+++ b/python/cugraph/cugraph/tests/community/test_k_truss_subgraph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -98,7 +98,7 @@ def test_ktruss_subgraph_Graph(_, nx_ground_truth):
 
     k = 5
     G = polbooks.get_graph(download=True, create_using=cugraph.Graph(directed=False))
-    k_subgraph = cugraph.ktruss_subgraph(G, k)
+    k_subgraph = cugraph.ktruss_subgraph(G, k, use_weights=False)
 
     compare_k_truss(k_subgraph, k, nx_ground_truth)
 

--- a/python/cugraph/cugraph/tests/community/test_subgraph_extraction.py
+++ b/python/cugraph/cugraph/tests/community/test_subgraph_extraction.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -51,7 +51,7 @@ def cugraph_call(M, verts, directed=True):
     G.from_cudf_edgelist(cu_M, source="0", destination="1", edge_attr="weight")
 
     cu_verts = cudf.Series(verts)
-    return cugraph.subgraph(G, cu_verts)
+    return cugraph.induced_subgraph(G, cu_verts)
 
 
 def nx_call(M, verts, directed=True):
@@ -116,7 +116,7 @@ def test_subgraph_extraction_Graph_nx(graph_file):
     nx_sub = nx.subgraph(G, verts)
 
     cu_verts = cudf.Series(verts)
-    cu_sub = cugraph.subgraph(G, cu_verts)
+    cu_sub = cugraph.induced_subgraph(G, cu_verts)
 
     for (u, v) in cu_sub.edges():
         assert nx_sub.has_edge(u, v)
@@ -147,12 +147,12 @@ def test_subgraph_extraction_multi_column(graph_file):
     verts_G1["v_0"] = verts
     verts_G1["v_1"] = verts + 1000
 
-    sG1 = cugraph.subgraph(G1, verts_G1)
+    sG1 = cugraph.induced_subgraph(G1, verts_G1)
 
     G2 = cugraph.Graph()
     G2.from_cudf_edgelist(cu_M, source="src_0", destination="dst_0", edge_attr="weight")
 
-    sG2 = cugraph.subgraph(G2, verts)
+    sG2 = cugraph.induced_subgraph(G2, verts)
 
     # FIXME: Replace with multi-column view_edge_list()
     edgelist_df = sG1.edgelist.edgelist_df
@@ -180,7 +180,7 @@ def test_subgraph_extraction_graph_not_renumbered():
     G.from_cudf_edgelist(
         gdf, source="src", destination="dst", edge_attr="wgt", renumber=False
     )
-    Sg = cugraph.subgraph(G, sverts)
+    Sg = cugraph.induced_subgraph(G, sverts)
 
     assert Sg.number_of_vertices() == 3
     assert Sg.number_of_edges() == 3

--- a/python/cugraph/cugraph/tests/generators/test_rmat.py
+++ b/python/cugraph/cugraph/tests/generators/test_rmat.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -17,7 +17,7 @@ import pytest
 import cudf
 import cugraph
 from cugraph.generators import rmat
-from cupy.sparse import coo_matrix, triu, tril
+from cupyx.scipy.sparse import coo_matrix, triu, tril
 import numpy as np
 import cupy as cp
 

--- a/python/cugraph/cugraph/tests/link_prediction/test_overlap.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_overlap.py
@@ -182,7 +182,9 @@ def test_directed_graph_check(graph_file, use_weight):
 
     vertex_pair = vertex_pair[:5]
     with pytest.raises(ValueError):
-        cugraph.overlap(G1, vertex_pair, use_weight)
+        cugraph.overlap(
+            G1, vertex_pair, do_expensive_check=False, use_weight=use_weight
+        )
 
 
 @pytest.mark.sg

--- a/python/cugraph/cugraph/tests/link_prediction/test_sorensen.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_sorensen.py
@@ -219,7 +219,9 @@ def test_directed_graph_check(read_csv, use_weight):
 
     vertex_pair = vertex_pair[:5]
     with pytest.raises(ValueError):
-        cugraph.sorensen(G1, vertex_pair, use_weight)
+        cugraph.sorensen(
+            G1, vertex_pair, do_expensive_check=False, use_weight=use_weight
+        )
 
 
 @pytest.mark.sg

--- a/python/cugraph/cugraph/tests/sampling/test_egonet.py
+++ b/python/cugraph/cugraph/tests/sampling/test_egonet.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -63,7 +63,8 @@ def test_batched_ego_graphs(graph_file, seeds, radius):
     )
 
     # cugraph
-    df, offsets = cugraph.batched_ego_graphs(Gnx, seeds, radius=radius)
+    with pytest.warns(DeprecationWarning):
+        df, offsets = cugraph.batched_ego_graphs(Gnx, seeds, radius=radius)
     for i in range(len(seeds)):
         ego_nx = nx.ego_graph(Gnx, seeds[i], radius=radius)
         ego_df = df[offsets[i] : offsets[i + 1]]

--- a/python/cugraph/cugraph/tests/utils/test_utils_mg.py
+++ b/python/cugraph/cugraph/tests/utils/test_utils_mg.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023, NVIDIA CORPORATION.
+# Copyright (c) 2018-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -50,7 +50,7 @@ def test_from_edgelist(dask_client, directed):
     chunksize = dcg.get_chunksize(input_data_path)
     ddf = dask_cudf.read_csv(
         input_data_path,
-        chunksize=chunksize,
+        blocksize=chunksize,
         delimiter=" ",
         names=["src", "dst", "value"],
         dtype=["int32", "int32", "float32"],

--- a/python/cugraph/pytest.ini
+++ b/python/cugraph/pytest.ini
@@ -59,5 +59,7 @@ python_functions =
 
 filterwarnings =
           error:::cudf
+          error::FutureWarning
+          error::DeprecationWarning
           # Called via dask. Not obviously addressable in cugraph.
           ignore:The behavior of array concatenation with empty entries is deprecated:FutureWarning:cudf


### PR DESCRIPTION
Follow up to https://github.com/rapidsai/cugraph/pull/4223 and https://github.com/rapidsai/build-planning/issues/26, cugraph tests will fail if a `FutureWarning` or `DeprecationWarning` is raised