### PR TITLE
Address Leiden numbering issue

### DIFF
--- a/cpp/src/community/leiden_impl.cuh
+++ b/cpp/src/community/leiden_impl.cuh
@@ -613,10 +613,12 @@ void relabel_cluster_ids(raft::handle_t const& handle,
       handle.get_comms(), unique_cluster_ids.size(), handle.get_stream());
 
     std::vector<vertex_t> cluster_ids_starts(cluster_ids_size_per_rank.size());
-    std::exclusive_scan(cluster_ids_size_per_rank.begin(), cluster_ids_size_per_rank.end(), cluster_ids_starts.begin(), size_t{0});
-    auto& comm                 = handle.get_comms();
-    local_cluster_id_first     = cluster_ids_starts[comm.get_rank()];
-
+    std::exclusive_scan(cluster_ids_size_per_rank.begin(),
+                        cluster_ids_size_per_rank.end(),
+                        cluster_ids_starts.begin(),
+                        size_t{0});
+    auto& comm             = handle.get_comms();
+    local_cluster_id_first = cluster_ids_starts[comm.get_rank()];
   }
 
   rmm::device_uvector<vertex_t> numbering_indices(unique_cluster_ids.size(), handle.get_stream());
@@ -714,9 +716,8 @@ std::pair<size_t, weight_t> leiden(
                clustering + local_num_verts,
                unique_cluster_ids.begin());
 
-
   detail::relabel_cluster_ids<vertex_t, multi_gpu>(
-      handle, unique_cluster_ids, clustering, local_num_verts);
+    handle, unique_cluster_ids, clustering, local_num_verts);
 
   return std::make_pair(dendrogram->num_levels(), modularity);
 }

--- a/cpp/src/community/leiden_impl.cuh
+++ b/cpp/src/community/leiden_impl.cuh
@@ -617,8 +617,7 @@ void relabel_cluster_ids(raft::handle_t const& handle,
                         cluster_ids_size_per_rank.end(),
                         cluster_ids_starts.begin(),
                         size_t{0});
-    auto& comm             = handle.get_comms();
-    local_cluster_id_first = cluster_ids_starts[comm.get_rank()];
+    local_cluster_id_first = cluster_ids_starts[handle.get_comms().get_rank()];
   }
 
   rmm::device_uvector<vertex_t> numbering_indices(unique_cluster_ids.size(), handle.get_stream());

--- a/cpp/src/community/leiden_impl.cuh
+++ b/cpp/src/community/leiden_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -718,52 +718,51 @@ std::pair<size_t, weight_t> leiden(
   rmm::device_uvector<vertex_t> unique_cluster_ids(local_num_verts, handle.get_stream());
 
   thrust::copy(handle.get_thrust_policy(),
-                     clustering,
-                     clustering + local_num_verts,
-                     unique_cluster_ids.begin());
+               clustering,
+               clustering + local_num_verts,
+               unique_cluster_ids.begin());
 
   thrust::sort(handle.get_thrust_policy(), unique_cluster_ids.begin(), unique_cluster_ids.end());
 
