### PR TITLE
Add cuda-python dependency

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -12,6 +12,7 @@ dependencies:
 - c-compiler
 - cmake>=3.26.4,!=3.30.0
 - cuda-nvtx
+- cuda-python>=11.8.5,<12.0a0
 - cuda-version=11.8
 - cudatoolkit
 - cudf==25.2.*,>=0.0.0a0

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -15,6 +15,7 @@ dependencies:
 - cuda-nvcc
 - cuda-nvtx-dev
 - cuda-profiler-api
+- cuda-python>=12.6.2,<13.0a0
 - cuda-version=12.5
 - cudf==25.2.*,>=0.0.0a0
 - cupy>=12.0.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -401,6 +401,15 @@ dependencies:
             # dataset APIs require [http] extras for use with cudf.
           - fsspec[http]>=0.6.0
     specific:
+      - output_types: [conda, requirements, pyproject]
+        matrices:
+          - matrix:
+              cuda: "12.*"
+            packages:
+              - cuda-python>=12.6.2,<13.0a0
+          - matrix: # All CUDA 11 versions
+            packages:
+              - cuda-python>=11.8.5,<12.0a0
       - output_types: pyproject
         matrices:
           - matrix:

--- a/python/cugraph/pyproject.toml
+++ b/python/cugraph/pyproject.toml
@@ -23,6 +23,7 @@ authors = [
 license = { text = "Apache 2.0" }
 requires-python = ">=3.10"
 dependencies = [
+    "cuda-python>=11.8.5,<12.0a0",
     "cudf==25.2.*,>=0.0.0a0",
     "cupy-cuda11x>=12.0.0",
     "dask-cuda==25.2.*,>=0.0.0a0",


### PR DESCRIPTION
cuGraph depends on `cuda-python` but does not currently list that dependency. This PR adds it.
