### PR TITLE
Fix issues when building with upcoming cccl

### DIFF
--- a/cpp/include/cugraph/utilities/shuffle_comm.cuh
+++ b/cpp/include/cugraph/utilities/shuffle_comm.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -447,7 +447,7 @@ ValueIterator mem_frugal_partition(
     value_first,
     value_last,
     value_group_id_less_t<typename thrust::iterator_traits<ValueIterator>::value_type,
-                            ValueToGroupIdOp>{value_to_group_id_op, pivot}));
+                          ValueToGroupIdOp>{value_to_group_id_op, pivot}));
   auto second_size  = num_elements - first_size;
 
   auto tmp_buffer =

--- a/cpp/include/cugraph/utilities/shuffle_comm.cuh
+++ b/cpp/include/cugraph/utilities/shuffle_comm.cuh
@@ -145,21 +145,21 @@ compute_tx_rx_counts_offsets_ranks(raft::comms::comms_t const& comm,
 
 template <typename key_type, typename KeyToGroupIdOp>
 struct key_group_id_less_t {
-  KeyToGroupIdOp key_to_group_id_op{};
+  KeyToGroupIdOp key_to_group_id_op;
   int pivot{};
   __device__ bool operator()(key_type k) const { return key_to_group_id_op(k) < pivot; }
 };
 
 template <typename value_type, typename ValueToGroupIdOp>
 struct value_group_id_less_t {
-  ValueToGroupIdOp value_to_group_id_op{};
+  ValueToGroupIdOp value_to_group_id_op;
   int pivot{};
   __device__ bool operator()(value_type v) const { return value_to_group_id_op(v) < pivot; }
 };
 
 template <typename key_type, typename value_type, typename KeyToGroupIdOp>
 struct kv_pair_group_id_less_t {
-  KeyToGroupIdOp key_to_group_id_op{};
+  KeyToGroupIdOp key_to_group_id_op;
   int pivot{};
   __device__ bool operator()(thrust::tuple<key_type, value_type> t) const
   {
@@ -169,14 +169,14 @@ struct kv_pair_group_id_less_t {
 
 template <typename value_type, typename ValueToGroupIdOp>
 struct value_group_id_greater_equal_t {
-  ValueToGroupIdOp value_to_group_id_op{};
+  ValueToGroupIdOp value_to_group_id_op;
   int pivot{};
   __device__ bool operator()(value_type v) const { return value_to_group_id_op(v) >= pivot; }
 };
 
 template <typename key_type, typename value_type, typename KeyToGroupIdOp>
 struct kv_pair_group_id_greater_equal_t {
-  KeyToGroupIdOp key_to_group_id_op{};
+  KeyToGroupIdOp key_to_group_id_op;
   int pivot{};
   __device__ bool operator()(thrust::tuple<key_type, value_type> t) const
   {
@@ -447,7 +447,7 @@ ValueIterator mem_frugal_partition(
     value_first,
     value_last,
     value_group_id_less_t<typename thrust::iterator_traits<ValueIterator>::value_type,
-                          ValueToGroupIdOp>{value_to_group_id_op, pivot}));
+                            ValueToGroupIdOp>{value_to_group_id_op, pivot}));
   auto second_size  = num_elements - first_size;
 
   auto tmp_buffer =

--- a/cpp/src/prims/property_op_utils.cuh
+++ b/cpp/src/prims/property_op_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/prims/property_op_utils.cuh
+++ b/cpp/src/prims/property_op_utils.cuh
@@ -127,9 +127,7 @@ template <typename T, template <typename> typename Op>
 struct property_op : public Op<T> {};
 
 template <typename... Args, template <typename> typename Op>
-struct property_op<thrust::tuple<Args...>, Op>
-  : public thrust::
-      binary_function<thrust::tuple<Args...>, thrust::tuple<Args...>, thrust::tuple<Args...>> {
+struct property_op<thrust::tuple<Args...>, Op> {
   using Type = thrust::tuple<Args...>;
 
  private:

--- a/cpp/src/traversal/extract_bfs_paths_impl.cuh
+++ b/cpp/src/traversal/extract_bfs_paths_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/traversal/extract_bfs_paths_impl.cuh
+++ b/cpp/src/traversal/extract_bfs_paths_impl.cuh
@@ -30,6 +30,7 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/functional>
 #include <thrust/binary_search.h>
 #include <thrust/count.h>
 #include <thrust/distance.h>
@@ -52,7 +53,7 @@ template <typename vertex_t>
 struct compute_max {
   vertex_t __device__ operator()(vertex_t lhs, vertex_t rhs)
   {
-    return thrust::max<vertex_t>(lhs, rhs);
+    return cuda::std::max<vertex_t>(lhs, rhs);
   }
 };
 

--- a/cpp/tests/utilities/check_utilities.hpp
+++ b/cpp/tests/utilities/check_utilities.hpp
@@ -97,7 +97,7 @@ struct device_nearly_equal {
   bool __device__ operator()(type_t lhs, type_t rhs) const
   {
     return std::abs(lhs - rhs) <
-           cuda::std::max(thrust::max(lhs, rhs) * threshold_ratio, threshold_magnitude);
+           cuda::std::max(cuda::std::max(lhs, rhs) * threshold_ratio, threshold_magnitude);
   }
 };
 


### PR DESCRIPTION
We are removing a lot of deprecated thrust features, so replace them by the equivalent `cuda::std` ones