### PR TITLE
Streamline graph creation in C API to allow for easier addition of new parameters

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -626,6 +626,7 @@ add_library(cugraph_c
         src/c_api/array.cpp
         src/c_api/degrees.cu
         src/c_api/degrees_result.cpp
+        src/c_api/edgelist.cpp
         src/c_api/error.cpp
         src/c_api/graph_sg.cpp
         src/c_api/graph_mg.cpp

--- a/cpp/include/cugraph_c/edgelist.h
+++ b/cpp/include/cugraph_c/edgelist.h
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cugraph_c/array.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  int32_t align_;
+} cugraph_edgelist_t;
+
+typedef struct {
+  int32_t align_;
+} cugraph_single_edgelist_view_t;
+
+/**
+ * @brief     Create an edgelist objects.  A graph can be constructed by a collection
+ *            of lists of edges.  Logically these will be concatenated into a single list.
+ *
+ * @param [in]  handle           Handle for accessing resources
+ * @param [in]  num_lists        Number of edgelist view to be populated
+ * @param [in]  store_transposed If true the edges are specified in transposed format
+ * @param [out] edgelists        Pointer to constructed edgelist object
+ * @param [out] error            Pointer to an error object storing details of any error.  Will
+ *                               be populated if error code is not CUGRAPH_SUCCESS
+ *
+ * @return error code
+ */
+cugraph_error_code_t cugraph_edgelist_create(const cugraph_resource_handle_t* handle,
+                                             size_t num_lists,
+                                             bool_t store_transposed,
+                                             cugraph_edgelist_t** edgelist,
+                                             cugraph_error_t** error);
+
+/**
+ * @brief    Set number of edges on an edgelist
+ *
+ * @param [in]  edgelist    Edge list to update
+ * @param [in]  list_index  Index of edge list to update
+ * @param [in]  num_edges   Number of edges
+ * @param [out] error       Pointer to an error object storing details of any error.  Will
+ *                          be populated if error code is not CUGRAPH_SUCCESS
+ */
+cugraph_error_code_t cugraph_edgelist_set_num_edges(cugraph_edgelist_t* edgelist,
+                                                    size_t list_index,
+                                                    size_t num_edges,
+                                                    cugraph_error_t** error);
+
+/**
+ * @brief     Add vertices to edgelist object
+ *
+ * @param [in]     handle              Handle for accessing resources
+ * @param [in/out] edgelist            A pointer to the edgelist object
+ * @param [in]     list_index          Index of edgelist to update
+ * @param [in]     num_vertices        Number of vertices specified.  In MG context this would
+ *                                     be the number of vertices specified on this GPU
+ * @param [in]     dtype               Datatype for vertices
+ * @param [out]    vertices_array_view Pointer to view of vertices array
+ * @param [out]    error               Pointer to an error object storing details of any error. Will
+ *                                     be populated if error code is not CUGRAPH_SUCCESS
+ *
+ * @return error code
+ */
+cugraph_error_code_t cugraph_edgelist_add_vertices(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t num_vertices,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** vertices_array_view,
+  cugraph_error_t** error);
+
+/**
+ * @brief     Add major vertices to edgelist object.  For a non-transposed graph these are the
+ *            source vertices of the edges.  For a transposed graph these are the destination
+ *            vertices.
+ *
+ * Note that an edgelist should be created either with offsets/indices or with
+ * majors/minors, specifying both is an error.
+ *
+ * @param [in]     handle            Handle for accessing resources
+ * @param [in/out] edgelist          A pointer to the edgelist object
+ * @param [in]     list_index        Index of edgelist to update
+ * @param [in]     size              Number of entries in list
+ * @param [in]     dtype             Datatype for major vertices
+ * @param [out]    majors_array_view Pointer to view of majors array
+ * @param [out]    error             Pointer to an error object storing details of any error.  Will
+ *                                   be populated if error code is not CUGRAPH_SUCCESS
+ *
+ * @return error code
+ */
+cugraph_error_code_t cugraph_edgelist_add_major_vertices(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t size,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** majors_array_view,
+  cugraph_error_t** error);
+
+/**
+ * @brief     Add minor vertices to edgelist object.  For a non-transposed graph these are the
+ *            destination vertices of the edges.  For a transposed graph these are the source
+ *            vertices.
+ *
+ * Note that an edgelist should be created either with offsets/indices or with
+ * majors/minors, specifying both is an error.
+ *
+ * @param [in]     handle            Handle for accessing resources
+ * @param [in/out] edgelist          A pointer to the edgelist object
+ * @param [in]     list_index        Index of edgelist to update
+ * @param [in]     size              Number of entries in list
+ * @param [in]     dtype             Datatype for minor vertices
+ * @param [out]    minors_array_view Pointer to view of minors array
+ * @param [out]    error             Pointer to an error object storing details of any error.  Will
+ *                                   be populated if error code is not CUGRAPH_SUCCESS
+ *
+ * @return error code
+ */
+cugraph_error_code_t cugraph_edgelist_add_minor_vertices(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t size,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** minors_array_view,
+  cugraph_error_t** error);
+
+/**
+ * @brief     Add offsets to edgelist object.  A CSR is only supported with
+ *            and edgelist of size 1, so the list_index is assumed to be zero.
+ *
+ * Note that an edgelist should be created either with offsets/indices or with
+ * majors/minors, specifying both is an error.
+ *
+ * @param [in]     handle             Handle for accessing resources
+ * @param [in/out] edgelist           A pointer to the edgelist object
+ * @param [in]     dtype              Datatype for offsets
+ * @param [in]     size               Number of entries in list
+ * @param [out]    offsets_array_view Pointer to view of majors array
+ * @param [out]    error              Pointer to an error object storing details of any error.  Will
+ *                                    be populated if error code is not CUGRAPH_SUCCESS
+ *
+ * @return error code
+ */
+cugraph_error_code_t cugraph_edgelist_add_offsets(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  cugraph_data_type_id_t dtype,
+  size_t size,
+  cugraph_type_erased_device_array_view_t** offsets_array_view,
+  cugraph_error_t** error);
+
+/**
+ * @brief     Add indices to edgelist object.  A CSR is only supported with
+ *            an edgelist of size 1, so the list_index is assumed to be zero.
+ *
+ * Note that an edgelist should be created either with offsets/indices or with
+ * majors/minors, specifying both is an error.
+ *
+ * @param [in]     handle            Handle for accessing resources
+ * @param [in/out] edgelist          A pointer to the edgelist object
+ * @param [in]     dtype             Datatype for minor vertices
+ * @param [in]     size              Number of entries in list
+ * @param [out]    minors_array_view Pointer to view of minors array
+ * @param [out]    error             Pointer to an error object storing details of any error.  Will
+ *                                   be populated if error code is not CUGRAPH_SUCCESS
+ *
+ * @return error code
+ */
+cugraph_error_code_t cugraph_edgelist_add_indices(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  cugraph_data_type_id_t dtype,
+  size_t size,
+  cugraph_type_erased_device_array_view_t** indices_array_view,
+  cugraph_error_t** error);
+
+/**
+ * @brief     Add weights to edgelist object.
+ *
+ * @param [in]     handle             Handle for accessing resources
+ * @param [in/out] edgelist           A pointer to the edgelist object
+ * @param [in]     list_index         Index of edgelist to update
+ * @param [in]     size               Number of entries in list
+ * @param [in]     dtype              Datatype for minor vertices
+ * @param [out]    weights_array_view Pointer to view of weights array
+ * @param [out]    error              Pointer to an error object storing details of any error.  Will
+ *                                    be populated if error code is not CUGRAPH_SUCCESS
+ *
+ * @return error code
+ */
+cugraph_error_code_t cugraph_edgelist_add_weights(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t size,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** weights_array_view,
+  cugraph_error_t** error);
+
+/**
+ * @brief     Add edge ids to edgelist object.
+ *
+ * @param [in]     handle         Handle for accessing resources
+ * @param [in/out] edgelist       A pointer to the edgelist object
+ * @param [in]     list_index     Index of edgelist to update
+ * @param [in]     size           Number of entries in list
+ * @param [in]     dtype          Datatype for minor vertices
+ * @param [out]    ids_array_view Pointer to view of ids array
+ * @param [out]    error          Pointer to an error object storing details of any error.  Will
+ *                                be populated if error code is not CUGRAPH_SUCCESS
+ *
+ * @return error code
+ */
+cugraph_error_code_t cugraph_edgelist_add_edge_ids(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t size,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** ids_array_view,
+  cugraph_error_t** error);
+
+/**
+ * @brief     Add edge types to edgelist object.
+ *
+ * @param [in]     handle           Handle for accessing resources
+ * @param [in/out] edgelist         A pointer to the edgelist object
+ * @param [in]     list_index       Index of edgelist to update
+ * @param [in]     size             Number of entries in list
+ * @param [in]     dtype            Datatype for minor vertices
+ * @param [out]    types_array_view Pointer to view of types array
+ * @param [out]    error            Pointer to an error object storing details of any error.  Will
+ *                                  be populated if error code is not CUGRAPH_SUCCESS
+ *
+ * @return error code
+ */
+cugraph_error_code_t cugraph_edgelist_add_edge_types(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t size,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** types_array_view,
+  cugraph_error_t** error);
+
+/**
+ * @brief     Add edge start times to edgelist object.
+ *
+ * @param [in]     handle           Handle for accessing resources
+ * @param [in/out] edgelist         A pointer to the edgelist object
+ * @param [in]     list_index       Index of edgelist to update
+ * @param [in]     size             Number of entries in list
+ * @param [in]     dtype            Datatype for minor vertices
+ * @param [out]    times_array_view Pointer to view of times array
+ * @param [out]    error            Pointer to an error object storing details of any error.  Will
+ *                                  be populated if error code is not CUGRAPH_SUCCESS
+ *
+ * @return error code
+ */
+cugraph_error_code_t cugraph_edgelist_add_edge_start_times(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t size,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** times_array_view,
+  cugraph_error_t** error);
+
+/**
+ * @brief     Add edge end times to edgelist object.
+ *
+ * @param [in]     handle           Handle for accessing resources
+ * @param [in/out] edgelist         A pointer to the edgelist object
+ * @param [in]     list_index       Index of edgelist to update
+ * @param [in]     size             Number of entries in list
+ * @param [in]     dtype            Datatype for minor vertices
+ * @param [out]    times_array_view Pointer to view of times array
+ * @param [out]    error            Pointer to an error object storing details of any error.  Will
+ *                                  be populated if error code is not CUGRAPH_SUCCESS
+ *
+ * @return error code
+ */
+cugraph_error_code_t cugraph_edgelist_add_edge_end_times(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t size,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** times_array_view,
+  cugraph_error_t** error);
+
+/**
+ * @brief     Destroy an edgelist
+ *
+ * @param [in]  edgelist  A pointer to the edgelist object to destroy
+ */
+void cugraph_edgelist_free(cugraph_edgelist_t* edgelist);
+
+#ifdef __cplusplus
+}
+#endif

