### PR TITLE
Add upper bound to prevent usage of numba 0.61.0

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -35,7 +35,7 @@ dependencies:
 - networkx>=2.5.1
 - ninja
 - notebook>=0.5.0
-- numba>=0.57
+- numba>=0.59.1,<0.61.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - nvcc_linux-64=11.8

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -41,7 +41,7 @@ dependencies:
 - networkx>=2.5.1
 - ninja
 - notebook>=0.5.0
-- numba>=0.57
+- numba>=0.59.1,<0.61.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - ogb

--- a/conda/recipes/cugraph-service/meta.yaml
+++ b/conda/recipes/cugraph-service/meta.yaml
@@ -62,7 +62,7 @@ outputs:
         - cupy >=12.0.0
         - dask-cuda ={{ minor_version }}
         - dask-cudf ={{ minor_version }}
-        - numba >=0.57
+        - numba >=0.59.1,<0.61.0a0
         - numpy >=1.23,<3.0a0
         - python
         - rapids-dask-dependency ={{ minor_version }}

--- a/conda/recipes/cugraph-service/meta.yaml
+++ b/conda/recipes/cugraph-service/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 
 {% set version = environ['RAPIDS_PACKAGE_VERSION'].lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version = version.split('.')[0] + '.' + version.split('.')[1] %}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -402,7 +402,7 @@ dependencies:
       - output_types: [conda, pyproject]
         packages:
           - &dask rapids-dask-dependency==25.2.*,>=0.0.0a0
-          - &numba numba>=0.57
+          - &numba numba>=0.59.1,<0.61.0a0
           - &numpy numpy>=1.23,<3.0a0
       - output_types: conda
         packages:

--- a/python/cugraph-service/server/pyproject.toml
+++ b/python/cugraph-service/server/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "cupy-cuda11x>=12.0.0",
     "dask-cuda==25.2.*,>=0.0.0a0",
     "dask-cudf==25.2.*,>=0.0.0a0",
-    "numba>=0.57",
+    "numba>=0.59.1,<0.61.0a0",
     "numpy>=1.23,<3.0a0",
     "rapids-dask-dependency==25.2.*,>=0.0.0a0",
     "rmm==25.2.*,>=0.0.0a0",

--- a/python/cugraph/pyproject.toml
+++ b/python/cugraph/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "dask-cudf==25.2.*,>=0.0.0a0",
     "fsspec[http]>=0.6.0",
     "libcugraph==25.2.*,>=0.0.0a0",
-    "numba>=0.57",
+    "numba>=0.59.1,<0.61.0a0",
     "numpy>=1.23,<3.0a0",
     "pylibcugraph==25.2.*,>=0.0.0a0",
     "pylibraft==25.2.*,>=0.0.0a0",


### PR DESCRIPTION
Numba 0.61.0 just got released with couple of breaking changes, this pr is required to unblock the ci.

xref: https://github.com/rapidsai/cudf/pull/17777