### PR TITLE
WIP: [DO NOT MERGE] Update fmt (to 11.0.2) and spdlog (to 1.14.1).

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -113,6 +113,7 @@ jobs:
   #     script: ci/test_wheel_pylibcugraph.sh
   wheel-build-cugraph:
     # needs: wheel-tests-pylibcugraph
+    needs: wheel-build-pylibcugraph
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,89 +12,89 @@ concurrency:
 jobs:
   pr-builder:
     needs:
-      - checks
+      # - checks
       - conda-cpp-build
-      - conda-cpp-tests
-      - conda-cpp-checks
-      - conda-notebook-tests
+      # - conda-cpp-tests
+      # - conda-cpp-checks
+      # - conda-notebook-tests
       - conda-python-build
-      - conda-python-tests
-      - docs-build
+      # - conda-python-tests
+      # - docs-build
       - wheel-build-pylibcugraph
-      - wheel-tests-pylibcugraph
+      # - wheel-tests-pylibcugraph
       - wheel-build-cugraph
-      - wheel-tests-cugraph
+      # - wheel-tests-cugraph
       - wheel-build-nx-cugraph
-      - wheel-tests-nx-cugraph
+      # - wheel-tests-nx-cugraph
       - wheel-build-cugraph-dgl
-      - wheel-tests-cugraph-dgl
+      # - wheel-tests-cugraph-dgl
       - wheel-build-cugraph-pyg
-      - wheel-tests-cugraph-pyg
+      # - wheel-tests-cugraph-pyg
       - wheel-build-cugraph-equivariant
-      - wheel-tests-cugraph-equivariant
+      # - wheel-tests-cugraph-equivariant
       - devcontainer
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
-  checks:
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10
-    with:
-      enable_check_generated_files: false
+  # checks:
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10
+  #   with:
+  #     enable_check_generated_files: false
   conda-cpp-build:
-    needs: checks
+    # needs: checks
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-24.10
     with:
       build_type: pull-request
       node_type: cpu32
-  conda-cpp-tests:
-    needs: conda-cpp-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-24.10
-    with:
-      build_type: pull-request
-  conda-cpp-checks:
-    needs: conda-cpp-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      enable_check_symbols: true
-      symbol_exclusions: (cugraph::ops|hornet|void writeEdgeCountsKernel|void markUniqueOffsetsKernel)
+  # conda-cpp-tests:
+  #   needs: conda-cpp-build
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  # conda-cpp-checks:
+  #   needs: conda-cpp-build
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     enable_check_symbols: true
+  #     symbol_exclusions: (cugraph::ops|hornet|void writeEdgeCountsKernel|void markUniqueOffsetsKernel)
   conda-python-build:
     needs: conda-cpp-build
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.10
     with:
       build_type: pull-request
-  conda-python-tests:
-    needs: conda-python-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.10
-    with:
-      build_type: pull-request
-  conda-notebook-tests:
-    needs: conda-python-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      node_type: "gpu-v100-latest-1"
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:cuda11.8.0-ubuntu22.04-py3.10"
-      run_script: "ci/test_notebooks.sh"
-  docs-build:
-    needs: conda-python-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      node_type: "gpu-v100-latest-1"
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:cuda11.8.0-ubuntu22.04-py3.10"
-      run_script: "ci/build_docs.sh"
+  # conda-python-tests:
+  #   needs: conda-python-build
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  # conda-notebook-tests:
+  #   needs: conda-python-build
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     node_type: "gpu-v100-latest-1"
+  #     arch: "amd64"
+  #     container_image: "rapidsai/ci-conda:cuda11.8.0-ubuntu22.04-py3.10"
+  #     run_script: "ci/test_notebooks.sh"
+  # docs-build:
+  #   needs: conda-python-build
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     node_type: "gpu-v100-latest-1"
+  #     arch: "amd64"
+  #     container_image: "rapidsai/ci-conda:cuda11.8.0-ubuntu22.04-py3.10"
+  #     run_script: "ci/build_docs.sh"
   wheel-build-pylibcugraph:
-    needs: checks
+    # needs: checks
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
     with:
@@ -104,15 +104,15 @@ jobs:
       extra-repo-sha: branch-24.10
       extra-repo-deploy-key: CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY
       node_type: cpu32
-  wheel-tests-pylibcugraph:
-    needs: wheel-build-pylibcugraph
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      script: ci/test_wheel_pylibcugraph.sh
+  # wheel-tests-pylibcugraph:
+  #   needs: wheel-build-pylibcugraph
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_wheel_pylibcugraph.sh
   wheel-build-cugraph:
