### PR TITLE
Install mg test executables

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -221,6 +221,7 @@ function(ConfigureTestMG CMAKE_TEST_NAME)
         PERCENT 100
         INSTALL_COMPONENT_SET testing_mg
     )
+    rapids_test_record_install(TARGET ${CMAKE_TEST_NAME} COMPONENT testing_mg)
     set_tests_properties(${CMAKE_TEST_NAME} PROPERTIES LABELS "CUGRAPH_MG")
 
 endfunction()
@@ -303,6 +304,7 @@ function(ConfigureCTestMG CMAKE_TEST_NAME)
         PERCENT 100
         INSTALL_COMPONENT_SET testing_mg
     )
+    rapids_test_record_install(TARGET ${CMAKE_TEST_NAME} COMPONENT testing_mg)
     set_tests_properties(${CMAKE_TEST_NAME} PROPERTIES LABELS "CUGRAPH_C_MG")
 
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -220,8 +220,8 @@ function(ConfigureTestMG CMAKE_TEST_NAME)
         GPUS ${GPU_COUNT}
         PERCENT 100
         INSTALL_COMPONENT_SET testing_mg
+        INSTALL_TARGET ${CMAKE_TEST_NAME}
     )
-    rapids_test_record_install(TARGET ${CMAKE_TEST_NAME} COMPONENT testing_mg)
     set_tests_properties(${CMAKE_TEST_NAME} PROPERTIES LABELS "CUGRAPH_MG")
 
 endfunction()
@@ -303,8 +303,8 @@ function(ConfigureCTestMG CMAKE_TEST_NAME)
         GPUS ${GPU_COUNT}
         PERCENT 100
         INSTALL_COMPONENT_SET testing_mg
+        INSTALL_TARGET ${CMAKE_TEST_NAME}
     )
-    rapids_test_record_install(TARGET ${CMAKE_TEST_NAME} COMPONENT testing_mg)
     set_tests_properties(${CMAKE_TEST_NAME} PROPERTIES LABELS "CUGRAPH_C_MG")
 
 

--- a/rapids_config.cmake
+++ b/rapids_config.cmake
@@ -25,9 +25,6 @@ else()
       "Could not determine RAPIDS version. Contents of VERSION file:\n${_rapids_version_formatted}")
 endif()
 
-# TODO: Remove these two lines before merging
-set(rapids-cmake-repo KyleFromNVIDIA/rapids-cmake)
-set(rapids-cmake-branch rapids_add_test-install_target)
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/CUGRAPH_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake")
   file(
     DOWNLOAD

--- a/rapids_config.cmake
+++ b/rapids_config.cmake
@@ -25,6 +25,9 @@ else()
       "Could not determine RAPIDS version. Contents of VERSION file:\n${_rapids_version_formatted}")
 endif()
 
+# TODO: Remove these two lines before merging
+set(rapids-cmake-repo https://github.com/KyleFromNVIDIA/rapids-cmake.git)
+set(rapids-cmake-branch rapids_add_test-install_target)
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/CUGRAPH_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake")
   file(
     DOWNLOAD

--- a/rapids_config.cmake
+++ b/rapids_config.cmake
@@ -26,7 +26,7 @@ else()
 endif()
 
 # TODO: Remove these two lines before merging
-set(rapids-cmake-repo https://github.com/KyleFromNVIDIA/rapids-cmake.git)
+set(rapids-cmake-repo KyleFromNVIDIA/rapids-cmake)
 set(rapids-cmake-branch rapids_add_test-install_target)
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/CUGRAPH_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake")
   file(


### PR DESCRIPTION
`rapids_test_add()` does not install the executables we need, because it's checking the value of `${MPIEXEC_EXECUTABLE}` and seeing that it's not a target. Install the target separately.