### PR TITLE
WIP: remove more uses of cugraph-ops

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,9 +76,6 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel_pylibcugraph.sh
-      extra-repo: rapidsai/cugraph-ops
-      extra-repo-sha: branch-25.02
-      extra-repo-deploy-key: CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY
       node_type: cpu32
   wheel-publish-pylibcugraph:
     needs: wheel-build-pylibcugraph
@@ -100,9 +97,6 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel_cugraph.sh
-      extra-repo: rapidsai/cugraph-ops
-      extra-repo-sha: branch-25.02
-      extra-repo-deploy-key: CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY
   wheel-publish-cugraph:
     needs: wheel-build-cugraph
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -129,9 +129,6 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel_pylibcugraph.sh
-      extra-repo: rapidsai/cugraph-ops
-      extra-repo-sha: branch-25.02
-      extra-repo-deploy-key: CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY
       node_type: cpu32
   wheel-tests-pylibcugraph:
     needs: [wheel-build-pylibcugraph, changed-files]
@@ -148,9 +145,6 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel_cugraph.sh
-      extra-repo: rapidsai/cugraph-ops
-      extra-repo-sha: branch-25.02
-      extra-repo-deploy-key: CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY
   wheel-tests-cugraph:
     needs: [wheel-build-cugraph, changed-files]
     secrets: inherit
@@ -166,7 +160,6 @@ jobs:
       arch: '["amd64"]'
       cuda: '["12.5"]'
       node_type: cpu32
-      extra-repo-deploy-key: CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY
       build_command: |
         sccache -z;
         build-all --verbose -j$(nproc --ignore=1) -DBUILD_CUGRAPH_MG_TESTS=ON;

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -26,7 +26,6 @@ dependencies:
 - graphviz
 - ipython
 - libcudf==25.2.*,>=0.0.0a0
-- libcugraphops==25.2.*,>=0.0.0a0
 - libraft-headers==25.2.*,>=0.0.0a0
 - libraft==25.2.*,>=0.0.0a0
 - librmm==25.2.*,>=0.0.0a0

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -29,7 +29,6 @@ dependencies:
 - ipython
 - libcublas-dev
 - libcudf==25.2.*,>=0.0.0a0
-- libcugraphops==25.2.*,>=0.0.0a0
 - libcurand-dev
 - libcusolver-dev
 - libcusparse-dev

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -69,7 +69,6 @@ requirements:
     - cuda-version ={{ cuda_version }}
     - doxygen {{ doxygen_version }}
     - libcudf ={{ minor_version }}
-    - libcugraphops ={{ minor_version }}
     - libraft ={{ minor_version }}
     - libraft-headers ={{ minor_version }}
     - librmm ={{ minor_version }}
@@ -114,7 +113,6 @@ outputs:
         - libcusolver
         - libcusparse
        {% endif %}
