### PR TITLE
Fix `from_pandas_edgelist` with duplicate edges

### DIFF
--- a/python/nx-cugraph/_nx_cugraph/__init__.py
+++ b/python/nx-cugraph/_nx_cugraph/__init__.py
@@ -297,8 +297,8 @@ def get_info():
 
 
 def _check_networkx_version():
-    import warnings
     import re
+    import warnings
 
     import networkx as nx
 

--- a/python/nx-cugraph/nx_cugraph/algorithms/components/connected.py
+++ b/python/nx-cugraph/nx_cugraph/algorithms/components/connected.py
@@ -15,7 +15,12 @@ import networkx as nx
 import pylibcugraph as plc
 
 from nx_cugraph.convert import _to_undirected_graph
-from nx_cugraph.utils import _groupby, networkx_algorithm, not_implemented_for
+from nx_cugraph.utils import (
+    _cp_unique,
+    _groupby,
+    networkx_algorithm,
+    not_implemented_for,
+)
 
 __all__ = [
     "number_connected_components",
@@ -44,7 +49,7 @@ def _number_connected_components(G, symmetrize=None):
         labels=None,
         do_expensive_check=False,
     )
-    return cp.unique(labels).size
+    return _cp_unique(labels).size
 
 
 @number_connected_components._can_run

--- a/python/nx-cugraph/nx_cugraph/algorithms/components/strongly_connected.py
+++ b/python/nx-cugraph/nx_cugraph/algorithms/components/strongly_connected.py
@@ -15,7 +15,7 @@ import networkx as nx
 import pylibcugraph as plc
 
 from nx_cugraph.convert import _to_directed_graph
-from nx_cugraph.utils import _groupby, index_dtype, not_implemented_for
+from nx_cugraph.utils import _cp_unique, _groupby, index_dtype, not_implemented_for
 
 __all__ = [
     "number_strongly_connected_components",
@@ -74,7 +74,7 @@ def number_strongly_connected_components(G):
     if G.src_indices.size == 0:
         return len(G)
     labels = _strongly_connected_components(G)
-    return cp.unique(labels).size
+    return _cp_unique(labels).size
 
 
 @not_implemented_for("undirected")

--- a/python/nx-cugraph/nx_cugraph/algorithms/core.py
+++ b/python/nx-cugraph/nx_cugraph/algorithms/core.py
@@ -17,6 +17,7 @@ import pylibcugraph as plc
 import nx_cugraph as nxcg
 from nx_cugraph.convert import _to_undirected_graph
 from nx_cugraph.utils import (
+    _cp_unique,
     _get_int_dtype,
     index_dtype,
     networkx_algorithm,
@@ -97,7 +98,7 @@ def k_truss(G, k):
             do_expensive_check=False,
         )
         # Renumber step 0: node indices
-        node_indices = cp.unique(cp.concatenate([src_indices, dst_indices]))
+        node_indices = _cp_unique(cp.concatenate([src_indices, dst_indices]))
         # Renumber step 1: edge values
         if edge_indices.dtype != edge_dtype:
             # The returned edge_indices may have different dtype (and float)

--- a/python/nx-cugraph/nx_cugraph/algorithms/traversal/breadth_first_search.py
+++ b/python/nx-cugraph/nx_cugraph/algorithms/traversal/breadth_first_search.py
@@ -19,7 +19,7 @@ import pylibcugraph as plc
 
 import nx_cugraph as nxcg
 from nx_cugraph.convert import _to_graph
-from nx_cugraph.utils import _groupby, index_dtype, networkx_algorithm
+from nx_cugraph.utils import _cp_unique, _groupby, index_dtype, networkx_algorithm
 
 __all__ = [
     "bfs_edges",
@@ -155,7 +155,7 @@ def bfs_tree(G, source, reverse=False, depth_limit=None, sort_neighbors=None):
             id_to_key=[source],
         )
     # TODO: create renumbering helper function(s)
-    unique_node_ids = cp.unique(cp.hstack((predecessors, node_ids)))
+    unique_node_ids = _cp_unique(cp.hstack((predecessors, node_ids)))
     # Renumber edges
     src_indices = cp.searchsorted(unique_node_ids, predecessors).astype(index_dtype)
     dst_indices = cp.searchsorted(unique_node_ids, node_ids).astype(index_dtype)

--- a/python/nx-cugraph/nx_cugraph/classes/graph.py
+++ b/python/nx-cugraph/nx_cugraph/classes/graph.py
@@ -695,9 +695,14 @@ class Graph:
                 is_multigraph=self.is_multigraph() and symmetrize is None,
                 is_symmetric=not self.is_directed() or symmetrize is not None,
             ),
