### PR TITLE
Updates README with new dataset, removes mention of script no longer used

### DIFF
--- a/benchmarks/nx-cugraph/pytest-based/README.md
+++ b/benchmarks/nx-cugraph/pytest-based/README.md
@@ -10,6 +10,7 @@ Our current benchmarks provide the following datasets:
 | --------    | ------- | ------- | ------- |
 | netscience  | 1,461    | 5,484 | Yes |
 | email-Eu-core  | 1,005    | 25,571 | Yes |
+| amazon0302  | 262111  | 1234877 | Yes |
 | cit-Patents  | 3,774,768    | 16,518,948 | Yes |
 | hollywood  | 1,139,905    | 57,515,616 | No |
 | soc-LiveJournal1  | 4,847,571    | 68,993,773 | Yes |
@@ -39,16 +40,8 @@ NOTE:
   ./run-main-benchmarks.sh
   ```
 
-#### 2. `get_graph_bench_dataset.py`
-This script downloads the specified dataset using `cugraph.datasets`.
-
-**Usage:**
-  ```bash
-  python get_graph_bench_dataset.py [dataset]
-  ```
-
-#### 3. `create_results_summary_page.py`
-This script is designed to be run after `run-gap-benchmarks.sh` in order to generate an HTML page displaying a results table comparing default NetworkX to nx-cugraph. The script also provides information about the current system, so it should be run on the machine on which benchmarks were run.
+#### 2. `create_results_summary_page.py`
+This script is designed to be run after `run-main-benchmarks.sh` in order to generate an HTML page displaying a results table comparing default NetworkX to nx-cugraph. The script also provides information about the current system, so it should be run on the machine on which benchmarks were run.
 
 **Usage:**
   ```bash


### PR DESCRIPTION
This is a doc-only PR which updates the README for nx-cugraph pytest-based benchmarks:
* Adds description of a dataset that's being used
* Removes mention of script no longer used