### PR TITLE
Add generic edge properties object

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -187,6 +187,9 @@ set(CUGRAPH_SOURCES
     src/community/detail/maximal_independent_moves_mg_v32_e32.cu
     src/detail/utility_wrappers_32.cu
     src/detail/utility_wrappers_64.cu
+    src/structure/edge_properties_v32.cpp
+    src/structure/edge_properties_v64.cpp
+    src/utilities/cugraph_data_type_id.cpp
     src/structure/graph_view_mg_v64_e64.cu
     src/structure/graph_view_mg_v32_e32.cu
     src/structure/remove_self_loops_sg_v32_e32.cu

--- a/cpp/include/cugraph/device_vector.hpp
+++ b/cpp/include/cugraph/device_vector.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "cugraph_c/types.h"
+#include <cugraph_c/types.h>
 
 #include <cugraph/utilities/cugraph_data_type_id.hpp>
 #include <cugraph/utilities/error.hpp>
@@ -71,33 +71,77 @@ class device_vector_t {
     data_ = vector.release();
   }
 
+  /**
+   * Return a pointer of the specified type to the beginning of the vector
+   *
+   * @tparam T      type for the array vector
+   *
+   * @return pointer to the beginning of the vector
+   */
   template <typename T>
   T* begin()
   {
     return reinterpret_cast<T*>(data_.data());
   }
 
+  /**
+   * Return a const pointer of the specified type to the beginning of the vector
+   *
+   * @tparam T      type for the array vector
+   *
+   * @return const pointer to the beginning of the vector
+   */
   template <typename T>
   T const* begin() const
   {
     return reinterpret_cast<T const*>(data_.data());
   }
 
+  /**
+   * Return a pointer of the specified type to the end of the vector
+   *
+   * @tparam T      type for the array vector
+   *
+   * @return pointer to the end of the vector
+   */
   template <typename T>
   T* end()
   {
     return reinterpret_cast<T*>(data_.data()) + size_;
   }
 
+  /**
+   * Return a const pointer of the specified type to the end of the vector
+   *
+   * @tparam T      type for the array vector
+   *
+   * @return const pointer to the end of the vector
+   */
   template <typename T>
   T const* end() const
   {
     return reinterpret_cast<T const*>(data_.data()) + size_;
   }
 
+  /**
+   * Return the type of the vector
+   *
+   * @return type id of the type stored in the vector
+   */
   cugraph_data_type_id_t type() const { return type_; }
+
+  /**
+   * Return the number of elements in the vector
+   *
+   * @return number of elements in the vector
+   */
   size_t size() const { return size_; }
 
+  /**
+   * Release the vector and shrink the memory used
+   *
+   * @param stream_view  CUDA stream
+   */
   void clear(rmm::cuda_stream_view stream_view)
   {
     data_.resize(0, stream_view);

--- a/cpp/include/cugraph/device_vector.hpp
+++ b/cpp/include/cugraph/device_vector.hpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "cugraph_c/types.h"
+
+#include <cugraph/utilities/cugraph_data_type_id.hpp>
+#include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/packed_bool_utils.hpp>
+
+#include <raft/core/handle.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/device_uvector.hpp>
+
+namespace cugraph {
+
+namespace detail {
+
+inline rmm::device_buffer allocate_buffer(raft::handle_t const& handle,
+                                          cugraph_data_type_id_t t,
+                                          size_t size)
+{
+  return (t == BOOL) ? rmm::device_buffer(cugraph::packed_bool_size(size) * data_type_size(t),
+                                          handle.get_stream())
+                     : rmm::device_buffer(size * data_type_size(t), handle.get_stream());
+}
+
+}  // namespace detail
+
+/**
+ * Class wrapping a type-erased device vector.
+ * */
+class device_vector_t {
+ public:
+  /**
+   * Constructor creating a device vector
+   *
+   * @param data_type    The data type of the vector
+   * @param size         The number of elements in the vector
+   */
+  device_vector_t(raft::handle_t const& handle, cugraph_data_type_id_t data_type, size_t size)
+    : data_(detail::allocate_buffer(handle, data_type, size)), type_(data_type), size_(size)
+  {
+  }
+
+  /**
+   * Constructor initializing device vector from an rmm device uvector
+   *
+   * @tparam T      type for the array/vector
+   * @param  vector Vector to
+   */
+  template <typename T>
+  device_vector_t(rmm::device_uvector<T>&& vector) : type_(type_to_id<T>()), size_(vector.size())
+  {
+    data_ = vector.release();
+  }
+
+  template <typename T>
+  T* begin()
+  {
+    return reinterpret_cast<T*>(data_.data());
+  }
+
+  template <typename T>
+  T const* begin() const
+  {
+    return reinterpret_cast<T const*>(data_.data());
+  }
+
+  template <typename T>
+  T* end()
+  {
+    return reinterpret_cast<T*>(data_.data()) + size_;
+  }
+
+  template <typename T>
+  T const* end() const
+  {
+    return reinterpret_cast<T const*>(data_.data()) + size_;
+  }
+
+  cugraph_data_type_id_t type() const { return type_; }
+  size_t size() const { return size_; }
+
+  void clear(rmm::cuda_stream_view stream_view)
+  {
+    data_.resize(0, stream_view);
+    data_.shrink_to_fit(stream_view);
+  }
+
+ private:
+  rmm::device_buffer data_{};
+  cugraph_data_type_id_t type_{NTYPES};
+  size_t size_{0};
+};
+
+}  // namespace cugraph

--- a/cpp/include/cugraph/edge_properties.hpp
+++ b/cpp/include/cugraph/edge_properties.hpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "cugraph/device_vector.hpp"
+#include "cugraph_c/types.h"
+
+#include <cugraph/edge_property.hpp>
+#include <cugraph/utilities/cugraph_data_type_id.hpp>
+#include <cugraph/utilities/error.hpp>
+
+#include <raft/core/handle.hpp>
+
+namespace cugraph {
+
+namespace detail {
+
+class edge_property_impl_t {
+ public:
+  edge_property_impl_t(raft::handle_t const& handle,
+                       cugraph_data_type_id_t data_type,
+                       std::vector<size_t> const& edge_counts);
+
+  edge_property_impl_t(cugraph_data_type_id_t data_type,
+                       std::vector<cugraph::device_vector_t>&& vectors);
+
+  template <typename value_type>
+  edge_property_impl_t(std::vector<rmm::device_uvector<value_type>>&& vectors,
+                       std::vector<size_t> const& edge_counts);
+
+  template <typename edge_t, typename value_t>
+  edge_property_view_t<edge_t, value_t const*> view(std::vector<size_t> const& edge_counts) const;
+
+  template <typename edge_t, typename value_t>
+  edge_property_view_t<edge_t, value_t*> mutable_view(std::vector<size_t> const& edge_counts);
+
+  cugraph_data_type_id_t data_type() const { return dtype_; }
+
+ private:
+  cugraph_data_type_id_t dtype_{NTYPES};
+  std::vector<cugraph::device_vector_t> vectors_{};
+};
+
+}  // namespace detail
+
+/**
+ * Class for containing a collection of edge properties.  Semantic interpretation of
+ * the properties is for the caller to interpret.
+ *
+ * Edge properties are labeled as in a vector, from 0 to n-1.  It is up to the caller to
+ * handle proper usage of the properties.
+ */
+class edge_properties_t {
+ public:
+  /**
+   * Constructor initializing properties from a graph view
+   *
+   * @tparam GraphViewType   type for the graph view
+   * @param  graph_view      Graph view object
+   */
+  template <typename GraphViewType>
+  edge_properties_t(GraphViewType const& graph_view);
+
+  /**
+   * Adds an empty property of the specified type.
+   *
+   * Fails if the property for @p idx is already defined
+   *
+   * @param  handle    Handle for resources
+   * @param  idx       Index of which property to add
+   * @param  data_type Data type of the property to add
+   */
+  void add_property(raft::handle_t const& handle, size_t idx, cugraph_data_type_id_t data_type);
+
+  /**
+   * Adds a property of the specified type initialized with the provided values
+   *
+   * Fails if the property for @p idx is already defined
+   *
+   * @tparam value_type  Type of the property
+   * @param  idx         Index of which property to add
+   * @param  buffers     Initial value of the property
+   */
+  template <typename value_type>
+  void add_property(size_t idx, std::vector<rmm::device_uvector<value_type>>&& buffers);
+
+  /**
+   * Adds a property initialized with the provided values
+   *
+   * Fails if the property for @p idx is already defined
+   *
+   * @param  idx        Index of which property to add
+   * @param  vectors    Type erased device vectors for the initial value
+   */
+  void add_property(size_t idx, std::vector<cugraph::device_vector_t>&& vectors);
+  /**
+   * Clears the specified property, releasing any allocated memory
+   *
+   * @param  idx     Index of which property to clear
+   */
+  void clear_property(size_t idx);
+
+  /**
+   * clears all properties, releasing any allocate memory
+   */
+  void clear_all_properties();
+
+  /**
+   * Returns true if property @p idx is defined
+   */
+  bool is_defined(size_t idx);
+
+  /**
+   * Returns data type of property @p idx
+   */
+  cugraph_data_type_id_t data_type(size_t idx);
+
+  /**
+   * Returns a read-only edge property view of the property using the provided types
+   *
+   * Throws exception if idx does not refer to a defined property.
+   * Throws exception if value_t does not match the property type
+   *
+   * @tparam edge_t     Typename for the edge
+   * @tparam value_t    Typename for the property
+   * @param  idx        Index of the property
+   *
+   * @returns a read-only view for accessing the property
+   */
+  template <typename edge_t, typename value_t>
+  edge_property_view_t<edge_t, value_t const*> view(size_t idx) const;
+
+  /**
+   * Returns a read-write edge property view of the property using the provided types
+   *
+   * Throws exception if idx does not refer to a defined property.
+   * Throws exception if value_t does not match the property type
+   *
+   * @tparam edge_t     Typename for the edge
+   * @tparam value_t    Typename for the property
+   * @param  idx        Index of the property
+   *
+   * @returns a read-write view for accessing the property
+   */
+  template <typename edge_t, typename value_t>
+  edge_property_view_t<edge_t, value_t*> mutable_view(size_t idx);
+
+  /**
+   * Return list of defined properties
+   */
+  std::vector<size_t> defined() const;
+
+ private:
+  std::vector<std::optional<detail::edge_property_impl_t>> properties_{};
+  std::vector<size_t> edge_counts_{};
+};
+
+}  // namespace cugraph

--- a/cpp/include/cugraph/edge_properties.hpp
+++ b/cpp/include/cugraph/edge_properties.hpp
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include "cugraph/device_vector.hpp"
-#include "cugraph_c/types.h"
+#include <cugraph_c/types.h>
 
+#include <cugraph/device_vector.hpp>
 #include <cugraph/edge_property.hpp>
 #include <cugraph/utilities/cugraph_data_type_id.hpp>
 #include <cugraph/utilities/error.hpp>
@@ -139,7 +139,7 @@ class edge_properties_t {
    * @tparam value_t    Typename for the property
    * @param  idx        Index of the property
    *
-   * @returns a read-only view for accessing the property
+   * @return a read-only view for accessing the property
    */
   template <typename edge_t, typename value_t>
   edge_property_view_t<edge_t, value_t const*> view(size_t idx) const;
@@ -154,13 +154,15 @@ class edge_properties_t {
    * @tparam value_t    Typename for the property
    * @param  idx        Index of the property
    *
-   * @returns a read-write view for accessing the property
+   * @return a read-write view for accessing the property
    */
   template <typename edge_t, typename value_t>
   edge_property_view_t<edge_t, value_t*> mutable_view(size_t idx);
 
   /**
    * Return list of defined properties
+   *
+   * @return vector of defined property indexes
    */
   std::vector<size_t> defined() const;
 

--- a/cpp/include/cugraph/utilities/cugraph_data_type_id.hpp
+++ b/cpp/include/cugraph/utilities/cugraph_data_type_id.hpp
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cugraph_c/types.h>
+
+#include <cugraph/utilities/error.hpp>
+
+#include <cstdint>
+#include <string>
+
+namespace cugraph {
+
+// Type conversion logic adapted from CUDF
+
+/**
+ * @brief Maps a C++ type to its corresponding `cugraph_data_type_id_t`
+ *
+ * When explicitly passed a template argument of a given type, returns the
+ * appropriate `cugraph_data_type_id_t` enum for the specified C++ type.
+ *
+ * For example:
+ *
+ * ```
+ * return cugraph::type_to_id<int32_t>();        // Returns INT32
+ * ```
+ *
+ * @tparam T The type to map to a `cugraph_data_type_id_t`
+ * @return The `cugraph_data_type_id_t` corresponding to the specified type
+ */
+template <typename T>
+inline constexpr cugraph_data_type_id_t type_to_id()
+{
+  return cugraph_data_type_id_t::NTYPES;
+};
+
+/**
+ * @brief Maps a `cugraph_data_type_id_t` types to its corresponding C++ type name string
+ *
+ */
+struct type_to_name_impl {
+  /**
+   * @brief Maps a `cugraph_data_type_id_t` types to its corresponding C++ type name string
+   *
+   * @return The C++ type name as string
+   */
+  template <typename T>
+  inline std::string operator()()
+  {
+    return "void";
+  }
+};
+
+template <cugraph_data_type_id_t t>
+struct id_to_type_impl {
+  using type = void;
+};
+
+/**
+ * @brief Maps a `cugraph_data_type_id_t` to its corresponding concrete C++ type
+ *
+ * Example:
+ * ```
+ * static_assert(std::is_same<int32_t, id_to_type<cugraph_data_type_id_t::INT32>);
+ * ```
+ * @tparam t The `cugraph_data_type_id_t` to map
+ */
+template <cugraph_data_type_id_t Id>
+using id_to_type = typename id_to_type_impl<Id>::type;
+
+/**
+ * @brief Macro used to define a mapping between a concrete C++ type and a
+ *`cugraph_data_type_id_t` enum.
+
+ * @param Type The concrete C++ type
+ * @param Id The `cugraph_data_type_id_t` enum
+ */
+#ifndef CUGRAPH_TYPE_MAPPING
+#define CUGRAPH_TYPE_MAPPING(Type, Id)                       \
+  template <>                                                \
+  constexpr inline cugraph_data_type_id_t type_to_id<Type>() \
+  {                                                          \
+    return Id;                                               \
+  }                                                          \
+  template <>                                                \
+  inline std::string type_to_name_impl::operator()<Type>()   \
+  {                                                          \
+    return #Type;                                            \
+  }                                                          \
+  template <>                                                \
+  struct id_to_type_impl<Id> {                               \
+    using type = Type;                                       \
+  };
+#endif
+
+// Defines all of the mappings between C++ types and their corresponding `cugraph_data_type_id_t`
+// values.
+CUGRAPH_TYPE_MAPPING(int8_t, cugraph_data_type_id_t::INT8)
+CUGRAPH_TYPE_MAPPING(int16_t, cugraph_data_type_id_t::INT16)
+CUGRAPH_TYPE_MAPPING(int32_t, cugraph_data_type_id_t::INT32)
+CUGRAPH_TYPE_MAPPING(int64_t, cugraph_data_type_id_t::INT64)
+CUGRAPH_TYPE_MAPPING(uint8_t, cugraph_data_type_id_t::UINT8)
+CUGRAPH_TYPE_MAPPING(uint16_t, cugraph_data_type_id_t::UINT16)
+CUGRAPH_TYPE_MAPPING(uint32_t, cugraph_data_type_id_t::UINT32)
+CUGRAPH_TYPE_MAPPING(uint64_t, cugraph_data_type_id_t::UINT64)
+CUGRAPH_TYPE_MAPPING(float, cugraph_data_type_id_t::FLOAT32)
+CUGRAPH_TYPE_MAPPING(double, cugraph_data_type_id_t::FLOAT64)
+
+// These are duplicative of uint8_t and uint64_t
+// CUGRAPH_TYPE_MAPPING(bool, cugraph_data_type_id_t::BOOL)
+// CUGRAPH_TYPE_MAPPING(size_t, cugraph_data_type_id_t::SIZE_T)
+
+/**
+ * @brief Invokes an `operator()` template with the type instantiation based on
+ * the specified `cudf::data_type`'s `id()`.
+ *
+ * Example usage with a functor that returns the size of the dispatched type:
+ *
+ * @code
+ * struct size_of_functor{
+ *  template <typename T>
+ *  int operator()(){
+ *    return sizeof(T);
+ *  }
+ * };
+ * cugraph_data_type_id_t t{INT32};
+ * cugraph::type_dispatcher(t, size_of_functor{});  // returns 4
+ * @endcode
+ *
+ * The `type_dispatcher` uses `cugraph::type_to_id<t>` to provide a default mapping
+ * of `cugraph_data_type_id_t`s to dispatched C++ types. However, this mapping may be
+ * customized by explicitly specifying a user-defined trait struct for the
+ * `IdTypeMap`. For example, to always dispatch `int32_t`
+ *
+ * @code
+ * template<cugraph_data_type_id_t t> struct always_int{ using type = int32_t; }
+ *
+ * // This will always invoke operator()<int32_t>
+ * cugraph::type_dispatcher<always_int>(data_type, f);
+ * @endcode
+ *
+ * It is sometimes necessary to customize the dispatched functor's
+ * `operator()` for different types.  This can be done in several ways.
+ *
+ * The first method is to use explicit template specialization. This is useful
+ * for specializing behavior for single types. For example, a functor that
+ * prints `int32_t` or `double` when invoked with either of those types, else it
+ * prints `unhandled type`:
+ *
+ * @code
+ * struct type_printer {
+ *   template <typename T>
+ *   void operator()() { std::cout << "unhandled type\n"; }
+ * };
+ *
+ * // Due to a bug in g++, explicit member function specializations need to be
+ * // defined outside of the class definition
+ * template <>
+ * void type_printer::operator()<int32_t>() { std::cout << "int32_t\n"; }
+ *
+ * template <>
+ * void type_printer::operator()<double>() { std::cout << "double\n"; }
+ * @endcode
+ *
+ * A second method is to use SFINAE with `std::enable_if_t`. This is useful for
+ * specializing for a set of types that share some property. For example, a
+ * functor that prints `integral` or `floating point` for integral or floating
+ * point types:
+ *
+ * @code
+ * struct integral_or_floating_point {
+ *   template <typename T,
+ *             std::enable_if_t<not std::is_integral_v<T>  and
+ *                              not std::is_floating_point_v<T> >* = nullptr>
+ *   void operator()() {
+ *     std::cout << "neither integral nor floating point\n "; }
+ *
+ *   template <typename T,
+ *             std::enable_if_t<std::is_integral_v<T> >* = nullptr>
+ *   void operator()() { std::cout << "integral\n"; }
+ *
+ *   template <typename T,
+ *             std::enable_if_t<std::is_floating_point_v<T> >* = nullptr>
+ *   void operator()() { std::cout << "floating point\n"; }
+ * };
+ * @endcode
+ *
+ * For more info on SFINAE and `std::enable_if`, see
+ * https://eli.thegreenplace.net/2014/sfinae-and-enable_if/
+ *
+ * The return type for all template instantiations of the functor's "operator()"
+ * lambda must be the same, else there will be a compiler error as you would be
+ * trying to return different types from the same function.
+ *
+ * @tparam id_to_type_impl Maps a `cugraph_data_type_id_t` its dispatched C++ type
+ * @tparam Functor The callable object's type
+ * @tparam Ts Variadic parameter pack type
+ * @param dtype The `cugraph_data_type_id_t` whose `id()` determines which template
+ * instantiation is invoked
+ * @param f The callable whose `operator()` template is invoked
+ * @param args Parameter pack of arguments forwarded to the `operator()`
+ * invocation
+ * @return Whatever is returned by the callable's `operator()`
+ */
+// This pragma disables a compiler warning that complains about the valid usage
+// of calling a __host__ functor from this function which is __host__ __device__
+#ifdef __CUDACC__
+#pragma nv_exec_check_disable
+#endif
+template <template <cugraph_data_type_id_t> typename IdTypeMap = id_to_type_impl,
+          typename Functor,
+          typename... Ts>
+#ifdef __CUDACC__
+__host__ __device__
+#endif
+  inline constexpr decltype(auto)
+  type_dispatcher(cugraph_data_type_id_t dtype, Functor f, Ts&&... args)
+{
+  switch (dtype) {
+    case cugraph_data_type_id_t::INT8:
+      return f.template operator()<typename IdTypeMap<cugraph_data_type_id_t::INT8>::type>(
+        std::forward<Ts>(args)...);
+    case cugraph_data_type_id_t::INT16:
+      return f.template operator()<typename IdTypeMap<cugraph_data_type_id_t::INT16>::type>(
+        std::forward<Ts>(args)...);
+    case cugraph_data_type_id_t::INT32:
+      return f.template operator()<typename IdTypeMap<cugraph_data_type_id_t::INT32>::type>(
+        std::forward<Ts>(args)...);
+    case cugraph_data_type_id_t::INT64:
+      return f.template operator()<typename IdTypeMap<cugraph_data_type_id_t::INT64>::type>(
+        std::forward<Ts>(args)...);
+    case cugraph_data_type_id_t::UINT8:
+      return f.template operator()<typename IdTypeMap<cugraph_data_type_id_t::UINT8>::type>(
+        std::forward<Ts>(args)...);
+    case cugraph_data_type_id_t::UINT16:
+      return f.template operator()<typename IdTypeMap<cugraph_data_type_id_t::UINT16>::type>(
+        std::forward<Ts>(args)...);
+    case cugraph_data_type_id_t::UINT32:
+      return f.template operator()<typename IdTypeMap<cugraph_data_type_id_t::UINT32>::type>(
+        std::forward<Ts>(args)...);
+    case cugraph_data_type_id_t::UINT64:
+      return f.template operator()<typename IdTypeMap<cugraph_data_type_id_t::UINT64>::type>(
+        std::forward<Ts>(args)...);
+    case cugraph_data_type_id_t::FLOAT32:
+      return f.template operator()<typename IdTypeMap<cugraph_data_type_id_t::FLOAT32>::type>(
+        std::forward<Ts>(args)...);
+    case cugraph_data_type_id_t::FLOAT64:
+      return f.template operator()<typename IdTypeMap<cugraph_data_type_id_t::FLOAT64>::type>(
+        std::forward<Ts>(args)...);
+    default: {
+#ifndef __CUDA_ARCH__
+      CUGRAPH_FAIL("Invalid type_id.");
+#else
+      // Invalid type_id, unchecked in device code, this should be unreachable
+#endif
+    }
+  }
+}
+
+/**
+ * @brief Return a name for a given type.
+ *
+ * The returned type names are intended for error messages and are not
+ * guaranteed to be stable.
+ *
+ * @param type The `data_type`
+ * @return Name of the type
+ */
+std::string type_to_name(cugraph_data_type_id_t type);
+
+// End of code adapted from CUDF
+
+/**
+ * @brief Return the size (in bytes) of the specified data type
+ *
+ * @param type The data type
+ * @return Size of the specified data type
+ */
+std::size_t data_type_size(cugraph_data_type_id_t type);
+
+}  // namespace cugraph

--- a/cpp/src/structure/edge_properties_impl.hpp
+++ b/cpp/src/structure/edge_properties_impl.hpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "cugraph/device_vector.hpp"
+#include "cugraph/edge_property.hpp"
+#include "cugraph/utilities/cugraph_data_type_id.hpp"
+
+#include <cugraph/edge_properties.hpp>
+
+#include <thrust/tabulate.h>
+
+#include <algorithm>
+
+namespace cugraph {
+
+namespace detail {
+
+template <typename value_type>
+edge_property_impl_t::edge_property_impl_t(std::vector<rmm::device_uvector<value_type>>&& buffers,
+                                           std::vector<size_t> const& edge_counts)
+{
+  CUGRAPH_EXPECTS(buffers.size() == edge_counts.size(),
+                  "Mismatch in buffer size (%lu) and edge counts size (%lu)",
+                  buffers.size(),
+                  edge_counts.size());
+  std::for_each(thrust::make_zip_iterator(buffers.begin(), edge_counts.begin()),
+                thrust::make_zip_iterator(buffers.end(), edge_counts.end()),
+                [](auto const& t) {
+                  CUGRAPH_EXPECTS(thrust::get<0>(t).size() == thrust::get<1>(t),
+                                  "Buffer size (%lu) and edge counts (%lu) should match",
+                                  thrust::get<0>(t).size(),
+                                  thrust::get<1>(t));
+                });
+
+  dtype_ = type_to_id<value_type>();
+  vectors_.reserve(edge_counts.size());
+  std::for_each(buffers.begin(), buffers.end(), [&vectors = vectors_](auto& buffer) {
+    vectors.push_back(cugraph::device_vector_t(std::move(buffer)));
+  });
+}
+
+template <typename edge_t, typename value_t>
+edge_property_view_t<edge_t, value_t const*> edge_property_impl_t::view(
+  std::vector<size_t> const& edge_counts) const
+{
+  CUGRAPH_EXPECTS(dtype_ == type_to_id<value_t>(),
+                  "Requesting invalid type for property, requesting type %s, property of type %s",
+                  type_to_name(type_to_id<value_t>()).c_str(),
+                  type_to_name(dtype_).c_str());
+
+  std::vector<edge_t> counts(edge_counts.size());
+  std::vector<value_t const*> value_iterators(edge_counts.size());
+
+  std::transform(edge_counts.begin(), edge_counts.end(), counts.begin(), [](size_t c) {
+    return static_cast<edge_t>(c);
+  });
+  std::transform(
+    vectors_.begin(), vectors_.end(), value_iterators.begin(), [](device_vector_t const& buff) {
+      return buff.begin<value_t>();
+    });
+
+  // FIXME: Could edge_property_view_t just use size_t instead of edge_t?
+  //  It's a small amount of host memory.
+  return edge_property_view_t<edge_t, value_t const*>{};
+}
+
+template <typename edge_t, typename value_t>
+edge_property_view_t<edge_t, value_t*> edge_property_impl_t::mutable_view(
+  std::vector<size_t> const& edge_counts)
+{
+  CUGRAPH_EXPECTS(dtype_ == type_to_id<value_t>(),
+                  "Requesting invalid type for property, requesting type %s, property of type %s",
+                  type_to_name(type_to_id<value_t>()).c_str(),
+                  type_to_name(dtype_).c_str());
+
+  std::vector<edge_t> counts(edge_counts.size());
+  std::vector<value_t*> value_iterators(edge_counts.size());
+
+  std::transform(edge_counts.begin(), edge_counts.end(), counts.begin(), [](size_t c) {
+    return static_cast<edge_t>(c);
+  });
+  std::transform(
+    vectors_.begin(), vectors_.end(), value_iterators.begin(), [](device_vector_t& buff) {
+      return buff.begin<value_t>();
+    });
+
+  // FIXME: Could edge_property_view_t just use size_t instead of edge_t?
+  //  It's a small amount of host memory.
+  return edge_property_view_t<edge_t, value_t*>{};
+}
+
+}  // namespace detail
+
+template <typename GraphViewType>
+edge_properties_t::edge_properties_t(GraphViewType const& graph_view)
+{
+  edge_counts_.resize(graph_view.number_of_local_edge_partitions());
+
+  thrust::tabulate(edge_counts_.begin(), edge_counts_.end(), [&graph_view](size_t i) {
+    return static_cast<size_t>(graph_view.local_edge_partition_view(i).number_of_edges());
+  });
+}
+
+template <typename value_type>
+void edge_properties_t::add_property(size_t idx,
+                                     std::vector<rmm::device_uvector<value_type>>&& buffers)
+{
+  if (idx < properties_.size()) {
+    CUGRAPH_EXPECTS(
+      !is_defined(idx), "Cannot replace an existing property (%lu), use clear_property first", idx);
+  } else {
+    // properties_.resize(idx + 1, std::nullopt);
+    properties_.reserve(idx + 1);
+    while (properties_.size() < (idx + 1)) {
+      properties_.push_back(std::nullopt);
+    }
+  }
+
+  properties_[idx] = detail::edge_property_impl_t(std::move(buffers), edge_counts_);
+}
+
+template <typename edge_t, typename value_t>
+edge_property_view_t<edge_t, value_t const*> edge_properties_t::view(size_t idx) const
+{
+  CUGRAPH_EXPECTS(idx < properties_.size(),
+                  "idx %lu out of range (only %lu properties)",
+                  idx,
+                  properties_.size());
+  CUGRAPH_EXPECTS(properties_[idx].has_value(), "property %lu is not defined", idx);
+  return properties_[idx]->view<edge_t, value_t>(edge_counts_);
+}
+
+template <typename edge_t, typename value_t>
+edge_property_view_t<edge_t, value_t*> edge_properties_t::mutable_view(size_t idx)
+{
+  CUGRAPH_EXPECTS(idx < properties_.size(),
+                  "idx %lu out of range (only %lu properties)",
+                  idx,
+                  properties_.size());
+  CUGRAPH_EXPECTS(properties_[idx].has_value(), "property %lu is not defined", idx);
+  return properties_[idx]->mutable_view<edge_t, value_t>(edge_counts_);
+}
+
+}  // namespace cugraph

--- a/cpp/src/structure/edge_properties_v32.cpp
+++ b/cpp/src/structure/edge_properties_v32.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cugraph/device_vector.hpp"
+#include "cugraph/utilities/error.hpp"
+#include "edge_properties_impl.hpp"
+
+#include <cugraph/graph.hpp>
+
+#include <thrust/iterator/discard_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
+
+#include <optional>
+
+namespace cugraph {
+
+namespace detail {
+
+edge_property_impl_t::edge_property_impl_t(raft::handle_t const& handle,
+                                           cugraph_data_type_id_t data_type,
+                                           std::vector<size_t> const& edge_counts)
+  : dtype_(data_type)
+{
+  vectors_.reserve(edge_counts.size());
+  std::for_each(edge_counts.begin(),
+                edge_counts.end(),
+                [&handle, data_type, &vectors = vectors_](size_t n_elements) {
+                  vectors.push_back(cugraph::device_vector_t(handle, data_type, n_elements));
+                });
+}
+
+edge_property_impl_t::edge_property_impl_t(cugraph_data_type_id_t data_type,
+                                           std::vector<cugraph::device_vector_t>&& vectors)
+  : dtype_(data_type), vectors_(std::move(vectors))
+{
+}
+
+template edge_property_impl_t::edge_property_impl_t(
+  std::vector<rmm::device_uvector<int32_t>>&& buffers, std::vector<size_t> const& edge_counts);
+
+}  // namespace detail
+
+void edge_properties_t::add_property(raft::handle_t const& handle,
+                                     size_t idx,
+                                     cugraph_data_type_id_t data_type)
+{
+  if (idx < properties_.size()) {
+    CUGRAPH_EXPECTS(
+      !is_defined(idx), "Cannot replace an existing property (%lu), use clear_property first", idx);
+  } else {
+    properties_.reserve(idx + 1);
+    while (properties_.size() < (idx + 1)) {
+      properties_.push_back(std::nullopt);
+    }
+  }
+
+  properties_[idx] = detail::edge_property_impl_t(handle, data_type, edge_counts_);
+}
+
+void edge_properties_t::add_property(size_t idx, std::vector<cugraph::device_vector_t>&& vectors)
+{
+  if (idx < properties_.size()) {
+    CUGRAPH_EXPECTS(
+      !is_defined(idx), "Cannot replace an existing property (%lu), use clear_property first", idx);
+  } else {
+    properties_.reserve(idx + 1);
+    while (properties_.size() < (idx + 1)) {
+      properties_.push_back(std::nullopt);
+    }
+  }
+
+  properties_[idx] = detail::edge_property_impl_t(vectors[0].type(), std::move(vectors));
+}
+
+void edge_properties_t::clear_property(size_t idx)
+{
+  if (idx < properties_.size()) { properties_[idx] = std::nullopt; }
+}
+
+void edge_properties_t::clear_all_properties()
+{
+  std::fill(properties_.begin(), properties_.end(), std::nullopt);
+}
+
+bool edge_properties_t::is_defined(size_t idx)
+{
+  return (idx < properties_.size() && properties_[idx].has_value());
+}
+
+cugraph_data_type_id_t edge_properties_t::data_type(size_t idx)
+{
+  return idx < properties_.size()
+           ? (properties_[idx].has_value() ? properties_[idx]->data_type() : NTYPES)
+           : NTYPES;
+}
+
+std::vector<size_t> edge_properties_t::defined() const
+{
+  std::vector<size_t> result;
+  result.reserve(std::count_if(
+    properties_.begin(), properties_.end(), [](auto const& p) { return p.has_value(); }));
+
+  std::copy_if(thrust::make_counting_iterator<size_t>(0),
+               thrust::make_counting_iterator(properties_.size()),
+               result.begin(),
+               [&properties = properties_](auto idx) { return properties[idx].has_value(); });
+
+  return result;
+}
+
+template edge_properties_t::edge_properties_t(
+  graph_view_t<int32_t, int32_t, false, false> const& graph_view);
+
+template edge_properties_t::edge_properties_t(
+  graph_view_t<int32_t, int32_t, false, true> const& graph_view);
+
+template edge_properties_t::edge_properties_t(
+  graph_view_t<int32_t, int32_t, true, false> const& graph_view);
+
+template edge_properties_t::edge_properties_t(
+  graph_view_t<int32_t, int32_t, true, true> const& graph_view);
+
+template void edge_properties_t::add_property(size_t idx,
+                                              std::vector<rmm::device_uvector<int32_t>>&& buffers);
+
+template edge_property_view_t<int32_t, int32_t const*> edge_properties_t::view<int32_t, int32_t>(
+  size_t idx) const;
+
+template edge_property_view_t<int32_t, int32_t*> edge_properties_t::mutable_view<int32_t, int32_t>(
+  size_t idx);
+
+}  // namespace cugraph

--- a/cpp/src/structure/edge_properties_v64.cpp
+++ b/cpp/src/structure/edge_properties_v64.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cugraph/device_vector.hpp"
+#include "cugraph/utilities/error.hpp"
+#include "edge_properties_impl.hpp"
+
+#include <cugraph/graph.hpp>
+
+#include <thrust/iterator/discard_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
+
+#include <optional>
+
+namespace cugraph {
+
+template edge_properties_t::edge_properties_t(
+  graph_view_t<int64_t, int64_t, false, false> const& graph_view);
+
+template edge_properties_t::edge_properties_t(
+  graph_view_t<int64_t, int64_t, false, true> const& graph_view);
+
+template edge_properties_t::edge_properties_t(
+  graph_view_t<int64_t, int64_t, true, false> const& graph_view);
+
+template edge_properties_t::edge_properties_t(
+  graph_view_t<int64_t, int64_t, true, true> const& graph_view);
+
+template void edge_properties_t::add_property(size_t idx,
+                                              std::vector<rmm::device_uvector<int64_t>>&& buffers);
+
+template edge_property_view_t<int64_t, int64_t const*> edge_properties_t::view<int64_t, int64_t>(
+  size_t idx) const;
+
+template edge_property_view_t<int64_t, int64_t*> edge_properties_t::mutable_view<int64_t, int64_t>(
+  size_t idx);
+
+}  // namespace cugraph

--- a/cpp/src/utilities/cugraph_data_type_id.cpp
+++ b/cpp/src/utilities/cugraph_data_type_id.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cugraph/utilities/cugraph_data_type_id.hpp>
+
+namespace cugraph {
+
+namespace {
+struct size_of_functor {
+  template <typename T>
+  int operator()()
+  {
+    return sizeof(T);
+  }
+};
+
+}  // namespace
+
+std::size_t data_type_size(cugraph_data_type_id_t t)
+{
+  return cugraph::type_dispatcher(t, size_of_functor{});
+}
+
+std::string type_to_name(cugraph_data_type_id_t type)
+{
+  return type_dispatcher(type, type_to_name_impl{});
+}
+
+}  // namespace cugraph


### PR DESCRIPTION
Adding features to support type-erased edge properties within cugraph.

Temporal graph support would require adding 2 additional edge properties.  This would result in 4x compile time and code size for functions that manipulate edge properties during the graph creation process.

This PR adds some new features to cugraph to reduce this compile time and provide the basis for adding the temporal edge properties to the graph in an efficient manner:
* device_vector_t - an analog to a cudf series... this is a type-erased structure for storing a vector that allows us to interpret it upon use rather than needing to templatize the types
* type_dispatcher - adapted from cudf to allow us to do dynamic type dispatching
* edge_properties_t - a single object that contains a collection of device_vector_t objects allowing us to pass the edge properties in a single unit between functions that need to operate on the