-    needs: wheel-tests-pylibcugraph
+    # needs: wheel-tests-pylibcugraph
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
     with:
@@ -121,71 +121,71 @@ jobs:
       extra-repo: rapidsai/cugraph-ops
       extra-repo-sha: branch-24.10
       extra-repo-deploy-key: CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY
-  wheel-tests-cugraph:
-    needs: wheel-build-cugraph
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      script: ci/test_wheel_cugraph.sh
+  # wheel-tests-cugraph:
+  #   needs: wheel-build-cugraph
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_wheel_cugraph.sh
   wheel-build-nx-cugraph:
-    needs: wheel-tests-pylibcugraph
+    # needs: wheel-tests-pylibcugraph
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
     with:
       build_type: pull-request
       script: ci/build_wheel_nx-cugraph.sh
-  wheel-tests-nx-cugraph:
-    needs: wheel-build-nx-cugraph
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      script: ci/test_wheel_nx-cugraph.sh
+  # wheel-tests-nx-cugraph:
+  #   needs: wheel-build-nx-cugraph
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_wheel_nx-cugraph.sh
   wheel-build-cugraph-dgl:
-    needs: wheel-tests-cugraph
+    # needs: wheel-tests-cugraph
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
     with:
       build_type: pull-request
       script: ci/build_wheel_cugraph-dgl.sh
-  wheel-tests-cugraph-dgl:
-    needs: wheel-build-cugraph-dgl
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      script: ci/test_wheel_cugraph-dgl.sh
-      matrix_filter: map(select(.ARCH == "amd64"))
+  # wheel-tests-cugraph-dgl:
+  #   needs: wheel-build-cugraph-dgl
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_wheel_cugraph-dgl.sh
+  #     matrix_filter: map(select(.ARCH == "amd64"))
   wheel-build-cugraph-pyg:
-    needs: wheel-tests-cugraph
+    # needs: wheel-tests-cugraph
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
     with:
       build_type: pull-request
       script: ci/build_wheel_cugraph-pyg.sh
-  wheel-tests-cugraph-pyg:
-    needs: wheel-build-cugraph-pyg
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      script: ci/test_wheel_cugraph-pyg.sh
-      matrix_filter: map(select(.ARCH == "amd64"))
+  # wheel-tests-cugraph-pyg:
+  #   needs: wheel-build-cugraph-pyg
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_wheel_cugraph-pyg.sh
+  #     matrix_filter: map(select(.ARCH == "amd64"))
   wheel-build-cugraph-equivariant:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.10
     with:
       build_type: pull-request
       script: ci/build_wheel_cugraph-equivariant.sh
-  wheel-tests-cugraph-equivariant:
-    needs: wheel-build-cugraph-equivariant
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
-    with:
-      build_type: pull-request
-      script: ci/test_wheel_cugraph-equivariant.sh
-      matrix_filter: map(select(.ARCH == "amd64"))
+  # wheel-tests-cugraph-equivariant:
+  #   needs: wheel-build-cugraph-equivariant
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.10
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_wheel_cugraph-equivariant.sh
+  #     matrix_filter: map(select(.ARCH == "amd64"))
   devcontainer:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@branch-24.10

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -11,6 +11,9 @@ source rapids-date-string
 
 export CMAKE_GENERATOR=Ninja
 
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
+source ./ci/use_conda_packages_from_prs.sh
+
 rapids-print-env
 
 rapids-logger "Begin cpp build"

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -11,6 +11,9 @@ source rapids-date-string
 
 export CMAKE_GENERATOR=Ninja
 
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
+source ./ci/use_conda_packages_from_prs.sh
+
 rapids-print-env
 
 CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)

--- a/ci/build_wheel_cugraph-dgl.sh
+++ b/ci/build_wheel_cugraph-dgl.sh
@@ -3,4 +3,6 @@
 
 set -euo pipefail
 
+source ./ci/use_wheels_from_prs.sh
+
 ./ci/build_wheel.sh cugraph-dgl python/cugraph-dgl

--- a/ci/build_wheel_cugraph-equivariant.sh
+++ b/ci/build_wheel_cugraph-equivariant.sh
@@ -3,4 +3,6 @@
 
 set -euo pipefail
 
+source ./ci/use_wheels_from_prs.sh
+
 ./ci/build_wheel.sh cugraph-equivariant python/cugraph-equivariant

--- a/ci/build_wheel_cugraph-pyg.sh
+++ b/ci/build_wheel_cugraph-pyg.sh
@@ -3,4 +3,6 @@
 
 set -euo pipefail
 
