### PR TITLE
Skip the benchmark ctests within CI

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -43,6 +43,9 @@ popd
 
 export GTEST_OUTPUT=xml:${RAPIDS_TESTS_DIR}/
 
+# Skip benchmark tests inside of CI
+export GTEST_FILTER="-*benchmark*"
+
 # Run libcugraph gtests from libcugraph-tests package
 rapids-logger "Run gtests"
 ./ci/run_ctests.sh -j10 && EXITCODE=$? || EXITCODE=$?;

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -12,7 +12,7 @@ dependencies:
 - aiohttp
 - breathe
 - c-compiler
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-nvtx
 - cuda-version=11.8
 - cudatoolkit

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -12,7 +12,7 @@ dependencies:
 - aiohttp
 - breathe
 - c-compiler
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvtx-dev

--- a/conda/recipes/cugraph-pyg/conda_build_config.yaml
+++ b/conda/recipes/cugraph-pyg/conda_build_config.yaml
@@ -10,7 +10,7 @@ cuda_compiler:
   - nvcc
 
 cmake_version:
-  - ">=3.26.4"
+  - ">=3.26.4,!=3.30.0"
 
 c_stdlib:
   - sysroot

--- a/conda/recipes/cugraph/conda_build_config.yaml
+++ b/conda/recipes/cugraph/conda_build_config.yaml
@@ -11,7 +11,7 @@ cuda11_compiler:
   - nvcc
 
 cmake_version:
-  - ">=3.26.4"
+  - ">=3.26.4,!=3.30.0"
 
 c_stdlib:
   - sysroot

--- a/conda/recipes/libcugraph/conda_build_config.yaml
+++ b/conda/recipes/libcugraph/conda_build_config.yaml
@@ -11,7 +11,7 @@ cuda11_compiler:
   - nvcc
 
 cmake_version:
-  - ">=3.26.4"
+  - ">=3.26.4,!=3.30.0"
 
 doxygen_version:
   - ">=1.8.11"

--- a/conda/recipes/pylibcugraph/conda_build_config.yaml
+++ b/conda/recipes/pylibcugraph/conda_build_config.yaml
@@ -11,7 +11,7 @@ cuda11_compiler:
   - nvcc
 
 cmake_version:
-  - ">=3.26.4"
+  - ">=3.26.4,!=3.30.0"
 
 c_stdlib:
   - sysroot

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -376,7 +376,7 @@ dependencies:
     common:
       - output_types: [conda, pyproject]
         packages:
-          - &cmake_ver cmake>=3.26.4
+          - &cmake_ver cmake>=3.26.4,!=3.30.0
           - ninja
   cpp_build:
     common:

--- a/python/cugraph/pyproject.toml
+++ b/python/cugraph/pyproject.toml
@@ -79,7 +79,7 @@ regex = "(?P<value>.*)"
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 requires = [
-    "cmake>=3.26.4",
+    "cmake>=3.26.4,!=3.30.0",
     "ninja",
     "pylibcugraph==24.8.*,>=0.0.0a0",
     "pylibraft==24.8.*,>=0.0.0a0",

--- a/python/pylibcugraph/pyproject.toml
+++ b/python/pylibcugraph/pyproject.toml
@@ -67,7 +67,7 @@ regex = "(?P<value>.*)"
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 requires = [
-    "cmake>=3.26.4",
+    "cmake>=3.26.4,!=3.30.0",
     "ninja",
     "pylibraft==24.8.*,>=0.0.0a0",
     "rmm==24.8.*,>=0.0.0a0",


### PR DESCRIPTION
We have been hitting OOM failures in CI due to some tests using larger amounts of memory.  Our C++ testing includes benchmark tests that allow us to test on larger data sets.

This PR will suppress execution of the benchmark tests within CI.  Disabling these tests shouldn't reduce code coverage in testing.  They are mainly used for developers to test larger scale graphs and see the impact on performance of different updates we make.  We plan on adding these to our nightly tests where we will probably only run the benchmark results, perhaps with larger data sets since we'll run serially on larger GPUs.

Also updated dependencies to skip cmake version 3.30.0