### PR TITLE
WIP: Prevent path conflict in builds

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -16,6 +16,7 @@ rapids-print-env
 version=$(rapids-generate-version)
 
 rapids-logger "Begin cpp build"
+conda config --set path_conflict prevent
 
 RAPIDS_PACKAGE_VERSION=${version} rapids-conda-retry mambabuild conda/recipes/libcugraph
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -29,6 +29,7 @@ for package_name in pylibcugraph cugraph cugraph-pyg cugraph-dgl; do
 done
 sed -i "/^__git_commit__/ s/= .*/= \"${git_commit}\"/g" "${package_dir}/nx-cugraph/_nx_cugraph/_version.py"
 
+conda config --set path_conflict prevent
 # TODO: Remove `--no-test` flags once importing on a CPU
 # node works correctly
 rapids-conda-retry mambabuild \


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/54

This will make builds fail when there are path conflicts