-            src_or_offset_array=src_indices,
-            dst_or_index_array=dst_indices,
-            weight_array=edge_array,
+            # Use `cp.asarray` to ensure that data is contiguous in device memory.
+            # We could, perhaps, update e.g. `self.src_indices` with the new contiguous
+            # array. This does not copy if arrays are already contiguous.
+            src_or_offset_array=cp.asarray(src_indices, order="C"),
+            dst_or_index_array=cp.asarray(dst_indices, order="C"),
+            weight_array=(
+                None if edge_array is None else cp.asarray(edge_array, order="C")
+            ),
             store_transposed=store_transposed,
             renumber=False,
             do_expensive_check=False,

--- a/python/nx-cugraph/nx_cugraph/classes/graph.py
+++ b/python/nx-cugraph/nx_cugraph/classes/graph.py
@@ -23,7 +23,7 @@ import pylibcugraph as plc
 
 import nx_cugraph as nxcg
 
-from ..utils import index_dtype
+from ..utils import _cp_unique, index_dtype
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterable, Iterator
@@ -490,7 +490,7 @@ class Graph:
             n = self.key_to_id[n]
         nbrs = self.dst_indices[self.src_indices == n]
         if self.is_multigraph():
-            nbrs = cp.unique(nbrs)
+            nbrs = _cp_unique(nbrs)
         return nbrs
 
     @networkx_api

--- a/python/nx-cugraph/nx_cugraph/classes/multigraph.py
+++ b/python/nx-cugraph/nx_cugraph/classes/multigraph.py
@@ -94,7 +94,10 @@ class MultiGraph(Graph):
             id_to_key=id_to_key,
             **attr,
         )
