### PR TITLE
Skip MG `dgl_uniform_sampler` test in nightlies

### DIFF
--- a/python/cugraph/cugraph/tests/gnn/test_dgl_uniform_sampler_mg.py
+++ b/python/cugraph/cugraph/tests/gnn/test_dgl_uniform_sampler_mg.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -20,6 +20,9 @@ import cudf
 import cupy as cp
 from cugraph.gnn.dgl_extensions.dgl_uniform_sampler import DGLUniformSampler
 
+
+pytestmark = pytest.mark.skip(reason="Skipping this file until dask worker \
+                              slowdown has been investigated")
 
 def assert_correct_eids(edge_df, sample_edge_id_df):
     # We test that all src, dst correspond to the correct


### PR DESCRIPTION
This PR adds a marker to skip `test_dgl_uniform_sampler_mg.py` in our nightly workflow on draco to unblock other tests that are waiting to be run.

This will be marked "Skipped" while it is being investigated. 