### PR TITLE
[BUG] Set Max PyTorch Version, Skip 11.4 Tests Using WholeGraph

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -53,7 +53,7 @@ dependencies:
 - pytest-cov
 - pytest-xdist
 - python-louvain
-- pytorch>=2.3
+- pytorch>=2.3,<2.5
 - raft-dask==24.12.*,>=0.0.0a0
 - rapids-build-backend>=0.3.1,<0.4.0.dev0
 - rapids-dask-dependency==24.12.*,>=0.0.0a0

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -53,7 +53,7 @@ dependencies:
 - pytest-cov
 - pytest-xdist
 - python-louvain
-- pytorch>=2.3,<2.5
+- pytorch>=2.3,<2.5a0
 - raft-dask==24.12.*,>=0.0.0a0
 - rapids-build-backend>=0.3.1,<0.4.0.dev0
 - rapids-dask-dependency==24.12.*,>=0.0.0a0

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -58,7 +58,7 @@ dependencies:
 - pytest-cov
 - pytest-xdist
 - python-louvain
-- pytorch>=2.3,<2.5
+- pytorch>=2.3,<2.5a0
 - raft-dask==24.12.*,>=0.0.0a0
 - rapids-build-backend>=0.3.1,<0.4.0.dev0
 - rapids-dask-dependency==24.12.*,>=0.0.0a0

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -58,7 +58,7 @@ dependencies:
 - pytest-cov
 - pytest-xdist
 - python-louvain
-- pytorch>=2.3
+- pytorch>=2.3,<2.5
 - raft-dask==24.12.*,>=0.0.0a0
 - rapids-build-backend>=0.3.1,<0.4.0.dev0
 - rapids-dask-dependency==24.12.*,>=0.0.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -507,7 +507,7 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
-          - &pytorch_conda pytorch>=2.3
+          - &pytorch_conda pytorch>=2.3,<2.5
           - torchdata
           - pydantic
           - ogb

--- a/python/cugraph/cugraph/tests/data_store/test_gnn_feat_storage_wholegraph.py
+++ b/python/cugraph/cugraph/tests/data_store/test_gnn_feat_storage_wholegraph.py
@@ -15,6 +15,8 @@ import pytest
 import numpy as np
 import os
 
+from cuda import cudart
+
 from cugraph.gnn import FeatureStore
 
 from cugraph.utilities.utils import import_optional, MissingModule
@@ -66,6 +68,9 @@ def runtest(rank: int, world_size: int):
 @pytest.mark.skipif(
     isinstance(pylibwholegraph, MissingModule), reason="wholegraph not available"
 )
+@pytest.mark.skipif(
+    cudart.cudaRuntimeGetVersion()[1] < 11080, reason="not compatible with CUDA < 11.8"
+)
 def test_feature_storage_wholegraph_backend():
     world_size = torch.cuda.device_count()
     print("gpu count:", world_size)
@@ -80,6 +85,9 @@ def test_feature_storage_wholegraph_backend():
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
 @pytest.mark.skipif(
     isinstance(pylibwholegraph, MissingModule), reason="wholegraph not available"
+)
+@pytest.mark.skipif(
+    cudart.cudaRuntimeGetVersion()[1] < 11080, reason="not compatible with CUDA < 11.8"
 )
 def test_feature_storage_wholegraph_backend_mg():
     world_size = torch.cuda.device_count()

--- a/python/cugraph/cugraph/tests/data_store/test_gnn_feat_storage_wholegraph.py
+++ b/python/cugraph/cugraph/tests/data_store/test_gnn_feat_storage_wholegraph.py
@@ -15,7 +15,7 @@ import pytest
 import numpy as np
 import os
 
-from cuda import cudart
+import numba.cuda
 
 from cugraph.gnn import FeatureStore
 
@@ -25,6 +25,11 @@ pylibwholegraph = import_optional("pylibwholegraph")
 wmb = import_optional("pylibwholegraph.binding.wholememory_binding")
 torch = import_optional("torch")
 wgth = import_optional("pylibwholegraph.torch")
+
+
+def get_cudart_version():
+    major, minor = numba.cuda.runtime.get_version()
+    return major * 1000 + minor * 10
 
 
 def runtest(rank: int, world_size: int):
@@ -66,10 +71,7 @@ def runtest(rank: int, world_size: int):
 @pytest.mark.sg
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
 @pytest.mark.skipif(
-    isinstance(pylibwholegraph, MissingModule), reason="wholegraph not available"
-)
-@pytest.mark.skipif(
-    cudart.cudaRuntimeGetVersion()[1] < 11080, reason="not compatible with CUDA < 11.8"
+    get_cudart_version() < 11080, reason="not compatible with CUDA < 11.8"
 )
 def test_feature_storage_wholegraph_backend():
     world_size = torch.cuda.device_count()
@@ -87,7 +89,7 @@ def test_feature_storage_wholegraph_backend():
     isinstance(pylibwholegraph, MissingModule), reason="wholegraph not available"
 )
 @pytest.mark.skipif(
-    cudart.cudaRuntimeGetVersion()[1] < 11080, reason="not compatible with CUDA < 11.8"
+    get_cudart_version() < 11080, reason="not compatible with CUDA < 11.8"
 )
 def test_feature_storage_wholegraph_backend_mg():
     world_size = torch.cuda.device_count()

--- a/python/cugraph/cugraph/tests/data_store/test_gnn_feat_storage_wholegraph.py
+++ b/python/cugraph/cugraph/tests/data_store/test_gnn_feat_storage_wholegraph.py
@@ -71,6 +71,9 @@ def runtest(rank: int, world_size: int):
 @pytest.mark.sg
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
 @pytest.mark.skipif(
+    isinstance(pylibwholegraph, MissingModule), reason="wholegraph not available"
+)
+@pytest.mark.skipif(
     get_cudart_version() < 11080, reason="not compatible with CUDA < 11.8"
 )
 def test_feature_storage_wholegraph_backend():


### PR DESCRIPTION
Set Max PyTorch Version, Skip 11.4 Tests Using WholeGraph