### PR TITLE
[IMP] Set the Default WG Memory Type to 'distributed' for the MNMG PyG Example

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/examples/gcn_dist_mnmg.py
+++ b/python/cugraph-pyg/cugraph_pyg/examples/gcn_dist_mnmg.py
@@ -65,7 +65,6 @@ def init_pytorch_worker(global_rank, local_rank, world_size, cugraph_id):
     from rmm.allocators.cupy import rmm_cupy_allocator
 
     cupy.cuda.set_allocator(rmm_cupy_allocator)
-    torch.distributed.barrier()
 
     from cugraph.testing.mg_utils import enable_spilling
 

--- a/python/cugraph-pyg/cugraph_pyg/examples/gcn_dist_mnmg.py
+++ b/python/cugraph-pyg/cugraph_pyg/examples/gcn_dist_mnmg.py
@@ -65,6 +65,7 @@ def init_pytorch_worker(global_rank, local_rank, world_size, cugraph_id):
     from rmm.allocators.cupy import rmm_cupy_allocator
 
     cupy.cuda.set_allocator(rmm_cupy_allocator)
+    torch.distributed.barrier()
 
     from cugraph.testing.mg_utils import enable_spilling
 
@@ -345,7 +346,7 @@ def parse_args():
     parser.add_argument("--dataset_root", type=str, default="dataset")
     parser.add_argument("--dataset", type=str, default="ogbn-products")
     parser.add_argument("--skip_partition", action="store_true")
-    parser.add_argument("--wg_mem_type", type=str, default="chunked")
+    parser.add_argument("--wg_mem_type", type=str, default="distributed")
 
     return parser.parse_args()
 


### PR DESCRIPTION
For MNMG processing, the only supported memory type is `distributed`.  While it is possible to test using `torchrun` on a single machine, when running on multiple machines, or a SLURM cluster, etc., anything other than `distributed` won't work.  Therefore, this PR makes `distributed` the default memory type for that example to avoid user confusion.