### PR TITLE
nx-cugraph: check networkx version

### DIFF
--- a/python/nx-cugraph/_nx_cugraph/__init__.py
+++ b/python/nx-cugraph/_nx_cugraph/__init__.py
@@ -296,6 +296,27 @@ def get_info():
     return d
 
 
+def _check_networkx_version():
+    import warnings
+
+    import networkx as nx
+
+    version_major, version_minor = nx.__version__.split(".")[:2]
+    if version_major != "3":
+        warnings.warn(
+            f"nx-cugraph version {__version__} is only known to work with networkx "
+            f"versions 3.x, but networkx {nx.__version__} is installed. "
+            "Perhaps try upgrading your Python environment.",
+            UserWarning,
+            stacklevel=2,
+        )
+    if len(version_minor) > 1:
+        raise RuntimeWarning(
+            f"nx-cugraph version {__version__} does not work with networkx version "
+            f"{nx.__version__}. Please upgrade (or fix) your Python environment."
+        )
+
+
 if __name__ == "__main__":
     from pathlib import Path
 

--- a/python/nx-cugraph/nx_cugraph/__init__.py
+++ b/python/nx-cugraph/nx_cugraph/__init__.py
@@ -33,3 +33,6 @@ from . import algorithms
 from .algorithms import *
 
 from _nx_cugraph._version import __git_commit__, __version__
+from _nx_cugraph import _check_networkx_version
+
+_check_networkx_version()


### PR DESCRIPTION
This is to address the feedback from @bdice in https://github.com/rapidsai/cugraph/pull/4531#discussion_r1697414065, which I was unable to do in that PR.

I know checking version strings is playing it fast-and-loose, but I believe we are abundantly safe to do so here, as networkx releases have been, and are expected to be, slow and predictable. Also, we do not have `packaging` as a runtime dependency (it _is_ a test dependency for finer control).

So, even better than using `packaging.version.parse`, this PR performs a sanity check on the networkx version. I put it in both `nx_cugraph.__init__` and `_nx_cugraph.__init__` to give us obvious breadcrumbs to discover and follow.