### PR TITLE
pip devcontainers: use UCX 1.17, prefer system installation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,6 +6,7 @@ ARG PYTHON_PACKAGE_MANAGER=conda
 FROM ${BASE} as pip-base
 
 ENV DEFAULT_VIRTUAL_ENV=rapids
+ENV RAPIDS_LIBUCX_PREFER_SYSTEM_LIBRARY=true
 
 RUN apt update -y \
  && DEBIAN_FRONTEND=noninteractive apt install -y \

--- a/.devcontainer/cuda11.8-pip/devcontainer.json
+++ b/.devcontainer/cuda11.8-pip/devcontainer.json
@@ -5,7 +5,7 @@
     "args": {
       "CUDA": "11.8",
       "PYTHON_PACKAGE_MANAGER": "pip",
-      "BASE": "rapidsai/devcontainers:25.02-cpp-cuda11.8-ucx1.15.0-openmpi-ubuntu22.04"
+      "BASE": "rapidsai/devcontainers:25.02-cpp-cuda11.8-ucx1.17.0-openmpi-ubuntu22.04"
     }
   },
   "runArgs": [

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -49,7 +49,7 @@ jobs:
       files_yaml: |
         test_cpp:
           - '**'
-          - '!.devcontainers/**'
+          - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!docs/**'
@@ -60,13 +60,13 @@ jobs:
           - '!readme_pages/**'
         test_notebooks:
           - '**'
-          - '!.devcontainers/**'
+          - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!docs/**'
         test_python:
           - '**'
-          - '!.devcontainers/**'
+          - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!docs/**'


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/118

Proposes the following changes for pip devcontainers:

* use UCX 1.17 (ref: https://github.com/rapidsai/cugraph-gnn/pull/79#discussion_r1861029925)
* prefer system installation of ucx to the one provided by the `libucx-cu{11,12}` wheels (ref: https://github.com/rapidsai/devcontainers/pull/421#issuecomment-2502324982)

And one other related change:

* skip most CI when a PR only changes files in the `.devcontainer/` directory (this was incorrectly spelled `.devcontainers/` before)