-        new_graph.edge_indices = edge_indices
+        # Ensure edge data is contiguous; don't copy if they are.
+        new_graph.edge_indices = (
+            None if edge_indices is None else cp.asarray(edge_indices, order="C")
+        )
         new_graph.edge_keys = edge_keys
         # Easy and fast sanity checks
         if (

--- a/python/nx-cugraph/nx_cugraph/convert.py
+++ b/python/nx-cugraph/nx_cugraph/convert.py
@@ -24,7 +24,7 @@ import numpy as np
 
 import nx_cugraph as nxcg
 
-from .utils import index_dtype, networkx_algorithm
+from .utils import _cp_unique, index_dtype, networkx_algorithm
 from .utils.misc import pairwise
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -737,7 +737,7 @@ def to_dict_of_lists(G, nodelist=None):
     # Sort indices so we can use `cp.unique` to determine boundaries.
     # This is like exporting to DCSR.
     if G.is_multigraph():
-        stacked = cp.unique(cp.vstack((src_indices, dst_indices)), axis=1)
+        stacked = _cp_unique(cp.vstack((src_indices, dst_indices)), axis=1)
         src_indices = stacked[0]
         dst_indices = stacked[1]
     else:
@@ -745,7 +745,7 @@ def to_dict_of_lists(G, nodelist=None):
         indices = cp.lexsort(stacked)
         src_indices = src_indices[indices]
         dst_indices = dst_indices[indices]
-    compressed_srcs, left_bounds = cp.unique(src_indices, return_index=True)
+    compressed_srcs, left_bounds = _cp_unique(src_indices, return_index=True)
     # Ensure we include isolate nodes in the result (and in proper order)
     rv = None
     if nodelist is not None:

--- a/python/nx-cugraph/nx_cugraph/relabel.py
+++ b/python/nx-cugraph/nx_cugraph/relabel.py
@@ -22,7 +22,7 @@ import numpy as np
 
 import nx_cugraph as nxcg
 
-from .utils import _get_int_dtype, _groupby, index_dtype, networkx_algorithm
+from .utils import _cp_unique, _get_int_dtype, _groupby, index_dtype, networkx_algorithm
 
 if TYPE_CHECKING:  # pragma: no cover
     from nx_cugraph.typing import AttrKey, Dtype, EdgeValue
@@ -209,12 +209,12 @@ def _deduplicate(
     stacked_dup = cp.vstack((src_indices, dst_indices))
     if not edge_values:
         # Drop duplicates
-        stacked = cp.unique(stacked_dup, axis=1)
+        stacked = _cp_unique(stacked_dup, axis=1)
     else:
         # Drop duplicates. This relies heavily on `_groupby`.
         # It has not been compared to alternative implementations.
         # I wonder if there are ways to use assignment using duplicate indices.
-        (stacked, ind, inv) = cp.unique(
+        (stacked, ind, inv) = _cp_unique(
             stacked_dup, axis=1, return_index=True, return_inverse=True
         )
         if int_dtype is not None and ind.dtype != int_dtype:

--- a/python/nx-cugraph/nx_cugraph/tests/test_convert_matrix.py
+++ b/python/nx-cugraph/nx_cugraph/tests/test_convert_matrix.py
@@ -17,6 +17,8 @@ import pytest
 import nx_cugraph as nxcg
 from nx_cugraph.utils import _cp_iscopied_asarray
 
+from .testing_utils import assert_graphs_equal
+
 try:
     import cudf
 except ModuleNotFoundError:
@@ -84,3 +86,18 @@ def test_from_pandas_edgelist(data, create_using):
             source.to_numpy(), orig_object=source
         )
         assert is_copied is True
+
+
+@pytest.mark.parametrize("edge_attr", [None, True])
+@pytest.mark.parametrize("create_using", CREATE_USING)
+def test_multiple_edges(edge_attr, create_using):
+    df = pd.DataFrame(
+        {
+            "source": [0, 0, 0, 1, 1, 2, 0, 0],
+            "target": [1, 1, 1, 0, 2, 0, 0, 0],
+            "x": [0, 1, 2, 3, 4, 5, 6, 7],
+        }
+    )
+    Gnx = nx.from_pandas_edgelist(df, edge_attr=edge_attr, create_using=create_using)
+    Gcg = nxcg.from_pandas_edgelist(df, edge_attr=edge_attr, create_using=create_using)
+    assert_graphs_equal(Gnx, Gcg)

--- a/python/nx-cugraph/pyproject.toml
+++ b/python/nx-cugraph/pyproject.toml
@@ -170,6 +170,7 @@ external = [
 ]
 ignore = [
     # Would be nice to fix these
+    "B905",  # `zip()` without an explicit `strict=` parameter (Note: possible since py39 was dropped; we should do this!)
     "D100",  # Missing docstring in public module
     "D101",  # Missing docstring in public class
     "D102",  # Missing docstring in public method
@@ -215,6 +216,7 @@ ignore = [
     "SIM105",  # Use contextlib.suppress(...) instead of try-except-pass (Note: try-except-pass is much faster)
     "SIM108",  # Use ternary operator ... instead of if-else-block (Note: if-else better for coverage and sometimes clearer)
     "TRY003",  # Avoid specifying long messages outside the exception class (Note: why?)
+    "UP038",  # Use `X | Y` in `isinstance` call instead of `(X, Y)` (Note: tuple is faster for now)
 
     # Ignored categories
     "C90",  # mccabe (Too strict, but maybe we should make things less complex)


### PR DESCRIPTION
When creating a `Graph` or `DiGraph`, duplicate edges should be dropped. Also, ensure arrays are contiguous when creating the PLC graph, which can lead to incorrect results.

For now, this was done by splitting out functionality from `relabel_nodes`, but I wonder if there could be a faster way to deduplicate when edge values also need handled.

Also, `cp.unique` was sometimes problematic for me on larger data sets, but I may have been running out of device memory. @rlratzel I'm curious how this will perform for you.