-        - libcugraphops ={{ minor_version }}
         - libraft ={{ minor_version }}
         - libraft-headers ={{ minor_version }}
         - librmm ={{ minor_version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -20,8 +20,6 @@ files:
       - depends_on_dask_cudf
       - depends_on_pylibraft
       - depends_on_raft_dask
-        # Deprecate pylibcugraphops
-      - depends_on_pylibcugraphops
       - depends_on_pylibwholegraph
       - depends_on_cupy
       - depends_on_pytorch
@@ -41,8 +39,6 @@ files:
       - cuda_version
       - docs
       - py_version
-        # Deprecate pylibcugraphops
-      - depends_on_pylibcugraphops
   test_cpp:
     output: none
     includes:
@@ -295,8 +291,6 @@ dependencies:
           - c-compiler
           - cxx-compiler
           - libcudf==25.2.*,>=0.0.0a0
-          # Deprecate libcugraphops
-          - libcugraphops==25.2.*,>=0.0.0a0
           - libraft-headers==25.2.*,>=0.0.0a0
           - libraft==25.2.*,>=0.0.0a0
           - librmm==25.2.*,>=0.0.0a0
@@ -339,6 +333,7 @@ dependencies:
           - nbsphinx
           - numpydoc
           - pydata-sphinx-theme
+          - pylibcugraphops==25.2.*,>=0.0.0a0
           - recommonmark
           - sphinx-copybutton
           - sphinx-markdown-tables
@@ -709,32 +704,6 @@ dependencies:
             packages:
               - pylibcugraph-cu11==25.2.*,>=0.0.0a0
           - {matrix: null, packages: [*pylibcugraph_unsuffixed]}
-
-  # deprecate pylibcugraphops
-  depends_on_pylibcugraphops:
-    common:
-      - output_types: conda
-        packages:
-          - &pylibcugraphops_unsuffixed pylibcugraphops==25.2.*,>=0.0.0a0
-      - output_types: requirements
-        packages:
-          # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
-          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
-    specific:
-      - output_types: [requirements, pyproject]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "true"
-            packages:
-              - pylibcugraphops-cu12==25.2.*,>=0.0.0a0
-          - matrix:
-              cuda: "11.*"
-              cuda_suffixed: "true"
-            packages:
-              - pylibcugraphops-cu11==25.2.*,>=0.0.0a0
-          - {matrix: null, packages: [*pylibcugraphops_unsuffixed]}
 
   depends_on_cupy:
     common:

--- a/python/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/CMakeLists.txt
@@ -32,13 +32,7 @@ project(
 option(FIND_CUGRAPH_CPP "Search for existing CUGRAPH C++ installations before defaulting to local files"
        OFF
 )
-option(USE_CUGRAPH_OPS "Enable all functions that call cugraph-ops" ON)
 option(USE_CUDA_MATH_WHEELS "Use the CUDA math wheels instead of the system libraries" OFF)
-
-if(NOT USE_CUGRAPH_OPS)
-    message(STATUS "Disabling libcugraph functions that reference cugraph-ops")
-    add_compile_definitions(NO_CUGRAPH_OPS)
-endif()
 
 # If the user requested it we attempt to find CUGRAPH.
 if(FIND_CUGRAPH_CPP)
@@ -54,14 +48,10 @@ if (NOT cugraph_FOUND)
 
   set(BUILD_TESTS OFF)
   set(BUILD_CUGRAPH_MG_TESTS OFF)
-  set(BUILD_CUGRAPH_OPS_CPP_TESTS OFF)
   set(CUDA_STATIC_RUNTIME ON)
   set(CUDA_STATIC_MATH_LIBRARIES ON)
   set(USE_RAFT_STATIC ON)
   set(CUGRAPH_COMPILE_RAFT_LIB ON)
-  set(CUGRAPH_USE_CUGRAPH_OPS_STATIC ON)
-  set(CUGRAPH_EXCLUDE_CUGRAPH_OPS_FROM_ALL ON)
-  set(ALLOW_CLONE_CUGRAPH_OPS ON)
 
   if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL 12.0)
     set(CUDA_STATIC_MATH_LIBRARIES OFF)


### PR DESCRIPTION
This repo should no longer need any build-time dependencies on cloning the `cugraph-ops` source code or pulling in its packages, as of these PRs:

* #4744
* #4765

As far as I understand it, the only place that `libcugraphops` / `pylibcugraphops` is still needed here is in docs builds, for things like this:

https://github.com/rapidsai/cugraph/blob/d71424346f7b10a507b2c7abffaaf288dafa4b0b/docs/cugraph/source/api_docs/cugraph-ops/python/pytorch.rst?plain=1#L5

This PR proposes the following:

* removing GitHub Actions configuration related to cloning the `cugraph-ops` repo
* removing CMake options related to `cugraph-ops`
  - `ALLOW_CLONE_CUGRAPH_OPS`
  - `CUGRAPH_EXCLUDE_CUGRAPH_OPS_FROM_ALL`
  - `CUGRAPH_USE_CUGRAPH_OPS_STATIC`
  - `USE_CUGRAPH_OPS`
* moving `pylibcugraphops` into conda-only part of the the `docs:` group in `dependencies.yaml`, so this repo will no longer have any dependencies on its wheels (e.g. in pip devcontainer environment solves)
* removing `libcugraphops` from `libcugraph` conda recipe

## Notes for Reviewers

### Benefits of these changes

* faster CI
* simplifies the pending work to introduce `libcugraph` wheel packages (https://github.com/rapidsai/rapids-wheels-planning/issues/53)