### PR TITLE
Replace `thrust::identity` with `cuda::std::identity`

### DIFF
--- a/cpp/src/mtmg/vertex_result.cuh
+++ b/cpp/src/mtmg/vertex_result.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 #include <cugraph/utilities/device_functors.cuh>
 #include <cugraph/vertex_partition_device_view.cuh>
 
-#include <thrust/functional.h>
+#include <cuda/std/functional>
 #include <thrust/gather.h>
 
 namespace cugraph {
@@ -129,7 +129,7 @@ rmm::device_uvector<result_t> vertex_result_view_t<result_t>::gather(
         vertex_gpu_ids.begin(),
         vertex_gpu_ids.end(),
         thrust::make_zip_iterator(local_vertices.begin(), vertex_pos.begin(), result.begin()),
-        thrust::identity{},
+        cuda::std::identity{},
         stream);
 
     //

--- a/cpp/src/prims/detail/per_v_transform_reduce_e.cuh
+++ b/cpp/src/prims/detail/per_v_transform_reduce_e.cuh
@@ -579,7 +579,8 @@ __global__ static void per_v_transform_reduce_e_mid_degree(
       reduced_e_op_result{};
     [[maybe_unused]] std::conditional_t<update_major && std::is_same_v<ReduceOp, reduce_op::any<T>>,
                                         int32_t,
-                                        std::byte /* dummy */> first_valid_lane_id{};
+                                        std::byte /* dummy */>
+      first_valid_lane_id{};
     if constexpr (update_major) {
       reduced_e_op_result =
         (lane_id == 0) ? init : identity_element;  // init == identity_element for reduce_op::any<T>
@@ -727,7 +728,8 @@ __global__ static void per_v_transform_reduce_e_high_degree(
   [[maybe_unused]] __shared__
     std::conditional_t<update_major && std::is_same_v<ReduceOp, reduce_op::any<T>>,
                        int32_t,
-                       std::byte /* dummy */> output_thread_id;
+                       std::byte /* dummy */>
+      output_thread_id;
 
   while (idx < static_cast<size_t>(thrust::distance(key_first, key_last))) {
     auto key   = *(key_first + idx);
@@ -768,7 +770,8 @@ __global__ static void per_v_transform_reduce_e_high_degree(
       reduced_e_op_result{};
     [[maybe_unused]] std::conditional_t<update_major && std::is_same_v<ReduceOp, reduce_op::any<T>>,
                                         int32_t,
-                                        std::byte /* dummy */> first_valid_thread_id{};
+                                        std::byte /* dummy */>
+      first_valid_thread_id{};
     if constexpr (update_major) {
       reduced_e_op_result = threadIdx.x == 0
                               ? init
@@ -1617,7 +1620,8 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
   [[maybe_unused]] std::conditional_t<GraphViewType::is_multi_gpu && update_major &&
                                         std::is_same_v<ReduceOp, reduce_op::any<T>>,
                                       int,
-                                      std::byte /* dummy */> subgroup_size{};
+                                      std::byte /* dummy */>
+    subgroup_size{};
   if constexpr (GraphViewType::is_multi_gpu && update_major &&
                 std::is_same_v<ReduceOp, reduce_op::any<T>>) {
     auto& comm                 = handle.get_comms();

--- a/cpp/src/prims/detail/per_v_transform_reduce_e.cuh
+++ b/cpp/src/prims/detail/per_v_transform_reduce_e.cuh
@@ -52,7 +52,6 @@
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 #include <thrust/for_each.h>
-#include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scatter.h>
@@ -580,8 +579,7 @@ __global__ static void per_v_transform_reduce_e_mid_degree(
       reduced_e_op_result{};
     [[maybe_unused]] std::conditional_t<update_major && std::is_same_v<ReduceOp, reduce_op::any<T>>,
                                         int32_t,
-                                        std::byte /* dummy */>
-      first_valid_lane_id{};
+                                        std::byte /* dummy */> first_valid_lane_id{};
     if constexpr (update_major) {
       reduced_e_op_result =
         (lane_id == 0) ? init : identity_element;  // init == identity_element for reduce_op::any<T>
@@ -729,8 +727,7 @@ __global__ static void per_v_transform_reduce_e_high_degree(
   [[maybe_unused]] __shared__
     std::conditional_t<update_major && std::is_same_v<ReduceOp, reduce_op::any<T>>,
                        int32_t,
-                       std::byte /* dummy */>
-      output_thread_id;
+                       std::byte /* dummy */> output_thread_id;
 
   while (idx < static_cast<size_t>(thrust::distance(key_first, key_last))) {
     auto key   = *(key_first + idx);
@@ -771,8 +768,7 @@ __global__ static void per_v_transform_reduce_e_high_degree(
       reduced_e_op_result{};
     [[maybe_unused]] std::conditional_t<update_major && std::is_same_v<ReduceOp, reduce_op::any<T>>,
                                         int32_t,
-                                        std::byte /* dummy */>
-      first_valid_thread_id{};
+                                        std::byte /* dummy */> first_valid_thread_id{};
     if constexpr (update_major) {
       reduced_e_op_result = threadIdx.x == 0
                               ? init
@@ -1621,8 +1617,7 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
   [[maybe_unused]] std::conditional_t<GraphViewType::is_multi_gpu && update_major &&
                                         std::is_same_v<ReduceOp, reduce_op::any<T>>,
                                       int,
-                                      std::byte /* dummy */>
-    subgroup_size{};
+                                      std::byte /* dummy */> subgroup_size{};
   if constexpr (GraphViewType::is_multi_gpu && update_major &&
                 std::is_same_v<ReduceOp, reduce_op::any<T>>) {
     auto& comm                 = handle.get_comms();
@@ -4004,7 +3999,7 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
                                         return (bitmap[packed_bool_offset(i)] &
                                                 packed_bool_mask(i)) == packed_bool_mask(i);
                                       })),
-                                  thrust::identity<bool>{})),
+                                  cuda::std::identity{})),
               handle.get_stream());
             // skip shrink_to_fit() to cut execution time
             std::exclusive_scan((*rx_value_sizes).begin(),
@@ -4064,7 +4059,7 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
                                             return (bitmap[packed_bool_offset(i)] &
                                                     packed_bool_mask(i)) == packed_bool_mask(i);
                                           })),
-                                      thrust::identity<bool>{})),
+                                      cuda::std::identity{})),
                   handle.get_stream());
                 // skip shrink_to_fit() to cut execution time
               } else {
@@ -4083,7 +4078,7 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
                                             return (bitmap[packed_bool_offset(i)] &
                                                     packed_bool_mask(i)) == packed_bool_mask(i);
                                           })),
