### PR TITLE
Migrate to `{{ stdlib("c") }}`

### DIFF
--- a/conda/recipes/cugraph-pyg/conda_build_config.yaml
+++ b/conda/recipes/cugraph-pyg/conda_build_config.yaml
@@ -12,5 +12,8 @@ cuda_compiler:
 cmake_version:
   - ">=3.26.4"
 
+c_stdlib:
+  - sysroot
+
 c_stdlib_version:
   - "2.17"

--- a/conda/recipes/cugraph-pyg/conda_build_config.yaml
+++ b/conda/recipes/cugraph-pyg/conda_build_config.yaml
@@ -12,5 +12,5 @@ cuda_compiler:
 cmake_version:
   - ">=3.26.4"
 
-sysroot_version:
+c_stdlib_version:
   - "2.17"

--- a/conda/recipes/cugraph-pyg/meta.yaml
+++ b/conda/recipes/cugraph-pyg/meta.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   build:
-    - sysroot_{{ target_platform }} {{ sysroot_version }}
+    - {{ stdlib("c") }}
   host:
     - cython >=3.0.0
     - python

--- a/conda/recipes/cugraph/conda_build_config.yaml
+++ b/conda/recipes/cugraph/conda_build_config.yaml
@@ -13,7 +13,7 @@ cuda11_compiler:
 cmake_version:
   - ">=3.26.4"
 
-sysroot_version:
+c_stdlib_version:
   - "2.17"
 
 ucx_py_version:

--- a/conda/recipes/cugraph/conda_build_config.yaml
+++ b/conda/recipes/cugraph/conda_build_config.yaml
@@ -13,6 +13,9 @@ cuda11_compiler:
 cmake_version:
   - ">=3.26.4"
 
+c_stdlib:
+  - sysroot
+
 c_stdlib_version:
   - "2.17"
 

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -53,7 +53,7 @@ requirements:
     - cuda-version ={{ cuda_version }}
     - cmake {{ cmake_version }}
     - ninja
-    - sysroot_{{ target_platform }} {{ sysroot_version }}
+    - {{ stdlib("c") }}
   host:
     - cuda-version ={{ cuda_version }}
     {% if cuda_major == "11" %}

--- a/conda/recipes/libcugraph/conda_build_config.yaml
+++ b/conda/recipes/libcugraph/conda_build_config.yaml
@@ -19,6 +19,9 @@ doxygen_version:
 nccl_version:
   - ">=2.9.9"
 
+c_stdlib:
+  - sysroot
+
 c_stdlib_version:
   - "2.17"
 

--- a/conda/recipes/libcugraph/conda_build_config.yaml
+++ b/conda/recipes/libcugraph/conda_build_config.yaml
@@ -19,7 +19,7 @@ doxygen_version:
 nccl_version:
   - ">=2.9.9"
 
-sysroot_version:
+c_stdlib_version:
   - "2.17"
 
 # The CTK libraries below are missing from the conda-forge::cudatoolkit

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - cmake {{ cmake_version }}
     - ninja
     - openmpi # Required for building cpp-mgtests (multi-GPU tests)
-    - sysroot_{{ target_platform }} {{ sysroot_version }}
+    - {{ stdlib("c") }}
   host:
     {% if cuda_major == "11" %}
     - cudatoolkit

--- a/conda/recipes/pylibcugraph/conda_build_config.yaml
+++ b/conda/recipes/pylibcugraph/conda_build_config.yaml
@@ -13,7 +13,7 @@ cuda11_compiler:
 cmake_version:
   - ">=3.26.4"
 
-sysroot_version:
+c_stdlib_version:
   - "2.17"
 
 ucx_py_version:

--- a/conda/recipes/pylibcugraph/conda_build_config.yaml
+++ b/conda/recipes/pylibcugraph/conda_build_config.yaml
@@ -13,6 +13,9 @@ cuda11_compiler:
 cmake_version:
   - ">=3.26.4"
 
+c_stdlib:
+  - sysroot
+
 c_stdlib_version:
   - "2.17"
 

--- a/conda/recipes/pylibcugraph/meta.yaml
+++ b/conda/recipes/pylibcugraph/meta.yaml
@@ -53,7 +53,7 @@ requirements:
     - cuda-version ={{ cuda_version }}
     - cmake {{ cmake_version }}
     - ninja
-    - sysroot_{{ target_platform }} {{ sysroot_version }}
+    - {{ stdlib("c") }}
   host:
     - cuda-version ={{ cuda_version }}
     {% if cuda_major == "11" %}


### PR DESCRIPTION
The `sysroot*` syntax is getting phased out (conda-forge/conda-forge.github.io#2102).
The recommendation is to move to `{{ stdlib("c") }}`.

Ref https://github.com/rapidsai/build-planning/issues/39
