### PR TITLE
Updates SG `PropertyGraph` and `cugraph-service` to apply `DataFrame.fillna()` based on latest cuDF changes

### DIFF
--- a/python/cugraph-service/server/cugraph_service_server/testing/benchmark_server_extension.py
+++ b/python/cugraph-service/server/cugraph_service_server/testing/benchmark_server_extension.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,12 +25,12 @@ from cugraph.generators import rmat
 def create_graph_from_builtin_dataset(dataset_name, mg=False, server=None):
     dataset_obj = getattr(datasets, dataset_name)
     # FIXME: create an MG graph if server is mg?
-    return dataset_obj.get_graph(fetch=True)
+    return dataset_obj.get_graph(download=True)
 
 
 def create_property_graph_from_builtin_dataset(dataset_name, mg=False, server=None):
     dataset_obj = getattr(datasets, dataset_name)
-    edgelist_df = dataset_obj.get_edgelist(fetch=True)
+    edgelist_df = dataset_obj.get_edgelist(download=True)
 
     if mg and (server is not None) and server.is_multi_gpu:
         G = MGPropertyGraph()

--- a/python/cugraph/cugraph/structure/property_graph.py
+++ b/python/cugraph/cugraph/structure/property_graph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -122,6 +122,17 @@ class EXPERIMENTAL__PropertyGraph:
     """
 
     _default_type_name = ""
+
+    _internal_col_names = set(
+        (
+            vertex_col_name,
+            src_col_name,
+            dst_col_name,
+            type_col_name,
+            edge_id_col_name,
+            weight_col_name,
+        )
+    )
 
     def __init__(self):
         # The dataframe containing the properties for each vertex.
@@ -1380,6 +1391,15 @@ class EXPERIMENTAL__PropertyGraph:
             Series is passed, the index or keys are the columns to fill
             and the values are the fill value for the corresponding column.
         """
+        # Omit internal columns if an object is passed in to be applied to the
+        # entire DataFrame and assume the intent is for users to fillna only on
+        # their data.
+        if type(val) not in [dict, self.__series_type]:
+            user_col_names = (
+                set(self.__vertex_prop_dataframe.columns) - self._internal_col_names
+            )
+            val = dict((k, val) for k in user_col_names)
+
         self.__vertex_prop_dataframe.fillna(val, inplace=True)
 
     def fillna_edges(self, val=0):
@@ -1394,6 +1414,14 @@ class EXPERIMENTAL__PropertyGraph:
             Series is passed, the index or keys are the columns to fill
             and the values are the fill value for the corresponding column.
         """
+        # Omit internal columns if an object is passed in to be applied to the
+        # entire DataFrame and assume the intent is for users to fillna only on
+        # their data.
+        if type(val) not in [dict, self.__series_type]:
+            user_col_names = (
+                set(self.__edge_prop_dataframe.columns) - self._internal_col_names
+            )
+            val = dict((k, val) for k in user_col_names)
 
         self.__edge_prop_dataframe.fillna(val, inplace=True)
 


### PR DESCRIPTION
This handles a [recent cuDF change](https://github.com/rapidsai/cudf/pull/15683) by applying non-dict and non-Series values for a `fillna()` call on `PropertyGraph` instances only to the user-defined columns, with the assumption that savvy users that intend to update the "internal" columns, or users that are aware of their own categorical dtype columns, will use a dict or Series value to properly apply dtypes as needed.

This also updates code in `cugraph-service` that serializes dataframes to numpy bytes to properly convert NA values when categoricals are present.

Notes:
* This is only applied to the SG `PropertyGraph` class.  The MG class needs further review as to how to best apply the same policy (and because there are other MG failing tests that need addressed).  Since this is blocking CI for the SG case only, this PR is being submitted now and MG will be addressed later, which should be okay since `PropertyGraph` is experimental.
* This could be considered a breaking change if `PropertyGraph` was not experimental.