### PR TITLE
Remove DeprecationWarnings from MG Uniform Neighbor Sample test

### DIFF
--- a/python/cugraph/cugraph/tests/sampling/test_uniform_neighbor_sample_mg.py
+++ b/python/cugraph/cugraph/tests/sampling/test_uniform_neighbor_sample_mg.py
@@ -386,7 +386,6 @@ def test_uniform_neighbor_sample_edge_properties(dask_client, return_offsets):
         ),
         fanout_vals=[-1, -1],
         with_replacement=False,
-        with_edge_properties=True,
         with_batch_ids=True,
         keep_batches_together=True,
         min_batch_id=0,
@@ -503,7 +502,6 @@ def test_uniform_neighbor_sample_edge_properties_self_loops(dask_client):
         ),
         fanout_vals=[2, 2],
         with_replacement=False,
-        with_edge_properties=True,
         with_batch_ids=True,
     ).compute()
 
@@ -550,7 +548,6 @@ def test_uniform_neighbor_sample_hop_id_order():
         cudf.Series([0, 1], dtype="int64"),
         fanout_vals=[2, 2, 2],
         with_replacement=False,
-        with_edge_properties=True,
     )
 
     for p in range(sampling_results.npartitions):
@@ -589,7 +586,6 @@ def test_uniform_neighbor_sample_hop_id_order_multi_batch():
         ),
         fanout_vals=[2, 2, 2],
         with_replacement=False,
-        with_edge_properties=True,
         with_batch_ids=True,
     )
 
@@ -649,7 +645,6 @@ def test_uniform_neighbor_edge_properties_sample_small_start_list(
         ),
         fanout_vals=[10, 25],
         with_replacement=with_replacement,
-        with_edge_properties=True,
         with_batch_ids=True,
     )
 
@@ -687,7 +682,6 @@ def test_uniform_neighbor_sample_without_dask_inputs(dask_client):
         ),
         fanout_vals=[2, 2],
         with_replacement=False,
-        with_edge_properties=True,
         with_batch_ids=True,
     ).compute()
 
@@ -753,7 +747,6 @@ def test_uniform_neighbor_sample_batched(dask_client, dataset, input_df, max_bat
         start_list=input_vertices,
         fanout_vals=[5, 5],
         with_replacement=False,
-        with_edge_properties=True,
         with_batch_ids=True,
     )
 
@@ -799,7 +792,6 @@ def test_uniform_neighbor_sample_exclude_sources_basic(dask_client):
             ),
             [2, 3, 3],
             with_replacement=False,
-            with_edge_properties=True,
             with_batch_ids=True,
             random_state=62,
             prior_sources_behavior="exclude",
@@ -842,7 +834,6 @@ def test_uniform_neighbor_sample_exclude_sources_email_eu_core(dask_client):
         seeds,
         [5, 4, 3, 2, 1],
         with_replacement=False,
-        with_edge_properties=True,
         with_batch_ids=False,
         prior_sources_behavior="exclude",
     ).compute()
@@ -888,7 +879,6 @@ def test_uniform_neighbor_sample_carry_over_sources_basic(dask_client):
             ),
             [2, 3, 3],
             with_replacement=False,
-            with_edge_properties=True,
             with_batch_ids=True,
             random_state=62,
             prior_sources_behavior="carryover",
@@ -936,7 +926,6 @@ def test_uniform_neighbor_sample_carry_over_sources_email_eu_core(dask_client):
         seeds,
         [5, 4, 3, 2, 1],
         with_replacement=False,
-        with_edge_properties=True,
         with_batch_ids=False,
         prior_sources_behavior="carryover",
     ).compute()
@@ -971,7 +960,6 @@ def test_uniform_neighbor_sample_deduplicate_sources_email_eu_core(dask_client):
         seeds,
         [5, 4, 3, 2, 1],
         with_replacement=False,
-        with_edge_properties=True,
         with_batch_ids=False,
         deduplicate_sources=True,
     ).compute()
@@ -1007,7 +995,6 @@ def test_uniform_neighbor_sample_renumber(dask_client, hops):
         seeds,
         hops,
         with_replacement=False,
-        with_edge_properties=True,
         with_batch_ids=False,
         deduplicate_sources=True,
         renumber=True,
@@ -1050,7 +1037,6 @@ def test_uniform_neighbor_sample_offset_renumber(dask_client, hops):
         seeds,
         hops,
         with_replacement=False,
-        with_edge_properties=True,
         with_batch_ids=False,
         deduplicate_sources=True,
         renumber=False,
@@ -1069,7 +1055,6 @@ def test_uniform_neighbor_sample_offset_renumber(dask_client, hops):
         seeds,
         hops,
         with_replacement=False,
-        with_edge_properties=True,
         with_batch_ids=False,
         deduplicate_sources=True,
         renumber=True,
@@ -1130,7 +1115,6 @@ def test_uniform_neighbor_sample_csr_csc_global(dask_client, hops, seed):
         seeds,
         hops,
         with_replacement=False,
-        with_edge_properties=True,
         with_batch_ids=False,
         deduplicate_sources=True,
         # carryover not valid because C++ sorts on (hop,src)
@@ -1190,7 +1174,6 @@ def test_uniform_neighbor_sample_csr_csc_local(dask_client, hops, seed):
         seeds,
         hops,
         with_replacement=False,
-        with_edge_properties=True,
         with_batch_ids=False,
         deduplicate_sources=True,
         prior_sources_behavior="carryover",


### PR DESCRIPTION
This PR removes kwargs for `uniform_neighbor_sample` that are deprecated.