### PR TITLE
Address deprecated summetrize_df(multi=False) calls in Python tests

### DIFF
--- a/python/cugraph/cugraph/tests/core/test_k_core_mg.py
+++ b/python/cugraph/cugraph/tests/core/test_k_core_mg.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -87,7 +87,7 @@ def input_expected_output(dask_client, input_combo):
     dstCol = sg_k_core_graph.destination_columns
     wgtCol = sg_k_core_graph.weight_column
     sg_k_core_results = (
-        symmetrize_df(sg_k_core_results, srcCol, dstCol, wgtCol)
+        symmetrize_df(sg_k_core_results, srcCol, dstCol, wgtCol, multi=True)
         .sort_values([srcCol, dstCol])
         .reset_index(drop=True)
     )

--- a/python/cugraph/cugraph/tests/internals/test_symmetrize_mg.py
+++ b/python/cugraph/cugraph/tests/internals/test_symmetrize_mg.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -252,6 +252,8 @@ def test_mg_symmetrize_df(dask_client, read_datasets):
     dst_col_name = read_datasets["dst_col_name"]
     val_col_name = read_datasets["val_col_name"]
 
-    sym_ddf = cugraph.symmetrize_ddf(ddf, src_col_name, dst_col_name, val_col_name)
+    sym_ddf = cugraph.symmetrize_ddf(
+        ddf, src_col_name, dst_col_name, val_col_name, multi=True
+    )
 
     compare(ddf, sym_ddf, src_col_name, dst_col_name, val_col_name)


### PR DESCRIPTION
Broken off from https://github.com/rapidsai/cugraph/pull/4271

Deprecated in favor of `multi=True` being the default