### PR TITLE
cugraph: declare pylibraft dependency for wheels

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -101,6 +101,7 @@ files:
       - depends_on_dask_cuda
       - depends_on_dask_cudf
       - depends_on_pylibcugraph
+      - depends_on_pylibraft
       - depends_on_raft_dask
       - depends_on_rmm
       - depends_on_ucx_py

--- a/python/cugraph/pyproject.toml
+++ b/python/cugraph/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "numba>=0.57",
     "numpy>=1.23,<3.0a0",
     "pylibcugraph==25.2.*,>=0.0.0a0",
+    "pylibraft==25.2.*,>=0.0.0a0",
     "raft-dask==25.2.*,>=0.0.0a0",
     "rapids-dask-dependency==25.2.*,>=0.0.0a0",
     "rmm==25.2.*,>=0.0.0a0",


### PR DESCRIPTION
Similar to #4854 

`cugraph-cu{11,12}` has a hard runtime dependency on `pylibraft`:

https://github.com/rapidsai/cugraph/blob/dd228f9f1bea23b74b17dc0f939ff1b0b15cee4f/python/cugraph/cugraph/dask/comms/comms.py#L29

But doesn't declare that dependency for wheels.
This PR explicitly declares it.

## Notes for Reviewers

This only affects wheels... this dependency is correctly declared in the `cugraph` conda packages.

https://github.com/rapidsai/cugraph/blob/dd228f9f1bea23b74b17dc0f939ff1b0b15cee4f/conda/recipes/cugraph/meta.yaml#L90

### How was this not caught in CI?

Other dependencies of `cugraph` pull it in.