### PR TITLE
Fix `test_property_graph_mg` Usage of Util Function

### DIFF
--- a/python/cugraph/cugraph/utilities/utils.py
+++ b/python/cugraph/cugraph/utilities/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -530,7 +530,7 @@ def create_list_series_from_2d_ar(ar, index):
         null_count=0,
         children=(offset_col, data),
     )
-    return cudf.Series(lc, index=index)
+    return cudf.Series._from_column(lc, index=index)
 
 
 def create_directory_with_overwrite(directory):


### PR DESCRIPTION
This PR fixes an issue that recently arose due to a change in constructing a `cudf.Series` object.

`test_property_graph_mg.py` uses a function from `utilities/utils.py` to construct a Series object from 2d arrays. The function is now using the correct `cudf.Series._from_column` API.