### PR TITLE
Add Additional Check for `NetworkX` Release Candidate Versions

### DIFF
--- a/python/nx-cugraph/_nx_cugraph/__init__.py
+++ b/python/nx-cugraph/_nx_cugraph/__init__.py
@@ -298,6 +298,7 @@ def get_info():
 
 def _check_networkx_version():
     import warnings
+    import re
 
     import networkx as nx
 
@@ -310,7 +311,11 @@ def _check_networkx_version():
             UserWarning,
             stacklevel=2,
         )
-    if len(version_minor) > 1:
+
+    # Allow single-digit minor versions, e.g. 3.4 and release candidates, e.g. 3.4rc0
+    pattern = r"^\d(rc\d+)?$"
+
+    if not re.match(pattern, version_minor):
         raise RuntimeWarning(
             f"nx-cugraph version {__version__} does not work with networkx version "
             f"{nx.__version__}. Please upgrade (or fix) your Python environment."


### PR DESCRIPTION
Part of https://github.com/rapidsai/graph_dl/issues/579

This PR allows `nx-cugraph` to operate with release candidate (under development) versions of `networkx`

What This Pattern Allows:
- Just a single digit: `3.4`, `3.9`, etc

- Release Candidate format: `3.4rc0`. `3.7rc2`

This is needed to complete adding nightly test coverage for development branches of `nx`