### PR TITLE
pr CI: make cugraph builds depend on pylibcugraph builds

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -152,7 +152,7 @@ jobs:
       build_type: pull-request
       script: ci/test_wheel_pylibcugraph.sh
   wheel-build-cugraph:
-    needs: wheel-tests-pylibcugraph
+    needs: wheel-build-pylibcugraph
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.02
     with:


### PR DESCRIPTION
Proposes the following change to the wheel jobs for PR CI:

```mermaid
---
title: Current
---
flowchart LR
    A[build-pylibcugraph] --> B[test-pylibcugraph]
    B --> C[build-cugraph]
    C --> D[test-cugraph]
```

```mermaid
---
title: Proposed
---
flowchart LR
    A[build-pylibcugraph] --> B[test-pylibcugraph]
    A --> C[build-cugraph]
    C --> D[test-cugraph]
```

## Notes for Reviewers

I think reducing the end-to-end time for changes here is even more important now that we have new downstream repos (https://github.com/rapidsai/nx-cugraph and https://github.com/rapidsai/cugraph-gnn) that depend on changes made here.

### Benefits of this change

* shorter end-to-end time for CI runs
  - *by parallelizing more work*
  - *by doing `cugraph-cu{11,12}` builds more frequently, which should mean more frequent population of the `sccache` cache*
* faster feedback about `cugraph-cu{11,12}` build issues
* consistency with the rest of RAPIDS (every other RAPIDS project has builds depend on builds, not tests, as far as I know)

### Costs of this change

* more at-one-moment load on GPU CI runners as a result of `cugraph` PRs (wheel tests for `cugraph` could now occupy 4 GPU runners at once instead of just 2)
  - *`pylibcugraph` test jobs tend to take around 6-10 minutes once scheduled onto a runner, so this shouldn't be too bad*