-                                      thrust::identity<bool>{})),
+                                      cuda::std::identity{})),
                   handle.get_stream());
                 // skip shrink_to_fit() to cut execution time
               }

--- a/cpp/src/prims/fill_edge_property.cuh
+++ b/cpp/src/prims/fill_edge_property.cuh
@@ -24,6 +24,7 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/functional>
 #include <cuda/std/optional>
 #include <thrust/fill.h>
 #include <thrust/iterator/constant_iterator.h>
@@ -106,7 +107,7 @@ void fill_edge_property(raft::handle_t const& handle,
                              thrust::make_constant_iterator(input) + edge_counts[i],
                              thrust::make_counting_iterator(edge_t{0}),
                              value_firsts[i],
-                             thrust::identity<T>{},
+                             cuda::std::identity{},
                              [edge_partition_e_mask = *edge_partition_e_mask] __device__(edge_t i) {
                                return edge_partition_e_mask.get(i);
                              });

--- a/cpp/src/sampling/negative_sampling_impl.cuh
+++ b/cpp/src/sampling/negative_sampling_impl.cuh
@@ -35,6 +35,7 @@
 
 #include <rmm/device_scalar.hpp>
 
+#include <cuda/std/functional>
 #include <thrust/adjacent_difference.h>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
@@ -359,7 +360,7 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> negativ
                                        begin_iter,
                                        begin_iter + batch_srcs.size(),
                                        has_edge_flags.begin(),
-                                       thrust::identity<bool>());
+                                       cuda::std::identity());
 
       batch_srcs.resize(thrust::distance(begin_iter, new_end), handle.get_stream());
       batch_dsts.resize(thrust::distance(begin_iter, new_end), handle.get_stream());

--- a/cpp/src/traversal/od_shortest_distances_impl.cuh
+++ b/cpp/src/traversal/od_shortest_distances_impl.cuh
@@ -37,9 +37,9 @@
 #include <raft/util/cudart_utils.hpp>
 #include <raft/util/integer_utils.hpp>
 
+#include <cuda/std/functional>
 #include <cuda/std/optional>
 #include <thrust/fill.h>
-#include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
@@ -385,7 +385,7 @@ kv_store_t<key_t, weight_t, false /* use_binary_search */> filter_key_to_dist_ma
                               detail::key_cuco_store_contains_device_view_t(key_set.view())});
 
     keep_count = thrust::count_if(
-      handle.get_thrust_policy(), keep_flags.begin(), keep_flags.end(), thrust::identity<bool>{});
+      handle.get_thrust_policy(), keep_flags.begin(), keep_flags.end(), cuda::std::identity{});
   }
 
   size_t new_kv_store_capacity = compute_kv_store_capacity(
@@ -398,7 +398,7 @@ kv_store_t<key_t, weight_t, false /* use_binary_search */> filter_key_to_dist_ma
                             old_key_buffer.end(),
                             old_value_buffer.begin(),
                             keep_flags.begin(),
-                            thrust::identity<bool>{},
+                            cuda::std::identity{},
                             handle.get_stream());
 
   return std::move(key_to_dist_map);
@@ -606,7 +606,7 @@ rmm::device_uvector<weight_t> od_shortest_distances(
                                                                  v_to_destination_indices.size()),
                                static_cast<od_idx_t>(origins.size()),
                                static_cast<od_idx_t>(destinations.size())})),
-                         thrust::identity<weight_t>{},
+                         cuda::std::identity{},
                          check_destination_index_t<vertex_t, od_idx_t, key_t>{
                            raft::device_span<od_idx_t const>(v_to_destination_indices.data(),
                                                              v_to_destination_indices.size()),
@@ -725,7 +725,7 @@ rmm::device_uvector<weight_t> od_shortest_distances(
                                                                    v_to_destination_indices.size()),
                                  static_cast<od_idx_t>(origins.size()),
                                  static_cast<od_idx_t>(destinations.size())})),
-                           thrust::identity<weight_t>{},
+                           cuda::std::identity{},
                            check_destination_index_t<vertex_t, od_idx_t, key_t>{
                              raft::device_span<od_idx_t const>(v_to_destination_indices.data(),
                                                                v_to_destination_indices.size()),
@@ -947,7 +947,7 @@ rmm::device_uvector<weight_t> od_shortest_distances(
                                                                  split_thresholds.end(),
                                                                  dist)));
                     },
-                    thrust::identity<key_t>{},
+                    cuda::std::identity{},
                     raft::device_span<size_t>(d_counters.data(), d_counters.size()));
               }
               std::vector<size_t> h_counters(d_counters.size());


### PR DESCRIPTION
It is deprecated and will be removed in an upcoming release