### PR TITLE
Update to CCCL 2.7.0-rc2.

### DIFF
--- a/rapids_config.cmake
+++ b/rapids_config.cmake
@@ -11,6 +11,10 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
+
+set(rapids-cmake-repo bdice/rapids-cmake)
+set(rapids-cmake-branch cccl-2.7.0-rc2)
+
 file(READ "${CMAKE_CURRENT_LIST_DIR}/VERSION" _rapids_version)
 if(_rapids_version MATCHES [[^([0-9][0-9])\.([0-9][0-9])\.([0-9][0-9])]])
   set(RAPIDS_VERSION_MAJOR "${CMAKE_MATCH_1}")


### PR DESCRIPTION
This PR updates to CCCL 2.7.0-rc2. Do not merge until all of RAPIDS is ready to update.

Part of https://github.com/rapidsai/build-planning/issues/115.
