### PR TITLE
remove ucx-proc dependency

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -70,7 +70,6 @@ dependencies:
 - thriftpy2>=0.4.15,!=0.5.0,!=0.5.1
 - torchdata
 - torchmetrics
-- ucx-proc=*=gpu
 - ucx-py==0.42.*,>=0.0.0a0
 - wheel
 name: all_cuda-118_arch-x86_64

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -75,7 +75,6 @@ dependencies:
 - thriftpy2>=0.4.15,!=0.5.0,!=0.5.1
 - torchdata
 - torchmetrics
-- ucx-proc=*=gpu
 - ucx-py==0.42.*,>=0.0.0a0
 - wheel
 name: all_cuda-125_arch-x86_64

--- a/conda/recipes/cugraph/meta.yaml
+++ b/conda/recipes/cugraph/meta.yaml
@@ -90,7 +90,6 @@ requirements:
     - raft-dask ={{ minor_version }}
     - rapids-dask-dependency ={{ minor_version }}
     - requests
-    - ucx-proc=*=gpu
     - ucx-py {{ ucx_py_version }}
 
 tests:

--- a/conda/recipes/libcugraph/meta.yaml
+++ b/conda/recipes/libcugraph/meta.yaml
@@ -72,7 +72,6 @@ requirements:
     - libraft ={{ minor_version }}
     - librmm ={{ minor_version }}
     - nccl {{ nccl_version }}
-    - ucx-proc=*=gpu
     - rapids-build-backend>=0.3.1,<0.4.0.dev0
 
 outputs:
@@ -113,7 +112,6 @@ outputs:
         - libraft ={{ minor_version }}
         - librmm ={{ minor_version }}
         - nccl {{ nccl_version }}
-        - ucx-proc=*=gpu
     about:
       home: https://rapids.ai/
       dev_url: https://github.com/rapidsai/cugraph

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -410,7 +410,6 @@ dependencies:
           - fsspec>=0.6.0
           - requests
           - nccl>=2.19
-          - ucx-proc=*=gpu
       - output_types: pyproject
         packages:
             # cudf uses fsspec but is protocol independent. cugraph


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/142

`ucx-proc` has been unnecessary for conda environments since UCX 1.14, and RAPIDS currently supports UCX 1.15+. This proposes removing that dependency from conda packages and environments here.

See the linked issue for more details.