### PR TITLE
Test nx-cugraph package instead of editable install

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -102,8 +102,6 @@ rapids-logger "pytest nx-cugraph"
 
 rapids-logger "pytest networkx using nx-cugraph backend"
 pushd python/nx-cugraph
-# Use editable install to make coverage work
-pip install -e . --no-deps
 ./run_nx_tests.sh
 # run_nx_tests.sh outputs coverage data, so check that total coverage is >0.0%
 # in case nx-cugraph failed to load but fallback mode allowed the run to pass.


### PR DESCRIPTION
We already have the built package, so test that instead of an editable install. This helps avoid having to install the build dependencies for nx-cugraph at test time.