### PR TITLE
use wildcards in auditwheel exclusions

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -40,12 +40,12 @@ EXCLUDE_ARGS=(
 # 'libraft' wheels are responsible for carrying a runtime dependency on
 # these based on RAFT's needs.
 EXCLUDE_ARGS+=(
-  --exclude "libcublas.so.12"
-  --exclude "libcublasLt.so.12"
-  --exclude "libcurand.so.10"
-  --exclude "libcusolver.so.11"
-  --exclude "libcusparse.so.12"
-  --exclude "libnvJitLink.so.12"
+  --exclude "libcublas.so.*"
+  --exclude "libcublasLt.so.*"
+  --exclude "libcurand.so.*"
+  --exclude "libcusolver.so.*"
+  --exclude "libcusparse.so.*"
+  --exclude "libnvJitLink.so.*"
 )
 
 if [[ "${package_dir}" != "python/libcugraph" ]]; then


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/137

Follow-up to #4804

Wheel builds here currently list out some shared library to exclude in `auditwheel repair`, which they pick up transitively via linking to `libraft`.

https://github.com/rapidsai/cugraph/blob/a9c923bb3f4a6a6f5a9d46337adc65d969717567/ci/build_wheel.sh#L42-L49

The version components of those library names can change when those libraries have ABI breakages, for example across CUDA major version boundaries. This proposes replacing specific versions with wildcards, to exclude *all* versions of those libraries.

## Notes for Reviewers

This is especially relevant given this: https://github.com/rapidsai/raft/pull/2548

For example, the latest `nvidia-cublas-cu11` has `libcublas.so.11` while `nvidia-cublas-cu12` has `libcublas.so.12`.