### PR TITLE
Address do_expensive_check FutureWarnings in Python tests

### DIFF
--- a/python/cugraph/cugraph/tests/link_prediction/test_overlap.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_overlap.py
@@ -182,7 +182,9 @@ def test_directed_graph_check(graph_file, use_weight):
 
     vertex_pair = vertex_pair[:5]
     with pytest.raises(ValueError):
-        cugraph.overlap(G1, vertex_pair, use_weight, do_expensive_check=False)
+        cugraph.overlap(
+            G1, vertex_pair, do_expensive_check=False, use_weight=use_weight
+        )
 
 
 @pytest.mark.sg

--- a/python/cugraph/cugraph/tests/link_prediction/test_overlap.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_overlap.py
@@ -182,7 +182,7 @@ def test_directed_graph_check(graph_file, use_weight):
 
     vertex_pair = vertex_pair[:5]
     with pytest.raises(ValueError):
-        cugraph.overlap(G1, vertex_pair, use_weight)
+        cugraph.overlap(G1, vertex_pair, use_weight, do_expensive_check=False)
 
 
 @pytest.mark.sg

--- a/python/cugraph/cugraph/tests/link_prediction/test_sorensen.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_sorensen.py
@@ -219,7 +219,9 @@ def test_directed_graph_check(read_csv, use_weight):
 
     vertex_pair = vertex_pair[:5]
     with pytest.raises(ValueError):
-        cugraph.sorensen(G1, vertex_pair, use_weight, do_expensive_check=False)
+        cugraph.sorensen(
+            G1, vertex_pair, do_expensive_check=False, use_weight=use_weight
+        )
 
 
 @pytest.mark.sg

--- a/python/cugraph/cugraph/tests/link_prediction/test_sorensen.py
+++ b/python/cugraph/cugraph/tests/link_prediction/test_sorensen.py
@@ -219,7 +219,7 @@ def test_directed_graph_check(read_csv, use_weight):
 
     vertex_pair = vertex_pair[:5]
     with pytest.raises(ValueError):
-        cugraph.sorensen(G1, vertex_pair, use_weight)
+        cugraph.sorensen(G1, vertex_pair, use_weight, do_expensive_check=False)
 
 
 @pytest.mark.sg


### PR DESCRIPTION
Looks like this parameter has no effect in `sorensen` and `overlap` so it should test equivalent behavior to set to `False` and avoid the `FutureWarning` 