### PR TITLE
Symmetrize edgelist when creating a CSR graph

### DIFF
--- a/cpp/src/c_api/graph_sg.cpp
+++ b/cpp/src/c_api/graph_sg.cpp
@@ -793,7 +793,7 @@ cugraph_error_code_t cugraph_graph_create_sg_from_csr(
                                      p_edge_ids,
                                      p_edge_type_ids,
                                      renumber,
-                                     FALSE,  // symmetrize
+                                     symmetrize,
                                      do_expensive_check);
 
   try {


### PR DESCRIPTION
This PR allows the edge list to be symmetrized when creating a graph from a CSR representation.

closes #4693 