+source ./ci/use_wheels_from_prs.sh
+
 ./ci/build_wheel.sh cugraph-pyg python/cugraph-pyg

--- a/ci/build_wheel_cugraph.sh
+++ b/ci/build_wheel_cugraph.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
+source ./ci/use_wheels_from_prs.sh
+
 # Download the pylibcugraph wheel built in the previous step and make it
 # available for pip to find.
 #
@@ -14,7 +16,7 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 # are used when creating the isolated build environment
 CPP_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="pylibcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 /tmp/pylibcugraph_dist)
 
-echo "pylibcugraph-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${CPP_WHEELHOUSE}/pylibcugraph_*.whl)" > ./constraints.txt
+echo "pylibcugraph-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${CPP_WHEELHOUSE}/pylibcugraph_*.whl)" >> ./constraints.txt
 export PIP_CONSTRAINT="${PWD}/constraints.txt"
 
 PARALLEL_LEVEL=$(python -c \

--- a/ci/build_wheel_nx-cugraph.sh
+++ b/ci/build_wheel_nx-cugraph.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
+
+source ./ci/use_wheels_from_prs.sh
 
 ./ci/build_wheel.sh nx-cugraph python/nx-cugraph

--- a/ci/build_wheel_pylibcugraph.sh
+++ b/ci/build_wheel_pylibcugraph.sh
@@ -15,6 +15,8 @@ case "${RAPIDS_CUDA_VERSION}" in
   ;;
 esac
 
+source ./ci/use_wheels_from_prs.sh
+
 export SKBUILD_CMAKE_ARGS="-DDETECT_CONDA_ENV=OFF;-DFIND_CUGRAPH_CPP=OFF;-DCPM_cugraph-ops_SOURCE=${GITHUB_WORKSPACE}/cugraph-ops/${EXTRA_CMAKE_ARGS}"
 export SKBUILD_BUILD_TOOL_ARGS="-j${PARALLEL_LEVEL};-l${PARALLEL_LEVEL}"
 

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -8,6 +8,8 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 . /opt/conda/etc/profile.d/conda.sh
 
+source ./ci/use_conda_packages_from_prs.sh
+
 rapids-logger "Generate C++ testing dependencies"
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -5,6 +5,8 @@ set -Eeuo pipefail
 
 . /opt/conda/etc/profile.d/conda.sh
 
+source ./ci/use_conda_packages_from_prs.sh
+
 rapids-logger "Generate notebook testing dependencies"
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -8,6 +8,8 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 . /opt/conda/etc/profile.d/conda.sh
 
+source ./ci/use_conda_packages_from_prs.sh
+
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/test_wheel_cugraph-dgl.sh
+++ b/ci/test_wheel_cugraph-dgl.sh
@@ -3,6 +3,8 @@
 
 set -eoxu pipefail
 
+source ./ci/use_wheels_from_prs.sh
+
 package_name="cugraph-dgl"
 package_dir="python/cugraph-dgl"
 

--- a/ci/test_wheel_cugraph-equivariant.sh
+++ b/ci/test_wheel_cugraph-equivariant.sh
@@ -3,6 +3,8 @@
 
 set -eoxu pipefail
 
+source ./ci/use_wheels_from_prs.sh
+
 package_name="cugraph-equivariant"
 package_dir="python/cugraph-equivariant"
 

--- a/ci/test_wheel_cugraph-pyg.sh
+++ b/ci/test_wheel_cugraph-pyg.sh
@@ -3,6 +3,8 @@
 
 set -eoxu pipefail
 
+source ./ci/use_wheels_from_prs.sh
+
 package_name="cugraph-pyg"
 package_dir="python/cugraph-pyg"
 

--- a/ci/test_wheel_cugraph.sh
+++ b/ci/test_wheel_cugraph.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 set -eoxu pipefail
+
+source ./ci/use_wheels_from_prs.sh
 
 # Download the pylibcugraph built in the previous step
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"

--- a/ci/test_wheel_nx-cugraph.sh
+++ b/ci/test_wheel_nx-cugraph.sh
@@ -3,6 +3,8 @@
 
 set -eoxu pipefail
 
+source ./ci/use_wheels_from_prs.sh
+
 # Download wheels built during this job.
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 RAPIDS_PY_WHEEL_NAME="pylibcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./local-deps

--- a/ci/test_wheel_pylibcugraph.sh
+++ b/ci/test_wheel_pylibcugraph.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 set -eoxu pipefail
+
+source ./ci/use_wheels_from_prs.sh
 
 ./ci/test_wheel.sh pylibcugraph python/pylibcugraph

--- a/ci/use_conda_packages_from_prs.sh
+++ b/ci/use_conda_packages_from_prs.sh
@@ -11,8 +11,9 @@ UCXX_CHANNEL=$(rapids-get-pr-conda-artifact ucxx 278 cpp)
 LIBRAFT_CHANNEL=$(rapids-get-pr-conda-artifact raft 2433 cpp)
 RAFT_CHANNEL=$(rapids-get-pr-conda-artifact raft 2433 python)
 
-LIBCUGRAPHOPS_CHANNEL=$(rapids-get-pr-conda-artifact cugraph-ops 692 cpp)
-PYLIBCUGRAPHOPS_CHANNEL=$(rapids-get-pr-conda-artifact cugraph-ops 692 python)
+# NOTE: rapids-get-pr-wheel-artifact seems to not work with private repos
+# LIBCUGRAPHOPS_CHANNEL=$(rapids-get-pr-conda-artifact cugraph-ops 692 cpp)
+# PYLIBCUGRAPHOPS_CHANNEL=$(rapids-get-pr-conda-artifact cugraph-ops 692 python)
 
 conda config --system --add channels "${LIBRMM_CHANNEL}"
 conda config --system --add channels "${RMM_CHANNEL}"
@@ -21,5 +22,5 @@ conda config --system --add channels "${CUDF_PYTHON_CHANNEL}"
 conda config --system --add channels "${UCXX_CHANNEL}"
 conda config --system --add channels "${LIBRAFT_CHANNEL}"
 conda config --system --add channels "${RAFT_CHANNEL}"
-conda config --system --add channels "${LIBCUGRAPHOPS_CHANNEL}"
-conda config --system --add channels "${PYLIBCUGRAPHOPS_CHANNEL}"
+# conda config --system --add channels "${LIBCUGRAPHOPS_CHANNEL}"
+# conda config --system --add channels "${PYLIBCUGRAPHOPS_CHANNEL}"

--- a/ci/use_conda_packages_from_prs.sh
+++ b/ci/use_conda_packages_from_prs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+LIBRMM_CHANNEL=$(rapids-get-pr-conda-artifact rmm 1678 cpp)
+RMM_CHANNEL=$(rapids-get-pr-conda-artifact rmm 1678 python)
+
+CUDF_CPP_CHANNEL=$(rapids-get-pr-conda-artifact cudf 16806 cpp)
+CUDF_PYTHON_CHANNEL=$(rapids-get-pr-conda-artifact cudf 16806 python)
+
+UCXX_CHANNEL=$(rapids-get-pr-conda-artifact ucxx 278 cpp)
+
+LIBRAFT_CHANNEL=$(rapids-get-pr-conda-artifact raft 2433 cpp)
+RAFT_CHANNEL=$(rapids-get-pr-conda-artifact raft 2433 python)
+
+LIBCUGRAPHOPS_CHANNEL=$(rapids-get-pr-conda-artifact cugraph-ops 692 cpp)
+PYLIBCUGRAPHOPS_CHANNEL=$(rapids-get-pr-conda-artifact cugraph-ops 692 python)
+
+conda config --system --add channels "${LIBRMM_CHANNEL}"
+conda config --system --add channels "${RMM_CHANNEL}"
+conda config --system --add channels "${CUDF_CPP_CHANNEL}"
+conda config --system --add channels "${CUDF_PYTHON_CHANNEL}"
+conda config --system --add channels "${UCXX_CHANNEL}"
+conda config --system --add channels "${LIBRAFT_CHANNEL}"
+conda config --system --add channels "${RAFT_CHANNEL}"
+conda config --system --add channels "${LIBCUGRAPHOPS_CHANNEL}"
+conda config --system --add channels "${PYLIBCUGRAPHOPS_CHANNEL}"

--- a/ci/use_wheels_from_prs.sh
+++ b/ci/use_wheels_from_prs.sh
@@ -41,9 +41,10 @@ PYLIBRAFT_CHANNEL=$(
   RAPIDS_PY_WHEEL_NAME=pylibraft_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact raft 2433 python
 )
 
-PYLIBCUGRAPHOPS_CHANNEL=$(
-  RAPIDS_PY_WHEEL_NAME=pylibraft_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact cugraph-ops 692 python
-)
+# NOTE: rapids-get-pr-wheel-artifact seems to not work with private repos
+# PYLIBCUGRAPHOPS_CHANNEL=$(
+#   RAPIDS_PY_WHEEL_NAME=pylibraft_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact cugraph-ops 692 python
+# )
 
 cat > /tmp/constraints.txt <<EOF
 librmm-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${LIBRMM_CHANNEL}/librmm_*.whl)
