### PR TITLE
Fix build strings in nx-cugraph

### DIFF
--- a/conda/recipes/nx-cugraph/meta.yaml
+++ b/conda/recipes/nx-cugraph/meta.yaml
@@ -14,9 +14,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  build:
-      number: {{ GIT_DESCRIBE_NUMBER }}
-      string: py{{ py_version }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: py{{ py_version }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
 
 requirements:
   host:


### PR DESCRIPTION
Build strings aren't being published correctly for `nx-cugraph` (see missing info in current nightlies: https://anaconda.org/rapidsai-nightly/nx-cugraph/files). This is due to a formatting or copy-paste problem in the `meta.yaml` recipe file. This PR fixes the problem.
