### PR TITLE
Fix CCCL 2.7.0-rc2 compile issue by removing reference from values.

### DIFF
--- a/cpp/libcugraph_etl/src/renumbering.cu
+++ b/cpp/libcugraph_etl/src/renumbering.cu
@@ -730,7 +730,7 @@ __global__ static void select_unrenumber_string(str_hash_value* idx_to_col_row,
 }
 
 struct struct_sort_descending {
-  __host__ __device__ bool operator()(str_hash_value& a, str_hash_value& b)
+  __host__ __device__ bool operator()(str_hash_value a, str_hash_value b)
   {
     return (a.count_ > b.count_);
   }


### PR DESCRIPTION
We are planning to migrate to CCCL 2.7.0 in RAPIDS 25.02. I found a compilation error in `libcugraph_etl` that is fixed by removing a reference `&` from a device comparator, and passing the parameters by value instead.

This is a pretty small fix but I expect we will want to build 24.12 with newer CCCL versions for DLFW releases. To avoid needing a backport for DLFW, I am targeting 24.12 with this change. I can retarget to 25.02 if desired.

This is extracted from #4743, but that PR shouldn't be merged (it includes testing changes that are not intended for merge).