### PR TITLE
add setuptools to host requirements for conda packages that need it

### DIFF
--- a/conda/recipes/cugraph-dgl/meta.yaml
+++ b/conda/recipes/cugraph-dgl/meta.yaml
@@ -22,6 +22,7 @@ requirements:
   host:
     - python
     - rapids-build-backend>=0.3.1,<0.4.0.dev0
+    - setuptools>=61.0.0
   run:
     - cugraph ={{ version }}
     - dgl >=1.1.0.cu*

--- a/conda/recipes/cugraph-equivariant/meta.yaml
+++ b/conda/recipes/cugraph-equivariant/meta.yaml
@@ -22,6 +22,7 @@ requirements:
   host:
     - python
     - rapids-build-backend>=0.3.1,<0.4.0.dev0
+    - setuptools>=61.0.0
   run:
     - pylibcugraphops ={{ minor_version }}
     - python

--- a/conda/recipes/cugraph-pyg/meta.yaml
+++ b/conda/recipes/cugraph-pyg/meta.yaml
@@ -24,8 +24,8 @@ requirements:
   host:
     - cython >=3.0.0
     - python
-    - scikit-build-core >=0.7.0
     - rapids-build-backend>=0.3.1,<0.4.0.dev0
+    - setuptools>=61.0.0
   run:
     - rapids-dask-dependency ={{ minor_version }}
     - numba >=0.57

--- a/conda/recipes/cugraph-service/meta.yaml
+++ b/conda/recipes/cugraph-service/meta.yaml
@@ -30,6 +30,7 @@ outputs:
         - pip
         - python
         - rapids-build-backend>=0.3.1,<0.4.0.dev0
+        - setuptools>=61.0.0
       run:
         - python
         - thriftpy2 >=0.4.15,!=0.5.0,!=0.5.1
@@ -51,7 +52,7 @@ outputs:
       host:
         - pip
         - python
-        - setuptools
+        - setuptools>=61.0.0
         - wheel
         - rapids-build-backend>=0.3.1,<0.4.0.dev0
       run:

--- a/conda/recipes/nx-cugraph/meta.yaml
+++ b/conda/recipes/nx-cugraph/meta.yaml
@@ -22,6 +22,7 @@ requirements:
   host:
     - python
     - rapids-build-backend>=0.3.1,<0.4.0.dev0
+    - setuptools>=61.0.0
   run:
     - pylibcugraph ={{ version }}
     - networkx >=3.0


### PR DESCRIPTION
@caryr35 pointed out to me this morning that `cugraph`'s nightly CI is failing. All `conda-python-build` jobs are failing like this, when building `nx-cugraph`

> ModuleNotFoundError: No module named 'setuptools'
> ...
> ValueError: Could not import build backend specified in pyproject.toml's tool.rapids-build-backend table. Make sure you specified the right optional dependency in your build-system.requires entry for rapids-build-backend.

([build link](https://github.com/rapidsai/cugraph/actions/runs/10176436224/job/28166520972))

**suspected root cause:**  `nx-cugraph` uses `setuptools.build_meta`, but `setuptools` isn't present in the conda build environment

## Notes for Reviewers

### Why is this targeting `branch-24.08`?

Looks like CI is failing there too: https://github.com/rapidsai/cugraph/actions/runs/10183681336/job/28171285190

### Why is this just breaking now?

I suspect that prior to this we were getting `setuptools` because it was a transitive dependency of one of `nx-cugraph`'s other build/host dependencies.

### How could we prevent stuff like this in the future?

We could add support for updating conda recipe files in `rapids-dependency-file-generator` (https://github.com/rapidsai/dependency-file-generator/issues/7).

`setuptools` was correctly added as a build dependency in `pyproject.toml` files here (automatically, via `dependencies.yaml` + `rapids-dependency-file-generator`), but the conda recipe `meta.yaml` files were missed.