### PR TITLE
Fix ListColumn constructor argument

### DIFF
--- a/python/cugraph/cugraph/utilities/utils.py
+++ b/python/cugraph/cugraph/utilities/utils.py
@@ -523,6 +523,7 @@ def create_list_series_from_2d_ar(ar, index):
     mask_col = cp.full(shape=n_rows, fill_value=True)
     mask = cudf._lib.transform.bools_to_mask(as_column(mask_col))
     lc = cudf.core.column.ListColumn(
+        data=None,
         size=n_rows,
         dtype=cudf.ListDtype(data.dtype),
         mask=mask,


### PR DESCRIPTION
A recent API change in cudf (https://github.com/rapidsai/cudf/pull/16465) now requires the `data` argument to be passed (consistent with the other Column subclasses)