### PR TITLE
Update nx-cugraph to NetworkX 3.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,4 +78,4 @@ repos:
         types_or: [python, markdown]
         language: python
         pass_filenames: false
-        additional_dependencies: ["networkx>=3.3"]
+        additional_dependencies: ["networkx>=3.4"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
         types: [python]
         language: python
         pass_filenames: false
-        additional_dependencies: ["networkx>=3.3"]
+        additional_dependencies: ["networkx>=3.4"]
   - repo: local
     hooks:
       - id: nx-cugraph-readme-update

--- a/python/nx-cugraph/_nx_cugraph/__init__.py
+++ b/python/nx-cugraph/_nx_cugraph/__init__.py
@@ -36,7 +36,7 @@ _info = {
     "backend_name": "cugraph",
     "project": "nx-cugraph",
     "package": "nx_cugraph",
-    "url": f"https://rapids.ai/nx-cugraph",
+    "url": "https://rapids.ai/nx-cugraph",
     "short_summary": "GPU-accelerated backend.",
     # "description": "TODO",
     "functions": {

--- a/python/nx-cugraph/_nx_cugraph/__init__.py
+++ b/python/nx-cugraph/_nx_cugraph/__init__.py
@@ -180,7 +180,7 @@ _info = {
         "ego_graph": "Weighted ego_graph with negative cycles is not yet supported. `NotImplementedError` will be raised if there are negative `distance` edge weights.",
         "eigenvector_centrality": "`nstart` parameter is not used, but it is checked for validity.",
         "from_pandas_edgelist": "cudf.DataFrame inputs also supported; value columns with str is unsuppported.",
-        "generic_bfs_edges": "`neighbors` and `sort_neighbors` parameters are not yet supported.",
+        "generic_bfs_edges": "`neighbors` parameter is not yet supported.",
         "katz_centrality": "`nstart` isn't used (but is checked), and `normalized=False` is not supported.",
         "louvain_communities": "`seed` parameter is currently ignored, and self-loops are not yet supported.",
         "pagerank": "`dangling` parameter is not supported, but it is checked for validity.",

--- a/python/nx-cugraph/nx_cugraph/tests/test_ego_graph.py
+++ b/python/nx-cugraph/nx_cugraph/tests/test_ego_graph.py
@@ -78,7 +78,7 @@ def test_ego_graph_cycle_graph(
             nx.ego_graph(Gnx, n, **kwargs, backend="cugraph")
         with pytest.raises(NotImplementedError, match="ego_graph"):
             nx.ego_graph(Gcg, n, **kwargs, backend="cugraph")
-        if _nxver < (3, 4):
+        if _nxver < (3, 4) or not nx.config.fallback_to_nx:
             with pytest.raises(NotImplementedError, match="ego_graph"):
                 nx.ego_graph(Gcg, n, **kwargs)
         else:
@@ -86,7 +86,6 @@ def test_ego_graph_cycle_graph(
             # these arguments, so it falls back to networkx. Hence, as it is currently
             # implemented, the input graph is `nxcg.CudaGraph`, but the output graph
             # is `nx.Graph`. Should networkx convert back to "cugraph" backend?
-            # TODO: make fallback to networkx configurable.
             H2cg = nx.ego_graph(Gcg, n, **kwargs)
             assert type(H2nx) is type(H2cg)
             assert_graphs_equal(H2nx, nxcg.from_networkx(H2cg, preserve_all_attrs=True))


### PR DESCRIPTION
This run `make` in `python/nx-cugraph` directory and update the pre-commit hook.

Also fixes `ego_graph` tests to check `nx.config.fallback_to_nx` configuration.