### PR TITLE
Skip/adjust doctests for deprecations

### DIFF
--- a/python/cugraph/cugraph/community/egonet.py
+++ b/python/cugraph/cugraph/community/egonet.py
@@ -199,9 +199,7 @@ def batched_ego_graphs(G, seeds, radius=1, center=True, undirected=None, distanc
     --------
     >>> from cugraph.datasets import karate
     >>> G = karate.get_graph(download=True)
-    >>> b_ego_graph, offsets = cugraph.batched_ego_graphs(G, seeds=[1,5],
-    ...                                                   radius=2)
-
+    >>> cugraph.batched_ego_graphs(G, seeds=[1,5], radius=2)  # doctest: +SKIP
     """
     warning_msg = "This function is deprecated. Batched support for multiple vertices \
          will be added to `ego_graph`"

--- a/python/cugraph/cugraph/community/ktruss_subgraph.py
+++ b/python/cugraph/cugraph/community/ktruss_subgraph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -174,8 +174,7 @@ def ktruss_subgraph(
     --------
     >>> from cugraph.datasets import karate
     >>> G = karate.get_graph(download=True)
-    >>> k_subgraph = cugraph.ktruss_subgraph(G, 3)
-
+    >>> k_subgraph = cugraph.ktruss_subgraph(G, 3, use_weights=False)
     """
 
     _ensure_compatible_cuda_version()

--- a/python/cugraph/cugraph/community/subgraph_extraction.py
+++ b/python/cugraph/cugraph/community/subgraph_extraction.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -64,8 +64,7 @@ def subgraph(
     >>> verts[1] = 1
     >>> verts[2] = 2
     >>> sverts = cudf.Series(verts)
-    >>> Sg = cugraph.subgraph(G, sverts)
-
+    >>> Sg = cugraph.subgraph(G, sverts)  # doctest: +SKIP
     """
 
     warning_msg = (

--- a/python/cugraph/cugraph/structure/symmetrize.py
+++ b/python/cugraph/cugraph/structure/symmetrize.py
@@ -73,8 +73,7 @@ def symmetrize_df(
     >>> # Download dataset from https://github.com/rapidsai/cugraph/datasets/..
     >>> M = cudf.read_csv(datasets_path / 'karate.csv', delimiter=' ',
     ...                   dtype=['int32', 'int32', 'float32'], header=None)
-    >>> sym_df = symmetrize_df(M, '0', '1')
-
+    >>> sym_df = symmetrize_df(M, '0', '1', multi=True)
     """
     if not isinstance(src_name, list):
         src_name = [src_name]
@@ -256,8 +255,7 @@ def symmetrize(
     >>> df['sources'] = cudf.Series(M['0'])
     >>> df['destinations'] = cudf.Series(M['1'])
     >>> df['values'] = cudf.Series(M['2'])
-    >>> src, dst, val = symmetrize(df, 'sources', 'destinations', 'values')
-
+    >>> src, dst, val = symmetrize(df, 'sources', 'destinations', 'values', multi=True)
     """
 
     # FIXME: Redundant check that should be done at the graph creation


### PR DESCRIPTION
xref https://github.com/rapidsai/cugraph/pull/4271

For methods/parameters that are deprecated, ensures the doctests will pass if `FutureWarning` or `DeprecationWarning` are made as errors