### PR TITLE
Fix CI issue in building docs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -84,7 +84,6 @@ jobs:
       container_image: "rapidsai/ci-conda:cuda11.8.0-ubuntu22.04-py3.10"
       run_script: "ci/test_notebooks.sh"
   docs-build:
-    needs: conda-python-build
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.06
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -84,6 +84,7 @@ jobs:
       container_image: "rapidsai/ci-conda:cuda11.8.0-ubuntu22.04-py3.10"
       run_script: "ci/test_notebooks.sh"
   docs-build:
+    needs: conda-python-build
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.06
     with:

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -14,10 +14,6 @@ rapids-dependency-file-generator \
 rapids-mamba-retry env create --yes -f env.yaml -n docs
 conda activate docs
 
-rapids-logger "Installing PyTorch wheel"
-PYTORCH_URL="https://download.pytorch.org/whl/cu118"
-rapids-retry python -m pip install torch==2.1.0 --index-url ${PYTORCH_URL}
-
 rapids-print-env
 
 rapids-logger "Downloading artifacts from previous jobs"
@@ -27,6 +23,12 @@ PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
   --channel "${PYTHON_CHANNEL}" \
+  --channel pytorch \
+  --channel pyg \
+  --channel nvidia \
+  pytorch=2.0.0 \
+  pytorch-cuda=11.8 \
+  pyg=*=*cu* \
   libcugraph \
   pylibcugraph \
   cugraph \

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -26,7 +26,7 @@ rapids-mamba-retry install \
   --channel pytorch \
   --channel pyg \
   --channel nvidia \
-  mkl<2024.1.0 \
+  'mkl<2024.1.0' \
   pytorch=2.0.0 \
   pytorch-cuda=11.8 \
   pyg=*=*cu* \

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -14,6 +14,10 @@ rapids-dependency-file-generator \
 rapids-mamba-retry env create --yes -f env.yaml -n docs
 conda activate docs
 
+rapids-logger "Installing PyTorch wheel"
+PYTORCH_URL="https://download.pytorch.org/whl/cu118"
+rapids-retry python -m pip install torch==2.1.0 --index-url ${PYTORCH_URL}
+
 rapids-print-env
 
 rapids-logger "Downloading artifacts from previous jobs"

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -26,6 +26,7 @@ rapids-mamba-retry install \
   --channel pytorch \
   --channel pyg \
   --channel nvidia \
+  mkl<2024.1.0 \
   pytorch=2.0.0 \
   pytorch-cuda=11.8 \
   pyg=*=*cu* \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -155,9 +155,9 @@ if [[ "${RAPIDS_CUDA_VERSION}" == "11.8.0" ]]; then
       --channel "${CPP_CHANNEL}" \
       --channel "${PYTHON_CHANNEL}" \
       --channel pytorch \
-      --channel pytorch-nightly \
       --channel dglteam/label/cu118 \
       --channel nvidia \
+      mkl<2024.1.0 \
       libcugraph \
       pylibcugraph \
       pylibcugraphops \
@@ -165,7 +165,7 @@ if [[ "${RAPIDS_CUDA_VERSION}" == "11.8.0" ]]; then
       cugraph-dgl \
       'dgl>=1.1.0.cu*,<=2.0.0.cu*' \
       'pytorch>=2.0' \
-      'pytorch-cuda>=11.8'
+      'pytorch-cuda=11.8'
 
     rapids-print-env
 
@@ -206,6 +206,7 @@ if [[ "${RAPIDS_CUDA_VERSION}" == "11.8.0" ]]; then
       --channel nvidia \
       --channel pyg \
       --channel rapidsai-nightly \
+      mkl<2024.1.0 \
       "cugraph-pyg" \
       "pytorch>=2.0,<2.1" \
       "pytorch-cuda=11.8"

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -206,7 +206,7 @@ if [[ "${RAPIDS_CUDA_VERSION}" == "11.8.0" ]]; then
       --channel nvidia \
       --channel pyg \
       --channel rapidsai-nightly \
-      mkl<2024.1.0 \
+      "mkl<2024.1.0" \
       "cugraph-pyg" \
       "pytorch>=2.0,<2.1" \
       "pytorch-cuda=11.8"

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -157,7 +157,7 @@ if [[ "${RAPIDS_CUDA_VERSION}" == "11.8.0" ]]; then
       --channel pytorch \
       --channel dglteam/label/cu118 \
       --channel nvidia \
-      mkl<2024.1.0 \
+      'mkl<2024.1.0' \
       libcugraph \
       pylibcugraph \
       pylibcugraphops \


### PR DESCRIPTION
`mkl=2024.1.0` breaks `pytorch` with the following error:
```
/__w/cugraph/cugraph/docs/cugraph /__w/cugraph/cugraph
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/conda/envs/docs/lib/python3.10/site-packages/cugraph/__init__.py", line 111, in <module>
    from cugraph import experimental
  File "/opt/conda/envs/docs/lib/python3.10/site-packages/cugraph/experimental/__init__.py", line 49, in <module>
    from cugraph.gnn.data_loading import BulkSampler
  File "/opt/conda/envs/docs/lib/python3.10/site-packages/cugraph/gnn/__init__.py", line 14, in <module>
    from .feature_storage.feat_storage import FeatureStore
  File "/opt/conda/envs/docs/lib/python3.10/site-packages/cugraph/gnn/feature_storage/feat_storage.py", line 22, in <module>
    torch = import_optional("torch")
  File "/opt/conda/envs/docs/lib/python3.10/site-packages/cugraph/utilities/utils.py", line 455, in import_optional
    return importlib.import_module(mod)
  File "/opt/conda/envs/docs/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/opt/conda/envs/docs/lib/python3.10/site-packages/torch/__init__.py", line 202, in <module>
    from torch._C import *  # noqa: F403
ImportError: /opt/conda/envs/docs/lib/python3.10/site-packages/torch/lib/libtorch_cpu.so: undefined symbol: iJIT_NotifyEvent
```
The same issue also reported [here](https://github.com/pytorch/pytorch/issues/123097) in PyTorch repo. 
This PR constrains `mkl<2024.1.0` in the test scripts where pytorch is required.