### PR TITLE
Fix bad Leiden result

### DIFF
--- a/cpp/src/community/leiden_impl.cuh
+++ b/cpp/src/community/leiden_impl.cuh
@@ -561,6 +561,13 @@ std::pair<std::unique_ptr<Dendrogram<vertex_t>>, weight_t> leiden(
           louvain_of_refined_graph.size(),
           false);
       }
+    } else {
+      // Reset dendrogram.
+      //    FIXME: Revisit how dendrogram is populated
+      detail::sequence_fill(handle.get_stream(),
+                            dendrogram->current_level_begin(),
+                            dendrogram->current_level_size(),
+                            current_graph_view.local_vertex_partition_range_first());
     }
 
     copied_louvain_partition.resize(0, handle.get_stream());


### PR DESCRIPTION
Once the termination criteria is met, the last level of the dendrogram contains a partitioning that reduces the overall modularity.  This update overwrites the final dendrogram level with a k to k mapping. 

This bug had a consequence of the numbering of the flattened Leiden partitions being non-consecutive integers.  This should now be resolved.

Closes #4368