-  unique_cluster_ids.resize(
-        thrust::distance(
-          unique_cluster_ids.begin(),
-          thrust::unique(handle.get_thrust_policy(), unique_cluster_ids.begin(), unique_cluster_ids.end())),
-        handle.get_stream());
-  
+  unique_cluster_ids.resize(thrust::distance(unique_cluster_ids.begin(),
+                                             thrust::unique(handle.get_thrust_policy(),
+                                                            unique_cluster_ids.begin(),
+                                                            unique_cluster_ids.end())),
+                            handle.get_stream());
+
   if constexpr (multi_gpu) {
     auto recvcounts = cugraph::host_scalar_allgather(
       handle.get_comms(), unique_cluster_ids.size(), handle.get_stream());
 
     std::vector<size_t> displacements(recvcounts.size());
     std::exclusive_scan(recvcounts.begin(), recvcounts.end(), displacements.begin(), size_t{0});
-    rmm::device_uvector<vertex_t> allgathered_unique_cluster_ids(displacements.back() + recvcounts.back(),
-                                                    handle.get_stream());
+    rmm::device_uvector<vertex_t> allgathered_unique_cluster_ids(
+      displacements.back() + recvcounts.back(), handle.get_stream());
     cugraph::device_allgatherv(handle.get_comms(),
-                                unique_cluster_ids.begin(),
-                                allgathered_unique_cluster_ids.begin(),
-                                recvcounts,
-                                displacements,
-                                handle.get_stream());
-    
-    thrust::sort(
-      handle.get_thrust_policy(),
-      allgathered_unique_cluster_ids.begin(),
-      allgathered_unique_cluster_ids.end());
+                               unique_cluster_ids.begin(),
+                               allgathered_unique_cluster_ids.begin(),
+                               recvcounts,
+                               displacements,
+                               handle.get_stream());
+
+    thrust::sort(handle.get_thrust_policy(),
+                 allgathered_unique_cluster_ids.begin(),
+                 allgathered_unique_cluster_ids.end());
 
     allgathered_unique_cluster_ids.resize(
-          thrust::distance(
-            allgathered_unique_cluster_ids.begin(),
-            thrust::unique(handle.get_thrust_policy(),
-            allgathered_unique_cluster_ids.begin(),
-            allgathered_unique_cluster_ids.end())),
-          handle.get_stream());
-    
-    detail::relabel_cluster_ids<vertex_t, multi_gpu>(handle, allgathered_unique_cluster_ids, clustering, local_num_verts);
+      thrust::distance(allgathered_unique_cluster_ids.begin(),
+                       thrust::unique(handle.get_thrust_policy(),
+                                      allgathered_unique_cluster_ids.begin(),
+                                      allgathered_unique_cluster_ids.end())),
+      handle.get_stream());
+
+    detail::relabel_cluster_ids<vertex_t, multi_gpu>(
+      handle, allgathered_unique_cluster_ids, clustering, local_num_verts);
 
   } else {
-    detail::relabel_cluster_ids<vertex_t, multi_gpu>(handle, unique_cluster_ids, clustering, local_num_verts);
+    detail::relabel_cluster_ids<vertex_t, multi_gpu>(
+      handle, unique_cluster_ids, clustering, local_num_verts);
   }
-
 
   return std::make_pair(dendrogram->num_levels(), modularity);
 }

--- a/cpp/tests/community/leiden_test.cpp
+++ b/cpp/tests/community/leiden_test.cpp
@@ -128,6 +128,21 @@ class Tests_Leiden : public ::testing::TestWithParam<std::tuple<Leiden_Usecase, 
       ASSERT_FLOAT_EQ(compare_modularity, expected_modularity);
       ASSERT_EQ(level, expected_level);
     }
+  
+    auto unique_clustering_v = cugraph::test::sort<vertex_t>(handle, clustering_v);
+
+    unique_clustering_v = cugraph::test::unique<vertex_t>(handle, std::move(unique_clustering_v));
+
+    auto expected_unique_clustering_v = cugraph::test::sequence<int32_t>(
+      handle, unique_clustering_v.size(), size_t{1}, int32_t{0});
+    
+    auto h_unique_clustering_v = cugraph::test::to_host(handle, unique_clustering_v);
+    auto h_expected_unique_clustering_v = cugraph::test::to_host(handle, expected_unique_clustering_v);
+
+    ASSERT_TRUE(std::equal(h_unique_clustering_v.begin(),
+                           h_unique_clustering_v.end(),
+                           h_expected_unique_clustering_v.begin()))
+      << "Returned cluster IDs are not numbered consecutively";
   }
 };
 

--- a/cpp/tests/community/leiden_test.cpp
+++ b/cpp/tests/community/leiden_test.cpp
@@ -9,8 +9,8 @@
  *
  */
 #include "utilities/base_fixture.hpp"
-#include "utilities/test_graphs.hpp"
 #include "utilities/conversion_utilities.hpp"
+#include "utilities/test_graphs.hpp"
 
 #include <cugraph/algorithms.hpp>
 #include <cugraph/graph.hpp>

--- a/cpp/tests/community/leiden_test.cpp
+++ b/cpp/tests/community/leiden_test.cpp
@@ -10,6 +10,7 @@
  */
 #include "utilities/base_fixture.hpp"
 #include "utilities/test_graphs.hpp"
+#include "utilities/conversion_utilities.hpp"
 
 #include <cugraph/algorithms.hpp>
 #include <cugraph/graph.hpp>

--- a/cpp/tests/community/leiden_test.cpp
+++ b/cpp/tests/community/leiden_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.  All rights reserved.
  *
  * NVIDIA CORPORATION and its licensors retain all intellectual property
  * and proprietary rights in and to this software, related documentation
@@ -128,16 +128,17 @@ class Tests_Leiden : public ::testing::TestWithParam<std::tuple<Leiden_Usecase, 
       ASSERT_FLOAT_EQ(compare_modularity, expected_modularity);
       ASSERT_EQ(level, expected_level);
     }
