### PR TITLE
Get breathe from conda

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -8,6 +8,7 @@ channels:
 - nvidia
 dependencies:
 - aiohttp
+- breathe>=4.35.0
 - c-compiler
 - certifi
 - cmake>=3.26.4,!=3.30.0
@@ -72,6 +73,4 @@ dependencies:
 - ucx-proc=*=gpu
 - ucx-py==0.42.*,>=0.0.0a0
 - wheel
-- pip:
-  - breathe>=4.35.0
 name: all_cuda-118_arch-x86_64

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -8,6 +8,7 @@ channels:
 - nvidia
 dependencies:
 - aiohttp
+- breathe>=4.35.0
 - c-compiler
 - certifi
 - cmake>=3.26.4,!=3.30.0
@@ -77,6 +78,4 @@ dependencies:
 - ucx-proc=*=gpu
 - ucx-py==0.42.*,>=0.0.0a0
 - wheel
-- pip:
-  - breathe>=4.35.0
 name: all_cuda-125_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -334,6 +334,7 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
+          - breathe>=4.35.0
           - doxygen
           - graphviz
           - ipython
@@ -345,9 +346,6 @@ dependencies:
           - sphinx-markdown-tables
           - sphinx
           - sphinxcontrib-websupport
-          - pip:
-            # Need new enough breathe
-            - breathe>=4.35.0
   py_version:
     specific:
       - output_types: [conda]


### PR DESCRIPTION
See https://github.com/rapidsai/cuvs/pull/554, the switch to pip for Breathe in #4839 is no longer required.