### PR TITLE
Use RMM adaptor constructor rather than factory function

### DIFF
--- a/cpp/src/prims/key_store.cuh
+++ b/cpp/src/prims/key_store.cuh
@@ -323,7 +323,7 @@ class key_cuco_store_t {
       static_cast<size_t>(static_cast<double>(num_keys) / load_factor),
       static_cast<size_t>(num_keys) + 1);  // cuco::static_map requires at least one empty slot
 
-    auto stream_adapter = stream_allocator_adaptor(
+    auto stream_adapter = rmm::mr::stream_allocator_adaptor(
       rmm::mr::polymorphic_allocator<std::byte>(rmm::mr::get_current_device_resource()), stream);
     cuco_store_ =
       std::make_unique<cuco_set_type>(cuco_size,

--- a/cpp/src/prims/key_store.cuh
+++ b/cpp/src/prims/key_store.cuh
@@ -28,6 +28,7 @@
 #include <cuco/static_set.cuh>
 
 #include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <type_traits>
@@ -322,7 +323,7 @@ class key_cuco_store_t {
       static_cast<size_t>(static_cast<double>(num_keys) / load_factor),
       static_cast<size_t>(num_keys) + 1);  // cuco::static_map requires at least one empty slot
 
-    auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(
+    auto stream_adapter = stream_allocator_adaptor(
       rmm::mr::polymorphic_allocator<std::byte>(rmm::mr::get_current_device_resource()), stream);
     cuco_store_ =
       std::make_unique<cuco_set_type>(cuco_size,

--- a/cpp/src/prims/kv_store.cuh
+++ b/cpp/src/prims/kv_store.cuh
@@ -820,7 +820,7 @@ class kv_cuco_store_t {
       static_cast<size_t>(static_cast<double>(num_keys) / load_factor),
       static_cast<size_t>(num_keys) + 1);  // cuco::static_map requires at least one empty slot
 
-    auto stream_adapter = rmm::mr::make_stream_allocator_adaptor(
+    auto stream_adapter = rmm::mr::stream_allocator_adaptor(
       rmm::mr::polymorphic_allocator<std::byte>(rmm::mr::get_current_device_resource()), stream);
     if constexpr (std::is_arithmetic_v<value_t>) {
       cuco_store_ =


### PR DESCRIPTION
RMM will be deprecating and removing its adaptor factory functions (`make_*_adaptor`). These were needed prior to C++17 due to the lack of CTAD, but since C++17 is our minimum supported version, we can drop them now. Users can simply call the constructor for the adaptors.

This PR replaces calls to `make_stream_allocator_adaptor()` with `stream_allocator_adaptor` ahead of the deprecation of these functions in RMM 24.10.