### PR TITLE
[BUG] Output Edge Labels in the Distributed Sampler

### DIFF
--- a/python/cugraph/cugraph/gnn/data_loading/dist_sampler.py
+++ b/python/cugraph/cugraph/gnn/data_loading/dist_sampler.py
@@ -256,7 +256,7 @@ class DistSampler:
             )
             if label is not None:
                 label_call_groups = list(label_call_groups) + (
-                    [torch.tensor([], dtype=torch.int64, device=input_id.device)]
+                    [torch.tensor([], dtype=label.dtype, device=label.device)]
                     * (int(num_call_groups) - len(label_call_groups))
                 )
 
@@ -366,6 +366,7 @@ class DistSampler:
 
         current_seeds, current_ix, current_label = current_seeds_and_ix
         num_seed_edges = current_ix.numel()
+        print(current_label)
 
         # The index gets stored as-is regardless of what makes it into
         # the final batch and in what order.

--- a/python/cugraph/cugraph/gnn/data_loading/dist_sampler.py
+++ b/python/cugraph/cugraph/gnn/data_loading/dist_sampler.py
@@ -577,7 +577,7 @@ class DistSampler:
         else:
             edges_call_groups, index_call_groups, label_call_groups = groups
 
-        print(input_label, label_call_groups, flush=True)
+        print(input_label.sum(), [c.sum() for c in label_call_groups], flush=True)
 
         sample_args = [
             batch_id_start,

--- a/python/cugraph/cugraph/gnn/data_loading/dist_sampler.py
+++ b/python/cugraph/cugraph/gnn/data_loading/dist_sampler.py
@@ -366,7 +366,6 @@ class DistSampler:
 
         current_seeds, current_ix, current_label = current_seeds_and_ix
         num_seed_edges = current_ix.numel()
-        print(current_label)
 
         # The index gets stored as-is regardless of what makes it into
         # the final batch and in what order.
@@ -577,6 +576,8 @@ class DistSampler:
             )
         else:
             edges_call_groups, index_call_groups, label_call_groups = groups
+
+        print(input_label, label_call_groups, flush=True)
 
         sample_args = [
             batch_id_start,

--- a/python/cugraph/cugraph/gnn/data_loading/dist_sampler.py
+++ b/python/cugraph/cugraph/gnn/data_loading/dist_sampler.py
@@ -571,7 +571,7 @@ class DistSampler:
         )
         if len(groups) == 2:
             edges_call_groups, index_call_groups = groups
-            label_call_groups = [torch.empty(dtype=torch.int32)] * len(
+            label_call_groups = [torch.tensor([], dtype=torch.int32)] * len(
                 edges_call_groups
             )
         else:

--- a/python/cugraph/cugraph/gnn/data_loading/dist_sampler.py
+++ b/python/cugraph/cugraph/gnn/data_loading/dist_sampler.py
@@ -577,7 +577,8 @@ class DistSampler:
         else:
             edges_call_groups, index_call_groups, label_call_groups = groups
 
-        print(input_label.sum(), [c.sum() for c in label_call_groups], flush=True)
+        if input_label is not None:
+            print(input_label.sum(), [c.sum() for c in label_call_groups], flush=True)
 
         sample_args = [
             batch_id_start,

--- a/python/cugraph/cugraph/gnn/data_loading/dist_sampler.py
+++ b/python/cugraph/cugraph/gnn/data_loading/dist_sampler.py
@@ -577,9 +577,6 @@ class DistSampler:
         else:
             edges_call_groups, index_call_groups, label_call_groups = groups
 
-        if input_label is not None:
-            print(input_label.sum(), [c.sum() for c in label_call_groups], flush=True)
-
         sample_args = [
             batch_id_start,
             batch_size,


### PR DESCRIPTION
We currently do not output edge labels in the distributed sampler, which breaks some link prediction workflows where the graph contains pre-labeled edges.  This PR adds support for that so these workflows can be enabled.