### PR TITLE
Add missing `<optional>` include

### DIFF
--- a/cpp/tests/centrality/betweenness_centrality_reference.hpp
+++ b/cpp/tests/centrality/betweenness_centrality_reference.hpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include <limits>
+#include <optional>
 #include <queue>
 #include <stack>
 #include <vector>


### PR DESCRIPTION
This PR fixes the [build error](https://github.com/rapidsai/cugraph/actions/runs/8713790822/job/23902856859?pr=4352#step:7:6141) in the pip devcontainers.