### PR TITLE
Fix shuffle comm operators with no default constructors

### DIFF
--- a/cpp/include/cugraph/utilities/shuffle_comm.cuh
+++ b/cpp/include/cugraph/utilities/shuffle_comm.cuh
@@ -145,43 +145,58 @@ compute_tx_rx_counts_offsets_ranks(raft::comms::comms_t const& comm,
 
 template <typename key_type, typename KeyToGroupIdOp>
 struct key_group_id_less_t {
-  KeyToGroupIdOp key_to_group_id_op{};
-  int pivot{};
+  key_group_id_less_t(KeyToGroupIdOp op, int pivot_) : key_to_group_id_op(::std::move(op)), pivot(pivot_) {}
   __device__ bool operator()(key_type k) const { return key_to_group_id_op(k) < pivot; }
+
+private:
+  KeyToGroupIdOp key_to_group_id_op;
+  int pivot;
 };
 
 template <typename value_type, typename ValueToGroupIdOp>
 struct value_group_id_less_t {
-  ValueToGroupIdOp value_to_group_id_op{};
-  int pivot{};
+  value_group_id_less_t(ValueToGroupIdOp op, int pivot_) : value_to_group_id_op(::std::move(op)), pivot(pivot_) {}
   __device__ bool operator()(value_type v) const { return value_to_group_id_op(v) < pivot; }
+
+private:
+  ValueToGroupIdOp value_to_group_id_op;
+  int pivot;
 };
 
 template <typename key_type, typename value_type, typename KeyToGroupIdOp>
 struct kv_pair_group_id_less_t {
-  KeyToGroupIdOp key_to_group_id_op{};
-  int pivot{};
+  kv_pair_group_id_less_t(KeyToGroupIdOp op, int pivot_) : key_to_group_id_op(::std::move(op)), pivot(pivot_) {}
   __device__ bool operator()(thrust::tuple<key_type, value_type> t) const
   {
     return key_to_group_id_op(thrust::get<0>(t)) < pivot;
   }
+
+private:
+  KeyToGroupIdOp key_to_group_id_op;
+  int pivot;
 };
 
 template <typename value_type, typename ValueToGroupIdOp>
 struct value_group_id_greater_equal_t {
-  ValueToGroupIdOp value_to_group_id_op{};
-  int pivot{};
+  value_group_id_greater_equal_t(ValueToGroupIdOp op, int pivot_) : value_to_group_id_op(::std::move(op)), pivot(pivot_) {}
   __device__ bool operator()(value_type v) const { return value_to_group_id_op(v) >= pivot; }
+
+private:
+  ValueToGroupIdOp value_to_group_id_op;
+  int pivot;
 };
 
 template <typename key_type, typename value_type, typename KeyToGroupIdOp>
 struct kv_pair_group_id_greater_equal_t {
-  KeyToGroupIdOp key_to_group_id_op{};
-  int pivot{};
+  kv_pair_group_id_greater_equal_t(KeyToGroupIdOp op, int pivot_) : key_to_group_id_op(::std::move(op)), pivot(pivot_) {}
   __device__ bool operator()(thrust::tuple<key_type, value_type> t) const
   {
     return key_to_group_id_op(thrust::get<0>(t)) >= pivot;
   }
+
+private:
+  KeyToGroupIdOp key_to_group_id_op;
+  int pivot;
 };
 
 template <typename ValueIterator, typename ValueToGroupIdOp>


### PR DESCRIPTION
Operators such as key_group_id_less_t are templated by functors which we instantiate using lambda functions. These lambda functions may have capture lists so that there is no default constructor, and we cannot call the default constructor of this operator.

This solves the following errors :
```

/home/caugonnet/git/caugonnet_cugraph/cpp/include/cugraph/utilities/shuffle_comm.cuh(172): error: the default constructor of "lambda [](auto)->auto" cannot be referenced -- it is a deleted function
    ValueToGroupIdOp value_to_group_id_op{};
                                         ^
          detected during:
            instantiation of class "cugraph::detail::value_group_id_greater_equal_t<value_type, ValueToGroupIdOp> [with value_type=int, ValueToGroupIdOp=lambda [](auto)->auto]" at line 626 of /home/caugonnet/git/caugonnet_cugraph/cpp/build/_deps/cccl-src/lib/cmake/libcudacxx/../../../libcudacxx/include/cuda/std/detail/libcxx/include/tuple
            instantiation of class "cuda::std::__4::__tuple_constraints<_Tp...> [with _Tp=<cugraph::detail::value_group_id_greater_equal_t<int, lambda [](auto)->auto>>]" at line 629 of /home/caugonnet/git/caugonnet_cugraph/cpp/build/_deps/cccl-src/lib/cmake/libcudacxx/../../../libcudacxx/include/cuda/std/detail/libcxx/include/tuple
            instantiation of class "cuda::std::__4::__tuple_constraints<_Tp...> [with _Tp=<cugraph::detail::value_group_id_greater_equal_t<int, lambda [](auto)->auto>>]" at line 157 of /home/caugonnet/git/caugonnet_cugraph/cpp/build/_deps/cccl-src/lib/cmake/libcudacxx/../../../libcudacxx/include/cuda/std/__type_traits/is_constructible.h
            instantiation of "const __nv_bool cuda::std::__4::is_constructible_v [with _Tp=cuda::std::__4::tuple<cugraph::detail::value_group_id_greater_equal_t<int, lambda [](auto)->auto>>, _Args=<>]" at line 51 of /home/caugonnet/git/caugonnet_cugraph/cpp/build/_deps/cccl-src/lib/cmake/libcudacxx/../../../libcudacxx/include/cuda/std/__functional/not_fn.h
            instantiation of class "cuda::std::__4::__not_fn_t<_Fn> [with _Fn=cugraph::detail::value_group_id_greater_equal_t<int, lambda [](auto)->auto>]" at line 56 of /home/caugonnet/git/caugonnet_cugraph/cpp/build/_deps/cccl-src/lib/cmake/libcudacxx/../../../libcudacxx/include/cuda/std/__functional/not_fn.h
            [ 3 instantiation contexts not shown ]
            instantiation of "ValueIterator cugraph::detail::mem_frugal_partition(ValueIterator, ValueIterator, ValueToGroupIdOp, int, rmm::cuda_stream_view) [with ValueIterator=int32_t *, ValueToGroupIdOp=lambda [](auto)->auto]" at line 615
            instantiation of "void cugraph::detail::mem_frugal_groupby(ValueIterator, ValueIterator, ValueToGroupIdOp, int, size_t, rmm::cuda_stream_view) [with ValueIterator=int32_t *, ValueToGroupIdOp=lambda [](auto)->auto]" at line 775
            instantiation of "rmm::device_uvector<size_t> cugraph::groupby_and_count(ValueIterator, ValueIterator, ValueToGroupIdOp, int, size_t, rmm::cuda_stream_view) [with ValueIterator=int32_t *, ValueToGroupIdOp=lambda [](auto)->auto]" at line 42 of /home/caugonnet/git/caugonnet_cugraph/cpp/src/utilities/shuffle_vertices.cuh
            instantiation of "rmm::device_uvector<vertex_t> cugraph::<unnamed>::shuffle_vertices_by_gpu_id_impl(const raft::handle_t &, rmm::device_uvector<vertex_t> &&, func_t) [with vertex_t=int32_t, func_t=cugraph::detail::compute_gpu_id_from_int_vertex_t<int32_t>]" at line 158 of /home/caugonnet/git/caugonnet_cugraph/cpp/src/utilities/shuffle_vertices.cuh
            instantiation of "rmm::device_uvector<vertex_t> cugraph::detail::shuffle_int_vertices_to_local_gpu_by_vertex_partitioning(const raft::handle_t &, rmm::device_uvector<vertex_t> &&, const std::vector<vertex_t, std::allocator<vertex_t>> &) [with vertex_t=int32_t]" at line 31 of /home/caugonnet/git/caugonnet_cugraph/cpp/src/utilities/shuffle_vertices_mg_v32_integral.cu
```