### PR TITLE
[BUG] Fix a hang issue in MG triangle counts (when invoked with a small number of vertices to update triangle counts)

### DIFF
--- a/cpp/src/community/triangle_count_impl.cuh
+++ b/cpp/src/community/triangle_count_impl.cuh
@@ -172,7 +172,14 @@ void triangle_count(raft::handle_t const& handle,
     }
   }
 
-  if (vertices.has_value() && ((*vertices).size() == 0)) { return; }
+  if (vertices.has_value()) {
+    auto aggregate_vertex_count =
+      multi_gpu
+        ? host_scalar_allreduce(
+            handle.get_comms(), (*vertices).size(), raft::comms::op_t::SUM, handle.get_stream())
+        : (*vertices).size();
+    if (aggregate_vertex_count == 0) { return; }
+  }
 
   auto cur_graph_view = graph_view;
 


### PR DESCRIPTION
MG triangle count computation hangs when invoked with a small number of vertices to update triangle counts (so some GPUs have 0 vertex to update); this PR fixes this hang issue.