### PR TITLE
remove openmpi ceiling

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -70,6 +70,7 @@ dependencies:
 - sphinx-markdown-tables
 - sphinx<6
 - sphinxcontrib-websupport
+- thriftpy2<=0.5.0
 - ucx-proc=*=gpu
 - ucx-py==0.39.*
 - wget

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -42,7 +42,7 @@ dependencies:
 - numpy>=1.23,<2.0a0
 - numpydoc
 - nvcc_linux-64=11.8
-- openmpi<5.0.3
+- openmpi
 - packaging>=21
 - pandas
 - pre-commit

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -47,7 +47,7 @@ dependencies:
 - numba>=0.57
 - numpy>=1.23,<2.0a0
 - numpydoc
-- openmpi<5.0.3
+- openmpi
 - packaging>=21
 - pandas
 - pre-commit

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -75,6 +75,7 @@ dependencies:
 - sphinx-markdown-tables
 - sphinx<6
 - sphinxcontrib-websupport
+- thriftpy2<=0.5.0
 - ucx-proc=*=gpu
 - ucx-py==0.39.*
 - wget

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -366,7 +366,7 @@ dependencies:
           - libraft-headers==24.8.*
           - libraft==24.8.*
           - librmm==24.8.*
-          - openmpi<5.0.3 # Required for building cpp-mgtests (multi-GPU tests)
+          - openmpi # Required for building cpp-mgtests (multi-GPU tests)
     specific:
       - output_types: [conda]
         matrices:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -545,6 +545,9 @@ dependencies:
       - output_types: [conda]
         packages:
           - pylibwholegraph==24.8.*
+          # this thriftpy2 entry can be removed entirely (or switched to a '!=')
+          # once a new release of that project resolves https://github.com/Thriftpy/thriftpy2/issues/281
+          - thriftpy2<=0.5.0
   test_python_pylibcugraph:
     common:
       - output_types: [conda, pyproject]


### PR DESCRIPTION
fixes #4474 

#4496 and related PRs introduced a ceiling on `openmpi`, a dependency that's only pulled in at test time, because `cugraph`'s builds were struggling to find it.

This proposes removing that pin, as the fixes in https://github.com/conda-forge/openmpi-feedstock/pull/159 should allow the package to again be found by e.g. `find_package(MPI)` in CMake scripts.