### PR TITLE
Adjust deprecated cugraph.subgraph usage in Python tests

### DIFF
--- a/python/cugraph/cugraph/tests/community/test_subgraph_extraction.py
+++ b/python/cugraph/cugraph/tests/community/test_subgraph_extraction.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -51,7 +51,7 @@ def cugraph_call(M, verts, directed=True):
     G.from_cudf_edgelist(cu_M, source="0", destination="1", edge_attr="weight")
 
     cu_verts = cudf.Series(verts)
-    return cugraph.subgraph(G, cu_verts)
+    return cugraph.induced_subgraph(G, cu_verts)
 
 
 def nx_call(M, verts, directed=True):
@@ -74,7 +74,7 @@ def test_subgraph_extraction_DiGraph(graph_file):
     verts[0] = 0
     verts[1] = 1
     verts[2] = 17
-    cu_sg = cugraph_call(M, verts, True)
+    cu_sg = cugraph_call(M, verts, True)[0]
     nx_sg = nx_call(M, verts, True)
     assert compare_edges(cu_sg, nx_sg)
 
@@ -88,7 +88,7 @@ def test_subgraph_extraction_Graph(graph_file):
     verts[0] = 0
     verts[1] = 1
     verts[2] = 17
-    cu_sg = cugraph_call(M, verts, False)
+    cu_sg = cugraph_call(M, verts, False)[0]
     nx_sg = nx_call(M, verts, False)
     assert compare_edges(cu_sg, nx_sg)
 
@@ -116,7 +116,7 @@ def test_subgraph_extraction_Graph_nx(graph_file):
     nx_sub = nx.subgraph(G, verts)
 
     cu_verts = cudf.Series(verts)
-    cu_sub = cugraph.subgraph(G, cu_verts)
+    cu_sub = cugraph.induced_subgraph(G, cu_verts)
 
     for (u, v) in cu_sub.edges():
         assert nx_sub.has_edge(u, v)
@@ -147,19 +147,19 @@ def test_subgraph_extraction_multi_column(graph_file):
     verts_G1["v_0"] = verts
     verts_G1["v_1"] = verts + 1000
 
-    sG1 = cugraph.subgraph(G1, verts_G1)
+    sG1 = cugraph.induced_subgraph(G1, verts_G1)
 
     G2 = cugraph.Graph()
     G2.from_cudf_edgelist(cu_M, source="src_0", destination="dst_0", edge_attr="weight")
 
-    sG2 = cugraph.subgraph(G2, verts)
+    sG2 = cugraph.induced_subgraph(G2, verts)
 
     # FIXME: Replace with multi-column view_edge_list()
-    edgelist_df = sG1.edgelist.edgelist_df
-    edgelist_df_res = sG1.unrenumber(edgelist_df, "src")
-    edgelist_df_res = sG1.unrenumber(edgelist_df_res, "dst")
+    edgelist_df = sG1[0].edgelist.edgelist_df
+    edgelist_df_res = sG1[0].unrenumber(edgelist_df, "src")
+    edgelist_df_res = sG1[0].unrenumber(edgelist_df_res, "dst")
     for i in range(len(edgelist_df_res)):
-        assert sG2.has_edge(
+        assert sG2[0].has_edge(
             edgelist_df_res["0_src"].iloc[i], edgelist_df_res["0_dst"].iloc[i]
         )
 
@@ -180,7 +180,7 @@ def test_subgraph_extraction_graph_not_renumbered():
     G.from_cudf_edgelist(
         gdf, source="src", destination="dst", edge_attr="wgt", renumber=False
     )
-    Sg = cugraph.subgraph(G, sverts)
+    Sg = cugraph.induced_subgraph(G, sverts)
 
     assert Sg.number_of_vertices() == 3
     assert Sg.number_of_edges() == 3

--- a/python/cugraph/cugraph/tests/community/test_subgraph_extraction.py
+++ b/python/cugraph/cugraph/tests/community/test_subgraph_extraction.py
@@ -116,7 +116,7 @@ def test_subgraph_extraction_Graph_nx(graph_file):
     nx_sub = nx.subgraph(G, verts)
 
     cu_verts = cudf.Series(verts)
-    cu_sub = cugraph.induced_subgraph(G, cu_verts)
+    cu_sub = cugraph.induced_subgraph(G, cu_verts)[0]
 
     for (u, v) in cu_sub.edges():
         assert nx_sub.has_edge(u, v)


### PR DESCRIPTION
Broken off from https://github.com/rapidsai/cugraph/pull/4271

Appears this was deprecated in favor of `induced_subgraph`