@@ -57,7 +58,8 @@ libucxx-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${LIBUCXX_CHANNEL}/libucxx_*.wh
 distributed-ucxx-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${DISTRIBUTED_UCXX_CHANNEL}/distributed_ucxx_*.whl)
 raft-dask-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${RAFT_DASK_CHANNEL}/raft_dask_*.whl)
 pylibraft-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${PYLIBRAFT_CHANNEL}/pylibraft_*.whl)
-pylibcugraphops-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${PYLIBCUGRAPHOPS_CHANNEL}/pylibcugraphops_*.whl)
 EOF
+
+# pylibcugraphops-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${PYLIBCUGRAPHOPS_CHANNEL}/pylibcugraphops_*.whl)
 
 export PIP_CONSTRAINT=/tmp/constraints.txt

--- a/ci/use_wheels_from_prs.sh
+++ b/ci/use_wheels_from_prs.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
+
+LIBRMM_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=rmm_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact rmm 1678 cpp
+)
+RMM_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=rmm_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact rmm 1678 python
+)
+
+UCXX_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=ucxx_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact ucxx 278 python
+)
+LIBUCXX_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=libucxx_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact ucxx 278 cpp
+)
+DISTRIBUTED_UCXX_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=distributed_ucxx_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact ucxx 278 python
+)
+
+CUDF_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=cudf_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact cudf 16806 python
+)
+LIBCUDF_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=libcudf_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact cudf 16806 cpp
+)
+PYLIBCUDF_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=pylibcudf_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact cudf 16806 python
+)
+DASK_CUDF_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=dask_cudf_${RAPIDS_PY_CUDA_SUFFIX} \
+  RAPIDS_PY_WHEEL_PURE=1 \
+    rapids-get-pr-wheel-artifact cudf 16806 python
+)
+
+RAFT_DASK_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=raft_dask_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact raft 2433 python
+)
+PYLIBRAFT_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=pylibraft_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact raft 2433 python
+)
+
+PYLIBCUGRAPHOPS_CHANNEL=$(
+  RAPIDS_PY_WHEEL_NAME=pylibraft_${RAPIDS_PY_CUDA_SUFFIX} rapids-get-pr-wheel-artifact cugraph-ops 692 python
+)
+
+cat > /tmp/constraints.txt <<EOF
+librmm-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${LIBRMM_CHANNEL}/librmm_*.whl)
+rmm-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${RMM_CHANNEL}/rmm_*.whl)
+cudf-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${CUDF_CHANNEL}/cudf_*.whl)
+libcudf-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${LIBCUDF_CHANNEL}/libcudf_*.whl)
+pylibcudf-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${PYLIBCUDF_CHANNEL}/pylibcudf_*.whl)
+dask-cudf-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${DASK_CUDF_CHANNEL}/dask_cudf_*.whl)
+ucxx-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${UCXX_CHANNEL}/ucxx_*.whl)
+libucxx-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${LIBUCXX_CHANNEL}/libucxx_*.whl)
+distributed-ucxx-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${DISTRIBUTED_UCXX_CHANNEL}/distributed_ucxx_*.whl)
+raft-dask-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${RAFT_DASK_CHANNEL}/raft_dask_*.whl)
+pylibraft-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${PYLIBRAFT_CHANNEL}/pylibraft_*.whl)
+pylibcugraphops-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${PYLIBCUGRAPHOPS_CHANNEL}/pylibcugraphops_*.whl)
+EOF
+
+export PIP_CONSTRAINT=/tmp/constraints.txt

--- a/rapids_config.cmake
+++ b/rapids_config.cmake
@@ -25,6 +25,8 @@ else()
       "Could not determine RAPIDS version. Contents of VERSION file:\n${_rapids_version_formatted}")
 endif()
 
+set(rapids-cmake-repo jameslamb/rapids-cmake)
+set(rapids-cmake-branch fmt-and-spdlog)
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/CUGRAPH_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake")
   file(
     DOWNLOAD


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/56

Now that most of `conda-forge` has been updated to `fmt >=11.0.1,<12` and `spdlog>=1.14.1,<1.15` (https://github.com/rapidsai/build-planning/issues/56#issuecomment-2334281452), we're attempting to upgrade RAPIDS to similar versions of those libraries.

This improves the likelihood that RAPIDS will be installable alongside newer versions of its
dependencies and complementary packages on conda-forge.

## Notes for Reviewers

**THIS SHOULD NOT BE MERGED**

This PR is testing changes made in https://github.com/rapidsai/rapids-cmake/pull/689.
