### PR TITLE
Include a thrust header that was missing to use thrust::max

### DIFF
--- a/cpp/tests/utilities/check_utilities.hpp
+++ b/cpp/tests/utilities/check_utilities.hpp
@@ -19,6 +19,7 @@
 
 #include <raft/core/handle.hpp>
 #include <raft/core/span.hpp>
+#include <thrust/extrema.h>
 
 #include <numeric>
 #include <type_traits>


### PR DESCRIPTION
The <thrust/extrema.h> header is needed to use thrust::max so we include it to avoid this error

cpp/tests/utilities/check_utilities.hpp: In member function ‘bool cugraph::test::device_nearly_equal<type_t>::operator()(type_t, type_t) const’:
cpp/tests/utilities/check_utilities.hpp:98:20: error: ‘max’ is not a member of ‘thrust’
98 | thrust::max(thrust::max(lhs, rhs) * threshold_ratio, threshold_magnitude);
| ^~~