### PR TITLE
Remove unused benchmark fixture in test_dask_mg_random_walks

### DIFF
--- a/python/cugraph/cugraph/tests/sampling/test_random_walks_mg.py
+++ b/python/cugraph/cugraph/tests/sampling/test_random_walks_mg.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -202,7 +202,7 @@ def input_graph(request):
 
 @pytest.mark.mg
 @pytest.mark.cugraph_ops
-def test_dask_mg_random_walks(dask_client, benchmark, input_graph):
+def test_dask_mg_random_walks(dask_client, input_graph):
     path_data, seeds, max_depth = calc_random_walks(input_graph)
     df_G = input_graph.input_df.compute().reset_index(drop=True)
     check_random_walks(input_graph, path_data, seeds, max_depth, df_G)


### PR DESCRIPTION
Removes an easy `PytestBenchmarkWarning` from the tests