### PR TITLE
Address PendingDeprecationWarning from _from_edgelist

### DIFF
--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -131,7 +131,7 @@ class simpleGraphImpl:
         edge_id=None,
         edge_type=None,
         renumber=True,
-        legacy_renum_only=True,
+        legacy_renum_only=False,
         store_transposed=False,
     ):
         if legacy_renum_only:


### PR DESCRIPTION
`__from_edgelist`'s default is causing a `PendingDeprecationWarning` from having a default of `legacy_renum_only=True`.

It appears that this parameter has no effect so it should be OK to change the default so that this warning doesn't appear