### PR TITLE
Fix MG `katz_centrality`: Check if DataFrame Arg is Not None

### DIFF
--- a/python/cugraph/cugraph/dask/centrality/katz_centrality.py
+++ b/python/cugraph/cugraph/dask/centrality/katz_centrality.py
@@ -162,7 +162,7 @@ def katz_centrality(
     do_expensive_check = False
 
     initial_hubs_guess_values = None
-    if nstart:
+    if nstart is not None:
         if input_graph.renumbered:
             if len(input_graph.renumber_map.implementation.col_names) > 1:
                 cols = nstart.columns[:-1].to_list()


### PR DESCRIPTION
[This](https://github.com/rapidsai/cudf/pull/16311) PR recently introduced some API changes that broke `test_katz_centrality_mg.py` because it was using an improper method of trying to evaluate a `cudf.DataFrame` to a truth value.


This PR adds a fix to check if the `nstart` argument is set to `None`.