### PR TITLE
Update doxygen comments to specify in,out instead of in/out

### DIFF
--- a/cpp/include/cugraph/detail/shuffle_wrappers.hpp
+++ b/cpp/include/cugraph/detail/shuffle_wrappers.hpp
@@ -213,12 +213,12 @@ shuffle_int_vertex_value_pairs_to_local_gpu_by_vertex_partitioning(
  *
  * @param[in] handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator,
  * and handles to various CUDA libraries) to run graph algorithms.
- * @param[in/out] d_edgelist_majors Vertex IDs for sources (if we are internally storing edges in
+ * @param[in,out] d_edgelist_majors Vertex IDs for sources (if we are internally storing edges in
  * the sparse 2D matrix using sources as major indices) or destinations (otherwise)
- * @param[in/out] d_edgelist_minors Vertex IDs for destinations (if we are internally storing edges
+ * @param[in,out] d_edgelist_minors Vertex IDs for destinations (if we are internally storing edges
  * in the sparse 2D matrix using sources as major indices) or sources (otherwise)
- * @param[in/out] d_edgelist_weights Optional edge weights
- * @param[in/out] d_edgelist_id_type_pairs Optional edge (ID, type) pairs
+ * @param[in,out] d_edgelist_weights Optional edge weights
+ * @param[in,out] d_edgelist_id_type_pairs Optional edge (ID, type) pairs
  * @param[in] groupby_and_count_local_partition_by_minor If set to true, groupby and count edges
  * based on (local partition ID, GPU ID) pairs (where GPU IDs are computed by applying the
  * compute_gpu_id_from_vertex_t function to the minor vertex ID). If set to false, groupby and count

--- a/cpp/include/cugraph_c/community_algorithms.h
+++ b/cpp/include/cugraph_c/community_algorithms.h
@@ -121,7 +121,7 @@ cugraph_error_code_t cugraph_louvain(const cugraph_resource_handle_t* handle,
  * @param [in]  handle       Handle for accessing resources
  * @param [in]  graph        Pointer to graph.  NOTE: Graph might be modified if the storage
  *                           needs to be transposed
- * @param [in/out] rng_state State of the random number generator, updated with each call
+ * @param [in,out] rng_state State of the random number generator, updated with each call
  * @param [in]  max_level    Maximum level in hierarchy
  * @param [in]  resolution   Resolution parameter (gamma) in modularity formula.
  *                           This changes the size of the communities.  Higher resolutions
@@ -181,7 +181,7 @@ void cugraph_hierarchical_clustering_result_free(cugraph_hierarchical_clustering
  * @brief     Compute ECG clustering
  *
  * @param [in]  handle        Handle for accessing resources
- * @param [in/out] rng_state  State of the random number generator, updated with each call
+ * @param [in,out] rng_state  State of the random number generator, updated with each call
  * @param [in]  graph         Pointer to graph.  NOTE: Graph might be modified if the storage
  *                            needs to be transposed
  * @param [in]  min_weight    Minimum edge weight in final graph

--- a/cpp/include/cugraph_c/graph_generators.h
+++ b/cpp/include/cugraph_c/graph_generators.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ void cugraph_coo_list_free(cugraph_coo_list_t* coo_list);
  * Vertex types will be int32 if scale < 32 and int64 if scale >= 32
  *
  * @param [in]     handle             Handle for accessing resources
- * @param [in/out] rng_state          State of the random number generator, updated with each call
+ * @param [in,out] rng_state          State of the random number generator, updated with each call
  * @param [in]     scale Scale factor to set the number of vertices in the graph. Vertex IDs have
  * values in [0, V), where V = 1 << @p scale.
  * @param [in]     num_edges          Number of edges to generate.
@@ -164,7 +164,7 @@ cugraph_error_code_t cugraph_generate_rmat_edgelist(const cugraph_resource_handl
  * Vertex types will be int32 if scale < 32 and int64 if scale >= 32
  *
  * @param [in]     handle             Handle for accessing resources
- * @param [in/out] rng_state          State of the random number generator, updated with each call
+ * @param [in,out] rng_state          State of the random number generator, updated with each call
  * @param [in]     n_edgelists Number of edge lists (graphs) to generate
  * @param [in]     min_scale Scale factor to set the minimum number of verties in the graph.
  * @param [in]     max_scale Scale factor to set the maximum number of verties in the graph.
@@ -204,8 +204,8 @@ cugraph_error_code_t cugraph_generate_rmat_edgelists(
  * Updates a COO to contain random edge weights
  *
  * @param [in]     handle             Handle for accessing resources
- * @param [in/out] rng_state          State of the random number generator, updated with each call
- * @param [in/out] coo                Opaque pointer to the coo, weights will be added (overwriting
+ * @param [in,out] rng_state          State of the random number generator, updated with each call
+ * @param [in,out] coo                Opaque pointer to the coo, weights will be added (overwriting
  * any existing weights)
  * @param [in]     dtype              The type of weight to generate (FLOAT32 or FLOAT64), ignored
  * unless include_weights is true
@@ -229,7 +229,7 @@ cugraph_error_code_t cugraph_generate_edge_weights(const cugraph_resource_handle
  * edges
  *
  * @param [in]     handle             Handle for accessing resources
- * @param [in/out] coo                Opaque pointer to the coo, weights will be added (overwriting
+ * @param [in,out] coo                Opaque pointer to the coo, weights will be added (overwriting
  * any existing weights)
  * @param [in]     multi_gpu          Flag if the COO is being created on multiple GPUs
  * @param [out]    error              Pointer to an error object storing details of any error.  Will
@@ -246,8 +246,8 @@ cugraph_error_code_t cugraph_generate_edge_ids(const cugraph_resource_handle_t* 
  * Updates a COO to contain edge types.  Edges types will be randomly generated.
  *
  * @param [in]     handle             Handle for accessing resources
- * @param [in/out] rng_state          State of the random number generator, updated with each call
- * @param [in/out] coo                Opaque pointer to the coo, weights will be added (overwriting
+ * @param [in,out] rng_state          State of the random number generator, updated with each call
+ * @param [in,out] coo                Opaque pointer to the coo, weights will be added (overwriting
  * any existing weights)
  * @param [in]     max_edge_type      Edge types will be randomly generated between min_edge_type
  * and max_edge_type

--- a/cpp/include/cugraph_c/sampling_algorithms.h
+++ b/cpp/include/cugraph_c/sampling_algorithms.h
@@ -348,7 +348,7 @@ void cugraph_sampling_options_free(cugraph_sampling_options_t* options);
  *                            parameter is only used with the retain_seeds option.
  * @param [in]  fanout       Host array defining the fan out at each step in the sampling algorithm.
  *                           We only support fanout values of type INT32
- * @param [in/out] rng_state State of the random number generator, updated with each call
+ * @param [in,out] rng_state State of the random number generator, updated with each call
  * @param [in]  sampling_options
  *                           Opaque pointer defining the sampling options.
  * @param [in]  do_expensive_check
@@ -599,7 +599,7 @@ cugraph_error_code_t cugraph_test_uniform_neighborhood_sample_result_create(
  *
  * @param [in]      handle        Handle for accessing resources
  * @param [in]      graph         Pointer to graph
- * @param [in/out]  rng_state     State of the random number generator, updated with each call
+ * @param [in,out]  rng_state     State of the random number generator, updated with each call
  * @param [in]      num_vertices  Number of vertices to sample
  * @param [out]     vertices      Device array view to populate label
  * @param [out]     error         Pointer to an error object storing details of

--- a/cpp/include/cugraph_c/traversal_algorithms.h
+++ b/cpp/include/cugraph_c/traversal_algorithms.h
@@ -88,7 +88,7 @@ void cugraph_paths_result_free(cugraph_paths_result_t* result);
  * @param [in]  handle       Handle for accessing resources
  * @param [in]  graph        Pointer to graph
  * FIXME:  Make this just [in], copy it if I need to temporarily modify internally
- * @param [in/out]  sources  Array of source vertices.  NOTE: Array might be modified if
+ * @param [in,out]  sources  Array of source vertices.  NOTE: Array might be modified if
  *                           renumbering is enabled for the graph
  * @param [in]  direction_optimizing If set to true, this algorithm switches between the push based
  * breadth-first search and pull based breadth-first search depending on the size of the


### PR DESCRIPTION
Doxygen documentation warnings exist in the documentation builds.  This fixes these errors.

Closes #4328 