### PR TITLE
fix PyPI URL in docs

### DIFF
--- a/docs/cugraph/source/installation/getting_cugraph.md
+++ b/docs/cugraph/source/installation/getting_cugraph.md
@@ -53,7 +53,7 @@ Note: This conda installation only applies to Linux and Python versions 3.9/3.10
 cuGraph, and all of RAPIDS, is available via pip.
 
 ```
-pip install cugraph-cu12 --extra-index-url=https://pypi.ngc.nvidia.com
+pip install cugraph-cu12 --extra-index-url=https://pypi.nvidia.com
 ```
 
 Replace `-cu12` with `-cu11` for packages supporting CUDA 11.


### PR DESCRIPTION
`https://pypi.ngc.nvidia.com` was retired a while ago, and RAPIDS wheels are now available from `https://pypi.nvidia.com` (see https://docs.rapids.ai/install).

This proposes removing one lingering reference to `pypi.ngc.nvidia.com` left over in this project's docs.

### How I tested this

```shell
docker run \
   --rm \
   python:3.10 \
   pip install --dry-run cugraph-cu12 --extra-index-url=https://pypi.nvidia.com
```

saw the expected output

```text
Collecting cugraph-cu12
  Downloading https://pypi.nvidia.com/cugraph-cu12/cugraph_cu12-24.2.0-cp310-cp310-manylinux_2_28_aarch64.whl (1318.6 MB)
```

This is the only use of that `ngc.nvidia.com` URL in this project.

```shell
git grep -E 'ngc\.'
```