### PR TITLE
Revert "Temporarily skip CUDA 11 wheel CI"

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -174,9 +174,6 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel_pylibcugraph.sh
-      # CUDA 11 wheel CI is disabled until
-      # https://github.com/rapidsai/build-planning/issues/137 is resolved.
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
   wheel-build-cugraph:
     needs: wheel-build-pylibcugraph
     secrets: inherit
@@ -192,9 +189,6 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel_cugraph.sh
-      # CUDA 11 wheel CI is disabled until
-      # https://github.com/rapidsai/build-planning/issues/137 is resolved.
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
   devcontainer:
     secrets: inherit
     needs: telemetry-setup

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,9 +49,6 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel_pylibcugraph.sh
-      # CUDA 11 wheel CI is disabled until
-      # https://github.com/rapidsai/build-planning/issues/137 is resolved.
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
   wheel-tests-cugraph:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.02
@@ -61,6 +58,3 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel_cugraph.sh
-      # CUDA 11 wheel CI is disabled until
-      # https://github.com/rapidsai/build-planning/issues/137 is resolved.
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))


### PR DESCRIPTION
Reverts rapidsai/cugraph#4876 now that https://github.com/rapidsai/raft/pull/2548 has landed.