-  
+
     auto unique_clustering_v = cugraph::test::sort<vertex_t>(handle, clustering_v);
 
     unique_clustering_v = cugraph::test::unique<vertex_t>(handle, std::move(unique_clustering_v));
 
-    auto expected_unique_clustering_v = cugraph::test::sequence<int32_t>(
-      handle, unique_clustering_v.size(), size_t{1}, int32_t{0});
-    
+    auto expected_unique_clustering_v =
+      cugraph::test::sequence<int32_t>(handle, unique_clustering_v.size(), size_t{1}, int32_t{0});
+
     auto h_unique_clustering_v = cugraph::test::to_host(handle, unique_clustering_v);
-    auto h_expected_unique_clustering_v = cugraph::test::to_host(handle, expected_unique_clustering_v);
+    auto h_expected_unique_clustering_v =
+      cugraph::test::to_host(handle, expected_unique_clustering_v);
 
     ASSERT_TRUE(std::equal(h_unique_clustering_v.begin(),
                            h_unique_clustering_v.end(),

--- a/cpp/tests/community/mg_leiden_test.cpp
+++ b/cpp/tests/community/mg_leiden_test.cpp
@@ -201,9 +201,9 @@ class Tests_MGLeiden
 
     unique_clustering_v = cugraph::test::unique<vertex_t>(*handle_, std::move(unique_clustering_v));
 
-    unique_clustering_v =
-      cugraph::test::device_allgatherv(*handle_, unique_clustering_v.data(), unique_clustering_v.size());
-    
+    unique_clustering_v = cugraph::test::device_allgatherv(
+      *handle_, unique_clustering_v.data(), unique_clustering_v.size());
+
     unique_clustering_v = cugraph::test::sort<vertex_t>(*handle_, unique_clustering_v);
 
     unique_clustering_v = cugraph::test::unique<vertex_t>(*handle_, std::move(unique_clustering_v));
@@ -215,8 +215,6 @@ class Tests_MGLeiden
 
     auto h_expected_unique_clustering_v =
       cugraph::test::to_host(*handle_, expected_unique_clustering_v);
-    
-
 
     ASSERT_TRUE(std::equal(h_unique_clustering_v.begin(),
                            h_unique_clustering_v.end(),
@@ -266,7 +264,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(Leiden_Usecase{100, 1, 1, false}),
     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
 
-//#if 0
+// #if 0
 INSTANTIATE_TEST_SUITE_P(rmat_small_tests,
                          Tests_MGLeiden_Rmat,
                          ::testing::Combine(::testing::Values(Leiden_Usecase{100, 1, false}),
@@ -296,6 +294,6 @@ INSTANTIATE_TEST_SUITE_P(
     // disable correctness checks for large graphs
     ::testing::Values(Leiden_Usecase{100, 1, 1, false}),
     ::testing::Values(cugraph::test::Rmat_Usecase(12, 32, 0.57, 0.19, 0.19, 0, true, false))));
-//#endif
+// #endif
 
 CUGRAPH_MG_TEST_PROGRAM_MAIN()

--- a/cpp/tests/community/mg_leiden_test.cpp
+++ b/cpp/tests/community/mg_leiden_test.cpp
@@ -175,6 +175,7 @@ class Tests_MGLeiden
     if (leiden_usecase.check_correctness_) {
       SCOPED_TRACE("compare modularity input");
 
+      // FIXME: The dendrogram is unused
       compare_sg_results<vertex_t, edge_t, weight_t>(*handle_,
                                                      rng_state,
                                                      mg_graph_view,
@@ -184,6 +185,50 @@ class Tests_MGLeiden
                                                      leiden_usecase.theta_,
                                                      mg_modularity);
     }
+
+    // Check numbering
+    vertex_t num_vertices = mg_graph_view.local_vertex_partition_range_size();
+    rmm::device_uvector<vertex_t> clustering_v(num_vertices, handle_->get_stream());
+    cugraph::leiden<vertex_t, edge_t, weight_t, true>(
+      *handle_,
+      rng_state,
+      mg_graph_view,
+      mg_edge_weight_view,
+      clustering_v.data(),
+      leiden_usecase.max_level_,
+      leiden_usecase.resolution_);
+    
+    // Ensure each rank has consecutive labels
+
+    auto unique_clustering_v = cugraph::test::sort<vertex_t>(*handle_, clustering_v);
+
+    unique_clustering_v = cugraph::test::unique<vertex_t>(*handle_, std::move(unique_clustering_v));
+
+    auto h_unique_clustering_v = cugraph::test::to_host(*handle_, unique_clustering_v);
+
+    auto expected_unique_clustering_v = cugraph::test::sequence<int32_t>(
+      *handle_, unique_clustering_v.size(), size_t{1}, h_unique_clustering_v[0]);
+    
+    auto h_expected_unique_clustering_v = cugraph::test::to_host(*handle_, expected_unique_clustering_v);
+
+    ASSERT_TRUE(std::equal(h_unique_clustering_v.begin(),
+                           h_unique_clustering_v.end(),
+                           h_expected_unique_clustering_v.begin()))
+      << "Returned cluster IDs are not numbered consecutively in each rank";
+
+    // Check if cluster IDs are globally numbered consecutively
+    auto cluster_ids_size_per_rank = cugraph::host_scalar_allgather(
+      handle_->get_comms(), h_unique_clustering_v.size(), handle_->get_stream());
+
+    assert(
+      h_unique_clustering_v.back() == (cluster_ids_size_per_rank[handle_->get_comms().get_rank - 1]));
+
+    // Necessary condition for the culster IDs to be globally numbered consecutively and coupled with
+    // the first check, it is sufficient.
+    EXPECT_EQ(
+      h_unique_clustering_v.back(),
+      cluster_ids_size_per_rank[handle_->get_comms().get_rank()] - 1)
+      << "Returned cluster IDs are not globally numbered consecutively";
   }
 
  private:

--- a/cpp/tests/community/mg_leiden_test.cpp
+++ b/cpp/tests/community/mg_leiden_test.cpp
@@ -264,7 +264,6 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(Leiden_Usecase{100, 1, 1, false}),
     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
 
-// #if 0
 INSTANTIATE_TEST_SUITE_P(rmat_small_tests,
                          Tests_MGLeiden_Rmat,
                          ::testing::Combine(::testing::Values(Leiden_Usecase{100, 1, false}),
@@ -294,6 +293,5 @@ INSTANTIATE_TEST_SUITE_P(
     // disable correctness checks for large graphs
     ::testing::Values(Leiden_Usecase{100, 1, 1, false}),
     ::testing::Values(cugraph::test::Rmat_Usecase(12, 32, 0.57, 0.19, 0.19, 0, true, false))));
-// #endif
 
 CUGRAPH_MG_TEST_PROGRAM_MAIN()

--- a/python/cugraph/cugraph/community/leiden.py
+++ b/python/cugraph/cugraph/community/leiden.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/community/leiden.py
+++ b/python/cugraph/cugraph/community/leiden.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/dask/community/leiden.py
+++ b/python/cugraph/cugraph/dask/community/leiden.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cugraph/cugraph/dask/community/leiden.py
+++ b/python/cugraph/cugraph/dask/community/leiden.py
@@ -156,13 +156,13 @@ def leiden(
             input_graph._plc_graph[w],
             max_iter,
             resolution,
-            random_state,
+            random_state + i,
             theta,
             do_expensive_check,
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for i, w in enumerate(Comms.get_workers())
     ]
 
     wait(result)

--- a/python/cugraph/cugraph/dask/community/leiden.py
+++ b/python/cugraph/cugraph/dask/community/leiden.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cugraph/cugraph/dask/community/leiden.py
+++ b/python/cugraph/cugraph/dask/community/leiden.py
@@ -156,7 +156,7 @@ def leiden(
             input_graph._plc_graph[w],
             max_iter,
             resolution,
-            random_state + i,
+            (random_state + i) if random_state is not None else random_state,
             theta,
             do_expensive_check,
             workers=[w],

--- a/python/cugraph/cugraph/tests/community/test_leiden.py
+++ b/python/cugraph/cugraph/tests/community/test_leiden.py
@@ -186,14 +186,17 @@ def test_leiden(graph_file):
     leiden_parts, leiden_mod = cugraph_leiden(G)
     louvain_parts, louvain_mod = cugraph_louvain(G)
 
-    unique_parts = leiden_parts["partition"].drop_duplicates().sort_values(
-        ascending=True).reset_index(drop=True)
-    
+    unique_parts = (
+        leiden_parts["partition"]
+        .drop_duplicates()
+        .sort_values(ascending=True)
+        .reset_index(drop=True)
+    )
+
     idx_col = cudf.Series(unique_parts.index)
 
     # Ensure Leiden cluster's ID are numbered consecutively
-    assert_series_equal(
-        unique_parts, idx_col, check_dtype=False, check_names=False)
+    assert_series_equal(unique_parts, idx_col, check_dtype=False, check_names=False)
 
     # Leiden modularity score is smaller than Louvain's
     assert leiden_mod >= (0.75 * louvain_mod)
@@ -212,14 +215,17 @@ def test_leiden_nx(graph_file):
     leiden_parts, leiden_mod = cugraph_leiden(G)
     louvain_parts, louvain_mod = cugraph_louvain(G)
 
-    unique_parts = cudf.Series(leiden_parts.values()).drop_duplicates().sort_values(
-        ascending=True).reset_index(drop=True)
-    
+    unique_parts = (
+        cudf.Series(leiden_parts.values())
+        .drop_duplicates()
+        .sort_values(ascending=True)
+        .reset_index(drop=True)
+    )
+
     idx_col = cudf.Series(unique_parts.index)
 
     # Ensure Leiden cluster's ID are numbered consecutively
-    assert_series_equal(
-        unique_parts, idx_col, check_dtype=False, check_names=False)
+    assert_series_equal(unique_parts, idx_col, check_dtype=False, check_names=False)
 
     # Calculating modularity scores for comparison
     # Leiden modularity score is smaller than Louvain's

--- a/python/cugraph/cugraph/tests/community/test_leiden.py
+++ b/python/cugraph/cugraph/tests/community/test_leiden.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import networkx as nx
 
 import cugraph
 import cudf
+from cudf.testing.testing import assert_series_equal
 from cugraph.testing import utils, UNDIRECTED_DATASETS
 from cugraph.datasets import karate_asymmetric
 
@@ -185,6 +186,15 @@ def test_leiden(graph_file):
     leiden_parts, leiden_mod = cugraph_leiden(G)
     louvain_parts, louvain_mod = cugraph_louvain(G)
 
+    unique_parts = leiden_parts["partition"].drop_duplicates().sort_values(
+        ascending=True).reset_index(drop=True)
+    
+    idx_col = cudf.Series(unique_parts.index)
+
+    # Ensure Leiden cluster's ID are numbered consecutively
+    assert_series_equal(
+        unique_parts, idx_col, check_dtype=False, check_names=False)
+
     # Leiden modularity score is smaller than Louvain's
     assert leiden_mod >= (0.75 * louvain_mod)
 
@@ -201,6 +211,15 @@ def test_leiden_nx(graph_file):
 
     leiden_parts, leiden_mod = cugraph_leiden(G)
     louvain_parts, louvain_mod = cugraph_louvain(G)
+
+    unique_parts = cudf.Series(leiden_parts.values()).drop_duplicates().sort_values(
+        ascending=True).reset_index(drop=True)
+    
+    idx_col = cudf.Series(unique_parts.index)
+
+    # Ensure Leiden cluster's ID are numbered consecutively
+    assert_series_equal(
+        unique_parts, idx_col, check_dtype=False, check_names=False)
 
     # Calculating modularity scores for comparison
     # Leiden modularity score is smaller than Louvain's

--- a/python/cugraph/cugraph/tests/community/test_leiden_mg.py
+++ b/python/cugraph/cugraph/tests/community/test_leiden_mg.py
@@ -66,14 +66,18 @@ def test_mg_leiden_with_edgevals_undirected_graph(dask_client, dataset):
     dg = get_mg_graph(dataset, directed=False)
     parts, mod = dcg.leiden(dg)
 
-    unique_parts = parts["partition"].compute().drop_duplicates().sort_values(
-        ascending=True).reset_index(drop=True)
-    
+    unique_parts = (
+        parts["partition"]
+        .compute()
+        .drop_duplicates()
+        .sort_values(ascending=True)
+        .reset_index(drop=True)
+    )
+
     idx_col = cudf.Series(unique_parts.index)
 
     # Ensure Leiden cluster's ID are numbered consecutively
-    assert_series_equal(
-        unique_parts, idx_col, check_dtype=False, check_names=False)
+    assert_series_equal(unique_parts, idx_col, check_dtype=False, check_names=False)
 
     # FIXME: either call Nx with the same dataset and compare results, or
     # hardcode golden results to compare to.


### PR DESCRIPTION
Our current implementation of Leiden can return non contiguous cluster IDs however, there is an unused utility function [relabel_cluster_ids](https://github.com/rapidsai/cugraph/blob/branch-25.02/cpp/src/community/leiden_impl.cuh#L601:L604) that serves the purpose of relabeling.

This PR
- Addresses the Leiden numbering issue from [4791](#4791)  by calling `relabel_cluster_ids` after flattening the dendrogram. 
- Fixes a bug in the MG python API of Leiden which requires a different seed for each GPU in the C++ API
- Add SG and MG C++ tests
- Add a python SG and MG test capturing the numbering issue


closes #4791 