### PR TITLE
Refactor C++ unit tests to allow finer grained filtering

### DIFF
--- a/cpp/tests/centrality/edge_betweenness_centrality_test.cpp
+++ b/cpp/tests/centrality/edge_betweenness_centrality_test.cpp
@@ -218,7 +218,7 @@ TEST_P(Tests_EdgeBetweennessCentrality_Rmat, CheckInt64Int64FloatFloat)
 }
 
 INSTANTIATE_TEST_SUITE_P(
-  file_test_pass,
+  file_test,
   Tests_EdgeBetweennessCentrality_File,
   ::testing::Combine(
     // enable correctness checks
@@ -230,8 +230,22 @@ INSTANTIATE_TEST_SUITE_P(
                       EdgeBetweennessCentrality_Usecase{20, true, false, true},
                       EdgeBetweennessCentrality_Usecase{20, true, true, false},
                       EdgeBetweennessCentrality_Usecase{20, true, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_EdgeBetweennessCentrality_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(EdgeBetweennessCentrality_Usecase{20, false, false, false},
+                      EdgeBetweennessCentrality_Usecase{20, false, false, true},
+                      EdgeBetweennessCentrality_Usecase{20, false, true, false},
+                      EdgeBetweennessCentrality_Usecase{20, false, true, true},
+                      EdgeBetweennessCentrality_Usecase{20, true, false, false},
+                      EdgeBetweennessCentrality_Usecase{20, true, false, true},
+                      EdgeBetweennessCentrality_Usecase{20, true, true, false},
+                      EdgeBetweennessCentrality_Usecase{20, true, true, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/centrality/eigenvector_centrality_test.cpp
+++ b/cpp/tests/centrality/eigenvector_centrality_test.cpp
@@ -269,7 +269,7 @@ TEST_P(Tests_EigenvectorCentrality_Rmat, CheckInt64Int64FloatFloat)
 }
 
 INSTANTIATE_TEST_SUITE_P(
-  file_test_pass,
+  file_test_test,
   Tests_EigenvectorCentrality_File,
   ::testing::Combine(
     // enable correctness checks
@@ -280,7 +280,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
-  file_large_pass,
+  file_large_test,
   Tests_EigenvectorCentrality_File,
   ::testing::Combine(
     // enable correctness checks

--- a/cpp/tests/centrality/eigenvector_centrality_test.cpp
+++ b/cpp/tests/centrality/eigenvector_centrality_test.cpp
@@ -277,8 +277,18 @@ INSTANTIATE_TEST_SUITE_P(
                       EigenvectorCentrality_Usecase{500, false, true},
                       EigenvectorCentrality_Usecase{500, true, false},
                       EigenvectorCentrality_Usecase{500, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_pass,
+  Tests_EigenvectorCentrality_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(EigenvectorCentrality_Usecase{500, false, false},
+                      EigenvectorCentrality_Usecase{500, false, true},
+                      EigenvectorCentrality_Usecase{500, true, false},
+                      EigenvectorCentrality_Usecase{500, true, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/centrality/katz_centrality_test.cpp
+++ b/cpp/tests/centrality/katz_centrality_test.cpp
@@ -281,8 +281,18 @@ INSTANTIATE_TEST_SUITE_P(
                       KatzCentrality_Usecase{false, true},
                       KatzCentrality_Usecase{true, false},
                       KatzCentrality_Usecase{true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_KatzCentrality_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(KatzCentrality_Usecase{false, false},
+                      KatzCentrality_Usecase{false, true},
+                      KatzCentrality_Usecase{true, false},
+                      KatzCentrality_Usecase{true, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/centrality/mg_betweenness_centrality_test.cpp
+++ b/cpp/tests/centrality/mg_betweenness_centrality_test.cpp
@@ -218,7 +218,7 @@ TEST_P(Tests_MGBetweennessCentrality_Rmat, CheckInt64Int64FloatFloat)
 }
 
 INSTANTIATE_TEST_SUITE_P(
-  file_test_pass,
+  file_test,
   Tests_MGBetweennessCentrality_File,
   ::testing::Combine(
     // enable correctness checks
@@ -230,8 +230,22 @@ INSTANTIATE_TEST_SUITE_P(
                       BetweennessCentrality_Usecase{20, false, true, false, true},
                       BetweennessCentrality_Usecase{20, false, true, true, false},
                       BetweennessCentrality_Usecase{20, false, true, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGBetweennessCentrality_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(BetweennessCentrality_Usecase{20, false, false, false, false},
+                      BetweennessCentrality_Usecase{20, false, false, false, true},
+                      BetweennessCentrality_Usecase{20, false, false, true, false},
+                      BetweennessCentrality_Usecase{20, false, false, true, true},
+                      BetweennessCentrality_Usecase{20, false, true, false, false},
+                      BetweennessCentrality_Usecase{20, false, true, false, true},
+                      BetweennessCentrality_Usecase{20, false, true, true, false},
+                      BetweennessCentrality_Usecase{20, false, true, true, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/centrality/mg_edge_betweenness_centrality_test.cpp
+++ b/cpp/tests/centrality/mg_edge_betweenness_centrality_test.cpp
@@ -222,7 +222,7 @@ TEST_P(Tests_MGEdgeBetweennessCentrality_Rmat, CheckInt64Int64FloatFloat)
 }
 
 INSTANTIATE_TEST_SUITE_P(
-  file_test_pass,
+  file_test,
   Tests_MGEdgeBetweennessCentrality_File,
   ::testing::Combine(
     // enable correctness checks
@@ -230,8 +230,18 @@ INSTANTIATE_TEST_SUITE_P(
                       EdgeBetweennessCentrality_Usecase{20, false, false, true},
                       EdgeBetweennessCentrality_Usecase{20, false, true, false},
                       EdgeBetweennessCentrality_Usecase{20, false, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGEdgeBetweennessCentrality_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(EdgeBetweennessCentrality_Usecase{20, false, false, false},
+                      EdgeBetweennessCentrality_Usecase{20, false, false, true},
+                      EdgeBetweennessCentrality_Usecase{20, false, true, false},
+                      EdgeBetweennessCentrality_Usecase{20, false, true, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/centrality/mg_eigenvector_centrality_test.cpp
+++ b/cpp/tests/centrality/mg_eigenvector_centrality_test.cpp
@@ -261,8 +261,18 @@ INSTANTIATE_TEST_SUITE_P(
                       EigenvectorCentrality_Usecase{500, false, true},
                       EigenvectorCentrality_Usecase{500, true, false},
                       EigenvectorCentrality_Usecase{500, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGEigenvectorCentrality_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(EigenvectorCentrality_Usecase{500, false, false},
+                      EigenvectorCentrality_Usecase{500, false, true},
+                      EigenvectorCentrality_Usecase{500, true, false},
+                      EigenvectorCentrality_Usecase{500, true, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/centrality/mg_katz_centrality_test.cpp
+++ b/cpp/tests/centrality/mg_katz_centrality_test.cpp
@@ -252,8 +252,18 @@ INSTANTIATE_TEST_SUITE_P(
                       KatzCentrality_Usecase{false, true},
                       KatzCentrality_Usecase{true, false},
                       KatzCentrality_Usecase{true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGKatzCentrality_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(KatzCentrality_Usecase{false, false},
+                      KatzCentrality_Usecase{false, true},
+                      KatzCentrality_Usecase{true, false},
+                      KatzCentrality_Usecase{true, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/community/mg_weighted_matching_test.cpp
+++ b/cpp/tests/community/mg_weighted_matching_test.cpp
@@ -69,7 +69,7 @@ class Tests_MGWeightedMatching
 
     constexpr bool multi_gpu = true;
 
-    bool test_weighted    = false;
+    bool test_weighted    = true;
     bool renumber         = true;
     bool drop_self_loops  = false;
     bool drop_multi_edges = false;

--- a/cpp/tests/link_analysis/hits_test.cpp
+++ b/cpp/tests/link_analysis/hits_test.cpp
@@ -338,10 +338,20 @@ INSTANTIATE_TEST_SUITE_P(
                       Hits_Usecase{true, false, true},
                       Hits_Usecase{true, true, true}),
     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"),
                       cugraph::test::File_Usecase("test/datasets/dolphins.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_Hits_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(Hits_Usecase{false, false, true},
+                      Hits_Usecase{false, true, true},
+                      Hits_Usecase{true, false, true},
+                      Hits_Usecase{true, true, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+                      cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
+                      cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(rmat_small_test,
                          Tests_Hits_Rmat,

--- a/cpp/tests/link_analysis/mg_hits_test.cpp
+++ b/cpp/tests/link_analysis/mg_hits_test.cpp
@@ -289,8 +289,18 @@ INSTANTIATE_TEST_SUITE_P(
                       Hits_Usecase{false, true},
                       Hits_Usecase{true, false},
                       Hits_Usecase{true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGHits_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(Hits_Usecase{false, false},
+                      Hits_Usecase{false, true},
+                      Hits_Usecase{true, false},
+                      Hits_Usecase{true, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/link_analysis/mg_pagerank_test.cpp
+++ b/cpp/tests/link_analysis/mg_pagerank_test.cpp
@@ -297,8 +297,22 @@ TEST_P(Tests_MGPageRank_Rmat, CheckInt64Int64FloatFloat)
     std::get<0>(param), override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
 
+INSTANTIATE_TEST_SUITE_P(file_tests,
+                         Tests_MGPageRank_File,
+                         ::testing::Combine(
+                           // enable correctness checks
+                           ::testing::Values(PageRank_Usecase{0.0, false, false},
+                                             PageRank_Usecase{0.0, false, true},
+                                             PageRank_Usecase{0.0, true, false},
+                                             PageRank_Usecase{0.0, true, true},
+                                             PageRank_Usecase{0.5, false, false},
+                                             PageRank_Usecase{0.5, false, true},
+                                             PageRank_Usecase{0.5, true, false},
+                                             PageRank_Usecase{0.5, true, true}),
+                           ::testing::Values(cugraph::test::File_Usecase("karate.csv"))));
+
 INSTANTIATE_TEST_SUITE_P(
-  file_tests,
+  file_large_tests,
   Tests_MGPageRank_File,
   ::testing::Combine(
     // enable correctness checks
@@ -310,8 +324,7 @@ INSTANTIATE_TEST_SUITE_P(
                       PageRank_Usecase{0.5, false, true},
                       PageRank_Usecase{0.5, true, false},
                       PageRank_Usecase{0.5, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("karate.csv"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/prims/mg_count_if_e.cu
+++ b/cpp/tests/prims/mg_count_if_e.cu
@@ -322,13 +322,21 @@ TEST_P(Tests_MGCountIfE_Rmat, CheckInt64Int64FloatTransposeTrue)
 INSTANTIATE_TEST_SUITE_P(
   file_test,
   Tests_MGCountIfE_File,
+  ::testing::Combine(::testing::Values(Prims_Usecase{false, false, true},
+                                       Prims_Usecase{false, true, true},
+                                       Prims_Usecase{true, false, true},
+                                       Prims_Usecase{true, true, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGCountIfE_File,
   ::testing::Combine(
     ::testing::Values(Prims_Usecase{false, false, true},
                       Prims_Usecase{false, true, true},
                       Prims_Usecase{true, false, true},
                       Prims_Usecase{true, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/prims/mg_count_if_v.cu
+++ b/cpp/tests/prims/mg_count_if_v.cu
@@ -212,10 +212,15 @@ TEST_P(Tests_MGCountIfV_Rmat, CheckInt64Int64FloatTransposeTrue)
 INSTANTIATE_TEST_SUITE_P(
   file_test,
   Tests_MGCountIfV_File,
+  ::testing::Combine(::testing::Values(Prims_Usecase{true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGCountIfV_File,
   ::testing::Combine(
     ::testing::Values(Prims_Usecase{true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/prims/mg_extract_transform_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_e.cu
@@ -365,10 +365,15 @@ TEST_P(Tests_MGExtractTransformE_Rmat, CheckInt64Int64FloatInt32Int32)
 INSTANTIATE_TEST_SUITE_P(
   file_test,
   Tests_MGExtractTransformE_File,
+  ::testing::Combine(::testing::Values(Prims_Usecase{false, true}, Prims_Usecase{true, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGExtractTransformE_File,
   ::testing::Combine(
     ::testing::Values(Prims_Usecase{false, true}, Prims_Usecase{true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/prims/mg_extract_transform_v_frontier_outgoing_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_v_frontier_outgoing_e.cu
@@ -468,10 +468,15 @@ TEST_P(Tests_MGExtractTransformVFrontierOutgoingE_Rmat, CheckInt64Int64FloatInt3
 INSTANTIATE_TEST_SUITE_P(
   file_test,
   Tests_MGExtractTransformVFrontierOutgoingE_File,
+  ::testing::Combine(::testing::Values(Prims_Usecase{false, true}, Prims_Usecase{true, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGExtractTransformVFrontierOutgoingE_File,
   ::testing::Combine(
     ::testing::Values(Prims_Usecase{false, true}, Prims_Usecase{true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/prims/mg_per_v_random_select_transform_outgoing_e.cu
+++ b/cpp/tests/prims/mg_per_v_random_select_transform_outgoing_e.cu
@@ -563,8 +563,29 @@ INSTANTIATE_TEST_SUITE_P(
                       Prims_Usecase{size_t{1000}, size_t{4}, true, true, false, true},
                       Prims_Usecase{size_t{1000}, size_t{4}, true, true, true, false},
                       Prims_Usecase{size_t{1000}, size_t{4}, true, true, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGPerVRandomSelectTransformOutgoingE_File,
+  ::testing::Combine(
+    ::testing::Values(Prims_Usecase{size_t{1000}, size_t{4}, false, false, false, false},
+                      Prims_Usecase{size_t{1000}, size_t{4}, false, false, false, true},
+                      Prims_Usecase{size_t{1000}, size_t{4}, false, false, true, false},
+                      Prims_Usecase{size_t{1000}, size_t{4}, false, false, true, true},
+                      Prims_Usecase{size_t{1000}, size_t{4}, false, true, false, false},
+                      Prims_Usecase{size_t{1000}, size_t{4}, false, true, false, true},
+                      Prims_Usecase{size_t{1000}, size_t{4}, false, true, true, false},
+                      Prims_Usecase{size_t{1000}, size_t{4}, false, true, true, true},
+                      Prims_Usecase{size_t{1000}, size_t{4}, true, false, false, false},
+                      Prims_Usecase{size_t{1000}, size_t{4}, true, false, false, true},
+                      Prims_Usecase{size_t{1000}, size_t{4}, true, false, true, false},
+                      Prims_Usecase{size_t{1000}, size_t{4}, true, false, true, true},
+                      Prims_Usecase{size_t{1000}, size_t{4}, true, true, false, false},
+                      Prims_Usecase{size_t{1000}, size_t{4}, true, true, false, true},
+                      Prims_Usecase{size_t{1000}, size_t{4}, true, true, true, false},
+                      Prims_Usecase{size_t{1000}, size_t{4}, true, true, true, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/prims/mg_per_v_transform_reduce_dst_key_aggregated_outgoing_e.cu
+++ b/cpp/tests/prims/mg_per_v_transform_reduce_dst_key_aggregated_outgoing_e.cu
@@ -568,13 +568,21 @@ TEST_P(Tests_MGPerVTransformReduceDstKeyAggregatedOutgoingE_Rmat,
 INSTANTIATE_TEST_SUITE_P(
   file_test,
   Tests_MGPerVTransformReduceDstKeyAggregatedOutgoingE_File,
+  ::testing::Combine(::testing::Values(Prims_Usecase{false, false, true},
+                                       Prims_Usecase{false, true, true},
+                                       Prims_Usecase{true, false, true},
+                                       Prims_Usecase{true, true, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGPerVTransformReduceDstKeyAggregatedOutgoingE_File,
   ::testing::Combine(
     ::testing::Values(Prims_Usecase{false, false, true},
                       Prims_Usecase{false, true, true},
                       Prims_Usecase{true, false, true},
                       Prims_Usecase{true, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/prims/mg_per_v_transform_reduce_incoming_outgoing_e.cu
+++ b/cpp/tests/prims/mg_per_v_transform_reduce_incoming_outgoing_e.cu
@@ -610,13 +610,21 @@ TEST_P(Tests_MGPerVTransformReduceIncomingOutgoingE_Rmat, CheckInt64Int64FloatTr
 INSTANTIATE_TEST_SUITE_P(
   file_test,
   Tests_MGPerVTransformReduceIncomingOutgoingE_File,
+  ::testing::Combine(::testing::Values(Prims_Usecase{false, false, true},
+                                       Prims_Usecase{false, true, true},
+                                       Prims_Usecase{true, false, true},
+                                       Prims_Usecase{true, true, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGPerVTransformReduceIncomingOutgoingE_File,
   ::testing::Combine(
     ::testing::Values(Prims_Usecase{false, false, true},
                       Prims_Usecase{false, true, true},
                       Prims_Usecase{true, false, true},
                       Prims_Usecase{true, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/prims/mg_reduce_v.cu
+++ b/cpp/tests/prims/mg_reduce_v.cu
@@ -314,12 +314,18 @@ TEST_P(Tests_MGReduceV_Rmat, CheckInt64Int64FloatTransposeTrue)
 INSTANTIATE_TEST_SUITE_P(
   file_test,
   Tests_MGReduceV_File,
+  ::testing::Combine(::testing::Values(Prims_Usecase{true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGReduceV_File,
   ::testing::Combine(
     ::testing::Values(Prims_Usecase{true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
+
 INSTANTIATE_TEST_SUITE_P(rmat_small_test,
                          Tests_MGReduceV_Rmat,
                          ::testing::Combine(::testing::Values(Prims_Usecase{true}),

--- a/cpp/tests/prims/mg_transform_e.cu
+++ b/cpp/tests/prims/mg_transform_e.cu
@@ -448,13 +448,21 @@ TEST_P(Tests_MGTransformE_Rmat, CheckInt64Int64FloatBoolTransposeTrue)
 INSTANTIATE_TEST_SUITE_P(
   file_test,
   Tests_MGTransformE_File,
+  ::testing::Combine(::testing::Values(Prims_Usecase{false, false, true},
+                                       Prims_Usecase{false, true, true},
+                                       Prims_Usecase{true, false, true},
+                                       Prims_Usecase{true, true, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGTransformE_File,
   ::testing::Combine(
     ::testing::Values(Prims_Usecase{false, false, true},
                       Prims_Usecase{false, true, true},
                       Prims_Usecase{true, false, true},
                       Prims_Usecase{true, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/prims/mg_transform_reduce_e.cu
+++ b/cpp/tests/prims/mg_transform_reduce_e.cu
@@ -338,13 +338,21 @@ TEST_P(Tests_MGTransformReduceE_Rmat, CheckInt64Int64FloatTransposeTrue)
 INSTANTIATE_TEST_SUITE_P(
   file_test,
   Tests_MGTransformReduceE_File,
+  ::testing::Combine(::testing::Values(Prims_Usecase{false, false, true},
+                                       Prims_Usecase{false, true, true},
+                                       Prims_Usecase{true, false, true},
+                                       Prims_Usecase{true, true, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGTransformReduceE_File,
   ::testing::Combine(
     ::testing::Values(Prims_Usecase{false, false, true},
                       Prims_Usecase{false, true, true},
                       Prims_Usecase{true, false, true},
                       Prims_Usecase{true, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/prims/mg_transform_reduce_e_by_src_dst_key.cu
+++ b/cpp/tests/prims/mg_transform_reduce_e_by_src_dst_key.cu
@@ -464,13 +464,21 @@ TEST_P(Tests_MGTransformReduceEBySrcDstKey_Rmat, CheckInt64Int64FloatTransposeTr
 INSTANTIATE_TEST_SUITE_P(
   file_test,
   Tests_MGTransformReduceEBySrcDstKey_File,
+  ::testing::Combine(::testing::Values(Prims_Usecase{false, false, true},
+                                       Prims_Usecase{false, true, true},
+                                       Prims_Usecase{true, false, true},
+                                       Prims_Usecase{true, true, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGTransformReduceEBySrcDstKey_File,
   ::testing::Combine(
     ::testing::Values(Prims_Usecase{false, false, true},
                       Prims_Usecase{false, true, true},
                       Prims_Usecase{true, false, true},
                       Prims_Usecase{true, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/prims/mg_transform_reduce_v.cu
+++ b/cpp/tests/prims/mg_transform_reduce_v.cu
@@ -356,10 +356,15 @@ TEST_P(Tests_MGTransformReduceV_Rmat, CheckInt64Int64FloatTransposeTrue)
 INSTANTIATE_TEST_SUITE_P(
   file_test,
   Tests_MGTransformReduceV_File,
+  ::testing::Combine(::testing::Values(Prims_Usecase{true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGTransformReduceV_File,
   ::testing::Combine(
     ::testing::Values(Prims_Usecase{true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/prims/mg_transform_reduce_v_frontier_outgoing_e_by_src_dst.cu
+++ b/cpp/tests/prims/mg_transform_reduce_v_frontier_outgoing_e_by_src_dst.cu
@@ -721,10 +721,15 @@ TEST_P(Tests_MGTransformReduceVFrontierOutgoingEBySrcDst_Rmat, CheckInt64Int64Fl
 INSTANTIATE_TEST_SUITE_P(
   file_test,
   Tests_MGTransformReduceVFrontierOutgoingEBySrcDst_File,
+  ::testing::Combine(::testing::Values(Prims_Usecase{false, true}, Prims_Usecase{true, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGTransformReduceVFrontierOutgoingEBySrcDst_File,
   ::testing::Combine(
     ::testing::Values(Prims_Usecase{false, true}, Prims_Usecase{true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/sampling/biased_neighbor_sampling.cpp
+++ b/cpp/tests/sampling/biased_neighbor_sampling.cpp
@@ -258,13 +258,21 @@ TEST_P(Tests_Biased_Neighbor_Sampling_Rmat, CheckInt64Int64Float)
 INSTANTIATE_TEST_SUITE_P(
   file_test,
   Tests_Biased_Neighbor_Sampling_File,
+  ::testing::Combine(::testing::Values(Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, false, false},
+                                       Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, false, true},
+                                       Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, true, false},
+                                       Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, true, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_Biased_Neighbor_Sampling_File,
   ::testing::Combine(
     ::testing::Values(Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, false, false},
                       Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, false, true},
                       Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, true, false},
                       Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/sampling/mg_biased_neighbor_sampling.cpp
+++ b/cpp/tests/sampling/mg_biased_neighbor_sampling.cpp
@@ -313,13 +313,21 @@ TEST_P(Tests_MGBiased_Neighbor_Sampling_Rmat, CheckInt64Int64Float)
 INSTANTIATE_TEST_SUITE_P(
   file_test,
   Tests_MGBiased_Neighbor_Sampling_File,
+  ::testing::Combine(::testing::Values(Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, false, false},
+                                       Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, false, true},
+                                       Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, true, false},
+                                       Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, true, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGBiased_Neighbor_Sampling_File,
   ::testing::Combine(
     ::testing::Values(Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, false, false},
                       Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, false, true},
                       Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, true, false},
                       Biased_Neighbor_Sampling_Usecase{{4, 10}, 128, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/sampling/mg_random_walks_test.cpp
+++ b/cpp/tests/sampling/mg_random_walks_test.cpp
@@ -286,35 +286,53 @@ TEST_P(Tests_Node2VecRandomWalks_Rmat, Initialize_i32_i32_f)
 }
 
 INSTANTIATE_TEST_SUITE_P(
-  simple_test,
+  file_test,
+  Tests_UniformRandomWalks_File,
+  ::testing::Combine(::testing::Values(UniformRandomWalks_Usecase{false, 0, true},
+                                       UniformRandomWalks_Usecase{true, 0, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_test,
+  Tests_BiasedRandomWalks_File,
+  ::testing::Combine(::testing::Values(BiasedRandomWalks_Usecase{false, 0, true},
+                                       BiasedRandomWalks_Usecase{true, 0, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_test,
+  Tests_Node2VecRandomWalks_File,
+  ::testing::Combine(::testing::Values(Node2VecRandomWalks_Usecase{4, 8, false, 0, true},
+                                       Node2VecRandomWalks_Usecase{4, 8, true, 0, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
   Tests_UniformRandomWalks_File,
   ::testing::Combine(
     ::testing::Values(UniformRandomWalks_Usecase{false, 0, true},
                       UniformRandomWalks_Usecase{true, 0, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
-  simple_test,
+  file_large_test,
   Tests_BiasedRandomWalks_File,
   ::testing::Combine(
     ::testing::Values(BiasedRandomWalks_Usecase{false, 0, true},
                       BiasedRandomWalks_Usecase{true, 0, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
-  simple_test,
+  file_large_test,
   Tests_Node2VecRandomWalks_File,
   ::testing::Combine(
     ::testing::Values(Node2VecRandomWalks_Usecase{4, 8, false, 0, true},
                       Node2VecRandomWalks_Usecase{4, 8, true, 0, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/sampling/mg_uniform_neighbor_sampling.cpp
+++ b/cpp/tests/sampling/mg_uniform_neighbor_sampling.cpp
@@ -340,8 +340,17 @@ INSTANTIATE_TEST_SUITE_P(
                       Uniform_Neighbor_Sampling_Usecase{{4, 10}, 128, false, true},
                       Uniform_Neighbor_Sampling_Usecase{{4, 10}, 128, true, false},
                       Uniform_Neighbor_Sampling_Usecase{{4, 10}, 128, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGUniform_Neighbor_Sampling_File,
+  ::testing::Combine(
+    ::testing::Values(Uniform_Neighbor_Sampling_Usecase{{4, 10}, 128, false, false},
+                      Uniform_Neighbor_Sampling_Usecase{{4, 10}, 128, false, true},
+                      Uniform_Neighbor_Sampling_Usecase{{4, 10}, 128, true, false},
+                      Uniform_Neighbor_Sampling_Usecase{{4, 10}, 128, true, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/sampling/sg_random_walks_test.cpp
+++ b/cpp/tests/sampling/sg_random_walks_test.cpp
@@ -252,24 +252,36 @@ INSTANTIATE_TEST_SUITE_P(
 #endif
 
 INSTANTIATE_TEST_SUITE_P(
-  simple_test,
+  file_test,
+  Tests_BiasedRandomWalks_File,
+  ::testing::Combine(::testing::Values(BiasedRandomWalks_Usecase{false, 0, true},
+                                       BiasedRandomWalks_Usecase{true, 0, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_test,
+  Tests_Node2VecRandomWalks_File,
+  ::testing::Combine(::testing::Values(Node2VecRandomWalks_Usecase{4, 8, false, 0, true},
+                                       Node2VecRandomWalks_Usecase{4, 8, true, 0, true}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
   Tests_BiasedRandomWalks_File,
   ::testing::Combine(
     ::testing::Values(BiasedRandomWalks_Usecase{false, 0, true},
                       BiasedRandomWalks_Usecase{true, 0, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
-  simple_test,
+  file_large_test,
   Tests_Node2VecRandomWalks_File,
   ::testing::Combine(
     ::testing::Values(Node2VecRandomWalks_Usecase{4, 8, false, 0, true},
                       Node2VecRandomWalks_Usecase{4, 8, true, 0, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/sampling/uniform_neighbor_sampling.cpp
+++ b/cpp/tests/sampling/uniform_neighbor_sampling.cpp
@@ -278,8 +278,17 @@ INSTANTIATE_TEST_SUITE_P(
                       Uniform_Neighbor_Sampling_Usecase{{4, 10}, 128, false, true},
                       Uniform_Neighbor_Sampling_Usecase{{4, 10}, 128, true, false},
                       Uniform_Neighbor_Sampling_Usecase{{4, 10}, 128, true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_Uniform_Neighbor_Sampling_File,
+  ::testing::Combine(
+    ::testing::Values(Uniform_Neighbor_Sampling_Usecase{{4, 10}, 128, false, false},
+                      Uniform_Neighbor_Sampling_Usecase{{4, 10}, 128, false, true},
+                      Uniform_Neighbor_Sampling_Usecase{{4, 10}, 128, true, false},
+                      Uniform_Neighbor_Sampling_Usecase{{4, 10}, 128, true, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/structure/degree_test.cpp
+++ b/cpp/tests/structure/degree_test.cpp
@@ -145,10 +145,13 @@ TEST_P(Tests_Degree, CheckInt32Int32FloatTransposeTrue)
   run_current_test<int32_t, int32_t, true>(GetParam());
 }
 
-INSTANTIATE_TEST_SUITE_P(simple_test,
+INSTANTIATE_TEST_SUITE_P(file_test,
                          Tests_Degree,
-                         ::testing::Values(Degree_Usecase("test/datasets/karate.mtx"),
-                                           Degree_Usecase("test/datasets/web-Google.mtx"),
+                         ::testing::Values(Degree_Usecase("test/datasets/karate.mtx")));
+
+INSTANTIATE_TEST_SUITE_P(file_large_test,
+                         Tests_Degree,
+                         ::testing::Values(Degree_Usecase("test/datasets/web-Google.mtx"),
                                            Degree_Usecase("test/datasets/ljournal-2008.mtx"),
                                            Degree_Usecase("test/datasets/webbase-1M.mtx")));
 

--- a/cpp/tests/structure/induced_subgraph_test.cpp
+++ b/cpp/tests/structure/induced_subgraph_test.cpp
@@ -274,7 +274,7 @@ TEST_P(Tests_InducedSubgraph_Rmat, CheckInt32Int32FloatTransposeTrue)
 #endif
 
 INSTANTIATE_TEST_SUITE_P(
-  karate_test,
+  file_test,
   Tests_InducedSubgraph_File,
   ::testing::Combine(
     ::testing::Values(InducedSubgraph_Usecase{std::vector<size_t>{0}, false, false},
@@ -294,7 +294,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
-  web_google_test,
+  web_google_large_test,
   Tests_InducedSubgraph_File,
   ::testing::Combine(
     ::testing::Values(InducedSubgraph_Usecase{std::vector<size_t>{250, 130, 15}, false, false},
@@ -304,7 +304,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
-  ljournal_2008_test,
+  ljournal_2008_large_test,
   Tests_InducedSubgraph_File,
   ::testing::Combine(
     ::testing::Values(InducedSubgraph_Usecase{std::vector<size_t>{9130, 1200, 300}, false, false},
@@ -314,7 +314,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
-  webbase_1M_test,
+  webbase_1M_large_test,
   Tests_InducedSubgraph_File,
   ::testing::Combine(
     ::testing::Values(InducedSubgraph_Usecase{std::vector<size_t>{700}, false, false},

--- a/cpp/tests/structure/mg_induced_subgraph_test.cu
+++ b/cpp/tests/structure/mg_induced_subgraph_test.cu
@@ -322,7 +322,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
-  web_google_test,
+  web_google_large_test,
   Tests_MGInducedSubgraph_File,
   ::testing::Combine(
     ::testing::Values(InducedSubgraph_Usecase{std::vector<size_t>{250, 130, 15}, false, false},
@@ -332,7 +332,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
-  ljournal_2008_test,
+  ljournal_2008_large_test,
   Tests_MGInducedSubgraph_File,
   ::testing::Combine(
     ::testing::Values(InducedSubgraph_Usecase{std::vector<size_t>{300, 20, 400}, false, false},
@@ -342,7 +342,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(
-  webbase_1M_test,
+  webbase_1M_large_test,
   Tests_MGInducedSubgraph_File,
   ::testing::Combine(
     ::testing::Values(InducedSubgraph_Usecase{std::vector<size_t>{700}, false, false},

--- a/cpp/tests/structure/mg_symmetrize_test.cpp
+++ b/cpp/tests/structure/mg_symmetrize_test.cpp
@@ -299,8 +299,18 @@ INSTANTIATE_TEST_SUITE_P(
                       Symmetrize_Usecase{true, false},
                       Symmetrize_Usecase{false, true},
                       Symmetrize_Usecase{true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGSymmetrize_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(Symmetrize_Usecase{false, false},
+                      Symmetrize_Usecase{true, false},
+                      Symmetrize_Usecase{false, true},
+                      Symmetrize_Usecase{true, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/structure/mg_transpose_storage_test.cpp
+++ b/cpp/tests/structure/mg_transpose_storage_test.cpp
@@ -295,8 +295,15 @@ INSTANTIATE_TEST_SUITE_P(
   ::testing::Combine(
     // enable correctness checks
     ::testing::Values(TransposeStorage_Usecase{false}, TransposeStorage_Usecase{true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGTransposeStorage_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(TransposeStorage_Usecase{false}, TransposeStorage_Usecase{true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/structure/mg_transpose_test.cpp
+++ b/cpp/tests/structure/mg_transpose_test.cpp
@@ -291,8 +291,15 @@ INSTANTIATE_TEST_SUITE_P(
   ::testing::Combine(
     // enable correctness checks
     ::testing::Values(Transpose_Usecase{false}, Transpose_Usecase{true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGTranspose_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(Transpose_Usecase{false}, Transpose_Usecase{true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/structure/renumbering_test.cpp
+++ b/cpp/tests/structure/renumbering_test.cpp
@@ -134,15 +134,21 @@ TEST_P(Tests_Renumbering_Rmat, CheckInt32Int32FloatFloat)
   run_current_test<int32_t, int32_t, float>(std::get<0>(param), std::get<1>(param));
 }
 
+INSTANTIATE_TEST_SUITE_P(file_test,
+                         Tests_Renumbering_File,
+                         ::testing::Combine(
+                           // enable correctness checks
+                           ::testing::Values(Renumbering_Usecase{}),
+                           ::testing::Values(cugraph::test::File_Usecase("negative-vertex-id.csv"),
+                                             cugraph::test::File_Usecase("karate.csv"))));
+
 INSTANTIATE_TEST_SUITE_P(
-  file_test,
+  file_large_test,
   Tests_Renumbering_File,
   ::testing::Combine(
     // enable correctness checks
     ::testing::Values(Renumbering_Usecase{}),
-    ::testing::Values(cugraph::test::File_Usecase("negative-vertex-id.csv"),
-                      cugraph::test::File_Usecase("karate.csv"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/structure/symmetrize_test.cpp
+++ b/cpp/tests/structure/symmetrize_test.cpp
@@ -471,8 +471,18 @@ INSTANTIATE_TEST_SUITE_P(
                       Symmetrize_Usecase{true, false},
                       Symmetrize_Usecase{false, true},
                       Symmetrize_Usecase{true, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_Symmetrize_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(Symmetrize_Usecase{false, false},
+                      Symmetrize_Usecase{true, false},
+                      Symmetrize_Usecase{false, true},
+                      Symmetrize_Usecase{true, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/structure/transpose_storage_test.cpp
+++ b/cpp/tests/structure/transpose_storage_test.cpp
@@ -248,8 +248,15 @@ INSTANTIATE_TEST_SUITE_P(
   ::testing::Combine(
     // enable correctness checks
     ::testing::Values(TransposeStorage_Usecase{false}, TransposeStorage_Usecase{true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_TransposeStorage_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(TransposeStorage_Usecase{false}, TransposeStorage_Usecase{true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/structure/transpose_test.cpp
+++ b/cpp/tests/structure/transpose_test.cpp
@@ -232,8 +232,15 @@ INSTANTIATE_TEST_SUITE_P(
   ::testing::Combine(
     // enable correctness checks
     ::testing::Values(Transpose_Usecase{false}, Transpose_Usecase{true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_Transpose_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(Transpose_Usecase{false}, Transpose_Usecase{true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/structure/weight_sum_test.cpp
+++ b/cpp/tests/structure/weight_sum_test.cpp
@@ -247,8 +247,15 @@ INSTANTIATE_TEST_SUITE_P(
   ::testing::Combine(
     // enable correctness checks
     ::testing::Values(WeightSum_Usecase{false}, WeightSum_Usecase{true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_WeightSum_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(WeightSum_Usecase{false}, WeightSum_Usecase{true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/traversal/mg_bfs_test.cpp
+++ b/cpp/tests/traversal/mg_bfs_test.cpp
@@ -314,8 +314,15 @@ INSTANTIATE_TEST_SUITE_P(
   ::testing::Combine(
     // enable correctness checks
     ::testing::Values(BFS_Usecase{0, false}, BFS_Usecase{0, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGBFS_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(BFS_Usecase{0, false}, BFS_Usecase{0, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 

--- a/cpp/tests/traversal/mg_k_hop_nbrs_test.cpp
+++ b/cpp/tests/traversal/mg_k_hop_nbrs_test.cpp
@@ -277,8 +277,18 @@ INSTANTIATE_TEST_SUITE_P(
                       KHopNbrs_Usecase{1024, 2, true},
                       KHopNbrs_Usecase{1024, 1, false},
                       KHopNbrs_Usecase{1024, 1, true}),
-    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"),
-                      cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_MGKHopNbrs_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(KHopNbrs_Usecase{1024, 2, false},
+                      KHopNbrs_Usecase{1024, 2, true},
+                      KHopNbrs_Usecase{1024, 1, false},
+                      KHopNbrs_Usecase{1024, 1, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
                       cugraph::test::File_Usecase("test/datasets/ljournal-2008.mtx"),
                       cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
 


### PR DESCRIPTION
Running all of the C++ unit tests can take a long time.

This PR splits the file-based tests into small versus large tests.  The large tests (usually named file_large_test) can be skipped by setting the following environment variable:

`export GTEST_FILTER="-*large*"`

You can skip both the large tests and the benchmark tests with the following:

`export GTEST_FILTER="-*benchmark*:*large*"`

By default all tests will be run.