### PR TITLE
Add `--cpu-only` or `--gpu-only` Arguments to `nx-cugraph` Benchmark

### DIFF
--- a/benchmarks/nx-cugraph/pytest-based/README.md
+++ b/benchmarks/nx-cugraph/pytest-based/README.md
@@ -19,13 +19,22 @@ Our current benchmarks provide the following datasets:
 ### Scripts
 
 #### 1. `run-main-benchmarks.sh`
-This script allows users to run selected algorithms across multiple datasets and backends. All results are stored inside a sub-directory (`logs/`) and output files are named based on the combination of parameters for that benchmark.
+This script allows users to run the main algorithms across multiple datasets and backends. All results are stored inside a sub-directory (`logs/`) and output files are named based on the combination of parameters for that benchmark.
 
-NOTE: If running with all algorithms, datasets, and backends, this script may take a few hours to finish running.
+NOTE: If running with all algorithms, datasets on CPU, this script may take a few hours to finish running.
 
 **Usage:**
+ - Run with `--cpu-only`:
   ```bash
-  bash run-main-benchmarks.sh  # edit this script directly
+  ./run-main-benchmarks.sh --cpu-only
+  ```
+ - Run with `--gpu-only`:
+  ```bash
+  ./run-main-benchmarks.sh --gpu-only
+  ```
+ - Run without any arguments (all backends):
+  ```bash
+  ./run-main-benchmarks.sh
   ```
 
 #### 2. `get_graph_bench_dataset.py`

--- a/benchmarks/nx-cugraph/pytest-based/README.md
+++ b/benchmarks/nx-cugraph/pytest-based/README.md
@@ -19,7 +19,7 @@ Our current benchmarks provide the following datasets:
 ### Scripts
 
 #### 1. `run-main-benchmarks.sh`
-This script allows users to run the main algorithms across multiple datasets and backends. All results are stored inside a sub-directory (`logs/`) and output files are named based on the combination of parameters for that benchmark.
+This script allows users to run a small set of commonly-used algorithms across multiple datasets and backends. All results are stored inside a sub-directory (`logs/`) and output files are named based on the combination of parameters for that benchmark.
 
 NOTE: If running with all algorithms, datasets on CPU, this script may take a few hours to finish running.
 

--- a/benchmarks/nx-cugraph/pytest-based/README.md
+++ b/benchmarks/nx-cugraph/pytest-based/README.md
@@ -46,7 +46,7 @@ This script downloads the specified dataset using `cugraph.datasets`.
   ```
 
 #### 3. `create_results_summary_page.py`
-This script is designed to be run after `run-gap-benchmarks.sh` in order to generate an HTML page displaying a results table comparing default NetworkX to nx-cugraph. The script also provides information about the current system.
+This script is designed to be run after `run-gap-benchmarks.sh` in order to generate an HTML page displaying a results table comparing default NetworkX to nx-cugraph. The script also provides information about the current system, so it should be run on the machine on which benchmarks were run.
 
 **Usage:**
   ```bash

--- a/benchmarks/nx-cugraph/pytest-based/README.md
+++ b/benchmarks/nx-cugraph/pytest-based/README.md
@@ -21,7 +21,7 @@ Our current benchmarks provide the following datasets:
 #### 1. `run-main-benchmarks.sh`
 This script allows users to run a small set of commonly-used algorithms across multiple datasets and backends. All results are stored inside a sub-directory (`logs/`) and output files are named based on the combination of parameters for that benchmark.
 
-NOTE: If running with all algorithms, datasets on CPU, this script may take a few hours to finish running.
+NOTE: If running with all algorithms and datasets using NetworkX without an accelerated backend, this script may take a few hours to finish running.
 
 **Usage:**
  - Run with `--cpu-only`:

--- a/benchmarks/nx-cugraph/pytest-based/run-main-benchmarks.sh
+++ b/benchmarks/nx-cugraph/pytest-based/run-main-benchmarks.sh
@@ -27,6 +27,13 @@ algos="
     triangles
     bfs_predecessors
 "
+datasets="
+   netscience
+   email_Eu_core
+   cit_patents
+   hollywood
+   soc-livejournal
+"
 # None backend is default networkx
 # cugraph-preconvert backend is nx-cugraph
 backends="
@@ -51,7 +58,8 @@ fi
 
 for algo in $algos; do
     for dataset in $datasets; do
-    python get_graph_bench_dataset.py $dataset
+	# this script can be used to download benchmarking datasets by name via cugraph.datasets
+    # python get_graph_bench_dataset.py $dataset
         for backend in $backends; do
             name="${backend}__${algo}__${dataset}"
             echo "Running: $backend, $dataset, bench_$algo"

--- a/benchmarks/nx-cugraph/pytest-based/run-main-benchmarks.sh
+++ b/benchmarks/nx-cugraph/pytest-based/run-main-benchmarks.sh
@@ -59,7 +59,7 @@ fi
 for algo in $algos; do
     for dataset in $datasets; do
 	# this script can be used to download benchmarking datasets by name via cugraph.datasets
-    python get_graph_bench_dataset.py $dataset
+    	python get_graph_bench_dataset.py $dataset
         for backend in $backends; do
             name="${backend}__${algo}__${dataset}"
             echo "Running: $backend, $dataset, bench_$algo"

--- a/benchmarks/nx-cugraph/pytest-based/run-main-benchmarks.sh
+++ b/benchmarks/nx-cugraph/pytest-based/run-main-benchmarks.sh
@@ -59,7 +59,7 @@ fi
 for algo in $algos; do
     for dataset in $datasets; do
 	# this script can be used to download benchmarking datasets by name via cugraph.datasets
-    # python get_graph_bench_dataset.py $dataset
+    python get_graph_bench_dataset.py $dataset
         for backend in $backends; do
             name="${backend}__${algo}__${dataset}"
             echo "Running: $backend, $dataset, bench_$algo"

--- a/benchmarks/nx-cugraph/pytest-based/run-main-benchmarks.sh
+++ b/benchmarks/nx-cugraph/pytest-based/run-main-benchmarks.sh
@@ -27,19 +27,27 @@ algos="
     triangles
     bfs_predecessors
 "
-datasets="
-   netscience
-   email_Eu_core
-   cit_patents
-   hollywood
-   soc-livejournal
-"
 # None backend is default networkx
 # cugraph-preconvert backend is nx-cugraph
 backends="
     None
     cugraph-preconverted
 "
+# check for --cpu-only or --gpu-only args
+if [[ "$#" -eq 1 ]]; then
+    case $1 in
+        --cpu-only)
+            backends="None"
+            ;;
+        --gpu-only)
+            backends="cugraph-preconverted"
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+fi
 
 for algo in $algos; do
     for dataset in $datasets; do


### PR DESCRIPTION
This PR is a follow-up to https://github.com/rapidsai/cugraph/pull/4616

This PR adds the following CLI argument options for `benchmarks/nx-cugraph/pytest-based/run-main-benchmarks.sh` 
 - `--cpu-only`
 - `--gpu-only`

And adds minor updates to the README