### PR TITLE
Increase max_iterations in MG HITS TEST

### DIFF
--- a/cpp/tests/link_analysis/mg_hits_test.cpp
+++ b/cpp/tests/link_analysis/mg_hits_test.cpp
@@ -91,7 +91,7 @@ class Tests_MGHits : public ::testing::TestWithParam<std::tuple<Hits_Usecase, in
       mg_graph_view.attach_edge_mask((*edge_mask).view());
     }
 
-    auto maximum_iterations = 200;
+    auto maximum_iterations = 400;
     weight_t epsilon        = 1e-7;
     rmm::device_uvector<weight_t> d_mg_hubs(mg_graph_view.local_vertex_partition_range_size(),
                                             handle_->get_stream());


### PR DESCRIPTION
Increase max_iterations in MG HITS tests (with edge masking).

With masking, we may end up with different graphs with different numbers of GPUs; this results in higher iteration counts for convergence for certain GPU counts. Increase the maximum iteration count to consider this.