### PR TITLE
Remove upper bounds on cuda-python to allow 12.6.2 and 11.8.5

### DIFF
--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -75,10 +75,10 @@ requirements:
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
     {% if cuda_major == "11" %}
     - cudatoolkit
-    - cuda-python >=11.7.1,<12.0a0,<=11.8.3
+    - cuda-python >=11.7.1,<12.0a0
     {% else %}
     - cuda-cudart
-    - cuda-python >=12.0,<13.0a0,<=12.6.0
+    - cuda-python >=12.0,<13.0a0
     {% endif %}
     - cudf ={{ minor_version }}
     - cupy >=12.0.0


### PR DESCRIPTION
Now that some upstream bugs have been fixed, we can allow cuda-python 12.6.2 and 11.8.5.

See https://github.com/NVIDIA/cuda-python/issues/226#issuecomment-2472355738 for more information.