--- a/cpp/include/cugraph_c/graph.h
+++ b/cpp/include/cugraph_c/graph.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cugraph_c/array.h>
+#include <cugraph_c/edgelist.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,8 +36,42 @@ typedef struct {
   bool_t is_multigraph;
 } cugraph_graph_properties_t;
 
+typedef struct {
+  bool_t store_transposed;
+  bool_t renumber;
+  bool_t drop_self_loops;
+  bool_t drop_multi_edges;
+  bool_t symmetrize;
+  bool_t multi_gpu;
+} cugraph_graph_creation_flags_t;
+
+/**
+ * @brief     Construct a graph
+ *
+ * @param [in]  handle         Handle for accessing resources
+ * @param [in]  properties     Properties of the constructed graph
+ * @param [in]  edgelist       Edgelist object containing all of the vertex and edge data
+ * @param [in]  flags          Graph creation flags
+ * @param [in]  do_expensive_check    If true, do expensive checks to validate the input data
+ *    is consistent with software assumptions.  If false bypass these checks.
+ * @param [out] graph          A pointer to the graph object
+ * @param [out] error          Pointer to an error object storing details of any error.  Will
+ *                             be populated if error code is not CUGRAPH_SUCCESS
+ *
+ * @return error code
+ */
+cugraph_error_code_t cugraph_graph_create(const cugraph_resource_handle_t* handle,
+                                          const cugraph_graph_properties_t* properties,
+                                          const cugraph_edgelist_t* edgelist,
+                                          const cugraph_graph_creation_flags_t flags,
+                                          bool_t do_expensive_check,
+                                          cugraph_graph_t** graph,
+                                          cugraph_error_t** error);
+
 /**
  * @brief     Construct an SG graph
+ *
+ * @deprecated  This API will be deleted, use cugraph_graph_create instead
  *
  * @param [in]  handle         Handle for accessing resources
  * @param [in]  properties     Properties of the constructed graph
@@ -94,6 +129,8 @@ cugraph_error_code_t cugraph_graph_create_sg(
 /**
  * @brief     Construct an SG graph from a CSR input
  *
+ * @deprecated  This API will be deleted, use cugraph_graph_create instead
+ *
  * @param [in]  handle         Handle for accessing resources
  * @param [in]  properties     Properties of the constructed graph
  * @param [in]  offsets        Device array containing the CSR offsets array
@@ -136,6 +173,8 @@ cugraph_error_code_t cugraph_graph_create_sg_from_csr(
 
 /**
  * @brief     Construct an MG graph
+ *
+ * @deprecated  This API will be deleted, use cugraph_graph_create instead
  *
  * @param [in]  handle          Handle for accessing resources
  * @param [in]  properties      Properties of the constructed graph

--- a/cpp/src/c_api/edgelist.cpp
+++ b/cpp/src/c_api/edgelist.cpp
@@ -1,0 +1,437 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "c_api/edgelist.hpp"
+
+#include "c_api/error.hpp"
+#include "c_api/resource_handle.hpp"
+
+#include <cugraph_c/edgelist.h>
+
+extern "C" cugraph_error_code_t cugraph_edgelist_create(const cugraph_resource_handle_t* handle,
+                                                        size_t num_lists,
+                                                        bool_t store_transposed,
+                                                        cugraph_edgelist_t** edgelist,
+                                                        cugraph_error_t** error)
+{
+  *edgelist = reinterpret_cast<cugraph_edgelist_t*>(
+    new cugraph::c_api::cugraph_edgelist_t{num_lists, store_transposed});
+  return CUGRAPH_SUCCESS;
+}
+
+extern "C" cugraph_error_code_t cugraph_edgelist_set_num_edges(cugraph_edgelist_t* edgelist,
+                                                               size_t list_index,
+                                                               size_t num_edges,
+                                                               cugraph_error_t** error)
+{
+  auto p_edgelist        = reinterpret_cast<cugraph::c_api::cugraph_edgelist_t*>(edgelist);
+  p_edgelist->num_edges_ = num_edges;
+  return CUGRAPH_SUCCESS;
+}
+
+namespace {
+
+cugraph_error_code_t add_list(cugraph_resource_handle_t const* handle,
+                              std::vector<cugraph_type_erased_device_array_t*>& list,
+                              size_t list_index,
+                              size_t num_lists,
+                              size_t size,
+                              cugraph_data_type_id_t dtype,
+                              cugraph_type_erased_device_array_view_t** view,
+                              cugraph_error_t** error)
+{
+  if (list.size() == 0) {
+    list.resize(num_lists);
+    std::fill(list.begin(), list.end(), nullptr);
+  }
+
+  CAPI_EXPECTS(list_index < list.size(),
+               CUGRAPH_INVALID_INPUT,
+               "list_index must be less than num_lists",
+               *error);
+  CAPI_EXPECTS(list[list_index] == nullptr,
+               CUGRAPH_INVALID_INPUT,
+               "Tried to create an entry that already exists",
+               *error);
+
+  auto error_code =
+    cugraph_type_erased_device_array_create(handle, size, dtype, &list[list_index], error);
+  if (error_code == CUGRAPH_SUCCESS) {
+    *view = cugraph_type_erased_device_array_view(list[list_index]);
+  }
+
+  return error_code;
+}
+
+}  // namespace
+
+extern "C" cugraph_error_code_t cugraph_edgelist_add_vertices(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t num_vertices,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** vertices_array_view,
+  cugraph_error_t** error)
+{
+  auto p_edgelist = reinterpret_cast<cugraph::c_api::cugraph_edgelist_t*>(edgelist);
+
+  CAPI_EXPECTS((p_edgelist->vertex_type_ == NTYPES) || (p_edgelist->vertex_type_ == dtype),
+               CUGRAPH_INVALID_INPUT,
+               "Trying to create vertex array of wrong type",
+               *error);
+
+  p_edgelist->vertex_type_ = dtype;
+
+  return add_list(handle,
+                  p_edgelist->vertices_,
+                  list_index,
+                  p_edgelist->num_lists_,
+                  num_vertices,
+                  dtype,
+                  vertices_array_view,
+                  error);
+}
+
+extern "C" cugraph_error_code_t cugraph_edgelist_add_major_vertices(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t size,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** majors_array_view,
+  cugraph_error_t** error)
+{
+  auto p_edgelist = reinterpret_cast<cugraph::c_api::cugraph_edgelist_t*>(edgelist);
+
+  CAPI_EXPECTS((p_edgelist->vertex_type_ == NTYPES) || (p_edgelist->vertex_type_ == dtype),
+               CUGRAPH_INVALID_INPUT,
+               "Trying to create majors array of wrong type",
+               *error);
+
+  CAPI_EXPECTS(!p_edgelist->offsets_ && !p_edgelist->indices_,
+               CUGRAPH_INVALID_INPUT,
+               "Cannot specify both offsets/indices and majors/minors",
+               *error);
+
+  p_edgelist->vertex_type_ = dtype;
+
+  return add_list(handle,
+                  p_edgelist->majors_,
+                  list_index,
+                  p_edgelist->num_lists_,
+                  size,
+                  dtype,
+                  majors_array_view,
+                  error);
+}
+
+extern "C" cugraph_error_code_t cugraph_edgelist_add_minor_vertices(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t size,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** minors_array_view,
+  cugraph_error_t** error)
+{
+  auto p_edgelist = reinterpret_cast<cugraph::c_api::cugraph_edgelist_t*>(edgelist);
+
+  CAPI_EXPECTS(p_edgelist != nullptr,
+               CUGRAPH_INVALID_INPUT,
+               "Trying to add edge times to unintialized edgelist",
+               *error);
+
+  CAPI_EXPECTS((p_edgelist->vertex_type_ == NTYPES) || (p_edgelist->vertex_type_ == dtype),
+               CUGRAPH_INVALID_INPUT,
+               "Trying to create minors array of wrong type",
+               *error);
+
+  CAPI_EXPECTS(!p_edgelist->offsets_ && !p_edgelist->indices_,
+               CUGRAPH_INVALID_INPUT,
+               "Cannot specify both offsets/indices and majors/minors",
+               *error);
+
+  p_edgelist->vertex_type_ = dtype;
+
+  return add_list(handle,
+                  p_edgelist->minors_,
+                  list_index,
+                  p_edgelist->num_lists_,
+                  size,
+                  dtype,
+                  minors_array_view,
+                  error);
+}
+
+extern "C" cugraph_error_code_t cugraph_edgelist_add_offsets(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  cugraph_data_type_id_t dtype,
+  size_t size,
+  cugraph_type_erased_device_array_view_t** offsets_array_view,
+  cugraph_error_t** error)
+{
+  auto p_edgelist = reinterpret_cast<cugraph::c_api::cugraph_edgelist_t*>(edgelist);
+
+  CAPI_EXPECTS(p_edgelist != nullptr,
+               CUGRAPH_INVALID_INPUT,
+               "Trying to add offsets to unintialized edgelist",
+               *error);
+
+  CAPI_EXPECTS(!p_edgelist->offsets_,
+               CUGRAPH_INVALID_INPUT,
+               "Trying to add offsets after already initialized",
+               *error);
+
+  CAPI_EXPECTS(p_edgelist->num_lists_ == 1,
+               CUGRAPH_INVALID_INPUT,
+               "edgelist with offsets/indices can only have one list",
+               *error);
+
+  CAPI_EXPECTS((p_edgelist->majors_.size() == 0) && (p_edgelist->minors_.size() == 0),
+               CUGRAPH_INVALID_INPUT,
+               "Cannot specify both offsets/indices and majors/minors",
+               *error);
+
+  cugraph_type_erased_device_array_t* array;
+  auto error_code = cugraph_type_erased_device_array_create(handle, size, dtype, &array, error);
+
+  if (error_code == CUGRAPH_SUCCESS) {
+    p_edgelist->offsets_.reset(array);
+    *offsets_array_view = cugraph_type_erased_device_array_view(array);
+  }
+
+  return error_code;
+}
+
+extern "C" cugraph_error_code_t cugraph_edgelist_add_indices(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  cugraph_data_type_id_t dtype,
+  size_t size,
+  cugraph_type_erased_device_array_view_t** indices_array_view,
+  cugraph_error_t** error)
+{
+  auto p_edgelist = reinterpret_cast<cugraph::c_api::cugraph_edgelist_t*>(edgelist);
+
+  CAPI_EXPECTS(p_edgelist != nullptr,
+               CUGRAPH_INVALID_INPUT,
+               "Trying to add indices to unintialized edgelist",
+               *error);
+
+  CAPI_EXPECTS(!p_edgelist->indices_,
+               CUGRAPH_INVALID_INPUT,
+               "Trying to add indices after already initialized",
+               *error);
+
+  CAPI_EXPECTS(p_edgelist->num_lists_ == 1,
+               CUGRAPH_INVALID_INPUT,
+               "edgelist with offsets/indices can only have one list",
+               *error);
+
+  CAPI_EXPECTS((p_edgelist->majors_.size() == 0) && (p_edgelist->minors_.size() == 0),
+               CUGRAPH_INVALID_INPUT,
+               "Cannot specify both offsets/indices and majors/minors",
+               *error);
+
+  cugraph_type_erased_device_array_t* array;
+  auto error_code = cugraph_type_erased_device_array_create(handle, size, dtype, &array, error);
+
+  if (error_code == CUGRAPH_SUCCESS) {
+    p_edgelist->indices_.reset(array);
+    *indices_array_view = cugraph_type_erased_device_array_view(array);
+  }
+
+  return error_code;
+}
+
+extern "C" cugraph_error_code_t cugraph_edgelist_add_weights(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t size,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** weights_array_view,
+  cugraph_error_t** error)
+{
+  auto p_edgelist = reinterpret_cast<cugraph::c_api::cugraph_edgelist_t*>(edgelist);
+
+  CAPI_EXPECTS(p_edgelist != nullptr,
+               CUGRAPH_INVALID_INPUT,
+               "Trying to add edge times to unintialized edgelist",
+               *error);
+
+  CAPI_EXPECTS(
+    (p_edgelist->edge_weight_type_ == NTYPES) || (p_edgelist->edge_weight_type_ == dtype),
+    CUGRAPH_INVALID_INPUT,
+    "Trying to create weights array of wrong type",
+    *error);
+
+  p_edgelist->edge_weight_type_ = dtype;
+
+  return add_list(handle,
+                  p_edgelist->weights_,
+                  list_index,
+                  p_edgelist->num_lists_,
+                  size,
+                  dtype,
+                  weights_array_view,
+                  error);
+}
+
+extern "C" cugraph_error_code_t cugraph_edgelist_add_edge_ids(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t size,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** ids_array_view,
+  cugraph_error_t** error)
+{
+  auto p_edgelist = reinterpret_cast<cugraph::c_api::cugraph_edgelist_t*>(edgelist);
+
+  CAPI_EXPECTS(p_edgelist != nullptr,
+               CUGRAPH_INVALID_INPUT,
+               "Trying to add edge times to unintialized edgelist",
+               *error);
+
+  CAPI_EXPECTS((p_edgelist->edge_id_type_ == NTYPES) || (p_edgelist->edge_id_type_ == dtype),
+               CUGRAPH_INVALID_INPUT,
+               "Trying to create edge id array of wrong type",
+               *error);
+
+  p_edgelist->edge_id_type_ = dtype;
+
+  return add_list(handle,
+                  p_edgelist->edge_ids_,
+                  list_index,
+                  p_edgelist->num_lists_,
+                  size,
+                  dtype,
+                  ids_array_view,
+                  error);
+}
+
+extern "C" cugraph_error_code_t cugraph_edgelist_add_edge_types(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t size,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** types_array_view,
+  cugraph_error_t** error)
+{
+  auto p_edgelist = reinterpret_cast<cugraph::c_api::cugraph_edgelist_t*>(edgelist);
+
+  CAPI_EXPECTS(p_edgelist != nullptr,
+               CUGRAPH_INVALID_INPUT,
+               "Trying to add edge times to unintialized edgelist",
+               *error);
+
+  CAPI_EXPECTS((p_edgelist->edge_type_type_ == NTYPES) || (p_edgelist->edge_type_type_ == dtype),
+               CUGRAPH_INVALID_INPUT,
+               "Trying to create edge types array of wrong type",
+               *error);
+
+  p_edgelist->edge_type_type_ = dtype;
+
+  return add_list(handle,
+                  p_edgelist->edge_types_,
+                  list_index,
+                  p_edgelist->num_lists_,
+                  size,
+                  dtype,
+                  types_array_view,
+                  error);
+}
+
+extern "C" cugraph_error_code_t cugraph_edgelist_add_edge_start_times(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t size,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** times_array_view,
+  cugraph_error_t** error)
+{
+  auto p_edgelist = reinterpret_cast<cugraph::c_api::cugraph_edgelist_t*>(edgelist);
+
+  CAPI_EXPECTS(p_edgelist != nullptr,
+               CUGRAPH_INVALID_INPUT,
+               "Trying to add edge times to unintialized edgelist",
+               *error);
+
+  CAPI_EXPECTS((p_edgelist->edge_time_type_ == NTYPES) || (p_edgelist->edge_time_type_ == dtype),
+               CUGRAPH_INVALID_INPUT,
+               "Trying to create edge start time array of wrong type",
+               *error);
+
+  p_edgelist->edge_time_type_ = dtype;
+
+  return add_list(handle,
+                  p_edgelist->edge_start_times_,
+                  list_index,
+                  p_edgelist->num_lists_,
+                  size,
+                  dtype,
+                  times_array_view,
+                  error);
+}
+
+extern "C" cugraph_error_code_t cugraph_edgelist_add_edge_end_times(
+  const cugraph_resource_handle_t* handle,
+  cugraph_edgelist_t* edgelist,
+  size_t list_index,
+  size_t size,
+  cugraph_data_type_id_t dtype,
+  cugraph_type_erased_device_array_view_t** times_array_view,
+  cugraph_error_t** error)
+{
+  auto p_edgelist = reinterpret_cast<cugraph::c_api::cugraph_edgelist_t*>(edgelist);
+
+  CAPI_EXPECTS(p_edgelist != nullptr,
+               CUGRAPH_INVALID_INPUT,
+               "Trying to add edge times to unintialized edgelist",
+               *error);
+
+  CAPI_EXPECTS((p_edgelist->edge_time_type_ == NTYPES) || (p_edgelist->edge_time_type_ == dtype),
+               CUGRAPH_INVALID_INPUT,
+               "Trying to create edge end times array of wrong type",
+               *error);
+
+  p_edgelist->edge_time_type_ = dtype;
+
+  return add_list(handle,
+                  p_edgelist->edge_end_times_,
+                  list_index,
+                  p_edgelist->num_lists_,
+                  // TODO: In all add_list calls for edge properties... need to keep
+                  //   overall size of edges in an std::vector and check that sizes match
+                  size,
+                  dtype,
+                  times_array_view,
+                  error);
+}
+
+extern "C" void cugraph_edgelist_free(cugraph_edgelist_t* edgelist)
+{
+  if (edgelist != nullptr) {
+    auto p_edgelist = reinterpret_cast<cugraph::c_api::cugraph_edgelist_t*>(edgelist);
+    delete p_edgelist;
+    edgelist = nullptr;
+  }
+}

--- a/cpp/src/c_api/edgelist.hpp
+++ b/cpp/src/c_api/edgelist.hpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cugraph_c/edgelist.h>
+
+#include <c_api/array.hpp>
+
+#include <limits>
+
+namespace cugraph {
+namespace c_api {
+
+struct cugraph_edgelist_t {
+  size_t num_lists_{1};
+  bool store_transposed_{false};
+  size_t num_edges_{std::numeric_limits<size_t>::max()};
+
+  std::unique_ptr<::cugraph_type_erased_device_array_t> offsets_{};
+  std::unique_ptr<::cugraph_type_erased_device_array_t> indices_{};
+
+  std::vector<::cugraph_type_erased_device_array_t*> vertices_{};
+  std::vector<::cugraph_type_erased_device_array_t*> majors_{};
+  std::vector<::cugraph_type_erased_device_array_t*> minors_{};
+  std::vector<::cugraph_type_erased_device_array_t*> weights_{};
+  std::vector<::cugraph_type_erased_device_array_t*> edge_ids_{};
+  std::vector<::cugraph_type_erased_device_array_t*> edge_types_{};
+  std::vector<::cugraph_type_erased_device_array_t*> edge_start_times_{};
+  std::vector<::cugraph_type_erased_device_array_t*> edge_end_times_{};
+
+  cugraph_data_type_id_t vertex_type_{NTYPES};
+  cugraph_data_type_id_t edge_weight_type_{NTYPES};
+  cugraph_data_type_id_t edge_id_type_{NTYPES};
+  cugraph_data_type_id_t edge_type_type_{NTYPES};
+  cugraph_data_type_id_t edge_time_type_{NTYPES};
+};
+
+}  // namespace c_api
+}  // namespace cugraph

--- a/cpp/src/c_api/graph.cpp
+++ b/cpp/src/c_api/graph.cpp
@@ -1,0 +1,812 @@
+/*
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "c_api/graph.hpp"
+
+#include "c_api/abstract_functor.hpp"
+#include "c_api/array.hpp"
+#include "c_api/error.hpp"
+#include "c_api/generic_cascaded_dispatch.hpp"
+#include "c_api/graph_helper.hpp"
+#include "c_api/resource_handle.hpp"
+
+#include <cugraph_c/graph.h>
+
+#include <cugraph/detail/utility_wrappers.hpp>
+#include <cugraph/graph_functions.hpp>
+
+#include <limits>
+
+namespace {
+
+struct create_graph_functor : public cugraph::c_api::abstract_functor {
+  raft::handle_t const& handle_;
+  cugraph_graph_properties_t const* properties_;
+  cugraph::c_api::cugraph_type_erased_device_array_view_t const* vertices_;
+  cugraph::c_api::cugraph_type_erased_device_array_view_t const* src_;
+  cugraph::c_api::cugraph_type_erased_device_array_view_t const* dst_;
+  cugraph::c_api::cugraph_type_erased_device_array_view_t const* weights_;
+  cugraph::c_api::cugraph_type_erased_device_array_view_t const* edge_ids_;
+  cugraph::c_api::cugraph_type_erased_device_array_view_t const* edge_type_ids_;
+  bool_t renumber_;
+  bool_t drop_self_loops_;
+  bool_t drop_multi_edges_;
+  bool_t symmetrize_;
+  bool_t do_expensive_check_;
+  cugraph_data_type_id_t edge_type_;
+  cugraph::c_api::cugraph_graph_t* result_{};
+
+  create_graph_functor(raft::handle_t const& handle,
+                       cugraph_graph_properties_t const* properties,
+                       cugraph::c_api::cugraph_type_erased_device_array_view_t const* vertices,
+                       cugraph::c_api::cugraph_type_erased_device_array_view_t const* src,
+                       cugraph::c_api::cugraph_type_erased_device_array_view_t const* dst,
+                       cugraph::c_api::cugraph_type_erased_device_array_view_t const* weights,
+                       cugraph::c_api::cugraph_type_erased_device_array_view_t const* edge_ids,
+                       cugraph::c_api::cugraph_type_erased_device_array_view_t const* edge_type_ids,
+                       bool_t renumber,
+                       bool_t drop_self_loops,
+                       bool_t drop_multi_edges,
+                       bool_t symmetrize,
+                       bool_t do_expensive_check,
+                       cugraph_data_type_id_t edge_type)
+    : abstract_functor(),
+      properties_(properties),
+      handle_(handle),
+      vertices_(vertices),
+      src_(src),
+      dst_(dst),
+      weights_(weights),
+      edge_ids_(edge_ids),
+      edge_type_ids_(edge_type_ids),
+      renumber_(renumber),
+      drop_self_loops_(drop_self_loops),
+      drop_multi_edges_(drop_multi_edges),
+      symmetrize_(symmetrize),
+      do_expensive_check_(do_expensive_check),
+      edge_type_(edge_type)
+  {
+  }
+
+  template <typename vertex_t,
+            typename edge_t,
+            typename weight_t,
+            typename edge_type_id_t,
+            bool store_transposed,
+            bool multi_gpu>
+  void operator()()
+  {
+    if constexpr (multi_gpu || !cugraph::is_candidate<vertex_t, edge_t, weight_t>::value) {
+      unsupported();
+    } else {
+      if (do_expensive_check_) {
+        // FIXME:  Need an implementation here.
+      }
+
+      std::optional<rmm::device_uvector<vertex_t>> new_number_map;
+
+      std::optional<cugraph::edge_property_t<
+        cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
+        weight_t>>
+        new_edge_weights{std::nullopt};
+
+      std::optional<cugraph::edge_property_t<
+        cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
+        edge_t>>
+        new_edge_ids{std::nullopt};
+
+      std::optional<cugraph::edge_property_t<
+        cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
+        edge_type_id_t>>
+        new_edge_types{std::nullopt};
+
+      std::optional<rmm::device_uvector<vertex_t>> vertex_list =
+        vertices_ ? std::make_optional(
+                      rmm::device_uvector<vertex_t>(vertices_->size_, handle_.get_stream()))
+                  : std::nullopt;
+
+      if (vertex_list) {
+        raft::copy<vertex_t>(vertex_list->data(),
+                             vertices_->as_type<vertex_t>(),
+                             vertices_->size_,
+                             handle_.get_stream());
+      }
+
+      rmm::device_uvector<vertex_t> edgelist_srcs(src_->size_, handle_.get_stream());
+      rmm::device_uvector<vertex_t> edgelist_dsts(dst_->size_, handle_.get_stream());
+
+      raft::copy<vertex_t>(
+        edgelist_srcs.data(), src_->as_type<vertex_t>(), src_->size_, handle_.get_stream());
+      raft::copy<vertex_t>(
+        edgelist_dsts.data(), dst_->as_type<vertex_t>(), dst_->size_, handle_.get_stream());
+
+      std::optional<rmm::device_uvector<weight_t>> edgelist_weights =
+        weights_
+          ? std::make_optional(rmm::device_uvector<weight_t>(weights_->size_, handle_.get_stream()))
+          : std::nullopt;
+
+      if (edgelist_weights) {
+        raft::copy<weight_t>(edgelist_weights->data(),
+                             weights_->as_type<weight_t>(),
+                             weights_->size_,
+                             handle_.get_stream());
+      }
+
+      std::optional<rmm::device_uvector<edge_t>> edgelist_edge_ids =
+        edge_ids_
+          ? std::make_optional(rmm::device_uvector<edge_t>(edge_ids_->size_, handle_.get_stream()))
+          : std::nullopt;
+
+      if (edgelist_edge_ids) {
+        raft::copy<edge_t>(edgelist_edge_ids->data(),
+                           edge_ids_->as_type<edge_t>(),
+                           edge_ids_->size_,
+                           handle_.get_stream());
+      }
+
+      std::optional<rmm::device_uvector<edge_type_id_t>> edgelist_edge_types =
+        edge_type_ids_ ? std::make_optional(rmm::device_uvector<edge_type_id_t>(
+                           edge_type_ids_->size_, handle_.get_stream()))
+                       : std::nullopt;
+
+      if (edgelist_edge_types) {
+        raft::copy<edge_type_id_t>(edgelist_edge_types->data(),
+                                   edge_type_ids_->as_type<edge_type_id_t>(),
+                                   edge_type_ids_->size_,
+                                   handle_.get_stream());
+      }
+
+      auto graph = new cugraph::graph_t<vertex_t, edge_t, store_transposed, multi_gpu>(handle_);
+
+      rmm::device_uvector<vertex_t>* number_map =
+        new rmm::device_uvector<vertex_t>(0, handle_.get_stream());
+
+      auto edge_weights = new cugraph::edge_property_t<
+        cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
+        weight_t>(handle_);
+
+      auto edge_ids = new cugraph::edge_property_t<
+        cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
+        edge_t>(handle_);
+
+      auto edge_types = new cugraph::edge_property_t<
+        cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
+        edge_type_id_t>(handle_);
+
+      if (drop_self_loops_) {
+        std::tie(
+          edgelist_srcs, edgelist_dsts, edgelist_weights, edgelist_edge_ids, edgelist_edge_types) =
+          cugraph::remove_self_loops(handle_,
+                                     std::move(edgelist_srcs),
+                                     std::move(edgelist_dsts),
+                                     std::move(edgelist_weights),
+                                     std::move(edgelist_edge_ids),
+                                     std::move(edgelist_edge_types));
+      }
+
+      if (drop_multi_edges_) {
+        std::tie(
+          edgelist_srcs, edgelist_dsts, edgelist_weights, edgelist_edge_ids, edgelist_edge_types) =
+          cugraph::remove_multi_edges(handle_,
+                                      std::move(edgelist_srcs),
+                                      std::move(edgelist_dsts),
+                                      std::move(edgelist_weights),
+                                      std::move(edgelist_edge_ids),
+                                      std::move(edgelist_edge_types),
+                                      properties_->is_symmetric
+                                        ? true /* keep minimum weight edges to maintain symmetry */
+                                        : false);
+      }
+
+      if (symmetrize_) {
+        if (edgelist_edge_ids || edgelist_edge_types) {
+          // Currently doesn't support the symmetrization with edge_ids and edge_types
+          unsupported();
+        }
+
+        // Symmetrize the edgelist
+        std::tie(edgelist_srcs, edgelist_dsts, edgelist_weights) =
+          cugraph::symmetrize_edgelist<vertex_t, weight_t, store_transposed, multi_gpu>(
+            handle_,
+            std::move(edgelist_srcs),
+            std::move(edgelist_dsts),
+            std::move(edgelist_weights),
+            false);
+      }
+
+      std::tie(*graph, new_edge_weights, new_edge_ids, new_edge_types, new_number_map) =
+        cugraph::create_graph_from_edgelist<vertex_t,
+                                            edge_t,
+                                            weight_t,
+                                            edge_t,
+                                            edge_type_id_t,
+                                            store_transposed,
+                                            multi_gpu>(
+          handle_,
+          std::move(vertex_list),
+          std::move(edgelist_srcs),
+          std::move(edgelist_dsts),
+          std::move(edgelist_weights),
+          std::move(edgelist_edge_ids),
+          std::move(edgelist_edge_types),
+          cugraph::graph_properties_t{properties_->is_symmetric, properties_->is_multigraph},
+          renumber_,
+          do_expensive_check_);
+
+      if (renumber_) {
+        *number_map = std::move(new_number_map.value());
+      } else {
+        number_map->resize(graph->number_of_vertices(), handle_.get_stream());
+        cugraph::detail::sequence_fill(handle_.get_stream(),
+                                       number_map->data(),
+                                       number_map->size(),
+                                       graph->view().local_vertex_partition_range_first());
+      }
+
+      if (new_edge_weights) { *edge_weights = std::move(new_edge_weights.value()); }
+      if (new_edge_ids) { *edge_ids = std::move(new_edge_ids.value()); }
+      if (new_edge_types) { *edge_types = std::move(new_edge_types.value()); }
+
+      // Set up return
+      auto result = new cugraph::c_api::cugraph_graph_t{
+        src_->type_,
+        edge_type_,
+        weights_ ? weights_->type_ : cugraph_data_type_id_t::FLOAT32,
+        edge_type_ids_ ? edge_type_ids_->type_ : cugraph_data_type_id_t::INT32,
+        store_transposed,
+        multi_gpu,
+        graph,
+        number_map,
+        new_edge_weights ? edge_weights : nullptr,
+        new_edge_ids ? edge_ids : nullptr,
+        new_edge_types ? edge_types : nullptr};
+
+      result_ = reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(result);
+    }
+  }
+};
+
+struct create_graph_csr_functor : public cugraph::c_api::abstract_functor {
+  raft::handle_t const& handle_;
+  cugraph_graph_properties_t const* properties_;
+  cugraph::c_api::cugraph_type_erased_device_array_view_t const* offsets_;
+  cugraph::c_api::cugraph_type_erased_device_array_view_t const* indices_;
+  cugraph::c_api::cugraph_type_erased_device_array_view_t const* weights_;
+  cugraph::c_api::cugraph_type_erased_device_array_view_t const* edge_ids_;
+  cugraph::c_api::cugraph_type_erased_device_array_view_t const* edge_type_ids_;
+  bool_t renumber_;
+  bool_t symmetrize_;
+  bool_t do_expensive_check_;
+  cugraph::c_api::cugraph_graph_t* result_{};
+
+  create_graph_csr_functor(
+    raft::handle_t const& handle,
+    cugraph_graph_properties_t const* properties,
+    cugraph::c_api::cugraph_type_erased_device_array_view_t const* offsets,
+    cugraph::c_api::cugraph_type_erased_device_array_view_t const* indices,
+    cugraph::c_api::cugraph_type_erased_device_array_view_t const* weights,
+    cugraph::c_api::cugraph_type_erased_device_array_view_t const* edge_ids,
+    cugraph::c_api::cugraph_type_erased_device_array_view_t const* edge_type_ids,
+    bool_t renumber,
+    bool_t symmetrize,
+    bool_t do_expensive_check)
+    : abstract_functor(),
+      properties_(properties),
+      handle_(handle),
+      offsets_(offsets),
+      indices_(indices),
+      weights_(weights),
+      edge_ids_(edge_ids),
+      edge_type_ids_(edge_type_ids),
+      renumber_(renumber),
+      symmetrize_(symmetrize),
+      do_expensive_check_(do_expensive_check)
+  {
+  }
+
+  template <typename vertex_t,
+            typename edge_t,
+            typename weight_t,
+            typename edge_type_id_t,
+            bool store_transposed,
+            bool multi_gpu>
+  void operator()()
+  {
+    if constexpr (multi_gpu || !cugraph::is_candidate<vertex_t, edge_t, weight_t>::value) {
+      unsupported();
+    } else {
+      if (do_expensive_check_) {
+        // FIXME:  Need an implementation here.
+      }
+
+      std::optional<rmm::device_uvector<vertex_t>> new_number_map;
+
+      std::optional<cugraph::edge_property_t<
+        cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
+        weight_t>>
+        new_edge_weights{std::nullopt};
+
+      std::optional<cugraph::edge_property_t<
+        cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
+        edge_t>>
+        new_edge_ids{std::nullopt};
+
+      std::optional<cugraph::edge_property_t<
+        cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
+        edge_type_id_t>>
+        new_edge_types{std::nullopt};
+
+      std::optional<rmm::device_uvector<vertex_t>> vertex_list = std::make_optional(
+        rmm::device_uvector<vertex_t>(offsets_->size_ - 1, handle_.get_stream()));
+
+      cugraph::detail::sequence_fill(
+        handle_.get_stream(), vertex_list->data(), vertex_list->size(), vertex_t{0});
+
+      rmm::device_uvector<vertex_t> edgelist_srcs(0, handle_.get_stream());
+      rmm::device_uvector<vertex_t> edgelist_dsts(indices_->size_, handle_.get_stream());
+
+      edgelist_srcs = cugraph::c_api::expand_sparse_offsets(
+        raft::device_span<edge_t const>{offsets_->as_type<edge_t>(), offsets_->size_},
+        vertex_t{0},
+        handle_.get_stream());
+      raft::copy<vertex_t>(
+        edgelist_dsts.data(), indices_->as_type<vertex_t>(), indices_->size_, handle_.get_stream());
+
+      std::optional<rmm::device_uvector<weight_t>> edgelist_weights =
+        weights_
+          ? std::make_optional(rmm::device_uvector<weight_t>(weights_->size_, handle_.get_stream()))
+          : std::nullopt;
+
+      if (edgelist_weights) {
+        raft::copy<weight_t>(edgelist_weights->data(),
+                             weights_->as_type<weight_t>(),
+                             weights_->size_,
+                             handle_.get_stream());
+      }
+
+      std::optional<std::tuple<rmm::device_uvector<edge_t>, rmm::device_uvector<edge_type_id_t>>>
+        edgelist_edge_tuple{};
+
+      std::optional<rmm::device_uvector<edge_t>> edgelist_edge_ids =
+        edge_ids_
+          ? std::make_optional(rmm::device_uvector<edge_t>(edge_ids_->size_, handle_.get_stream()))
+          : std::nullopt;
+
+      if (edgelist_edge_ids) {
+        raft::copy<edge_t>(edgelist_edge_ids->data(),
+                           edge_ids_->as_type<edge_t>(),
+                           edge_ids_->size_,
+                           handle_.get_stream());
+      }
+
+      std::optional<rmm::device_uvector<edge_type_id_t>> edgelist_edge_types =
+        edge_type_ids_ ? std::make_optional(rmm::device_uvector<edge_type_id_t>(
+                           edge_type_ids_->size_, handle_.get_stream()))
+                       : std::nullopt;
+
+      if (edgelist_edge_types) {
+        raft::copy<edge_type_id_t>(edgelist_edge_types->data(),
+                                   edge_type_ids_->as_type<edge_type_id_t>(),
+                                   edge_type_ids_->size_,
+                                   handle_.get_stream());
+      }
+
+      auto graph = new cugraph::graph_t<vertex_t, edge_t, store_transposed, multi_gpu>(handle_);
+
+      rmm::device_uvector<vertex_t>* number_map =
+        new rmm::device_uvector<vertex_t>(0, handle_.get_stream());
+
+      auto edge_weights = new cugraph::edge_property_t<
+        cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
+        weight_t>(handle_);
+
+      auto edge_ids = new cugraph::edge_property_t<
+        cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
+        edge_t>(handle_);
+
+      auto edge_types = new cugraph::edge_property_t<
+        cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
+        edge_type_id_t>(handle_);
+
+      if (symmetrize_) {
+        if (edgelist_edge_ids || edgelist_edge_types) {
+          // Currently doesn't support the symmetrization with edge_ids and edge_types
+          unsupported();
+        }
+
+        // Symmetrize the edgelist
+        std::tie(edgelist_srcs, edgelist_dsts, edgelist_weights) =
+          cugraph::symmetrize_edgelist<vertex_t, weight_t, store_transposed, multi_gpu>(
+            handle_,
+            std::move(edgelist_srcs),
+            std::move(edgelist_dsts),
+            std::move(edgelist_weights),
+            false);
+      }
+
+      std::tie(*graph, new_edge_weights, new_edge_ids, new_edge_types, new_number_map) =
+        cugraph::create_graph_from_edgelist<vertex_t,
+                                            edge_t,
+                                            weight_t,
+                                            edge_t,
+                                            edge_type_id_t,
+                                            store_transposed,
+                                            multi_gpu>(
+          handle_,
+          std::move(vertex_list),
+          std::move(edgelist_srcs),
+          std::move(edgelist_dsts),
+          std::move(edgelist_weights),
+          std::move(edgelist_edge_ids),
+          std::move(edgelist_edge_types),
+          cugraph::graph_properties_t{properties_->is_symmetric, properties_->is_multigraph},
+          renumber_,
+          do_expensive_check_);
+
+      if (renumber_) {
+        *number_map = std::move(new_number_map.value());
+      } else {
+        number_map->resize(graph->number_of_vertices(), handle_.get_stream());
+        cugraph::detail::sequence_fill(handle_.get_stream(),
+                                       number_map->data(),
+                                       number_map->size(),
+                                       graph->view().local_vertex_partition_range_first());
+      }
+
+      if (new_edge_weights) { *edge_weights = std::move(new_edge_weights.value()); }
+      if (new_edge_ids) { *edge_ids = std::move(new_edge_ids.value()); }
+      if (new_edge_types) { *edge_types = std::move(new_edge_types.value()); }
+
+      // Set up return
+      auto result = new cugraph::c_api::cugraph_graph_t{
+        indices_->type_,
+        offsets_->type_,
+        weights_ ? weights_->type_ : cugraph_data_type_id_t::FLOAT32,
+        edge_type_ids_ ? edge_type_ids_->type_ : cugraph_data_type_id_t::INT32,
+        store_transposed,
+        multi_gpu,
+        graph,
+        number_map,
+        new_edge_weights ? edge_weights : nullptr,
+        new_edge_ids ? edge_ids : nullptr,
+        new_edge_types ? edge_types : nullptr};
+
+      result_ = reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(result);
+    }
+  }
+};
+
+struct destroy_graph_functor : public cugraph::c_api::abstract_functor {
+  void* graph_;
+  void* number_map_;
+  void* edge_weights_;
+  void* edge_ids_;
+  void* edge_types_;
+
+  destroy_graph_functor(
+    void* graph, void* number_map, void* edge_weights, void* edge_ids, void* edge_types)
+    : abstract_functor(),
+      graph_(graph),
+      number_map_(number_map),
+      edge_weights_(edge_weights),
+      edge_ids_(edge_ids),
+      edge_types_(edge_types)
+  {
+  }
+
+  template <typename vertex_t,
+            typename edge_t,
+            typename weight_t,
+            typename edge_type_id_t,
+            bool store_transposed,
+            bool multi_gpu>
+  void operator()()
+  {
+    auto internal_graph_pointer =
+      reinterpret_cast<cugraph::graph_t<vertex_t, edge_t, store_transposed, multi_gpu>*>(graph_);
+
+    delete internal_graph_pointer;
+
+    auto internal_number_map_pointer =
+      reinterpret_cast<rmm::device_uvector<vertex_t>*>(number_map_);
+
+    delete internal_number_map_pointer;
+
+    auto internal_edge_weight_pointer = reinterpret_cast<
+      cugraph::edge_property_t<cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
+                               weight_t>*>(edge_weights_);
+    if (internal_edge_weight_pointer) { delete internal_edge_weight_pointer; }
+
+    auto internal_edge_id_pointer = reinterpret_cast<
+      cugraph::edge_property_t<cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
+                               edge_t>*>(edge_ids_);
+    if (internal_edge_id_pointer) { delete internal_edge_id_pointer; }
+
+    auto internal_edge_type_pointer = reinterpret_cast<
+      cugraph::edge_property_t<cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
+                               edge_type_id_t>*>(edge_types_);
+    if (internal_edge_type_pointer) { delete internal_edge_type_pointer; }
+  }
+};
+
+}  // namespace
+
+extern "C" cugraph_error_code_t cugraph_graph_create_sg(
+  const cugraph_resource_handle_t* handle,
+  const cugraph_graph_properties_t* properties,
+  const cugraph_type_erased_device_array_view_t* vertices,
+  const cugraph_type_erased_device_array_view_t* src,
+  const cugraph_type_erased_device_array_view_t* dst,
+  const cugraph_type_erased_device_array_view_t* weights,
+  const cugraph_type_erased_device_array_view_t* edge_ids,
+  const cugraph_type_erased_device_array_view_t* edge_type_ids,
+  bool_t store_transposed,
+  bool_t renumber,
+  bool_t drop_self_loops,
+  bool_t drop_multi_edges,
+  bool_t symmetrize,
+  bool_t do_expensive_check,
+  cugraph_graph_t** graph,
+  cugraph_error_t** error)
+{
+  constexpr bool multi_gpu = false;
+  constexpr size_t int32_threshold{std::numeric_limits<int32_t>::max()};
+
+  *graph = nullptr;
+  *error = nullptr;
+
+  auto p_handle = reinterpret_cast<cugraph::c_api::cugraph_resource_handle_t const*>(handle);
+  auto p_vertices =
+    reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(vertices);
+  auto p_src =
+    reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(src);
+  auto p_dst =
+    reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(dst);
+  auto p_weights =
+    reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(weights);
+  auto p_edge_ids =
+    reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(edge_ids);
+  auto p_edge_type_ids =
+    reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(edge_type_ids);
+
+  if (symmetrize == TRUE) {
+    CAPI_EXPECTS((properties->is_symmetric == TRUE),
+                 CUGRAPH_INVALID_INPUT,
+                 "Invalid input arguments: The graph property must be symmetric if 'symmetrize' is "
+                 "set to True.",
+                 *error);
+  }
+
+  CAPI_EXPECTS(p_src->size_ == p_dst->size_,
+               CUGRAPH_INVALID_INPUT,
+               "Invalid input arguments: src size != dst size.",
+               *error);
+
+  CAPI_EXPECTS((p_vertices == nullptr) || (p_src->type_ == p_vertices->type_),
+               CUGRAPH_INVALID_INPUT,
+               "Invalid input arguments: src type != vertices type.",
+               *error);
+
+  CAPI_EXPECTS(p_src->type_ == p_dst->type_,
+               CUGRAPH_INVALID_INPUT,
+               "Invalid input arguments: src type != dst type.",
+               *error);
+
+  CAPI_EXPECTS((weights == nullptr) || (p_weights->size_ == p_src->size_),
+               CUGRAPH_INVALID_INPUT,
+               "Invalid input arguments: src size != weights size.",
+               *error);
+
+  cugraph_data_type_id_t edge_type;
+  cugraph_data_type_id_t weight_type;
+
+  if (p_src->size_ < int32_threshold) {
+    edge_type = p_src->type_;
+  } else {
+    edge_type = cugraph_data_type_id_t::INT64;
+  }
+
+  if (weights != nullptr) {
+    weight_type = p_weights->type_;
+  } else {
+    weight_type = cugraph_data_type_id_t::FLOAT32;
+  }
+
+  CAPI_EXPECTS((edge_ids == nullptr) || (p_edge_ids->type_ == edge_type),
+               CUGRAPH_INVALID_INPUT,
+               "Invalid input arguments: Edge id type must match edge type",
+               *error);
+
+  CAPI_EXPECTS((edge_ids == nullptr) || (p_edge_ids->size_ == p_src->size_),
+               CUGRAPH_INVALID_INPUT,
+               "Invalid input arguments: src size != edge id prop size",
+               *error);
+
+  CAPI_EXPECTS((edge_type_ids == nullptr) || (p_edge_type_ids->size_ == p_src->size_),
+               CUGRAPH_INVALID_INPUT,
+               "Invalid input arguments: src size != edge type prop size",
+               *error);
+
+  cugraph_data_type_id_t edge_type_id_type = cugraph_data_type_id_t::INT32;
+  if (edge_type_ids != nullptr) { edge_type_id_type = p_edge_type_ids->type_; }
+
+  ::create_graph_functor functor(*p_handle->handle_,
+                                 properties,
+                                 p_vertices,
+                                 p_src,
+                                 p_dst,
+                                 p_weights,
+                                 p_edge_ids,
+                                 p_edge_type_ids,
+                                 renumber,
+                                 drop_self_loops,
+                                 drop_multi_edges,
+                                 symmetrize,
+                                 do_expensive_check,
+                                 edge_type);
+
+  try {
+    cugraph::c_api::vertex_dispatcher(p_src->type_,
+                                      edge_type,
+                                      weight_type,
+                                      edge_type_id_type,
+                                      store_transposed,
+                                      multi_gpu,
+                                      functor);
+
+    if (functor.error_code_ != CUGRAPH_SUCCESS) {
+      *error = reinterpret_cast<cugraph_error_t*>(functor.error_.release());
+      return functor.error_code_;
+    }
+
+    *graph = reinterpret_cast<cugraph_graph_t*>(functor.result_);
+  } catch (std::exception const& ex) {
+    *error = reinterpret_cast<cugraph_error_t*>(new cugraph::c_api::cugraph_error_t{ex.what()});
+    return CUGRAPH_UNKNOWN_ERROR;
+  }
+
+  return CUGRAPH_SUCCESS;
+}
+
+cugraph_error_code_t cugraph_graph_create_sg_from_csr(
+  const cugraph_resource_handle_t* handle,
+  const cugraph_graph_properties_t* properties,
+  const cugraph_type_erased_device_array_view_t* offsets,
+  const cugraph_type_erased_device_array_view_t* indices,
+  const cugraph_type_erased_device_array_view_t* weights,
+  const cugraph_type_erased_device_array_view_t* edge_ids,
+  const cugraph_type_erased_device_array_view_t* edge_type_ids,
+  bool_t store_transposed,
+  bool_t renumber,
+  bool_t symmetrize,
+  bool_t do_expensive_check,
+  cugraph_graph_t** graph,
+  cugraph_error_t** error)
+{
+  constexpr bool multi_gpu = false;
+
+  *graph = nullptr;
+  *error = nullptr;
+
+  auto p_handle = reinterpret_cast<cugraph::c_api::cugraph_resource_handle_t const*>(handle);
+  auto p_offsets =
+    reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(offsets);
+  auto p_indices =
+    reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(indices);
+  auto p_weights =
+    reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(weights);
+  auto p_edge_ids =
+    reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(edge_ids);
+  auto p_edge_type_ids =
+    reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(edge_type_ids);
+
+  CAPI_EXPECTS((weights == nullptr) || (p_weights->size_ == p_indices->size_),
+               CUGRAPH_INVALID_INPUT,
+               "Invalid input arguments: src size != weights size.",
+               *error);
+
+  cugraph_data_type_id_t weight_type;
+
+  if (weights != nullptr) {
+    weight_type = p_weights->type_;
+  } else {
+    weight_type = cugraph_data_type_id_t::FLOAT32;
+  }
+
+  if (symmetrize == TRUE) {
+    CAPI_EXPECTS((properties->is_symmetric == TRUE),
+                 CUGRAPH_INVALID_INPUT,
+                 "Invalid input arguments: The graph property must be symmetric if 'symmetrize' is "
+                 "set to True.",
+                 *error);
+  }
+
+  CAPI_EXPECTS(
+    (edge_type_ids == nullptr && edge_ids == nullptr) ||
+      (edge_type_ids != nullptr && edge_ids != nullptr),
+    CUGRAPH_INVALID_INPUT,
+    "Invalid input arguments: either none or both of edge ids and edge types must be provided.",
+    *error);
+
+  CAPI_EXPECTS(
+    (edge_type_ids == nullptr && edge_ids == nullptr) || (p_edge_ids->type_ == p_offsets->type_),
+    CUGRAPH_INVALID_INPUT,
+    "Invalid input arguments: Edge id type must match edge type",
+    *error);
+
+  CAPI_EXPECTS(
+    (edge_type_ids == nullptr && edge_ids == nullptr) ||
+      (p_edge_ids->size_ == p_indices->size_ && p_edge_type_ids->size_ == p_indices->size_),
+    CUGRAPH_INVALID_INPUT,
+    "Invalid input arguments: src size != edge prop size",
+    *error);
+
+  ::create_graph_csr_functor functor(*p_handle->handle_,
+                                     properties,
+                                     p_offsets,
+                                     p_indices,
+                                     p_weights,
+                                     p_edge_ids,
+                                     p_edge_type_ids,
+                                     renumber,
+                                     FALSE,  // symmetrize
+                                     do_expensive_check);
+
+  try {
+    cugraph::c_api::vertex_dispatcher(p_indices->type_,
+                                      p_offsets->type_,
+                                      weight_type,
+                                      p_indices->type_,
+                                      store_transposed,
+                                      multi_gpu,
+                                      functor);
+
+    if (functor.error_code_ != CUGRAPH_SUCCESS) {
+      *error = reinterpret_cast<cugraph_error_t*>(functor.error_.release());
+      return functor.error_code_;
+    }
+
+    *graph = reinterpret_cast<cugraph_graph_t*>(functor.result_);
+  } catch (std::exception const& ex) {
+    *error = reinterpret_cast<cugraph_error_t*>(new cugraph::c_api::cugraph_error_t{ex.what()});
+    return CUGRAPH_UNKNOWN_ERROR;
+  }
+
+  return CUGRAPH_SUCCESS;
+}
+
+extern "C" void cugraph_graph_free(cugraph_graph_t* ptr_graph)
+{
+  if (ptr_graph != NULL) {
+    auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(ptr_graph);
+
+    destroy_graph_functor functor(internal_pointer->graph_,
+                                  internal_pointer->number_map_,
+                                  internal_pointer->edge_weights_,
+                                  internal_pointer->edge_ids_,
+                                  internal_pointer->edge_types_);
+
+    cugraph::c_api::vertex_dispatcher(internal_pointer->vertex_type_,
+                                      internal_pointer->edge_type_,
+                                      internal_pointer->weight_type_,
+                                      internal_pointer->edge_type_id_type_,
+                                      internal_pointer->store_transposed_,
+                                      internal_pointer->multi_gpu_,
+                                      functor);
+
+    delete internal_pointer;
+  }
+}


### PR DESCRIPTION
This PR creates an edgelist object that will contain the COO/CSR information along with all edge properties to support graph creation.  This will allow us to add new features (and new edge attributes) with a smaller impact on the C API footprint.  It should also simplify the API a bit.

The PR also marks the old methods as deprecated so that we can phase them out.