### PR TITLE
Fix triangle count test bug

### DIFF
--- a/python/cugraph/cugraph/tests/community/test_triangle_count.py
+++ b/python/cugraph/cugraph/tests/community/test_triangle_count.py
@@ -112,8 +112,8 @@ def test_triangles_int64(input_combo):
     G.edgelist.edgelist_df = G.edgelist.edgelist_df.astype(
         {"src": "int64", "dst": "int64"}
     )
-
     count_int64 = cugraph.triangle_count(G)["counts"].sum()
+
     assert G.edgelist.edgelist_df["src"].dtype == "int64"
     assert G.edgelist.edgelist_df["dst"].dtype == "int64"
     assert count_int32 == count_int64

--- a/python/cugraph/cugraph/tests/community/test_triangle_count.py
+++ b/python/cugraph/cugraph/tests/community/test_triangle_count.py
@@ -105,7 +105,7 @@ def test_triangles(input_combo):
 @pytest.mark.sg
 def test_triangles_int64(input_combo):
     Gnx = input_combo["Gnx"]
-    count_legacy_32 = cugraph.triangle_count(Gnx)
+    count_int32 = cugraph.triangle_count(Gnx)["counts"].sum()
 
     graph_file = input_combo["graph_file"]
     G = graph_file.get_graph()
@@ -113,16 +113,10 @@ def test_triangles_int64(input_combo):
         {"src": "int64", "dst": "int64"}
     )
 
-    count_exp_64 = (
-        cugraph.triangle_count(G)
-        .sort_values("vertex")
-        .reset_index(drop=True)
-        .rename(columns={"counts": "exp_cugraph_counts"})
-    )
-    cugraph_exp_triangle_results = count_exp_64["exp_cugraph_counts"].sum()
+    count_int64 = cugraph.triangle_count(G)["counts"].sum()
     assert G.edgelist.edgelist_df["src"].dtype == "int64"
     assert G.edgelist.edgelist_df["dst"].dtype == "int64"
-    assert cugraph_exp_triangle_results == count_legacy_32
+    assert count_int32 == count_int64
 
 
 @pytest.mark.sg

--- a/python/cugraph/cugraph/tests/community/test_triangle_count.py
+++ b/python/cugraph/cugraph/tests/community/test_triangle_count.py
@@ -122,25 +122,15 @@ def test_triangles_int64(input_combo):
 @pytest.mark.sg
 def test_triangles_no_weights(input_combo):
     G_weighted = input_combo["Gnx"]
-    count_legacy = (
-        cugraph.triangle_count(G_weighted)
-        .sort_values("vertex")
-        .reset_index(drop=True)
-        .rename(columns={"counts": "exp_cugraph_counts"})
-    )
+    count_triangles_nx_graph = cugraph.triangle_count(G_weighted)["counts"].sum()
 
     graph_file = input_combo["graph_file"]
     G = graph_file.get_graph(ignore_weights=True)
 
     assert G.is_weighted() is False
-    triangle_count = (
-        cugraph.triangle_count(G)
-        .sort_values("vertex")
-        .reset_index(drop=True)
-        .rename(columns={"counts": "exp_cugraph_counts"})
-    )
-    cugraph_exp_triangle_results = triangle_count["exp_cugraph_counts"].sum()
-    assert cugraph_exp_triangle_results == count_legacy
+    count_triangles = cugraph.triangle_count(G)["counts"].sum()
+
+    assert count_triangles_nx_graph == count_triangles
 
 
 @pytest.mark.sg

--- a/python/cugraph/cugraph/tests/traversal/test_paths.py
+++ b/python/cugraph/cugraph/tests/traversal/test_paths.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -205,8 +205,11 @@ def test_shortest_path_length_no_path(graphs):
 def test_shortest_path_length_no_target(graphs, load_traversal_results):
     cugraph_G, cupy_df = graphs
 
-    cugraph_path_1_to_all = cugraph.shortest_path_length(
-        cugraph_G, 1).sort_values("vertex").reset_index(drop=True)
+    cugraph_path_1_to_all = (
+        cugraph.shortest_path_length(cugraph_G, 1)
+        .sort_values("vertex")
+        .reset_index(drop=True)
+    )
     golden_path_1_to_all = get_resultset(
         resultset_name="traversal",
         algo="shortest_path_length",
@@ -223,7 +226,8 @@ def test_shortest_path_length_no_target(graphs, load_traversal_results):
         cugraph_path_1_to_all["distance"],
         cupy_path_1_to_all["distance"],
         check_names=False,
-        check_dtype=False,)
+        check_dtype=False,
+    )
 
     # results for vertex 8 and 9 are not returned
     assert cugraph_path_1_to_all.shape[0] == len(golden_path_1_to_all) + 2

--- a/python/cugraph/cugraph/tests/traversal/test_paths.py
+++ b/python/cugraph/cugraph/tests/traversal/test_paths.py
@@ -22,6 +22,7 @@ import cudf
 import cupy
 import cugraph
 from cugraph.testing import get_resultset, load_resultset
+from cudf.testing.testing import assert_series_equal
 from cupyx.scipy.sparse import coo_matrix as cupy_coo_matrix
 
 
@@ -204,7 +205,8 @@ def test_shortest_path_length_no_path(graphs):
 def test_shortest_path_length_no_target(graphs, load_traversal_results):
     cugraph_G, cupy_df = graphs
 
-    cugraph_path_1_to_all = cugraph.shortest_path_length(cugraph_G, 1)
+    cugraph_path_1_to_all = cugraph.shortest_path_length(
+        cugraph_G, 1).sort_values("vertex").reset_index(drop=True)
     golden_path_1_to_all = get_resultset(
         resultset_name="traversal",
         algo="shortest_path_length",
@@ -217,7 +219,11 @@ def test_shortest_path_length_no_target(graphs, load_traversal_results):
 
     # Cast networkx graph on cugraph vertex column type from str to int.
     # SSSP preserves vertex type, convert for comparison
-    assert cugraph_path_1_to_all == cupy_path_1_to_all
+    assert_series_equal(
+        cugraph_path_1_to_all["distance"],
+        cupy_path_1_to_all["distance"],
+        check_names=False,
+        check_dtype=False,)
 
     # results for vertex 8 and 9 are not returned
     assert cugraph_path_1_to_all.shape[0] == len(golden_path_1_to_all) + 2


### PR DESCRIPTION
This PR count the total number of triangles before testing it against the ground truth. It also remove an unnecessary sorting before testing.