### PR TITLE
Replace `thrust::tuple` with `cuda::std::tuple`

### DIFF
--- a/cpp/examples/developers/vertex_and_edge_partition/vertex_and_edge_partition.cu
+++ b/cpp/examples/developers/vertex_and_edge_partition/vertex_and_edge_partition.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -238,15 +238,15 @@ void look_into_vertex_and_edge_partitions(
 
   if (renumber_map) {
     thrust::for_each(thrust::host,
-                     thrust::make_zip_iterator(thrust::make_tuple(
+                     thrust::make_zip_iterator(cuda::std::make_tuple(
                        h_vertices_in_this_proces.begin(),
                        thrust::make_counting_iterator(renumbered_vertex_id_of_local_first))),
-                     thrust::make_zip_iterator(thrust::make_tuple(
+                     thrust::make_zip_iterator(cuda::std::make_tuple(
                        h_vertices_in_this_proces.end(),
                        thrust::make_counting_iterator(renumbered_vertex_id_of_local_last))),
                      [comm_rank](auto old_and_new_id_pair) {
-                       auto old_id = thrust::get<0>(old_and_new_id_pair);
-                       auto new_id = thrust::get<1>(old_and_new_id_pair);
+                       auto old_id = cuda::std::get<0>(old_and_new_id_pair);
+                       auto new_id = cuda::std::get<1>(old_and_new_id_pair);
                        printf("owner rank = %d, original vertex id %d is renumbered to  %d\n",
                               comm_rank,
                               static_cast<int>(old_id),

--- a/cpp/include/cugraph/detail/decompress_edge_partition.cuh
+++ b/cpp/include/cugraph/detail/decompress_edge_partition.cuh
@@ -24,13 +24,13 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/sequence.h>
-#include <thrust/tuple.h>
 
 #include <optional>
 #include <tuple>

--- a/cpp/include/cugraph/edge_partition_device_view.cuh
+++ b/cpp/include/cugraph/edge_partition_device_view.cuh
@@ -27,12 +27,12 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/distance.h>
 #include <thrust/execution_policy.h>
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
-#include <thrust/tuple.h>
 
 #include <cassert>
 #include <optional>
@@ -167,13 +167,13 @@ class edge_partition_device_view_base_t {
   }
 
   // major_idx == major offset if CSR/CSC, major_offset != major_idx if DCSR/DCSC
-  __device__ thrust::tuple<vertex_t const*, edge_t, edge_t> local_edges(
+  __device__ cuda::std::tuple<vertex_t const*, edge_t, edge_t> local_edges(
     vertex_t major_idx) const noexcept
   {
     auto edge_offset  = offsets_[major_idx];
     auto local_degree = offsets_[major_idx + 1] - edge_offset;
     auto indices      = indices_.data() + edge_offset;
-    return thrust::make_tuple(indices, edge_offset, local_degree);
+    return cuda::std::make_tuple(indices, edge_offset, local_degree);
   }
 
   // major_idx == major offset if CSR/CSC, major_offset != major_idx if DCSR/DCSC

--- a/cpp/include/cugraph/edge_partition_edge_property_device_view.cuh
+++ b/cpp/include/cugraph/edge_partition_edge_property_device_view.cuh
@@ -59,7 +59,7 @@ class edge_partition_edge_property_device_view_t {
   __device__ value_t get(edge_t offset) const
   {
     if constexpr (has_packed_bool_element) {
-      static_assert(is_packed_bool, "unimplemented for thrust::tuple types.");
+      static_assert(is_packed_bool, "unimplemented for cuda::std::tuple types.");
       auto mask = cugraph::packed_bool_mask(offset);
       return static_cast<bool>(*(value_first_ + cugraph::packed_bool_offset(offset)) & mask);
     } else {
@@ -74,7 +74,7 @@ class edge_partition_edge_property_device_view_t {
   set(edge_t offset, value_t val) const
   {
     if constexpr (has_packed_bool_element) {
-      static_assert(is_packed_bool, "unimplemented for thrust::tuple types.");
+      static_assert(is_packed_bool, "unimplemented for cuda::std::tuple types.");
       auto mask = cugraph::packed_bool_mask(offset);
       if (val) {
         atomicOr(value_first_ + cugraph::packed_bool_offset(offset), mask);
@@ -93,7 +93,7 @@ class edge_partition_edge_property_device_view_t {
   atomic_and(edge_t offset, value_t val) const
   {
     if constexpr (has_packed_bool_element) {
-      static_assert(is_packed_bool, "unimplemented for thrust::tuple types.");
+      static_assert(is_packed_bool, "unimplemented for cuda::std::tuple types.");
       auto mask = cugraph::packed_bool_mask(offset);
       auto old  = atomicAnd(value_first_ + cugraph::packed_bool_offset(offset),
                            val ? uint32_t{0xffffffff} : ~mask);
@@ -110,7 +110,7 @@ class edge_partition_edge_property_device_view_t {
   atomic_or(edge_t offset, value_t val) const
   {
     if constexpr (has_packed_bool_element) {
-      static_assert(is_packed_bool, "unimplemented for thrust::tuple types.");
+      static_assert(is_packed_bool, "unimplemented for cuda::std::tuple types.");
       auto mask = cugraph::packed_bool_mask(offset);
       auto old =
         atomicOr(value_first_ + cugraph::packed_bool_offset(offset), val ? mask : uint32_t{0});
@@ -137,7 +137,7 @@ class edge_partition_edge_property_device_view_t {
   elementwise_atomic_cas(edge_t offset, value_t compare, value_t val) const
   {
     if constexpr (has_packed_bool_element) {
-      static_assert(is_packed_bool, "unimplemented for thrust::tuple types.");
+      static_assert(is_packed_bool, "unimplemented for cuda::std::tuple types.");
       cuda::atomic_ref<uint32_t, cuda::thread_scope_device> word(
         *(value_first_ + cugraph::packed_bool_offset(offset)));
       auto mask = cugraph::packed_bool_mask(offset);

--- a/cpp/include/cugraph/edge_partition_endpoint_property_device_view.cuh
+++ b/cpp/include/cugraph/edge_partition_endpoint_property_device_view.cuh
@@ -81,7 +81,7 @@ class edge_partition_endpoint_property_device_view_t {
   {
     auto val_offset = value_offset(offset);
     if constexpr (has_packed_bool_element) {
-      static_assert(is_packed_bool, "unimplemented for thrust::tuple types.");
+      static_assert(is_packed_bool, "unimplemented for cuda::std::tuple types.");
       auto mask = cugraph::packed_bool_mask(val_offset);
       return static_cast<bool>(*(value_first_ + cugraph::packed_bool_offset(val_offset)) & mask);
     } else {
@@ -97,7 +97,7 @@ class edge_partition_endpoint_property_device_view_t {
   {
     auto val_offset = value_offset(offset);
     if constexpr (has_packed_bool_element) {
-      static_assert(is_packed_bool, "unimplemented for thrust::tuple types.");
+      static_assert(is_packed_bool, "unimplemented for cuda::std::tuple types.");
       auto mask = cugraph::packed_bool_mask(val_offset);
       auto old  = atomicAnd(value_first_ + cugraph::packed_bool_offset(val_offset),
                            val ? cugraph::packed_bool_full_mask() : ~mask);
@@ -115,7 +115,7 @@ class edge_partition_endpoint_property_device_view_t {
   {
     auto val_offset = value_offset(offset);
     if constexpr (has_packed_bool_element) {
-      static_assert(is_packed_bool, "unimplemented for thrust::tuple types.");
+      static_assert(is_packed_bool, "unimplemented for cuda::std::tuple types.");
       auto mask = cugraph::packed_bool_mask(val_offset);
       auto old  = atomicOr(value_first_ + cugraph::packed_bool_offset(val_offset),
                           val ? mask : cugraph::packed_bool_empty_mask());
@@ -144,7 +144,7 @@ class edge_partition_endpoint_property_device_view_t {
   {
     auto val_offset = value_offset(offset);
     if constexpr (has_packed_bool_element) {
-      static_assert(is_packed_bool, "unimplemented for thrust::tuple types.");
+      static_assert(is_packed_bool, "unimplemented for cuda::std::tuple types.");
       cuda::atomic_ref<uint32_t, cuda::thread_scope_device> word(
         *(value_first_ + cugraph::packed_bool_offset(val_offset)));
       auto mask = cugraph::packed_bool_mask(val_offset);

--- a/cpp/include/cugraph/edge_src_dst_property.hpp
+++ b/cpp/include/cugraph/edge_src_dst_property.hpp
@@ -25,9 +25,9 @@
 #include <raft/core/host_span.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
 
 #include <optional>
 #include <type_traits>

--- a/cpp/include/cugraph/src_dst_lookup_container.hpp
+++ b/cpp/include/cugraph/src_dst_lookup_container.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <unordered_map>
 #include <vector>
@@ -34,7 +34,7 @@ namespace cugraph {
 template <typename edge_id_t,
           typename edge_type_t,
           typename vertex_t,
-          typename value_t = thrust::tuple<vertex_t, vertex_t>>
+          typename value_t = cuda::std::tuple<vertex_t, vertex_t>>
 class lookup_container_t {
   template <typename _edge_id_t, typename _edge_type_t, typename _vertex_t, typename _value_t>
   struct lookup_container_impl;

--- a/cpp/include/cugraph/utilities/atomic_ops.cuh
+++ b/cpp/include/cugraph/utilities/atomic_ops.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@
 
 #include <raft/util/device_atomics.cuh>
 
+#include <cuda/std/tuple>
 #include <thrust/detail/type_traits/iterator/is_discard_iterator.h>
 #include <thrust/iterator/detail/any_assign.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/memory.h>
-#include <thrust/tuple.h>
 
 namespace cugraph {
 
@@ -36,8 +36,8 @@ __device__ constexpr TupleType thrust_tuple_atomic_and(Iterator iter,
                                                        TupleType tup,
                                                        std::index_sequence<Is...>)
 {
-  return thrust::make_tuple(
-    atomicAnd(&(thrust::raw_reference_cast(thrust::get<Is>(*iter))), thrust::get<Is>(tup))...);
+  return cuda::std::make_tuple(atomicAnd(&(thrust::raw_reference_cast(cuda::std::get<Is>(*iter))),
+                                         cuda::std::get<Is>(tup))...);
 }
 
 template <typename Iterator, typename TupleType, std::size_t... Is>
@@ -45,8 +45,8 @@ __device__ constexpr TupleType thrust_tuple_atomic_or(Iterator iter,
                                                       TupleType tup,
                                                       std::index_sequence<Is...>)
 {
-  return thrust::make_tuple(
-    atomicOr(&(thrust::raw_reference_cast(thrust::get<Is>(*iter))), thrust::get<Is>(tup))...);
+  return cuda::std::make_tuple(
+    atomicOr(&(thrust::raw_reference_cast(cuda::std::get<Is>(*iter))), cuda::std::get<Is>(tup))...);
 }
 
 template <typename Iterator, typename TupleType, std::size_t... Is>
@@ -54,8 +54,8 @@ __device__ constexpr TupleType thrust_tuple_atomic_add(Iterator iter,
                                                        TupleType tup,
                                                        std::index_sequence<Is...>)
 {
-  return thrust::make_tuple(
-    atomicAdd(&(thrust::raw_reference_cast(thrust::get<Is>(*iter))), thrust::get<Is>(tup))...);
+  return cuda::std::make_tuple(atomicAdd(&(thrust::raw_reference_cast(cuda::std::get<Is>(*iter))),
+                                         cuda::std::get<Is>(tup))...);
 }
 
 template <typename Iterator, typename TupleType, std::size_t... Is>
@@ -64,9 +64,9 @@ __device__ constexpr TupleType thrust_tuple_elementwise_atomic_cas(Iterator iter
                                                                    TupleType val_tup,
                                                                    std::index_sequence<Is...>)
 {
-  return thrust::make_tuple(atomicCAS(&(thrust::raw_reference_cast(thrust::get<Is>(*iter))),
-                                      thrust::get<Is>(comp_tup),
-                                      thrust::get<Is>(val_tup))...);
+  return cuda::std::make_tuple(atomicCAS(&(thrust::raw_reference_cast(cuda::std::get<Is>(*iter))),
+                                         cuda::std::get<Is>(comp_tup),
+                                         cuda::std::get<Is>(val_tup))...);
 }
 
 template <typename Iterator, typename TupleType, std::size_t... Is>
@@ -74,8 +74,8 @@ __device__ constexpr TupleType thrust_tuple_elementwise_atomic_min(Iterator iter
                                                                    TupleType tup,
                                                                    std::index_sequence<Is...>)
 {
-  return thrust::make_tuple(
-    atomicMin(&(thrust::raw_reference_cast(thrust::get<Is>(*iter))), thrust::get<Is>(tup))...);
+  return cuda::std::make_tuple(atomicMin(&(thrust::raw_reference_cast(cuda::std::get<Is>(*iter))),
+                                         cuda::std::get<Is>(tup))...);
 }
 
 template <typename Iterator, typename TupleType, std::size_t... Is>
@@ -83,8 +83,8 @@ __device__ constexpr TupleType thrust_tuple_elementwise_atomic_max(Iterator iter
                                                                    TupleType tup,
                                                                    std::index_sequence<Is...>)
 {
-  return thrust::make_tuple(
-    atomicMax(&(thrust::raw_reference_cast(thrust::get<Is>(*iter))), thrust::get<Is>(tup))...);
+  return cuda::std::make_tuple(atomicMax(&(thrust::raw_reference_cast(cuda::std::get<Is>(*iter))),
+                                         cuda::std::get<Is>(tup))...);
 }
 
 }  // namespace detail
@@ -114,7 +114,7 @@ __device__
   atomic_and(Iterator iter, T value)
 {
   return detail::thrust_tuple_atomic_and(
-    iter, value, std::make_index_sequence<thrust::tuple_size<T>::value>{});
+    iter, value, std::make_index_sequence<cuda::std::tuple_size<T>::value>{});
 }
 
 template <typename Iterator, typename T>
@@ -142,7 +142,7 @@ __device__
   atomic_or(Iterator iter, T value)
 {
   return detail::thrust_tuple_atomic_or(
-    iter, value, std::make_index_sequence<thrust::tuple_size<T>::value>{});
+    iter, value, std::make_index_sequence<cuda::std::tuple_size<T>::value>{});
 }
 
 template <typename Iterator, typename T>
@@ -169,10 +169,11 @@ __device__
                    T>
   atomic_add(Iterator iter, T value)
 {
-  static_assert(thrust::tuple_size<typename thrust::iterator_traits<Iterator>::value_type>::value ==
-                thrust::tuple_size<T>::value);
+  static_assert(
+    cuda::std::tuple_size<typename thrust::iterator_traits<Iterator>::value_type>::value ==
+    cuda::std::tuple_size<T>::value);
   return detail::thrust_tuple_atomic_add(
-    iter, value, std::make_index_sequence<thrust::tuple_size<T>::value>{});
+    iter, value, std::make_index_sequence<cuda::std::tuple_size<T>::value>{});
 }
 
 template <typename Iterator, typename T>
@@ -193,7 +194,7 @@ __device__
   elementwise_atomic_cas(Iterator iter, T compare, T value)
 {
   return detail::thrust_tuple_elementwise_atomic_cas(
-    iter, compare, value, std::make_index_sequence<thrust::tuple_size<T>::value>{});
+    iter, compare, value, std::make_index_sequence<cuda::std::tuple_size<T>::value>{});
 }
 
 template <typename Iterator, typename T>
@@ -220,10 +221,11 @@ __device__
                    T>
   elementwise_atomic_min(Iterator iter, T const& value)
 {
-  static_assert(thrust::tuple_size<typename thrust::iterator_traits<Iterator>::value_type>::value ==
-                thrust::tuple_size<T>::value);
+  static_assert(
+    cuda::std::tuple_size<typename thrust::iterator_traits<Iterator>::value_type>::value ==
+    cuda::std::tuple_size<T>::value);
   return detail::thrust_tuple_elementwise_atomic_min(
-    iter, value, std::make_index_sequence<thrust::tuple_size<T>::value>{});
+    iter, value, std::make_index_sequence<cuda::std::tuple_size<T>::value>{});
 }
 
 template <typename Iterator, typename T>
@@ -250,10 +252,11 @@ __device__
                    T>
   elementwise_atomic_max(Iterator iter, T const& value)
 {
-  static_assert(thrust::tuple_size<typename thrust::iterator_traits<Iterator>::value_type>::value ==
-                thrust::tuple_size<T>::value);
+  static_assert(
+    cuda::std::tuple_size<typename thrust::iterator_traits<Iterator>::value_type>::value ==
+    cuda::std::tuple_size<T>::value);
   return detail::thrust_tuple_elementwise_atomic_max(
-    iter, value, std::make_index_sequence<thrust::tuple_size<T>::value>{});
+    iter, value, std::make_index_sequence<cuda::std::tuple_size<T>::value>{});
 }
 
 template <typename Iterator, typename T>

--- a/cpp/include/cugraph/utilities/dataframe_buffer.hpp
+++ b/cpp/include/cugraph/utilities/dataframe_buffer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
 
 #include <type_traits>
 
@@ -36,34 +36,35 @@ auto allocate_dataframe_buffer_tuple_impl(std::index_sequence<Is...>,
                                           size_t buffer_size,
                                           rmm::cuda_stream_view stream_view)
 {
-  return std::make_tuple(rmm::device_uvector<typename thrust::tuple_element<Is, TupleType>::type>(
-    buffer_size, stream_view)...);
+  return std::make_tuple(
+    rmm::device_uvector<typename cuda::std::tuple_element<Is, TupleType>::type>(buffer_size,
+                                                                                stream_view)...);
 }
 
 template <typename TupleType, std::size_t... Is>
 auto get_dataframe_buffer_begin_tuple_impl(std::index_sequence<Is...>, TupleType& buffer)
 {
-  return thrust::make_zip_iterator(thrust::make_tuple((std::get<Is>(buffer).begin())...));
+  return thrust::make_zip_iterator(cuda::std::make_tuple((std::get<Is>(buffer).begin())...));
 }
 
 template <typename TupleType, std::size_t... Is>
 auto get_dataframe_buffer_end_tuple_impl(std::index_sequence<Is...>, TupleType& buffer)
 {
-  return thrust::make_zip_iterator(thrust::make_tuple((std::get<Is>(buffer).end())...));
+  return thrust::make_zip_iterator(cuda::std::make_tuple((std::get<Is>(buffer).end())...));
 }
 
 template <typename TupleType, size_t... Is>
 auto get_dataframe_buffer_cbegin_tuple_impl(std::index_sequence<Is...>, TupleType& buffer)
 {
-  // thrust::make_tuple instead of std::make_tuple as this is fed to thrust::make_zip_iterator.
-  return thrust::make_zip_iterator(thrust::make_tuple((std::get<Is>(buffer).cbegin())...));
+  // cuda::std::make_tuple instead of std::make_tuple as this is fed to thrust::make_zip_iterator.
+  return thrust::make_zip_iterator(cuda::std::make_tuple((std::get<Is>(buffer).cbegin())...));
 }
 
 template <typename TupleType, std::size_t... Is>
 auto get_dataframe_buffer_cend_tuple_impl(std::index_sequence<Is...>, TupleType& buffer)
 {
-  // thrust::make_tuple instead of std::make_tuple as this is fed to thrust::make_zip_iterator.
-  return thrust::make_zip_iterator(thrust::make_tuple((std::get<Is>(buffer).cend())...));
+  // cuda::std::make_tuple instead of std::make_tuple as this is fed to thrust::make_zip_iterator.
+  return thrust::make_zip_iterator(cuda::std::make_tuple((std::get<Is>(buffer).cend())...));
 }
 
 }  // namespace detail
@@ -77,7 +78,7 @@ auto allocate_dataframe_buffer(size_t buffer_size, rmm::cuda_stream_view stream_
 template <typename T, typename std::enable_if_t<is_thrust_tuple_of_arithmetic<T>::value>* = nullptr>
 auto allocate_dataframe_buffer(size_t buffer_size, rmm::cuda_stream_view stream_view)
 {
-  size_t constexpr tuple_size = thrust::tuple_size<T>::value;
+  size_t constexpr tuple_size = cuda::std::tuple_size<T>::value;
   return detail::allocate_dataframe_buffer_tuple_impl<T>(
     std::make_index_sequence<tuple_size>(), buffer_size, stream_view);
 }
@@ -107,8 +108,9 @@ struct dataframe_buffer_iterator_type {
 };
 
 template <typename... Ts>
-struct dataframe_buffer_iterator_type<thrust::tuple<Ts...>> {
-  using type = thrust::zip_iterator<thrust::tuple<typename rmm::device_uvector<Ts>::iterator...>>;
+struct dataframe_buffer_iterator_type<cuda::std::tuple<Ts...>> {
+  using type =
+    thrust::zip_iterator<cuda::std::tuple<typename rmm::device_uvector<Ts>::iterator...>>;
 };
 
 template <typename T>
@@ -120,9 +122,9 @@ struct dataframe_buffer_const_iterator_type {
 };
 
 template <typename... Ts>
-struct dataframe_buffer_const_iterator_type<thrust::tuple<Ts...>> {
+struct dataframe_buffer_const_iterator_type<cuda::std::tuple<Ts...>> {
   using type =
-    thrust::zip_iterator<thrust::tuple<typename rmm::device_uvector<Ts>::const_iterator...>>;
+    thrust::zip_iterator<cuda::std::tuple<typename rmm::device_uvector<Ts>::const_iterator...>>;
 };
 
 template <typename T>

--- a/cpp/include/cugraph/utilities/device_comm.hpp
+++ b/cpp/include/cugraph/utilities/device_comm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,13 +22,13 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/detail/type_traits/iterator/is_discard_iterator.h>
 #include <thrust/device_ptr.h>
 #include <thrust/iterator/detail/any_assign.h>
 #include <thrust/iterator/detail/normal_iterator.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/memory.h>
-#include <thrust/tuple.h>
 
 #include <type_traits>
 
@@ -91,7 +91,7 @@ struct device_isend_tuple_iterator_element_impl {
   {
     using output_value_t = typename thrust::
       tuple_element<I, typename std::iterator_traits<OutputIterator>::value_type>::type;
-    auto tuple_element_input_first = thrust::get<I>(input_first.get_iterator_tuple());
+    auto tuple_element_input_first = cuda::std::get<I>(input_first.get_iterator_tuple());
     device_isend_impl<decltype(tuple_element_input_first), output_value_t>(
       comm, tuple_element_input_first, count, dst, static_cast<int>(base_tag + I), requests + I);
     device_isend_tuple_iterator_element_impl<InputIterator, OutputIterator, I + 1, N>().run(
@@ -151,7 +151,7 @@ struct device_irecv_tuple_iterator_element_impl {
   {
     using input_value_t = typename thrust::
       tuple_element<I, typename std::iterator_traits<InputIterator>::value_type>::type;
-    auto tuple_element_output_first = thrust::get<I>(output_first.get_iterator_tuple());
+    auto tuple_element_output_first = cuda::std::get<I>(output_first.get_iterator_tuple());
     device_irecv_impl<input_value_t, decltype(tuple_element_output_first)>(
       comm, tuple_element_output_first, count, src, static_cast<int>(base_tag + I), requests + I);
     device_irecv_tuple_iterator_element_impl<InputIterator, OutputIterator, I + 1, N>().run(
@@ -223,8 +223,8 @@ struct device_sendrecv_tuple_iterator_element_impl {
   {
     using output_value_t = typename thrust::
       tuple_element<I, typename std::iterator_traits<OutputIterator>::value_type>::type;
-    auto tuple_element_input_first  = thrust::get<I>(input_first.get_iterator_tuple());
-    auto tuple_element_output_first = thrust::get<I>(output_first.get_iterator_tuple());
+    auto tuple_element_input_first  = cuda::std::get<I>(input_first.get_iterator_tuple());
+    auto tuple_element_output_first = cuda::std::get<I>(output_first.get_iterator_tuple());
     device_sendrecv_impl<decltype(tuple_element_input_first), decltype(tuple_element_output_first)>(
       comm,
       tuple_element_input_first,
@@ -313,8 +313,8 @@ struct device_multicast_sendrecv_tuple_iterator_element_impl {
   {
     using output_value_t = typename thrust::
       tuple_element<I, typename std::iterator_traits<OutputIterator>::value_type>::type;
-    auto tuple_element_input_first  = thrust::get<I>(input_first.get_iterator_tuple());
-    auto tuple_element_output_first = thrust::get<I>(output_first.get_iterator_tuple());
+    auto tuple_element_input_first  = cuda::std::get<I>(input_first.get_iterator_tuple());
+    auto tuple_element_output_first = cuda::std::get<I>(output_first.get_iterator_tuple());
     device_multicast_sendrecv_impl<decltype(tuple_element_input_first),
                                    decltype(tuple_element_output_first)>(comm,
                                                                          tuple_element_input_first,
@@ -395,8 +395,8 @@ struct device_bcast_tuple_iterator_element_impl {
            rmm::cuda_stream_view stream_view) const
   {
     device_bcast_impl(comm,
-                      thrust::get<I>(input_first.get_iterator_tuple()),
-                      thrust::get<I>(output_first.get_iterator_tuple()),
+                      cuda::std::get<I>(input_first.get_iterator_tuple()),
+                      cuda::std::get<I>(output_first.get_iterator_tuple()),
                       count,
                       root,
                       stream_view);
@@ -456,8 +456,8 @@ struct device_allreduce_tuple_iterator_element_impl {
            rmm::cuda_stream_view stream_view) const
   {
     device_allreduce_impl(comm,
-                          thrust::get<I>(input_first.get_iterator_tuple()),
-                          thrust::get<I>(output_first.get_iterator_tuple()),
+                          cuda::std::get<I>(input_first.get_iterator_tuple()),
+                          cuda::std::get<I>(output_first.get_iterator_tuple()),
                           count,
                           op,
                           stream_view);
@@ -524,8 +524,8 @@ struct device_reduce_tuple_iterator_element_impl {
            rmm::cuda_stream_view stream_view) const
   {
     device_reduce_impl(comm,
-                       thrust::get<I>(input_first.get_iterator_tuple()),
-                       thrust::get<I>(output_first.get_iterator_tuple()),
+                       cuda::std::get<I>(input_first.get_iterator_tuple()),
+                       cuda::std::get<I>(output_first.get_iterator_tuple()),
                        count,
                        op,
                        root,
@@ -584,8 +584,8 @@ struct device_allgather_tuple_iterator_element_impl {
            rmm::cuda_stream_view stream_view) const
   {
     device_allgather_impl(comm,
-                          thrust::get<I>(input_first.get_iterator_tuple()),
-                          thrust::get<I>(output_first.get_iterator_tuple()),
+                          cuda::std::get<I>(input_first.get_iterator_tuple()),
+                          cuda::std::get<I>(output_first.get_iterator_tuple()),
                           sendcount,
                           stream_view);
     device_allgather_tuple_iterator_element_impl<InputIterator, OutputIterator, I + 1, N>().run(
@@ -646,8 +646,8 @@ struct device_allgatherv_tuple_iterator_element_impl {
            rmm::cuda_stream_view stream_view) const
   {
     device_allgatherv_impl(comm,
-                           thrust::get<I>(input_first.get_iterator_tuple()),
-                           thrust::get<I>(output_first.get_iterator_tuple()),
+                           cuda::std::get<I>(input_first.get_iterator_tuple()),
+                           cuda::std::get<I>(output_first.get_iterator_tuple()),
                            recvcounts,
                            displacements,
                            stream_view);
@@ -718,8 +718,8 @@ struct device_gatherv_tuple_iterator_element_impl {
            rmm::cuda_stream_view stream_view) const
   {
     device_gatherv_impl(comm,
-                        thrust::get<I>(input_first.get_iterator_tuple()),
-                        thrust::get<I>(output_first.get_iterator_tuple()),
+                        cuda::std::get<I>(input_first.get_iterator_tuple()),
+                        cuda::std::get<I>(output_first.get_iterator_tuple()),
                         sendcount,
                         recvcounts,
                         displacements,
@@ -775,11 +775,11 @@ device_isend(raft::comms::comms_t const& comm,
              raft::comms::request_t* requests)
 {
   static_assert(
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
-    thrust::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
+    cuda::std::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
 
   size_t constexpr tuple_size =
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
 
   detail::
     device_isend_tuple_iterator_element_impl<InputIterator, OutputIterator, size_t{0}, tuple_size>()
@@ -814,11 +814,11 @@ device_irecv(raft::comms::comms_t const& comm,
              raft::comms::request_t* requests)
 {
   static_assert(
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
-    thrust::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
+    cuda::std::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
 
   size_t constexpr tuple_size =
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
 
   detail::
     device_irecv_tuple_iterator_element_impl<InputIterator, OutputIterator, size_t{0}, tuple_size>()
@@ -857,11 +857,11 @@ device_sendrecv(raft::comms::comms_t const& comm,
                 rmm::cuda_stream_view stream_view)
 {
   static_assert(
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
-    thrust::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
+    cuda::std::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
 
   size_t constexpr tuple_size =
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
 
   detail::device_sendrecv_tuple_iterator_element_impl<InputIterator,
                                                       OutputIterator,
@@ -914,11 +914,11 @@ device_multicast_sendrecv(raft::comms::comms_t const& comm,
                           rmm::cuda_stream_view stream_view)
 {
   static_assert(
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
-    thrust::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
+    cuda::std::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
 
   size_t constexpr tuple_size =
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
 
   detail::device_multicast_sendrecv_tuple_iterator_element_impl<InputIterator,
                                                                 OutputIterator,
@@ -963,11 +963,11 @@ device_bcast(raft::comms::comms_t const& comm,
              rmm::cuda_stream_view stream_view)
 {
   static_assert(
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
-    thrust::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
+    cuda::std::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
 
   size_t constexpr tuple_size =
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
 
   detail::
     device_bcast_tuple_iterator_element_impl<InputIterator, OutputIterator, size_t{0}, tuple_size>()
@@ -1001,11 +1001,11 @@ device_allreduce(raft::comms::comms_t const& comm,
                  rmm::cuda_stream_view stream_view)
 {
   static_assert(
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
-    thrust::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
+    cuda::std::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
 
   size_t constexpr tuple_size =
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
 
   detail::device_allreduce_tuple_iterator_element_impl<InputIterator,
                                                        OutputIterator,
@@ -1043,11 +1043,11 @@ device_reduce(raft::comms::comms_t const& comm,
               rmm::cuda_stream_view stream_view)
 {
   static_assert(
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
-    thrust::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
+    cuda::std::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
 
   size_t constexpr tuple_size =
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
 
   detail::device_reduce_tuple_iterator_element_impl<InputIterator,
                                                     OutputIterator,
@@ -1081,11 +1081,11 @@ device_allgather(raft::comms::comms_t const& comm,
                  rmm::cuda_stream_view stream_view)
 {
   static_assert(
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
-    thrust::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
+    cuda::std::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
 
   size_t constexpr tuple_size =
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
 
   detail::device_allgather_tuple_iterator_element_impl<InputIterator,
                                                        OutputIterator,
@@ -1122,11 +1122,11 @@ device_allgatherv(raft::comms::comms_t const& comm,
                   rmm::cuda_stream_view stream_view)
 {
   static_assert(
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
-    thrust::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
+    cuda::std::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
 
   size_t constexpr tuple_size =
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
 
   detail::device_allgatherv_tuple_iterator_element_impl<InputIterator,
                                                         OutputIterator,
@@ -1167,11 +1167,11 @@ device_gatherv(raft::comms::comms_t const& comm,
                rmm::cuda_stream_view stream_view)
 {
   static_assert(
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
-    thrust::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value ==
+    cuda::std::tuple_size<typename thrust::iterator_traits<OutputIterator>::value_type>::value);
 
   size_t constexpr tuple_size =
-    thrust::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
+    cuda::std::tuple_size<typename thrust::iterator_traits<InputIterator>::value_type>::value;
 
   detail::device_gatherv_tuple_iterator_element_impl<InputIterator,
                                                      OutputIterator,

--- a/cpp/include/cugraph/utilities/packed_bool_utils.hpp
+++ b/cpp/include/cugraph/utilities/packed_bool_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 
 #include <cugraph/utilities/thrust_tuple_utils.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/iterator_traits.h>
-#include <thrust/tuple.h>
 
 #include <type_traits>
 #include <utility>
@@ -35,14 +35,14 @@ constexpr std::enable_if_t<cugraph::is_thrust_tuple_of_arithmetic<
 has_packed_bool_element(std::index_sequence<Is...>)
 {
   static_assert(
-    thrust::tuple_size<typename thrust::iterator_traits<ValueIterator>::value_type>::value ==
-    thrust::tuple_size<value_t>::value);
+    cuda::std::tuple_size<typename thrust::iterator_traits<ValueIterator>::value_type>::value ==
+    cuda::std::tuple_size<value_t>::value);
   return (... ||
-          (std::is_same_v<typename thrust::tuple_element<
+          (std::is_same_v<typename cuda::std::tuple_element<
                             Is,
                             typename thrust::iterator_traits<ValueIterator>::value_type>::type,
                           uint32_t> &&
-           std::is_same_v<typename thrust::tuple_element<Is, value_t>::type, bool>));
+           std::is_same_v<typename cuda::std::tuple_element<Is, value_t>::type, bool>));
 }
 
 }  // namespace detail
@@ -70,10 +70,10 @@ constexpr bool has_packed_bool_element()
            std::is_same_v<value_t, bool>;
   } else {
     static_assert(
-      thrust::tuple_size<typename thrust::iterator_traits<ValueIterator>::value_type>::value ==
-      thrust::tuple_size<value_t>::value);
+      cuda::std::tuple_size<typename thrust::iterator_traits<ValueIterator>::value_type>::value ==
+      cuda::std::tuple_size<value_t>::value);
     return detail::has_packed_bool_element<ValueIterator, value_t>(
-      std::make_index_sequence<thrust::tuple_size<value_t>::value>());
+      std::make_index_sequence<cuda::std::tuple_size<value_t>::value>());
   }
 }
 

--- a/cpp/include/cugraph/utilities/shuffle_comm.cuh
+++ b/cpp/include/cugraph/utilities/shuffle_comm.cuh
@@ -25,6 +25,7 @@
 
 #include <cuda/atomic>
 #include <cuda/functional>
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/count.h>
@@ -40,7 +41,6 @@
 #include <thrust/scatter.h>
 #include <thrust/sort.h>
 #include <thrust/tabulate.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <algorithm>
@@ -58,15 +58,15 @@ struct compute_group_id_count_pair_t {
   GroupIdIterator group_id_first{};
   GroupIdIterator group_id_last{};
 
-  __device__ thrust::tuple<int, size_t> operator()(size_t i) const
+  __device__ cuda::std::tuple<int, size_t> operator()(size_t i) const
   {
     static_assert(
       std::is_same_v<typename thrust::iterator_traits<GroupIdIterator>::value_type, int>);
     auto lower_it =
       thrust::lower_bound(thrust::seq, group_id_first, group_id_last, static_cast<int>(i));
     auto upper_it = thrust::upper_bound(thrust::seq, lower_it, group_id_last, static_cast<int>(i));
-    return thrust::make_tuple(static_cast<int>(i),
-                              static_cast<size_t>(thrust::distance(lower_it, upper_it)));
+    return cuda::std::make_tuple(static_cast<int>(i),
+                                 static_cast<size_t>(thrust::distance(lower_it, upper_it)));
   }
 };
 
@@ -161,9 +161,9 @@ template <typename key_type, typename value_type, typename KeyToGroupIdOp>
 struct kv_pair_group_id_less_t {
   KeyToGroupIdOp key_to_group_id_op;
   int pivot{};
-  __device__ bool operator()(thrust::tuple<key_type, value_type> t) const
+  __device__ bool operator()(cuda::std::tuple<key_type, value_type> t) const
   {
-    return key_to_group_id_op(thrust::get<0>(t)) < pivot;
+    return key_to_group_id_op(cuda::std::get<0>(t)) < pivot;
   }
 };
 
@@ -178,9 +178,9 @@ template <typename key_type, typename value_type, typename KeyToGroupIdOp>
 struct kv_pair_group_id_greater_equal_t {
   KeyToGroupIdOp key_to_group_id_op;
   int pivot{};
-  __device__ bool operator()(thrust::tuple<key_type, value_type> t) const
+  __device__ bool operator()(cuda::std::tuple<key_type, value_type> t) const
   {
-    return key_to_group_id_op(thrust::get<0>(t)) >= pivot;
+    return key_to_group_id_op(cuda::std::get<0>(t)) >= pivot;
   }
 };
 
@@ -204,13 +204,13 @@ void multi_partition(ValueIterator value_first,
     value_first,
     value_last,
     thrust::make_zip_iterator(
-      thrust::make_tuple(group_ids.begin(), intra_partition_offsets.begin())),
-    cuda::proclaim_return_type<thrust::tuple<int, size_t>>(
+      cuda::std::make_tuple(group_ids.begin(), intra_partition_offsets.begin())),
+    cuda::proclaim_return_type<cuda::std::tuple<int, size_t>>(
       [value_to_group_id_op, group_first, counts = counts.data()] __device__(auto value) {
         auto group_id = value_to_group_id_op(value);
         cuda::std::atomic_ref<size_t> counter(counts[group_id - group_first]);
-        return thrust::make_tuple(group_id,
-                                  counter.fetch_add(size_t{1}, cuda::std::memory_order_relaxed));
+        return cuda::std::make_tuple(group_id,
+                                     counter.fetch_add(size_t{1}, cuda::std::memory_order_relaxed));
       }));
 
   rmm::device_uvector<size_t> displacements(num_groups, stream_view);
@@ -221,7 +221,7 @@ void multi_partition(ValueIterator value_first,
     allocate_dataframe_buffer<typename thrust::iterator_traits<ValueIterator>::value_type>(
       num_values, stream_view);
   auto input_triplet_first = thrust::make_zip_iterator(
-    thrust::make_tuple(value_first, group_ids.begin(), intra_partition_offsets.begin()));
+    cuda::std::make_tuple(value_first, group_ids.begin(), intra_partition_offsets.begin()));
   auto tmp_value_first = get_dataframe_buffer_begin(tmp_value_buffer);
   thrust::for_each(
     rmm::exec_policy(stream_view),
@@ -230,9 +230,9 @@ void multi_partition(ValueIterator value_first,
     [group_first,
      displacements = displacements.data(),
      output_first  = get_dataframe_buffer_begin(tmp_value_buffer)] __device__(auto triplet) {
-      auto group_id            = thrust::get<1>(triplet);
-      auto offset              = displacements[group_id - group_first] + thrust::get<2>(triplet);
-      *(output_first + offset) = thrust::get<0>(triplet);
+      auto group_id            = cuda::std::get<1>(triplet);
+      auto offset              = displacements[group_id - group_first] + cuda::std::get<2>(triplet);
+      *(output_first + offset) = cuda::std::get<0>(triplet);
     });
   thrust::copy(
     rmm::exec_policy(stream_view), tmp_value_first, tmp_value_first + num_values, value_first);
@@ -259,13 +259,13 @@ void multi_partition(KeyIterator key_first,
     key_first,
     key_last,
     thrust::make_zip_iterator(
-      thrust::make_tuple(group_ids.begin(), intra_partition_offsets.begin())),
-    cuda::proclaim_return_type<thrust::tuple<int, size_t>>(
+      cuda::std::make_tuple(group_ids.begin(), intra_partition_offsets.begin())),
+    cuda::proclaim_return_type<cuda::std::tuple<int, size_t>>(
       [key_to_group_id_op, group_first, counts = counts.data()] __device__(auto key) {
         auto group_id = key_to_group_id_op(key);
         cuda::std::atomic_ref<size_t> counter(counts[group_id - group_first]);
-        return thrust::make_tuple(group_id,
-                                  counter.fetch_add(size_t{1}, cuda::std::memory_order_relaxed));
+        return cuda::std::make_tuple(group_id,
+                                     counter.fetch_add(size_t{1}, cuda::std::memory_order_relaxed));
       }));
 
   rmm::device_uvector<size_t> displacements(num_groups, stream_view);
@@ -278,9 +278,9 @@ void multi_partition(KeyIterator key_first,
   auto tmp_value_buffer =
     allocate_dataframe_buffer<typename thrust::iterator_traits<ValueIterator>::value_type>(
       num_keys, stream_view);
-  auto input_quadraplet_first = thrust::make_zip_iterator(
-    thrust::make_tuple(key_first, value_first, group_ids.begin(), intra_partition_offsets.begin()));
-  auto tmp_kv_pair_first = thrust::make_zip_iterator(thrust::make_tuple(
+  auto input_quadraplet_first = thrust::make_zip_iterator(cuda::std::make_tuple(
+    key_first, value_first, group_ids.begin(), intra_partition_offsets.begin()));
+  auto tmp_kv_pair_first      = thrust::make_zip_iterator(cuda::std::make_tuple(
     get_dataframe_buffer_begin(tmp_key_buffer), get_dataframe_buffer_begin(tmp_value_buffer)));
   thrust::for_each(rmm::exec_policy(stream_view),
                    input_quadraplet_first,
@@ -288,16 +288,16 @@ void multi_partition(KeyIterator key_first,
                    [group_first,
                     displacements = displacements.data(),
                     output_first  = tmp_kv_pair_first] __device__(auto quadraplet) {
-                     auto group_id = thrust::get<2>(quadraplet);
+                     auto group_id = cuda::std::get<2>(quadraplet);
                      auto offset =
-                       displacements[group_id - group_first] + thrust::get<3>(quadraplet);
-                     *(output_first + offset) =
-                       thrust::make_tuple(thrust::get<0>(quadraplet), thrust::get<1>(quadraplet));
+                       displacements[group_id - group_first] + cuda::std::get<3>(quadraplet);
+                     *(output_first + offset) = cuda::std::make_tuple(
+                       cuda::std::get<0>(quadraplet), cuda::std::get<1>(quadraplet));
                    });
   thrust::copy(rmm::exec_policy(stream_view),
                tmp_kv_pair_first,
                tmp_kv_pair_first + num_keys,
-               thrust::make_zip_iterator(thrust::make_tuple(key_first, value_first)));
+               thrust::make_zip_iterator(cuda::std::make_tuple(key_first, value_first)));
 }
 
 template <typename ValueIterator>
@@ -516,8 +516,8 @@ std::tuple<KeyIterator, ValueIterator> mem_frugal_partition(
   // thrust::copy_if (1.15.0) also uses temporary buffer
   auto max_elements_per_iteration = size_t{16} * 1024 * 1024;
   auto num_chunks    = (num_elements + max_elements_per_iteration - 1) / max_elements_per_iteration;
-  auto kv_pair_first = thrust::make_zip_iterator(thrust::make_tuple(key_first, value_first));
-  auto output_chunk_first = thrust::make_zip_iterator(thrust::make_tuple(
+  auto kv_pair_first = thrust::make_zip_iterator(cuda::std::make_tuple(key_first, value_first));
+  auto output_chunk_first = thrust::make_zip_iterator(cuda::std::make_tuple(
     get_dataframe_buffer_begin(tmp_key_buffer), get_dataframe_buffer_begin(tmp_value_buffer)));
   for (size_t i = 0; i < num_chunks; ++i) {
     output_chunk_first = thrust::copy_if(
@@ -677,7 +677,7 @@ void mem_frugal_groupby(
           mem_frugal_threshold) {
         if (group_lasts[i] - group_firsts[i] == 2) {
           auto kv_pair_first =
-            thrust::make_zip_iterator(thrust::make_tuple(key_firsts[i], value_firsts[i]));
+            thrust::make_zip_iterator(cuda::std::make_tuple(key_firsts[i], value_firsts[i]));
           thrust::partition(
             rmm::exec_policy(stream_view),
             kv_pair_first,
@@ -778,7 +778,7 @@ rmm::device_uvector<size_t> groupby_and_count(ValueIterator tx_value_first /* [I
   rmm::device_uvector<int> d_tx_dst_ranks(num_groups, stream_view);
   rmm::device_uvector<size_t> d_tx_value_counts(d_tx_dst_ranks.size(), stream_view);
   auto rank_count_pair_first = thrust::make_zip_iterator(
-    thrust::make_tuple(d_tx_dst_ranks.begin(), d_tx_value_counts.begin()));
+    cuda::std::make_tuple(d_tx_dst_ranks.begin(), d_tx_value_counts.begin()));
   thrust::tabulate(
     rmm::exec_policy(stream_view),
     rank_count_pair_first,
@@ -813,7 +813,7 @@ rmm::device_uvector<size_t> groupby_and_count(VertexIterator tx_key_first /* [IN
   rmm::device_uvector<int> d_tx_dst_ranks(num_groups, stream_view);
   rmm::device_uvector<size_t> d_tx_value_counts(d_tx_dst_ranks.size(), stream_view);
   auto rank_count_pair_first = thrust::make_zip_iterator(
-    thrust::make_tuple(d_tx_dst_ranks.begin(), d_tx_value_counts.begin()));
+    cuda::std::make_tuple(d_tx_dst_ranks.begin(), d_tx_value_counts.begin()));
   thrust::tabulate(rmm::exec_policy(stream_view),
                    rank_count_pair_first,
                    rank_count_pair_first + num_groups,

--- a/cpp/include/cugraph/utilities/thrust_tuple_utils.hpp
+++ b/cpp/include/cugraph/utilities/thrust_tuple_utils.hpp
@@ -17,8 +17,8 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/iterator_traits.h>
-#include <thrust/tuple.h>
 
 #include <array>
 #include <type_traits>
@@ -31,7 +31,7 @@ template <typename TupleType, size_t I, size_t N>
 struct is_thrust_tuple_of_arithemetic_impl {
   constexpr bool evaluate() const
   {
-    if (!std::is_arithmetic_v<typename thrust::tuple_element<I, TupleType>::type>) {
+    if (!std::is_arithmetic_v<typename cuda::std::tuple_element<I, TupleType>::type>) {
       return false;
     } else {
       return is_thrust_tuple_of_arithemetic_impl<TupleType, I + 1, N>().evaluate();
@@ -46,40 +46,40 @@ struct is_thrust_tuple_of_arithemetic_impl<TupleType, I, I> {
 
 template <typename TupleType, size_t I, size_t N>
 struct compute_thrust_tuple_element_sizes_impl {
-  void compute(std::array<size_t, thrust::tuple_size<TupleType>::value>& arr) const
+  void compute(std::array<size_t, cuda::std::tuple_size<TupleType>::value>& arr) const
   {
-    arr[I] = sizeof(typename thrust::tuple_element<I, TupleType>::type);
+    arr[I] = sizeof(typename cuda::std::tuple_element<I, TupleType>::type);
     compute_thrust_tuple_element_sizes_impl<TupleType, I + 1, N>().compute(arr);
   }
 };
 
 template <typename TupleType, size_t I>
 struct compute_thrust_tuple_element_sizes_impl<TupleType, I, I> {
-  void compute(std::array<size_t, thrust::tuple_size<TupleType>::value>& arr) const {}
+  void compute(std::array<size_t, cuda::std::tuple_size<TupleType>::value>& arr) const {}
 };
 
 template <typename TupleType, std::size_t... Is>
 size_t sum_thrust_tuple_element_sizes(std::index_sequence<Is...>)
 {
-  return (... + sizeof(typename thrust::tuple_element<Is, TupleType>::type));
+  return (... + sizeof(typename cuda::std::tuple_element<Is, TupleType>::type));
 }
 
 template <typename TupleType, std::size_t... Is>
 size_t min_thrust_tuple_element_sizes(std::index_sequence<Is...>)
 {
-  return std::min(sizeof(typename thrust::tuple_element<Is, TupleType>::type)...);
+  return std::min(sizeof(typename cuda::std::tuple_element<Is, TupleType>::type)...);
 }
 
 template <typename TupleType, std::size_t... Is>
 size_t max_thrust_tuple_element_sizes(std::index_sequence<Is...>)
 {
-  return std::max(sizeof(typename thrust::tuple_element<Is, TupleType>::type)...);
+  return std::max(sizeof(typename cuda::std::tuple_element<Is, TupleType>::type)...);
 }
 
 template <typename TupleType, std::size_t... Is>
 auto thrust_tuple_to_std_tuple(TupleType tup, std::index_sequence<Is...>)
 {
-  return std::make_tuple(thrust::get<Is>(tup)...);
+  return std::make_tuple(cuda::std::get<Is>(tup)...);
 }
 
 template <typename TupleType, std::size_t... Is>
@@ -87,21 +87,21 @@ auto std_tuple_to_thrust_tuple(TupleType tup, std::index_sequence<Is...>)
 {
   constexpr size_t maximum_thrust_tuple_size = 10;
   static_assert(std::tuple_size_v<TupleType> <= maximum_thrust_tuple_size);
-  return thrust::make_tuple(std::get<Is>(tup)...);
+  return cuda::std::make_tuple(std::get<Is>(tup)...);
 }
 
 template <typename TupleType, std::size_t... Is>
 constexpr TupleType thrust_tuple_of_arithmetic_numeric_limits_lowest(std::index_sequence<Is...>)
 {
-  return thrust::make_tuple(
-    std::numeric_limits<typename thrust::tuple_element<Is, TupleType>::type>::lowest()...);
+  return cuda::std::make_tuple(
+    std::numeric_limits<typename cuda::std::tuple_element<Is, TupleType>::type>::lowest()...);
 }
 
 template <typename TupleType, std::size_t... Is>
 constexpr TupleType thrust_tuple_of_arithmetic_numeric_limits_max(std::index_sequence<Is...>)
 {
-  return thrust::make_tuple(
-    std::numeric_limits<typename thrust::tuple_element<Is, TupleType>::type>::max()...);
+  return cuda::std::make_tuple(
+    std::numeric_limits<typename cuda::std::tuple_element<Is, TupleType>::type>::max()...);
 }
 
 }  // namespace detail
@@ -110,13 +110,13 @@ template <typename T>
 struct is_thrust_tuple : std::false_type {};
 
 template <typename... Ts>
-struct is_thrust_tuple<thrust::tuple<Ts...>> : std::true_type {};
+struct is_thrust_tuple<cuda::std::tuple<Ts...>> : std::true_type {};
 
 template <typename TupleType>
 struct is_thrust_tuple_of_arithmetic : std::false_type {};
 
 template <typename... Ts>
-struct is_thrust_tuple_of_arithmetic<thrust::tuple<Ts...>> {
+struct is_thrust_tuple_of_arithmetic<cuda::std::tuple<Ts...>> {
  private:
   template <typename T>
   static constexpr bool is_valid = std::is_arithmetic_v<T>;
@@ -129,7 +129,7 @@ template <typename TupleType>
 struct is_thrust_tuple_of_integral : std::false_type {};
 
 template <typename... Ts>
-struct is_thrust_tuple_of_integral<thrust::tuple<Ts...>> {
+struct is_thrust_tuple_of_integral<cuda::std::tuple<Ts...>> {
  private:
   template <typename T>
   static constexpr bool is_valid = std::is_integral_v<T>;
@@ -164,21 +164,21 @@ struct is_arithmetic_or_thrust_tuple_of_arithmetic
   : std::integral_constant<bool, std::is_arithmetic_v<T>> {};
 
 template <typename... Ts>
-struct is_arithmetic_or_thrust_tuple_of_arithmetic<thrust::tuple<Ts...>>
-  : std::integral_constant<bool, is_thrust_tuple_of_arithmetic<thrust::tuple<Ts...>>::value> {};
+struct is_arithmetic_or_thrust_tuple_of_arithmetic<cuda::std::tuple<Ts...>>
+  : std::integral_constant<bool, is_thrust_tuple_of_arithmetic<cuda::std::tuple<Ts...>>::value> {};
 
 template <typename T>
 struct thrust_tuple_size_or_one : std::integral_constant<size_t, 1> {};
 
 template <typename... Ts>
-struct thrust_tuple_size_or_one<thrust::tuple<Ts...>>
-  : std::integral_constant<size_t, thrust::tuple_size<thrust::tuple<Ts...>>::value> {};
+struct thrust_tuple_size_or_one<cuda::std::tuple<Ts...>>
+  : std::integral_constant<size_t, cuda::std::tuple_size<cuda::std::tuple<Ts...>>::value> {};
 
 template <typename TupleType>
 struct compute_thrust_tuple_element_sizes {
   auto operator()() const
   {
-    size_t constexpr tuple_size = thrust::tuple_size<TupleType>::value;
+    size_t constexpr tuple_size = cuda::std::tuple_size<TupleType>::value;
     std::array<size_t, tuple_size> ret;
     detail::compute_thrust_tuple_element_sizes_impl<TupleType, size_t{0}, tuple_size>().compute(
       ret);
@@ -190,28 +190,28 @@ template <typename TupleType>
 constexpr size_t sum_thrust_tuple_element_sizes()
 {
   return detail::sum_thrust_tuple_element_sizes<TupleType>(
-    std::make_index_sequence<thrust::tuple_size<TupleType>::value>());
+    std::make_index_sequence<cuda::std::tuple_size<TupleType>::value>());
 }
 
 template <typename TupleType>
 constexpr size_t min_thrust_tuple_element_sizes()
 {
   return detail::min_thrust_tuple_element_sizes<TupleType>(
-    std::make_index_sequence<thrust::tuple_size<TupleType>::value>());
+    std::make_index_sequence<cuda::std::tuple_size<TupleType>::value>());
 }
 
 template <typename TupleType>
 constexpr size_t max_thrust_tuple_element_sizes()
 {
   return detail::max_thrust_tuple_element_sizes<TupleType>(
-    std::make_index_sequence<thrust::tuple_size<TupleType>::value>());
+    std::make_index_sequence<cuda::std::tuple_size<TupleType>::value>());
 }
 
 template <typename TupleType>
 auto thrust_tuple_to_std_tuple(TupleType tup)
 {
   return detail::thrust_tuple_to_std_tuple(
-    tup, std::make_index_sequence<thrust::tuple_size<TupleType>::value>{});
+    tup, std::make_index_sequence<cuda::std::tuple_size<TupleType>::value>{});
 }
 
 template <typename TupleType>
@@ -226,11 +226,11 @@ auto std_tuple_to_thrust_tuple(TupleType tup)
 template <typename T>
 auto to_thrust_tuple(T scalar_value)
 {
-  return thrust::make_tuple(scalar_value);
+  return cuda::std::make_tuple(scalar_value);
 }
 
 template <typename... Ts>
-auto to_thrust_tuple(thrust::tuple<Ts...> tuple_value)
+auto to_thrust_tuple(cuda::std::tuple<Ts...> tuple_value)
 {
   return tuple_value;
 }
@@ -240,7 +240,7 @@ template <typename Iterator,
             std::is_arithmetic_v<typename std::iterator_traits<Iterator>::value_type>>* = nullptr>
 auto to_thrust_iterator_tuple(Iterator iter)
 {
-  return thrust::make_tuple(iter);
+  return cuda::std::make_tuple(iter);
 }
 
 template <typename Iterator,
@@ -270,7 +270,7 @@ __host__ __device__
   auto
   thrust_tuple_get_or_identity(T val)
 {
-  return thrust::get<I>(val);
+  return cuda::std::get<I>(val);
 }
 
 template <typename Iterator,
@@ -296,10 +296,10 @@ __host__ __device__
   auto
   thrust_tuple_get_or_identity(Iterator val)
 {
-  return thrust::get<I>(val.get_iterator_tuple());
+  return cuda::std::get<I>(val.get_iterator_tuple());
 }
-// a temporary function to emulate thrust::tuple_cat (not supported) using std::tuple_cat (should
-// retire once thrust::tuple is replaced with cuda::std::tuple)
+// a temporary function to emulate cuda::std::tuple_cat (not supported) using std::tuple_cat (should
+// retire once cuda::std::tuple is replaced with cuda::std::tuple)
 template <typename... TupleTypes>
 auto thrust_tuple_cat(TupleTypes... tups)
 {
@@ -310,21 +310,21 @@ template <typename TupleType>
 constexpr TupleType thrust_tuple_of_arithmetic_numeric_limits_lowest()
 {
   return detail::thrust_tuple_of_arithmetic_numeric_limits_lowest<TupleType>(
-    std::make_index_sequence<thrust::tuple_size<TupleType>::value>());
+    std::make_index_sequence<cuda::std::tuple_size<TupleType>::value>());
 }
 
 template <typename TupleType>
 constexpr TupleType thrust_tuple_of_arithmetic_numeric_limits_max()
 {
   return detail::thrust_tuple_of_arithmetic_numeric_limits_max<TupleType>(
-    std::make_index_sequence<thrust::tuple_size<TupleType>::value>());
+    std::make_index_sequence<cuda::std::tuple_size<TupleType>::value>());
 }
 
 template <typename TupleType, size_t I>
 struct thrust_tuple_get {
-  __device__ typename thrust::tuple_element<I, TupleType>::type operator()(TupleType tup) const
+  __device__ typename cuda::std::tuple_element<I, TupleType>::type operator()(TupleType tup) const
   {
-    return thrust::get<I>(tup);
+    return cuda::std::get<I>(tup);
   }
 };
 

--- a/cpp/src/centrality/eigenvector_centrality_impl.cuh
+++ b/cpp/src/centrality/eigenvector_centrality_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,12 +33,12 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/fill.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 namespace cugraph {
 namespace detail {
@@ -148,8 +148,11 @@ rmm::device_uvector<weight_t> eigenvector_centrality(
     auto diff_sum = transform_reduce_v(
       handle,
       pull_graph_view,
-      thrust::make_zip_iterator(thrust::make_tuple(centralities.begin(), old_centralities.data())),
-      [] __device__(auto, auto val) { return std::abs(thrust::get<0>(val) - thrust::get<1>(val)); },
+      thrust::make_zip_iterator(
+        cuda::std::make_tuple(centralities.begin(), old_centralities.data())),
+      [] __device__(auto, auto val) {
+        return std::abs(cuda::std::get<0>(val) - cuda::std::get<1>(val));
+      },
       weight_t{0.0});
 
     iter++;

--- a/cpp/src/centrality/katz_centrality_impl.cuh
+++ b/cpp/src/centrality/katz_centrality_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,12 +30,12 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/fill.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 namespace cugraph {
 namespace detail {
@@ -138,14 +138,15 @@ void katz_centrality(
     }
 
     if (betas != nullptr) {
-      auto val_first = thrust::make_zip_iterator(thrust::make_tuple(new_katz_centralities, betas));
+      auto val_first =
+        thrust::make_zip_iterator(cuda::std::make_tuple(new_katz_centralities, betas));
       thrust::transform(handle.get_thrust_policy(),
                         val_first,
                         val_first + pull_graph_view.local_vertex_partition_range_size(),
                         new_katz_centralities,
                         [] __device__(auto val) {
-                          auto const katz_centrality = thrust::get<0>(val);
-                          auto const beta            = thrust::get<1>(val);
+                          auto const katz_centrality = cuda::std::get<0>(val);
+                          auto const beta            = cuda::std::get<1>(val);
                           return katz_centrality + beta;
                         });
     }
@@ -153,8 +154,11 @@ void katz_centrality(
     auto diff_sum = transform_reduce_v(
       handle,
       pull_graph_view,
-      thrust::make_zip_iterator(thrust::make_tuple(new_katz_centralities, old_katz_centralities)),
-      [] __device__(auto, auto val) { return std::abs(thrust::get<0>(val) - thrust::get<1>(val)); },
+      thrust::make_zip_iterator(
+        cuda::std::make_tuple(new_katz_centralities, old_katz_centralities)),
+      [] __device__(auto, auto val) {
+        return std::abs(cuda::std::get<0>(val) - cuda::std::get<1>(val));
+      },
       result_t{0.0});
 
     iter++;

--- a/cpp/src/community/detail/common_methods.cuh
+++ b/cpp/src/community/detail/common_methods.cuh
@@ -31,6 +31,7 @@
 
 #include <cuda/functional>
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/functional.h>
@@ -39,7 +40,6 @@
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
-#include <thrust/tuple.h>
 
 CUCO_DECLARE_BITWISE_COMPARABLE(float)
 CUCO_DECLARE_BITWISE_COMPARABLE(double)
@@ -60,15 +60,15 @@ struct key_aggregated_edge_op_t {
   __device__ auto operator()(
     vertex_t src,
     vertex_t neighbor_cluster,
-    thrust::tuple<weight_t, vertex_t, weight_t, weight_t, weight_t> src_info,
+    cuda::std::tuple<weight_t, vertex_t, weight_t, weight_t, weight_t> src_info,
     weight_t a_new,
     weight_t new_cluster_sum) const
   {
-    auto k_k              = thrust::get<0>(src_info);
-    auto src_cluster      = thrust::get<1>(src_info);
-    auto a_old            = thrust::get<2>(src_info);
-    auto old_cluster_sum  = thrust::get<3>(src_info);
-    auto cluster_subtract = thrust::get<4>(src_info);
+    auto k_k              = cuda::std::get<0>(src_info);
+    auto src_cluster      = cuda::std::get<1>(src_info);
+    auto a_old            = cuda::std::get<2>(src_info);
+    auto old_cluster_sum  = cuda::std::get<3>(src_info);
+    auto cluster_subtract = cuda::std::get<4>(src_info);
 
     if (src_cluster == neighbor_cluster) new_cluster_sum -= cluster_subtract;
 
@@ -76,25 +76,25 @@ struct key_aggregated_edge_op_t {
                                      resolution * (a_new * k_k - a_old * k_k + k_k * k_k) /
                                        (total_edge_weight * total_edge_weight));
 
-    return thrust::make_tuple(neighbor_cluster, delta_modularity);
+    return cuda::std::make_tuple(neighbor_cluster, delta_modularity);
   }
 };
 
 // FIXME: a workaround for cudaErrorInvalidDeviceFunction error when device lambda is used
 template <typename vertex_t, typename weight_t>
 struct reduce_op_t {
-  using type                          = thrust::tuple<vertex_t, weight_t>;
-  static constexpr bool pure_function = true;  // this can be called from any process
-  inline static type const identity_element =
-    thrust::make_tuple(std::numeric_limits<weight_t>::lowest(), invalid_vertex_id<vertex_t>::value);
+  using type                                = cuda::std::tuple<vertex_t, weight_t>;
+  static constexpr bool pure_function       = true;  // this can be called from any process
+  inline static type const identity_element = cuda::std::make_tuple(
+    std::numeric_limits<weight_t>::lowest(), invalid_vertex_id<vertex_t>::value);
 
-  __device__ auto operator()(thrust::tuple<vertex_t, weight_t> p0,
-                             thrust::tuple<vertex_t, weight_t> p1) const
+  __device__ auto operator()(cuda::std::tuple<vertex_t, weight_t> p0,
+                             cuda::std::tuple<vertex_t, weight_t> p1) const
   {
-    auto id0 = thrust::get<0>(p0);
-    auto id1 = thrust::get<0>(p1);
-    auto wt0 = thrust::get<1>(p0);
-    auto wt1 = thrust::get<1>(p1);
+    auto id0 = cuda::std::get<0>(p0);
+    auto id1 = cuda::std::get<0>(p1);
+    auto wt0 = cuda::std::get<1>(p0);
+    auto wt1 = cuda::std::get<1>(p1);
 
     return (wt0 < wt1) ? p1 : ((wt0 > wt1) ? p0 : ((id0 < id1) ? p0 : p1));
   }
@@ -104,12 +104,13 @@ struct reduce_op_t {
 template <typename vertex_t, typename weight_t>
 struct count_updown_moves_op_t {
   bool up_down{};
-  __device__ auto operator()(thrust::tuple<vertex_t, thrust::tuple<vertex_t, weight_t>> p) const
+  __device__ auto operator()(
+    cuda::std::tuple<vertex_t, cuda::std::tuple<vertex_t, weight_t>> p) const
   {
-    vertex_t old_cluster       = thrust::get<0>(p);
-    auto new_cluster_gain_pair = thrust::get<1>(p);
-    vertex_t new_cluster       = thrust::get<0>(new_cluster_gain_pair);
-    weight_t delta_modularity  = thrust::get<1>(new_cluster_gain_pair);
+    vertex_t old_cluster       = cuda::std::get<0>(p);
+    auto new_cluster_gain_pair = cuda::std::get<1>(p);
+    vertex_t new_cluster       = cuda::std::get<0>(new_cluster_gain_pair);
+    weight_t delta_modularity  = cuda::std::get<1>(new_cluster_gain_pair);
 
     auto result_assignment =
       (delta_modularity > weight_t{0})
@@ -125,10 +126,10 @@ struct count_updown_moves_op_t {
 template <typename vertex_t, typename weight_t>
 struct cluster_update_op_t {
   bool up_down{};
-  __device__ auto operator()(vertex_t old_cluster, thrust::tuple<vertex_t, weight_t> p) const
+  __device__ auto operator()(vertex_t old_cluster, cuda::std::tuple<vertex_t, weight_t> p) const
   {
-    vertex_t new_cluster      = thrust::get<0>(p);
-    weight_t delta_modularity = thrust::get<1>(p);
+    vertex_t new_cluster      = cuda::std::get<0>(p);
+    weight_t delta_modularity = cuda::std::get<1>(p);
 
     return (delta_modularity > weight_t{0})
              ? (((new_cluster > old_cluster) != up_down) ? old_cluster : new_cluster)
@@ -349,24 +350,24 @@ rmm::device_uvector<vertex_t> update_clustering_by_delta_modularity(
       else if (src_cluster == nbr_cluster)
         sum = wt;
 
-      return thrust::make_tuple(sum, subtract);
+      return cuda::std::make_tuple(sum, subtract);
     },
-    thrust::make_tuple(weight_t{0}, weight_t{0}),
-    reduce_op::plus<thrust::tuple<weight_t, weight_t>>{},
+    cuda::std::make_tuple(weight_t{0}, weight_t{0}),
+    reduce_op::plus<cuda::std::tuple<weight_t, weight_t>>{},
     thrust::make_zip_iterator(
-      thrust::make_tuple(old_cluster_sum_v.begin(), cluster_subtract_v.begin())));
+      cuda::std::make_tuple(old_cluster_sum_v.begin(), cluster_subtract_v.begin())));
 
   edge_src_property_t<graph_view_t<vertex_t, edge_t, false, multi_gpu>,
-                      thrust::tuple<weight_t, weight_t>>
+                      cuda::std::tuple<weight_t, weight_t>>
     src_old_cluster_sum_subtract_pairs(handle);
 
   if constexpr (multi_gpu) {
     src_old_cluster_sum_subtract_pairs =
       edge_src_property_t<graph_view_t<vertex_t, edge_t, false, multi_gpu>,
-                          thrust::tuple<weight_t, weight_t>>(handle, graph_view);
+                          cuda::std::tuple<weight_t, weight_t>>(handle, graph_view);
     update_edge_src_property(handle,
                              graph_view,
-                             thrust::make_zip_iterator(thrust::make_tuple(
+                             thrust::make_zip_iterator(cuda::std::make_tuple(
                                old_cluster_sum_v.begin(), cluster_subtract_v.begin())),
                              src_old_cluster_sum_subtract_pairs.mutable_view());
     old_cluster_sum_v.resize(0, handle.get_stream());
@@ -375,11 +376,11 @@ rmm::device_uvector<vertex_t> update_clustering_by_delta_modularity(
     cluster_subtract_v.shrink_to_fit(handle.get_stream());
   }
 
-  auto output_buffer = allocate_dataframe_buffer<thrust::tuple<vertex_t, weight_t>>(
+  auto output_buffer = allocate_dataframe_buffer<cuda::std::tuple<vertex_t, weight_t>>(
     graph_view.local_vertex_partition_range_size(), handle.get_stream());
 
   auto cluster_old_sum_subtract_pair_first = thrust::make_zip_iterator(
-    thrust::make_tuple(old_cluster_sum_v.cbegin(), cluster_subtract_v.cbegin()));
+    cuda::std::make_tuple(old_cluster_sum_v.cbegin(), cluster_subtract_v.cbegin()));
   auto zipped_src_device_view =
     multi_gpu
       ? view_concat(src_vertex_weights_cache.view(),
@@ -412,16 +413,16 @@ rmm::device_uvector<vertex_t> update_clustering_by_delta_modularity(
                   next_clusters_v.data(), vertex_t{0}),
     cluster_key_weight_map.view(),
     detail::key_aggregated_edge_op_t<vertex_t, weight_t>{total_edge_weight, resolution},
-    thrust::make_tuple(vertex_t{-1}, weight_t{0}),
+    cuda::std::make_tuple(vertex_t{-1}, weight_t{0}),
     detail::reduce_op_t<vertex_t, weight_t>{},
     cugraph::get_dataframe_buffer_begin(output_buffer));
 
   int nr_moves = thrust::count_if(
     handle.get_thrust_policy(),
-    thrust::make_zip_iterator(thrust::make_tuple(
+    thrust::make_zip_iterator(cuda::std::make_tuple(
       next_clusters_v.begin(), cugraph::get_dataframe_buffer_begin(output_buffer))),
-    thrust::make_zip_iterator(
-      thrust::make_tuple(next_clusters_v.end(), cugraph::get_dataframe_buffer_end(output_buffer))),
+    thrust::make_zip_iterator(cuda::std::make_tuple(
+      next_clusters_v.end(), cugraph::get_dataframe_buffer_end(output_buffer))),
     detail::count_updown_moves_op_t<vertex_t, weight_t>{up_down});
 
   if (multi_gpu) {

--- a/cpp/src/community/detail/refine_impl.cuh
+++ b/cpp/src/community/detail/refine_impl.cuh
@@ -33,6 +33,7 @@
 #include <raft/random/rng_device.cuh>
 
 #include <cuda/functional>
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/distance.h>
 #include <thrust/execution_policy.h>
@@ -45,7 +46,6 @@
 #include <thrust/tabulate.h>
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
-#include <thrust/tuple.h>
 
 #include <optional>
 
@@ -71,24 +71,24 @@ struct leiden_key_aggregated_edge_op_t {
   __device__ auto operator()(
     vertex_t src,
     vertex_t neighboring_leiden_cluster,
-    thrust::tuple<weight_t, weight_t, weight_t, uint8_t, vertex_t, vertex_t> src_info,
+    cuda::std::tuple<weight_t, weight_t, weight_t, uint8_t, vertex_t, vertex_t> src_info,
     cluster_value_t keyed_data,
     weight_t aggregated_weight_to_neighboring_leiden_cluster) const
   {
     // Data associated with src vertex
-    auto src_weighted_deg          = thrust::get<0>(src_info);
-    auto src_vertex_cut_to_louvain = thrust::get<1>(src_info);
-    auto louvain_cluster_volume    = thrust::get<2>(src_info);
-    auto is_src_active             = thrust::get<3>(src_info);
-    auto src_leiden_cluster        = thrust::get<4>(src_info);
-    auto src_louvain_cluster       = thrust::get<5>(src_info);
+    auto src_weighted_deg          = cuda::std::get<0>(src_info);
+    auto src_vertex_cut_to_louvain = cuda::std::get<1>(src_info);
+    auto louvain_cluster_volume    = cuda::std::get<2>(src_info);
+    auto is_src_active             = cuda::std::get<3>(src_info);
+    auto src_leiden_cluster        = cuda::std::get<4>(src_info);
+    auto src_louvain_cluster       = cuda::std::get<5>(src_info);
 
     // Data associated with target leiden (aka refined) cluster
 
-    auto dst_leiden_volume             = thrust::get<0>(keyed_data);
-    auto dst_leiden_cut_to_louvain     = thrust::get<1>(keyed_data);
-    auto dst_leiden_cluster_id         = thrust::get<2>(keyed_data);
-    auto louvain_of_dst_leiden_cluster = thrust::get<3>(keyed_data);
+    auto dst_leiden_volume             = cuda::std::get<0>(keyed_data);
+    auto dst_leiden_cut_to_louvain     = cuda::std::get<1>(keyed_data);
+    auto dst_leiden_cluster_id         = cuda::std::get<2>(keyed_data);
+    auto louvain_of_dst_leiden_cluster = cuda::std::get<3>(keyed_data);
 
     // E(Cr, S-Cr) > ||Cr||*(||S|| -||Cr||)
     bool is_dst_leiden_cluster_well_connected =
@@ -126,7 +126,7 @@ struct leiden_key_aggregated_edge_op_t {
       }
     }
 
-    return thrust::make_tuple(mod_gain, neighboring_leiden_cluster);
+    return cuda::std::make_tuple(mod_gain, neighboring_leiden_cluster);
   }
 };
 
@@ -236,13 +236,13 @@ refine_clustering(
     graph_view.local_vertex_partition_range_size(), handle.get_stream());
 
   auto wcut_deg_and_cluster_vol_triple_begin =
-    thrust::make_zip_iterator(thrust::make_tuple(weighted_cut_of_vertices_to_louvain.begin(),
-                                                 weighted_degree_of_vertices.begin(),
-                                                 vertex_louvain_cluster_weights.begin()));
+    thrust::make_zip_iterator(cuda::std::make_tuple(weighted_cut_of_vertices_to_louvain.begin(),
+                                                    weighted_degree_of_vertices.begin(),
+                                                    vertex_louvain_cluster_weights.begin()));
   auto wcut_deg_and_cluster_vol_triple_end =
-    thrust::make_zip_iterator(thrust::make_tuple(weighted_cut_of_vertices_to_louvain.end(),
-                                                 weighted_degree_of_vertices.end(),
-                                                 vertex_louvain_cluster_weights.end()));
+    thrust::make_zip_iterator(cuda::std::make_tuple(weighted_cut_of_vertices_to_louvain.end(),
+                                                    weighted_degree_of_vertices.end(),
+                                                    vertex_louvain_cluster_weights.end()));
 
   thrust::transform(handle.get_thrust_policy(),
                     wcut_deg_and_cluster_vol_triple_begin,
@@ -250,9 +250,9 @@ refine_clustering(
                     singleton_and_connected_flags.begin(),
                     cuda::proclaim_return_type<uint8_t>([resolution, total_edge_weight] __device__(
                                                           auto wcut_wdeg_and_louvain_volume) {
-                      auto wcut           = thrust::get<0>(wcut_wdeg_and_louvain_volume);
-                      auto wdeg           = thrust::get<1>(wcut_wdeg_and_louvain_volume);
-                      auto louvain_volume = thrust::get<2>(wcut_wdeg_and_louvain_volume);
+                      auto wcut           = cuda::std::get<0>(wcut_wdeg_and_louvain_volume);
+                      auto wdeg           = cuda::std::get<1>(wcut_wdeg_and_louvain_volume);
+                      auto louvain_volume = cuda::std::get<2>(wcut_wdeg_and_louvain_volume);
                       return static_cast<uint8_t>(
                         wcut > (resolution * wdeg * (louvain_volume - wdeg) / total_edge_weight));
                     }));
@@ -392,26 +392,26 @@ refine_clustering(
 
         [] __device__(auto src,
                       auto dst,
-                      thrust::tuple<vertex_t, vertex_t> src_louvain_leidn,
-                      thrust::tuple<vertex_t, vertex_t> dst_louvain_leiden,
+                      cuda::std::tuple<vertex_t, vertex_t> src_louvain_leidn,
+                      cuda::std::tuple<vertex_t, vertex_t> dst_louvain_leiden,
                       auto wt) {
           weight_t refined_partition_volume_contribution{wt};
           weight_t refined_partition_cut_contribution{0};
 
-          auto src_louvain = thrust::get<0>(src_louvain_leidn);
-          auto src_leiden  = thrust::get<1>(src_louvain_leidn);
+          auto src_louvain = cuda::std::get<0>(src_louvain_leidn);
+          auto src_leiden  = cuda::std::get<1>(src_louvain_leidn);
 
-          auto dst_louvain = thrust::get<0>(dst_louvain_leiden);
-          auto dst_leiden  = thrust::get<1>(dst_louvain_leiden);
+          auto dst_louvain = cuda::std::get<0>(dst_louvain_leiden);
+          auto dst_leiden  = cuda::std::get<1>(dst_louvain_leiden);
 
           if (src_louvain == dst_louvain) {
             if (src_leiden != dst_leiden) { refined_partition_cut_contribution = wt; }
           }
-          return thrust::make_tuple(refined_partition_volume_contribution,
-                                    refined_partition_cut_contribution);
+          return cuda::std::make_tuple(refined_partition_volume_contribution,
+                                       refined_partition_cut_contribution);
         },
-        thrust::make_tuple(weight_t{0}, weight_t{0}),
-        reduce_op::plus<thrust::tuple<weight_t, weight_t>>{});
+        cuda::std::make_tuple(weight_t{0}, weight_t{0}),
+        reduce_op::plus<cuda::std::tuple<weight_t, weight_t>>{});
 
     //
     // Primitives to decide best (at least good) next clusters for vertices
@@ -496,20 +496,20 @@ refine_clustering(
     // leiden(Cr) // f(Cr)
     // louvain(Cr) // f(Cr)
     auto values_for_leiden_cluster_keys = thrust::make_zip_iterator(
-      thrust::make_tuple(refined_community_volumes.begin(),
-                         refined_community_cuts.begin(),
-                         leiden_keys_used_in_edge_reduction.begin(),
-                         louvain_of_leiden_keys_used_in_edge_reduction.begin()));
+      cuda::std::make_tuple(refined_community_volumes.begin(),
+                            refined_community_cuts.begin(),
+                            leiden_keys_used_in_edge_reduction.begin(),
+                            louvain_of_leiden_keys_used_in_edge_reduction.begin()));
 
-    using value_t = thrust::tuple<weight_t, weight_t, vertex_t, vertex_t>;
+    using value_t = cuda::std::tuple<weight_t, weight_t, vertex_t, vertex_t>;
     kv_store_t<vertex_t, value_t, true> leiden_cluster_key_values_map(
       leiden_keys_used_in_edge_reduction.begin(),
       leiden_keys_used_in_edge_reduction.begin() + leiden_keys_used_in_edge_reduction.size(),
       values_for_leiden_cluster_keys,
-      thrust::make_tuple(std::numeric_limits<weight_t>::max(),
-                         std::numeric_limits<weight_t>::max(),
-                         invalid_vertex_id<vertex_t>::value,
-                         invalid_vertex_id<vertex_t>::value),
+      cuda::std::make_tuple(std::numeric_limits<weight_t>::max(),
+                            std::numeric_limits<weight_t>::max(),
+                            invalid_vertex_id<vertex_t>::value,
+                            invalid_vertex_id<vertex_t>::value),
       false,
       handle.get_stream());
 
@@ -518,8 +518,9 @@ refine_clustering(
     //
 
     raft::random::DeviceState<raft::random::PCGenerator> device_state(rng_state);
-    auto gain_and_dst_output_pairs = allocate_dataframe_buffer<thrust::tuple<weight_t, vertex_t>>(
-      graph_view.local_vertex_partition_range_size(), handle.get_stream());
+    auto gain_and_dst_output_pairs =
+      allocate_dataframe_buffer<cuda::std::tuple<weight_t, vertex_t>>(
+        graph_view.local_vertex_partition_range_size(), handle.get_stream());
 
     per_v_transform_reduce_dst_key_aggregated_outgoing_e(
       handle,
@@ -532,8 +533,8 @@ refine_clustering(
       leiden_cluster_key_values_map.view(),
       detail::leiden_key_aggregated_edge_op_t<vertex_t, weight_t, value_t>{
         total_edge_weight, resolution, theta, device_state},
-      thrust::make_tuple(weight_t{0}, vertex_t{-1}),
-      reduce_op::maximum<thrust::tuple<weight_t, vertex_t>>(),
+      cuda::std::make_tuple(weight_t{0}, vertex_t{-1}),
+      reduce_op::maximum<cuda::std::tuple<weight_t, vertex_t>>(),
       cugraph::get_dataframe_buffer_begin(gain_and_dst_output_pairs));
 
     src_leiden_assignment_cache.clear(handle);
@@ -570,8 +571,8 @@ refine_clustering(
                                                 gain_and_dst_first,
                                                 gain_and_dst_last,
                                                 [] __device__(auto gain_dst_pair) {
-                                                  vertex_t dst  = thrust::get<1>(gain_dst_pair);
-                                                  weight_t gain = thrust::get<0>(gain_dst_pair);
+                                                  vertex_t dst  = cuda::std::get<1>(gain_dst_pair);
+                                                  weight_t gain = cuda::std::get<0>(gain_dst_pair);
                                                   return (gain > POSITIVE_GAIN) && (dst >= 0);
                                                 });
 
@@ -593,26 +594,26 @@ refine_clustering(
       std::make_optional(rmm::device_uvector<weight_t>(nr_valid_tuples, handle.get_stream()));
 
     auto d_src_dst_gain_iterator = thrust::make_zip_iterator(
-      thrust::make_tuple(d_srcs.begin(), d_dsts.begin(), (*d_weights).begin()));
+      cuda::std::make_tuple(d_srcs.begin(), d_dsts.begin(), (*d_weights).begin()));
 
     // edge (src, dst, gain)
     auto edge_begin = thrust::make_zip_iterator(
-      thrust::make_tuple(vertex_begin,
-                         thrust::get<1>(gain_and_dst_first.get_iterator_tuple()),
-                         thrust::get<0>(gain_and_dst_first.get_iterator_tuple())));
+      cuda::std::make_tuple(vertex_begin,
+                            cuda::std::get<1>(gain_and_dst_first.get_iterator_tuple()),
+                            cuda::std::get<0>(gain_and_dst_first.get_iterator_tuple())));
     auto edge_end = thrust::make_zip_iterator(
-      thrust::make_tuple(vertex_end,
-                         thrust::get<1>(gain_and_dst_last.get_iterator_tuple()),
-                         thrust::get<0>(gain_and_dst_last.get_iterator_tuple())));
+      cuda::std::make_tuple(vertex_end,
+                            cuda::std::get<1>(gain_and_dst_last.get_iterator_tuple()),
+                            cuda::std::get<0>(gain_and_dst_last.get_iterator_tuple())));
 
     thrust::copy_if(handle.get_thrust_policy(),
                     edge_begin,
                     edge_end,
                     d_src_dst_gain_iterator,
-                    [] __device__(thrust::tuple<vertex_t, vertex_t, weight_t> src_dst_gain) {
-                      vertex_t src  = thrust::get<0>(src_dst_gain);
-                      vertex_t dst  = thrust::get<1>(src_dst_gain);
-                      weight_t gain = thrust::get<2>(src_dst_gain);
+                    [] __device__(cuda::std::tuple<vertex_t, vertex_t, weight_t> src_dst_gain) {
+                      vertex_t src  = cuda::std::get<0>(src_dst_gain);
+                      vertex_t dst  = cuda::std::get<1>(src_dst_gain);
+                      weight_t gain = cuda::std::get<2>(src_dst_gain);
 
                       return (gain > POSITIVE_GAIN) && (dst >= 0);
                     });
@@ -713,7 +714,7 @@ refine_clustering(
       handle.get_thrust_policy(),
       vertices_in_mis.begin(),
       vertices_in_mis.end(),
-      [dst_first                     = thrust::get<1>(gain_and_dst_first.get_iterator_tuple()),
+      [dst_first                     = cuda::std::get<1>(gain_and_dst_first.get_iterator_tuple()),
        leiden_assignment             = leiden_assignment.data(),
        singleton_and_connected_flags = singleton_and_connected_flags.data(),
        v_first = graph_view.local_vertex_partition_range_first()] __device__(vertex_t v) {
@@ -734,7 +735,7 @@ refine_clustering(
       vertices_in_mis.end(),
       dst_vertices.begin(),
       cuda::proclaim_return_type<vertex_t>(
-        [dst_first = thrust::get<1>(gain_and_dst_first.get_iterator_tuple()),
+        [dst_first = cuda::std::get<1>(gain_and_dst_first.get_iterator_tuple()),
          v_first   = graph_view.local_vertex_partition_range_first()] __device__(vertex_t v) {
           auto dst = *(dst_first + v - v_first);
           return dst;

--- a/cpp/src/community/ecg_impl.cuh
+++ b/cpp/src/community/ecg_impl.cuh
@@ -109,8 +109,8 @@ std::tuple<rmm::device_uvector<vertex_t>, size_t, weight_t> ecg(
     view_concat(*edge_weight_view, modified_edge_weights.view()),
     [min_weight, ensemble_size = static_cast<weight_t>(ensemble_size)] __device__(
       auto, auto, cuda::std::nullopt_t, cuda::std::nullopt_t, auto edge_properties) {
-      auto e_weight    = thrust::get<0>(edge_properties);
-      auto e_frequency = thrust::get<1>(edge_properties);
+      auto e_weight    = cuda::std::get<0>(edge_properties);
+      auto e_frequency = cuda::std::get<1>(edge_properties);
       return min_weight + (e_weight - min_weight) * e_frequency / ensemble_size;
     },
     modified_edge_weights.mutable_view());

--- a/cpp/src/community/edge_triangle_count_impl.cuh
+++ b/cpp/src/community/edge_triangle_count_impl.cuh
@@ -29,10 +29,10 @@
 #include <raft/util/integer_utils.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/adjacent_difference.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/sort.h>
-#include <thrust/tuple.h>
 
 namespace cugraph {
 
@@ -55,8 +55,8 @@ struct update_edges_p_r_q_r_num_triangles {
       thrust::seq, intersection_offsets.begin() + 1, intersection_offsets.end(), i);
     auto idx = thrust::distance(intersection_offsets.begin() + 1, itr);
     if (edge_first_or_second == 0) {
-      auto p_r_pair = thrust::make_tuple(thrust::get<0>(*(edge_first + chunk_start + idx)),
-                                         intersection_indices[i]);
+      auto p_r_pair = cuda::std::make_tuple(cuda::std::get<0>(*(edge_first + chunk_start + idx)),
+                                            intersection_indices[i]);
 
       // Find its position in 'edges'
       auto itr_p_r_p_q =
@@ -65,8 +65,8 @@ struct update_edges_p_r_q_r_num_triangles {
       assert(*itr_p_r_p_q == p_r_pair);
       idx = thrust::distance(edge_first, itr_p_r_p_q);
     } else {
-      auto p_r_pair = thrust::make_tuple(thrust::get<1>(*(edge_first + chunk_start + idx)),
-                                         intersection_indices[i]);
+      auto p_r_pair = cuda::std::make_tuple(cuda::std::get<1>(*(edge_first + chunk_start + idx)),
+                                            intersection_indices[i]);
 
       // Find its position in 'edges'
       auto itr_p_r_p_q =
@@ -87,18 +87,18 @@ struct extract_p_r_q_r {
   raft::device_span<vertex_t const> intersection_indices{};
   EdgeIterator edge_first;
 
-  __device__ thrust::tuple<vertex_t, vertex_t> operator()(edge_t i) const
+  __device__ cuda::std::tuple<vertex_t, vertex_t> operator()(edge_t i) const
   {
     auto itr = thrust::upper_bound(
       thrust::seq, intersection_offsets.begin() + 1, intersection_offsets.end(), i);
     auto idx = thrust::distance(intersection_offsets.begin() + 1, itr);
 
     if (p_r_or_q_r == 0) {
-      return thrust::make_tuple(thrust::get<0>(*(edge_first + chunk_start + idx)),
-                                intersection_indices[i]);
+      return cuda::std::make_tuple(cuda::std::get<0>(*(edge_first + chunk_start + idx)),
+                                   intersection_indices[i]);
     } else {
-      return thrust::make_tuple(thrust::get<1>(*(edge_first + chunk_start + idx)),
-                                intersection_indices[i]);
+      return cuda::std::make_tuple(cuda::std::get<1>(*(edge_first + chunk_start + idx)),
+                                   intersection_indices[i]);
     }
   }
 };
@@ -110,13 +110,13 @@ struct extract_q_r {
   raft::device_span<vertex_t const> intersection_indices{};
   EdgeIterator edge_first;
 
-  __device__ thrust::tuple<vertex_t, vertex_t> operator()(edge_t i) const
+  __device__ cuda::std::tuple<vertex_t, vertex_t> operator()(edge_t i) const
   {
     auto itr = thrust::upper_bound(
       thrust::seq, intersection_offsets.begin() + 1, intersection_offsets.end(), i);
     auto idx  = thrust::distance(intersection_offsets.begin() + 1, itr);
-    auto pair = thrust::make_tuple(thrust::get<1>(*(edge_first + chunk_start + idx)),
-                                   intersection_indices[i]);
+    auto pair = cuda::std::make_tuple(cuda::std::get<1>(*(edge_first + chunk_start + idx)),
+                                      intersection_indices[i]);
 
     return pair;
   }
@@ -180,7 +180,7 @@ edge_property_t<graph_view_t<vertex_t, edge_t, false, multi_gpu>, edge_t> edge_t
 
     if constexpr (multi_gpu) {
       // stores all the pairs (p, r) and (q, r)
-      auto vertex_pair_buffer_tmp = allocate_dataframe_buffer<thrust::tuple<vertex_t, vertex_t>>(
+      auto vertex_pair_buffer_tmp = allocate_dataframe_buffer<cuda::std::tuple<vertex_t, vertex_t>>(
         intersection_indices.size() * 2, handle.get_stream());
 
       // tabulate with the size of intersection_indices, and call binary search on
@@ -226,7 +226,7 @@ edge_property_t<graph_view_t<vertex_t, edge_t, false, multi_gpu>, edge_t> edge_t
 
       rmm::device_uvector<edge_t> increase_count(count_p_r_q_r, handle.get_stream());
 
-      auto vertex_pair_buffer = allocate_dataframe_buffer<thrust::tuple<vertex_t, vertex_t>>(
+      auto vertex_pair_buffer = allocate_dataframe_buffer<cuda::std::tuple<vertex_t, vertex_t>>(
         count_p_r_q_r, handle.get_stream());
       thrust::reduce_by_key(handle.get_thrust_policy(),
                             get_dataframe_buffer_begin(vertex_pair_buffer_tmp),
@@ -234,7 +234,7 @@ edge_property_t<graph_view_t<vertex_t, edge_t, false, multi_gpu>, edge_t> edge_t
                             increase_count_tmp.begin(),
                             get_dataframe_buffer_begin(vertex_pair_buffer),
                             increase_count.begin(),
-                            thrust::equal_to<thrust::tuple<vertex_t, vertex_t>>{});
+                            thrust::equal_to<cuda::std::tuple<vertex_t, vertex_t>>{});
 
       rmm::device_uvector<vertex_t> pair_srcs(0, handle.get_stream());
       rmm::device_uvector<vertex_t> pair_dsts(0, handle.get_stream());
@@ -285,7 +285,7 @@ edge_property_t<graph_view_t<vertex_t, edge_t, false, multi_gpu>, edge_t> edge_t
          edge_first] __device__(auto idx) {
           auto src          = pair_srcs[idx];
           auto dst          = pair_dsts[idx];
-          auto p_r_q_r_pair = thrust::make_tuple(src, dst);
+          auto p_r_q_r_pair = cuda::std::make_tuple(src, dst);
 
           // Find its position in 'edges'
           auto itr_p_r_q_r =
@@ -357,7 +357,7 @@ edge_property_t<graph_view_t<vertex_t, edge_t, false, multi_gpu>, edge_t> edge_t
                                                       cuda::std::nullopt_t,
                                                       cuda::std::nullopt_t,
                                                       cuda::std::nullopt_t) {
-      auto pair = thrust::make_tuple(src, dst);
+      auto pair = cuda::std::make_tuple(src, dst);
 
       // Find its position in 'edges'
       auto itr_pair = thrust::lower_bound(thrust::seq, edge_first, edge_last, pair);

--- a/cpp/src/community/triangle_count_impl.cuh
+++ b/cpp/src/community/triangle_count_impl.cuh
@@ -28,6 +28,7 @@
 #include <cugraph/utilities/host_scalar_comm.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/count.h>
@@ -38,7 +39,6 @@
 #include <thrust/scatter.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 namespace cugraph {
 
@@ -64,7 +64,7 @@ struct is_two_or_greater_t {
 
 template <typename vertex_t, typename edge_t>
 struct extract_low_to_high_degree_edges_t {
-  __device__ cuda::std::optional<thrust::tuple<vertex_t, vertex_t>> operator()(
+  __device__ cuda::std::optional<cuda::std::tuple<vertex_t, vertex_t>> operator()(
     vertex_t src,
     vertex_t dst,
     edge_t src_out_degree,
@@ -72,27 +72,28 @@ struct extract_low_to_high_degree_edges_t {
     cuda::std::nullopt_t) const
   {
     return (src_out_degree < dst_out_degree)
-             ? cuda::std::optional<thrust::tuple<vertex_t, vertex_t>>{thrust::make_tuple(src, dst)}
+             ? cuda::std::optional<cuda::std::tuple<vertex_t, vertex_t>>{cuda::std::make_tuple(src,
+                                                                                               dst)}
              : (((src_out_degree == dst_out_degree) &&
                  (src < dst) /* tie-breaking using vertex ID */)
-                  ? cuda::std::optional<thrust::tuple<vertex_t, vertex_t>>{thrust::make_tuple(src,
-                                                                                              dst)}
+                  ? cuda::std::optional<cuda::std::tuple<vertex_t, vertex_t>>{cuda::std::make_tuple(
+                      src, dst)}
                   : cuda::std::nullopt);
   }
 };
 
 template <typename vertex_t, typename edge_t>
 struct intersection_op_t {
-  __device__ thrust::tuple<edge_t, edge_t, edge_t> operator()(
+  __device__ cuda::std::tuple<edge_t, edge_t, edge_t> operator()(
     vertex_t,
     vertex_t,
     cuda::std::nullopt_t,
     cuda::std::nullopt_t,
     raft::device_span<vertex_t const> intersection) const
   {
-    return thrust::make_tuple(static_cast<edge_t>(intersection.size()),
-                              static_cast<edge_t>(intersection.size()),
-                              edge_t{1});
+    return cuda::std::make_tuple(static_cast<edge_t>(intersection.size()),
+                                 static_cast<edge_t>(intersection.size()),
+                                 edge_t{1});
   }
 };
 

--- a/cpp/src/components/mis_impl.cuh
+++ b/cpp/src/components/mis_impl.cuh
@@ -69,12 +69,12 @@ rmm::device_uvector<vertex_t> maximal_independent_set(
                      thrust::copy_if(handle.get_thrust_policy(),
                                      vertex_begin,
                                      vertex_end,
-                                     thrust::make_zip_iterator(
-                                       thrust::make_tuple(out_degrees.begin(), in_degrees.begin())),
+                                     thrust::make_zip_iterator(cuda::std::make_tuple(
+                                       out_degrees.begin(), in_degrees.begin())),
                                      remaining_vertices.begin(),
                                      [] __device__(auto out_deg_and_in_deg) {
-                                       return !((thrust::get<0>(out_deg_and_in_deg) == 0) &&
-                                                (thrust::get<1>(out_deg_and_in_deg) == 0));
+                                       return !((cuda::std::get<0>(out_deg_and_in_deg) == 0) &&
+                                                (cuda::std::get<1>(out_deg_and_in_deg) == 0));
                                      })),
     handle.get_stream());
 
@@ -85,13 +85,13 @@ rmm::device_uvector<vertex_t> maximal_independent_set(
   // Set ranks of zero degree vetices to std::numeric_limits<vertex_t>::max()
   thrust::transform_if(
     handle.get_thrust_policy(),
-    thrust::make_zip_iterator(thrust::make_tuple(out_degrees.begin(), in_degrees.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(out_degrees.end(), in_degrees.end())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(out_degrees.begin(), in_degrees.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(out_degrees.end(), in_degrees.end())),
     ranks.begin(),
     cuda::proclaim_return_type<vertex_t>(
       [] __device__(auto) { return std::numeric_limits<vertex_t>::max(); }),
     [] __device__(auto in_out_degree) {
-      return (thrust::get<0>(in_out_degree) == 0) && (thrust::get<1>(in_out_degree) == 0);
+      return (cuda::std::get<0>(in_out_degree) == 0) && (cuda::std::get<1>(in_out_degree) == 0);
     });
 
   out_degrees.resize(0, handle.get_stream());

--- a/cpp/src/components/weakly_connected_components_impl.cuh
+++ b/cpp/src/components/weakly_connected_components_impl.cuh
@@ -36,6 +36,7 @@
 
 #include <cuda/functional>
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/distance.h>
@@ -54,7 +55,6 @@
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <algorithm>
@@ -107,10 +107,10 @@ accumulate_new_roots(raft::handle_t const& handle,
 
     rmm::device_uvector<vertex_t> tmp_new_roots(scan_size, handle.get_stream());
     rmm::device_uvector<vertex_t> tmp_indices(tmp_new_roots.size(), handle.get_stream());
-    auto input_pair_first = thrust::make_zip_iterator(thrust::make_tuple(
+    auto input_pair_first = thrust::make_zip_iterator(cuda::std::make_tuple(
       candidate_first + num_scanned, thrust::make_counting_iterator(vertex_t{0})));
     auto output_pair_first =
-      thrust::make_zip_iterator(thrust::make_tuple(tmp_new_roots.begin(), tmp_indices.begin()));
+      thrust::make_zip_iterator(cuda::std::make_tuple(tmp_new_roots.begin(), tmp_indices.begin()));
     tmp_new_roots.resize(
       static_cast<vertex_t>(thrust::distance(
         output_pair_first,
@@ -120,7 +120,7 @@ accumulate_new_roots(raft::handle_t const& handle,
           input_pair_first + scan_size,
           output_pair_first,
           [vertex_partition, components] __device__(auto pair) {
-            auto v = thrust::get<0>(pair);
+            auto v = cuda::std::get<0>(pair);
             return (
               components[vertex_partition.local_vertex_partition_offset_from_vertex_nocheck(v)] ==
               invalid_component_id<vertex_t>::value);
@@ -189,13 +189,14 @@ struct e_op_t {
   EdgeIterator edge_buffer_first{};
   size_t* num_edge_inserts{};
 
-  __device__ cuda::std::optional<vertex_t> operator()(thrust::tuple<vertex_t, vertex_t> tagged_src,
-                                                      vertex_t dst,
-                                                      cuda::std::nullopt_t,
-                                                      cuda::std::nullopt_t,
-                                                      cuda::std::nullopt_t) const
+  __device__ cuda::std::optional<vertex_t> operator()(
+    cuda::std::tuple<vertex_t, vertex_t> tagged_src,
+    vertex_t dst,
+    cuda::std::nullopt_t,
+    cuda::std::nullopt_t,
+    cuda::std::nullopt_t) const
   {
-    auto tag        = thrust::get<1>(tagged_src);
+    auto tag        = cuda::std::get<1>(tagged_src);
     auto dst_offset = dst - dst_first;
     auto old =
       dst_components.elementwise_atomic_cas(dst_offset, invalid_component_id<vertex_t>::value, tag);
@@ -205,7 +206,7 @@ struct e_op_t {
                                 static_cast<unsigned long long int>(1));
       // keep only the edges in the lower triangular part
       *(edge_buffer_first + edge_idx) =
-        tag >= old ? thrust::make_tuple(tag, old) : thrust::make_tuple(old, tag);
+        tag >= old ? cuda::std::make_tuple(tag, old) : cuda::std::make_tuple(old, tag);
     }
     return old == invalid_component_id<vertex_t>::value ? cuda::std::optional<vertex_t>{tag}
                                                         : cuda::std::nullopt;
@@ -222,7 +223,7 @@ struct v_op_t {
   vertex_partition_device_view_t<typename GraphViewType::vertex_type, GraphViewType::is_multi_gpu>
     vertex_partition{};
   vertex_type* level_components{};
-  decltype(thrust::make_zip_iterator(thrust::make_tuple(
+  decltype(thrust::make_zip_iterator(cuda::std::make_tuple(
     static_cast<vertex_type*>(nullptr), static_cast<vertex_type*>(nullptr)))) edge_buffer_first{};
   // FIXME: we can use cuda::atomic instead but currently on a system with x86 + GPU, this requires
   // placing the atomic variable on managed memory and this adds additional complication.
@@ -233,20 +234,20 @@ struct v_op_t {
   template <bool multi_gpu = GraphViewType::is_multi_gpu>
   __device__
     std::enable_if_t<multi_gpu,
-                     thrust::tuple<cuda::std::optional<size_t>, cuda::std::optional<std::byte>>>
-    operator()(thrust::tuple<vertex_type, vertex_type> tagged_v, int /* v_val */) const
+                     cuda::std::tuple<cuda::std::optional<size_t>, cuda::std::optional<std::byte>>>
+    operator()(cuda::std::tuple<vertex_type, vertex_type> tagged_v, int /* v_val */) const
   {
-    auto tag = thrust::get<1>(tagged_v);
-    auto v_offset =
-      vertex_partition.local_vertex_partition_offset_from_vertex_nocheck(thrust::get<0>(tagged_v));
+    auto tag      = cuda::std::get<1>(tagged_v);
+    auto v_offset = vertex_partition.local_vertex_partition_offset_from_vertex_nocheck(
+      cuda::std::get<0>(tagged_v));
     cuda::atomic_ref<vertex_type> v_component(*(level_components + v_offset));
     auto old     = invalid_component_id<vertex_type>::value;
     bool success = v_component.compare_exchange_strong(old, tag, cuda::std::memory_order_relaxed);
     if (!success && (old != tag)) {  // conflict
-      return thrust::make_tuple(cuda::std::optional<size_t>{bucket_idx_conflict},
-                                cuda::std::optional<std::byte>{std::byte{0}} /* dummy */);
+      return cuda::std::make_tuple(cuda::std::optional<size_t>{bucket_idx_conflict},
+                                   cuda::std::optional<std::byte>{std::byte{0}} /* dummy */);
     } else {
-      return thrust::make_tuple(
+      return cuda::std::make_tuple(
         success ? cuda::std::optional<size_t>{bucket_idx_next} : cuda::std::nullopt,
         success ? cuda::std::optional<std::byte>{std::byte{0}} /* dummy */ : cuda::std::nullopt);
     }
@@ -255,11 +256,11 @@ struct v_op_t {
   template <bool multi_gpu = GraphViewType::is_multi_gpu>
   __device__
     std::enable_if_t<!multi_gpu,
-                     thrust::tuple<cuda::std::optional<size_t>, cuda::std::optional<std::byte>>>
-    operator()(thrust::tuple<vertex_type, vertex_type> /* tagged_v */, int /* v_val */) const
+                     cuda::std::tuple<cuda::std::optional<size_t>, cuda::std::optional<std::byte>>>
+    operator()(cuda::std::tuple<vertex_type, vertex_type> /* tagged_v */, int /* v_val */) const
   {
-    return thrust::make_tuple(cuda::std::optional<size_t>{bucket_idx_next},
-                              cuda::std::optional<std::byte>{std::byte{0}} /* dummy */);
+    return cuda::std::make_tuple(cuda::std::optional<size_t>{bucket_idx_next},
+                                 cuda::std::optional<std::byte>{std::byte{0}} /* dummy */);
   }
 };
 
@@ -330,7 +331,7 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
 
     // 2-1. filter out isolated vertices
 
-    auto pair_first = thrust::make_zip_iterator(thrust::make_tuple(
+    auto pair_first = thrust::make_zip_iterator(cuda::std::make_tuple(
       thrust::make_counting_iterator(level_graph_view.local_vertex_partition_range_first()),
       degrees.begin()));
     thrust::transform(handle.get_thrust_policy(),
@@ -338,8 +339,8 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
                       pair_first + level_graph_view.local_vertex_partition_range_size(),
                       level_components,
                       [] __device__(auto pair) {
-                        auto v      = thrust::get<0>(pair);
-                        auto degree = thrust::get<1>(pair);
+                        auto v      = cuda::std::get<0>(pair);
+                        auto degree = cuda::std::get<1>(pair);
                         return degree > 0 ? invalid_component_id<vertex_t>::value : v;
                       });
 
@@ -480,7 +481,7 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
     edge_t edge_count{0};
 
     auto edge_buffer =
-      allocate_dataframe_buffer<thrust::tuple<vertex_t, vertex_t>>(0, handle.get_stream());
+      allocate_dataframe_buffer<cuda::std::tuple<vertex_t, vertex_t>>(0, handle.get_stream());
     // FIXME: we can use cuda::atomic instead but currently on a system with x86 + GPU, this
     // requires placing the atomic variable on managed memory and this adds additional complication.
     rmm::device_scalar<size_t> num_edge_inserts(size_t{0}, handle.get_stream());
@@ -525,7 +526,7 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
           });
 
         auto pair_first =
-          thrust::make_zip_iterator(thrust::make_tuple(new_roots.begin(), new_roots.begin()));
+          thrust::make_zip_iterator(cuda::std::make_tuple(new_roots.begin(), new_roots.begin()));
         vertex_frontier.bucket(bucket_idx_cur).insert(pair_first, pair_first + new_roots.size());
       }
 
@@ -535,8 +536,8 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
         update_edge_dst_property(
           handle,
           level_graph_view,
-          thrust::get<0>(vertex_frontier.bucket(bucket_idx_cur).begin().get_iterator_tuple()),
-          thrust::get<0>(vertex_frontier.bucket(bucket_idx_cur).end().get_iterator_tuple()),
+          cuda::std::get<0>(vertex_frontier.bucket(bucket_idx_cur).begin().get_iterator_tuple()),
+          cuda::std::get<0>(vertex_frontier.bucket(bucket_idx_cur).end().get_iterator_tuple()),
           level_components,
           edge_dst_components.mutable_view());
       }
@@ -602,15 +603,15 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
            edge_buffer_first = get_dataframe_buffer_begin(edge_buffer),
            num_edge_inserts  = num_edge_inserts.data()] __device__(auto tagged_v) {
             auto v_offset = vertex_partition.local_vertex_partition_offset_from_vertex_nocheck(
-              thrust::get<0>(tagged_v));
+              cuda::std::get<0>(tagged_v));
             auto old = *(level_components + v_offset);
-            auto tag = thrust::get<1>(tagged_v);
+            auto tag = cuda::std::get<1>(tagged_v);
             static_assert(sizeof(unsigned long long int) == sizeof(size_t));
             auto edge_idx = atomicAdd(reinterpret_cast<unsigned long long int*>(num_edge_inserts),
                                       static_cast<unsigned long long int>(1));
             // keep only the edges in the lower triangular part
             *(edge_buffer_first + edge_idx) =
-              tag >= old ? thrust::make_tuple(tag, old) : thrust::make_tuple(old, tag);
+              tag >= old ? cuda::std::make_tuple(tag, old) : cuda::std::make_tuple(old, tag);
           });
         conflict_bucket.clear();
       }
@@ -624,7 +625,7 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
                      edge_first + old_num_edge_inserts,
                      edge_first + new_num_edge_inserts);
         if (old_num_edge_inserts > 0) {
-          auto tmp_edge_buffer = allocate_dataframe_buffer<thrust::tuple<vertex_t, vertex_t>>(
+          auto tmp_edge_buffer = allocate_dataframe_buffer<cuda::std::tuple<vertex_t, vertex_t>>(
             new_num_edge_inserts, handle.get_stream());
           auto tmp_edge_first = get_dataframe_buffer_begin(tmp_edge_buffer);
           thrust::merge(handle.get_thrust_policy(),
@@ -647,8 +648,8 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
       vertex_frontier.swap_buckets(bucket_idx_cur, bucket_idx_next);
       edge_count = thrust::transform_reduce(
         handle.get_thrust_policy(),
-        thrust::get<0>(vertex_frontier.bucket(bucket_idx_cur).begin().get_iterator_tuple()),
-        thrust::get<0>(vertex_frontier.bucket(bucket_idx_cur).end().get_iterator_tuple()),
+        cuda::std::get<0>(vertex_frontier.bucket(bucket_idx_cur).begin().get_iterator_tuple()),
+        cuda::std::get<0>(vertex_frontier.bucket(bucket_idx_cur).end().get_iterator_tuple()),
         cuda::proclaim_return_type<edge_t>(
           [vertex_partition, degrees = degrees.data()] __device__(auto v) -> edge_t {
             return degrees[vertex_partition.local_vertex_partition_offset_from_vertex_nocheck(v)];
@@ -673,9 +674,9 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
       resize_dataframe_buffer(
         edge_buffer, static_cast<size_t>(num_inserts * 2), handle.get_stream());
       auto input_first  = get_dataframe_buffer_begin(edge_buffer);
-      auto output_first = thrust::make_zip_iterator(
-                            thrust::make_tuple(thrust::get<1>(input_first.get_iterator_tuple()),
-                                               thrust::get<0>(input_first.get_iterator_tuple()))) +
+      auto output_first = thrust::make_zip_iterator(cuda::std::make_tuple(
+                            cuda::std::get<1>(input_first.get_iterator_tuple()),
+                            cuda::std::get<0>(input_first.get_iterator_tuple()))) +
                           num_inserts;
       thrust::copy(
         handle.get_thrust_policy(), input_first, input_first + num_inserts, output_first);

--- a/cpp/src/converters/legacy/COOtoCSR.cuh
+++ b/cpp/src/converters/legacy/COOtoCSR.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@
 
 #include <cub/device/device_radix_sort.cuh>
 #include <cub/device/device_run_length_encode.cuh>
+#include <cuda/std/tuple>
 #include <thrust/device_ptr.h>
 #include <thrust/extrema.h>
 #include <thrust/fill.h>
@@ -41,7 +42,6 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/scan.h>
 #include <thrust/sort.h>
-#include <thrust/tuple.h>
 
 #include <algorithm>
 
@@ -74,14 +74,14 @@ VT sort(legacy::GraphCOOView<VT, ET, WT>& graph, rmm::cuda_stream_view stream_vi
       rmm::exec_policy(stream_view),
       graph.dst_indices,
       graph.dst_indices + graph.number_of_edges,
-      thrust::make_zip_iterator(thrust::make_tuple(graph.src_indices, graph.edge_data)));
+      thrust::make_zip_iterator(cuda::std::make_tuple(graph.src_indices, graph.edge_data)));
     RAFT_CUDA_TRY(cudaMemcpy(
       &max_dst_id, &(graph.dst_indices[graph.number_of_edges - 1]), sizeof(VT), cudaMemcpyDefault));
     thrust::stable_sort_by_key(
       rmm::exec_policy(stream_view),
       graph.src_indices,
       graph.src_indices + graph.number_of_edges,
-      thrust::make_zip_iterator(thrust::make_tuple(graph.dst_indices, graph.edge_data)));
+      thrust::make_zip_iterator(cuda::std::make_tuple(graph.dst_indices, graph.edge_data)));
     RAFT_CUDA_TRY(cudaMemcpy(
       &max_src_id, &(graph.src_indices[graph.number_of_edges - 1]), sizeof(VT), cudaMemcpyDefault));
   } else {

--- a/cpp/src/cores/core_number_impl.cuh
+++ b/cpp/src/cores/core_number_impl.cuh
@@ -29,6 +29,7 @@
 #include <raft/core/handle.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/distance.h>
 #include <thrust/for_each.h>
@@ -40,7 +41,6 @@
 #include <thrust/reduce.h>
 #include <thrust/remove.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <cstddef>
 
@@ -130,12 +130,13 @@ void core_number(raft::handle_t const& handle,
       auto in_degrees  = graph_view.compute_in_degrees(handle);
       auto out_degrees = graph_view.compute_out_degrees(handle);
       auto degree_pair_first =
-        thrust::make_zip_iterator(thrust::make_tuple(in_degrees.begin(), out_degrees.begin()));
-      thrust::transform(handle.get_thrust_policy(),
-                        degree_pair_first,
-                        degree_pair_first + in_degrees.size(),
-                        core_numbers,
-                        [] __device__(auto p) { return thrust::get<0>(p) + thrust::get<1>(p); });
+        thrust::make_zip_iterator(cuda::std::make_tuple(in_degrees.begin(), out_degrees.begin()));
+      thrust::transform(
+        handle.get_thrust_policy(),
+        degree_pair_first,
+        degree_pair_first + in_degrees.size(),
+        core_numbers,
+        [] __device__(auto p) { return cuda::std::get<0>(p) + cuda::std::get<1>(p); });
     }
   }
 
@@ -251,8 +252,8 @@ void core_number(raft::handle_t const& handle,
               auto new_core_number = v_val >= pushed_val ? v_val - pushed_val : edge_t{0};
               new_core_number      = new_core_number < (k - delta) ? (k - delta) : new_core_number;
               new_core_number      = new_core_number < k_first ? edge_t{0} : new_core_number;
-              return thrust::make_tuple(cuda::std::optional<size_t>{bucket_idx_next},
-                                        cuda::std::optional<edge_t>{new_core_number});
+              return cuda::std::make_tuple(cuda::std::optional<size_t>{bucket_idx_next},
+                                           cuda::std::optional<edge_t>{new_core_number});
             });
         }
 

--- a/cpp/src/cores/k_core_impl.cuh
+++ b/cpp/src/cores/k_core_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ k_core(raft::handle_t const& handle,
       thrust::make_counting_iterator(graph_view.local_vertex_partition_range_last()),
       core_numbers->end()),
     thrust::make_zip_iterator(subgraph_vertices.begin(), thrust::make_discard_iterator()),
-    [k] __device__(auto tuple) { return (k <= thrust::get<1>(tuple)); });
+    [k] __device__(auto tuple) { return (k <= cuda::std::get<1>(tuple)); });
 
   subgraph_vertices.resize(
     thrust::distance(

--- a/cpp/src/detail/graph_partition_utils.cuh
+++ b/cpp/src/detail/graph_partition_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,13 +124,15 @@ struct compute_gpu_id_from_ext_edge_endpoints_t {
   }
 
   __host__ __device__ int operator()(
-    thrust::tuple<vertex_t, vertex_t> pair /* major, minor */) const
+    cuda::std::tuple<vertex_t, vertex_t> pair /* major, minor */) const
   {
     cuco::murmurhash3_32<vertex_t> hash_func{};
-    auto major_vertex_partition_id = static_cast<int>(hash_func(thrust::get<0>(pair)) % comm_size);
-    auto minor_vertex_partition_id = static_cast<int>(hash_func(thrust::get<1>(pair)) % comm_size);
-    auto major_comm_rank           = major_vertex_partition_id % major_comm_size;
-    auto minor_comm_rank           = minor_vertex_partition_id / major_comm_size;
+    auto major_vertex_partition_id =
+      static_cast<int>(hash_func(cuda::std::get<0>(pair)) % comm_size);
+    auto minor_vertex_partition_id =
+      static_cast<int>(hash_func(cuda::std::get<1>(pair)) % comm_size);
+    auto major_comm_rank = major_vertex_partition_id % major_comm_size;
+    auto minor_comm_rank = minor_vertex_partition_id / major_comm_size;
     return partition_manager::compute_global_comm_rank_from_graph_subcomm_ranks(
       major_comm_size, minor_comm_size, major_comm_rank, minor_comm_rank);
   }
@@ -163,20 +165,20 @@ struct compute_gpu_id_from_int_edge_endpoints_t {
       major_comm_size, minor_comm_size, major_comm_rank, minor_comm_rank);
   }
 
-  __device__ int operator()(thrust::tuple<vertex_t, vertex_t> pair /* major, minor */) const
+  __device__ int operator()(cuda::std::tuple<vertex_t, vertex_t> pair /* major, minor */) const
   {
     auto major_vertex_partition_id =
       static_cast<int>(thrust::distance(vertex_partition_range_lasts.begin(),
                                         thrust::upper_bound(thrust::seq,
                                                             vertex_partition_range_lasts.begin(),
                                                             vertex_partition_range_lasts.end(),
-                                                            thrust::get<0>(pair))));
+                                                            cuda::std::get<0>(pair))));
     auto minor_vertex_partition_id =
       static_cast<int>(thrust::distance(vertex_partition_range_lasts.begin(),
                                         thrust::upper_bound(thrust::seq,
                                                             vertex_partition_range_lasts.begin(),
                                                             vertex_partition_range_lasts.end(),
-                                                            thrust::get<1>(pair))));
+                                                            cuda::std::get<1>(pair))));
     auto major_comm_rank = major_vertex_partition_id % major_comm_size;
     auto minor_comm_rank = minor_vertex_partition_id / major_comm_size;
     return partition_manager::compute_global_comm_rank_from_graph_subcomm_ranks(
@@ -198,11 +200,11 @@ struct compute_edge_partition_id_from_ext_edge_endpoints_t {
   }
 
   __host__ __device__ int operator()(
-    thrust::tuple<vertex_t, vertex_t> pair /* major, minor */) const
+    cuda::std::tuple<vertex_t, vertex_t> pair /* major, minor */) const
   {
     cuco::murmurhash3_32<vertex_t> hash_func{};
-    return (hash_func(thrust::get<0>(pair)) % comm_size) * minor_comm_size +
-           (hash_func(thrust::get<1>(pair)) % comm_size) / major_comm_size;
+    return (hash_func(cuda::std::get<0>(pair)) % comm_size) * minor_comm_size +
+           (hash_func(cuda::std::get<1>(pair)) % comm_size) / major_comm_size;
   }
 };
 
@@ -230,20 +232,20 @@ struct compute_edge_partition_id_from_int_edge_endpoints_t {
            (minor_vertex_partition_id) / major_comm_size;
   }
 
-  __device__ int operator()(thrust::tuple<vertex_t, vertex_t> pair /* major, minor */) const
+  __device__ int operator()(cuda::std::tuple<vertex_t, vertex_t> pair /* major, minor */) const
   {
     auto major_vertex_partition_id =
       static_cast<int>(thrust::distance(vertex_partition_range_lasts.begin(),
                                         thrust::upper_bound(thrust::seq,
                                                             vertex_partition_range_lasts.begin(),
                                                             vertex_partition_range_lasts.end(),
-                                                            thrust::get<0>(pair))));
+                                                            cuda::std::get<0>(pair))));
     auto minor_vertex_partition_id =
       static_cast<int>(thrust::distance(vertex_partition_range_lasts.begin(),
                                         thrust::upper_bound(thrust::seq,
                                                             vertex_partition_range_lasts.begin(),
                                                             vertex_partition_range_lasts.end(),
-                                                            thrust::get<1>(pair))));
+                                                            cuda::std::get<1>(pair))));
     return (major_vertex_partition_id)*minor_comm_size +
            (minor_vertex_partition_id) / major_comm_size;
   }
@@ -264,11 +266,11 @@ struct compute_local_edge_partition_id_from_ext_edge_endpoints_t {
   }
 
   __host__ __device__ int operator()(
-    thrust::tuple<vertex_t, vertex_t> pair /* major, minor */) const
+    cuda::std::tuple<vertex_t, vertex_t> pair /* major, minor */) const
   {
     return compute_edge_partition_id_from_ext_edge_endpoints_t<vertex_t>{
-             comm_size, major_comm_size, minor_comm_size}(thrust::get<0>(pair),
-                                                          thrust::get<1>(pair)) /
+             comm_size, major_comm_size, minor_comm_size}(cuda::std::get<0>(pair),
+                                                          cuda::std::get<1>(pair)) /
            comm_size;
   }
 };
@@ -287,11 +289,11 @@ struct compute_local_edge_partition_id_from_int_edge_endpoints_t {
            static_cast<int>(vertex_partition_range_lasts.size());
   }
 
-  __device__ int operator()(thrust::tuple<vertex_t, vertex_t> pair /* major, minor */) const
+  __device__ int operator()(cuda::std::tuple<vertex_t, vertex_t> pair /* major, minor */) const
   {
     return compute_edge_partition_id_from_int_edge_endpoints_t<vertex_t>{
-             vertex_partition_range_lasts, major_comm_size, minor_comm_size}(thrust::get<0>(pair),
-                                                                             thrust::get<1>(pair)) /
+             vertex_partition_range_lasts, major_comm_size, minor_comm_size}(
+             cuda::std::get<0>(pair), cuda::std::get<1>(pair)) /
            static_cast<int>(vertex_partition_range_lasts.size());
   }
 };

--- a/cpp/src/detail/groupby_and_count.cuh
+++ b/cpp/src/detail/groupby_and_count.cuh
@@ -26,11 +26,11 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/fill.h>
 #include <thrust/gather.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 
@@ -100,7 +100,7 @@ rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
     static_cast<size_t>(static_cast<double>(total_global_mem / element_size) * mem_frugal_ratio);
 
   auto pair_first = thrust::make_zip_iterator(
-    thrust::make_tuple(d_edgelist_majors.begin(), d_edgelist_minors.begin()));
+    cuda::std::make_tuple(d_edgelist_majors.begin(), d_edgelist_minors.begin()));
 
   rmm::device_uvector<size_t> result(0, handle.get_stream());
 
@@ -113,7 +113,7 @@ rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
        cugraph::detail::compute_vertex_partition_id_from_ext_vertex_t<vertex_t>{
          comm_size}] __device__(auto pair) {
       auto local_edge_partition_id = local_edge_partition_id_key_func(pair);
-      auto vertex_partition_id     = vertex_partition_id_key_func(thrust::get<1>(pair));
+      auto vertex_partition_id     = vertex_partition_id_key_func(cuda::std::get<1>(pair));
       return (local_edge_partition_id * major_comm_size) +
              ((vertex_partition_id) % major_comm_size);
     };

--- a/cpp/src/detail/groupby_and_count_mg_v32_e32.cu
+++ b/cpp/src/detail/groupby_and_count_mg_v32_e32.cu
@@ -24,11 +24,11 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/fill.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/scatter.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 

--- a/cpp/src/detail/groupby_and_count_mg_v64_e64.cu
+++ b/cpp/src/detail/groupby_and_count_mg_v64_e64.cu
@@ -24,11 +24,11 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/fill.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/scatter.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 

--- a/cpp/src/detail/utility_wrappers_32.cu
+++ b/cpp/src/detail/utility_wrappers_32.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/std/tuple>
 #include <thrust/count.h>
 #include <thrust/distance.h>
 #include <thrust/functional.h>
@@ -35,7 +36,6 @@
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
-#include <thrust/tuple.h>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/detail/utility_wrappers_64.cu
+++ b/cpp/src/detail/utility_wrappers_64.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/std/tuple>
 #include <thrust/count.h>
 #include <thrust/distance.h>
 #include <thrust/functional.h>
@@ -35,7 +36,6 @@
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
-#include <thrust/tuple.h>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/generators/erdos_renyi_generator.cuh
+++ b/cpp/src/generators/erdos_renyi_generator.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,13 +22,13 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/functional>
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_output_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/random.h>
-#include <thrust/tuple.h>
 
 namespace cugraph {
 
@@ -72,10 +72,10 @@ generate_erdos_renyi_graph_edgelist_gnp(raft::handle_t const& handle,
                   thrust::make_counting_iterator<size_t>(max_num_edges),
                   thrust::make_transform_output_iterator(
                     thrust::make_zip_iterator(src_v.begin(), dst_v.begin()),
-                    cuda::proclaim_return_type<thrust::tuple<vertex_t, vertex_t>>(
+                    cuda::proclaim_return_type<cuda::std::tuple<vertex_t, vertex_t>>(
                       [num_vertices] __device__(size_t index) {
-                        return thrust::make_tuple(static_cast<vertex_t>(index / num_vertices),
-                                                  static_cast<vertex_t>(index % num_vertices));
+                        return cuda::std::make_tuple(static_cast<vertex_t>(index / num_vertices),
+                                                     static_cast<vertex_t>(index % num_vertices));
                       })),
                   [generate_random_value, p] __device__(size_t index) {
                     return generate_random_value(index) < p;

--- a/cpp/src/generators/erdos_renyi_generator_sg_v32_e32.cu
+++ b/cpp/src/generators/erdos_renyi_generator_sg_v32_e32.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,13 +22,13 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/functional>
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_output_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/random.h>
-#include <thrust/tuple.h>
 
 namespace cugraph {
 

--- a/cpp/src/generators/erdos_renyi_generator_sg_v64_e64.cu
+++ b/cpp/src/generators/erdos_renyi_generator_sg_v64_e64.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,13 +22,13 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/functional>
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_output_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/random.h>
-#include <thrust/tuple.h>
 
 namespace cugraph {
 

--- a/cpp/src/generators/generate_bipartite_rmat_edgelist.cuh
+++ b/cpp/src/generators/generate_bipartite_rmat_edgelist.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,10 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 
@@ -69,7 +69,7 @@ generate_bipartite_rmat_edgelist(raft::handle_t const& handle,
   while (num_edges_generated < num_edges) {
     auto num_edges_to_generate =
       std::min(num_edges - num_edges_generated, max_edges_to_generate_per_iteration);
-    auto pair_first = thrust::make_zip_iterator(thrust::make_tuple(srcs.begin(), dsts.begin())) +
+    auto pair_first = thrust::make_zip_iterator(cuda::std::make_tuple(srcs.begin(), dsts.begin())) +
                       num_edges_generated;
 
     detail::uniform_random_fill(handle.get_stream(),
@@ -111,7 +111,7 @@ generate_bipartite_rmat_edgelist(raft::handle_t const& handle,
               dst_bit_set ? static_cast<vertex_t>(vertex_t{1} << (dst_scale - (level + 1))) : 0;
           }
         }
-        return thrust::make_tuple(src, dst);
+        return cuda::std::make_tuple(src, dst);
       });
     num_edges_generated += num_edges_to_generate;
   }

--- a/cpp/src/generators/generate_bipartite_rmat_edgelist_sg_v32_e32.cu
+++ b/cpp/src/generators/generate_bipartite_rmat_edgelist_sg_v32_e32.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,10 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 

--- a/cpp/src/generators/generate_bipartite_rmat_edgelist_sg_v64_e64.cu
+++ b/cpp/src/generators/generate_bipartite_rmat_edgelist_sg_v64_e64.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,10 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 

--- a/cpp/src/generators/generate_rmat_edgelist.cuh
+++ b/cpp/src/generators/generate_rmat_edgelist.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,10 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 
@@ -64,7 +64,7 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> generat
   while (num_edges_generated < num_edges) {
     auto num_edges_to_generate =
       std::min(num_edges - num_edges_generated, max_edges_to_generate_per_iteration);
-    auto pair_first = thrust::make_zip_iterator(thrust::make_tuple(srcs.begin(), dsts.begin())) +
+    auto pair_first = thrust::make_zip_iterator(cuda::std::make_tuple(srcs.begin(), dsts.begin())) +
                       num_edges_generated;
 
     detail::uniform_random_fill(
@@ -100,7 +100,7 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> generat
           src += src_bit_set ? static_cast<vertex_t>(vertex_t{1} << bit) : 0;
           dst += dst_bit_set ? static_cast<vertex_t>(vertex_t{1} << bit) : 0;
         }
-        return thrust::make_tuple(src, dst);
+        return cuda::std::make_tuple(src, dst);
       });
     num_edges_generated += num_edges_to_generate;
   }

--- a/cpp/src/generators/generate_rmat_edgelist_sg_v32_e32.cu
+++ b/cpp/src/generators/generate_rmat_edgelist_sg_v32_e32.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,10 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 

--- a/cpp/src/generators/generate_rmat_edgelist_sg_v64_e64.cu
+++ b/cpp/src/generators/generate_rmat_edgelist_sg_v64_e64.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,10 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 

--- a/cpp/src/generators/generator_tools_sg_v32_e32.cu
+++ b/cpp/src/generators/generator_tools_sg_v32_e32.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/distance.h>
 #include <thrust/execution_policy.h>
@@ -32,7 +33,6 @@
 #include <thrust/partition.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <numeric>

--- a/cpp/src/generators/generator_tools_sg_v64_e64.cu
+++ b/cpp/src/generators/generator_tools_sg_v64_e64.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/distance.h>
 #include <thrust/execution_policy.h>
@@ -32,7 +33,6 @@
 #include <thrust/partition.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <numeric>

--- a/cpp/src/generators/simple_generators_sg_v32_e32.cu
+++ b/cpp/src/generators/simple_generators_sg_v32_e32.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,12 +24,12 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/functional>
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/sequence.h>
-#include <thrust/tuple.h>
 
 #include <numeric>
 

--- a/cpp/src/generators/simple_generators_sg_v64_e64.cu
+++ b/cpp/src/generators/simple_generators_sg_v64_e64.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,12 +24,12 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/functional>
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/sequence.h>
-#include <thrust/tuple.h>
 
 #include <numeric>
 

--- a/cpp/src/link_analysis/hits_impl.cuh
+++ b/cpp/src/link_analysis/hits_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,13 +27,13 @@
 #include <cugraph/edge_src_dst_property.hpp>
 #include <cugraph/graph_view.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/fill.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 namespace cugraph {
 namespace detail {
@@ -163,8 +163,10 @@ std::tuple<result_t, size_t> hits(raft::handle_t const& handle,
     diff_sum = transform_reduce_v(
       handle,
       graph_view,
-      thrust::make_zip_iterator(thrust::make_tuple(curr_hubs, prev_hubs)),
-      [] __device__(auto, auto val) { return std::abs(thrust::get<0>(val) - thrust::get<1>(val)); },
+      thrust::make_zip_iterator(cuda::std::make_tuple(curr_hubs, prev_hubs)),
+      [] __device__(auto, auto val) {
+        return std::abs(cuda::std::get<0>(val) - cuda::std::get<1>(val));
+      },
       result_t{0});
 
     update_edge_src_property(handle, graph_view, curr_hubs, prev_src_hubs.mutable_view());

--- a/cpp/src/link_analysis/pagerank_impl.cuh
+++ b/cpp/src/link_analysis/pagerank_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/fill.h>
@@ -42,7 +43,6 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 namespace cugraph {
 namespace detail {
@@ -241,8 +241,8 @@ centrality_algorithm_metadata_t pagerank(
       pull_graph_view,
       thrust::make_zip_iterator(pageranks.begin(), vertex_out_weight_sums),
       [] __device__(auto, auto val) {
-        auto const pagerank       = thrust::get<0>(val);
-        auto const out_weight_sum = thrust::get<1>(val);
+        auto const pagerank       = cuda::std::get<0>(val);
+        auto const out_weight_sum = cuda::std::get<1>(val);
         return out_weight_sum == result_t{0.0} ? pagerank : result_t{0.0};
       },
       result_t{0.0});
@@ -255,8 +255,8 @@ centrality_algorithm_metadata_t pagerank(
         vertex_out_weight_sums + pull_graph_view.local_vertex_partition_range_size()),
       pageranks.begin(),
       [] __device__(auto val) {
-        auto const pagerank       = thrust::get<0>(val);
-        auto const out_weight_sum = thrust::get<1>(val);
+        auto const pagerank       = cuda::std::get<0>(val);
+        auto const out_weight_sum = cuda::std::get<1>(val);
         auto const divisor = out_weight_sum == result_t{0.0} ? result_t{1.0} : out_weight_sum;
         return pagerank / divisor;
       });
@@ -302,17 +302,17 @@ centrality_algorithm_metadata_t pagerank(
         pull_graph_view.local_vertex_partition_view());
       thrust::for_each(
         handle.get_thrust_policy(),
-        thrust::make_zip_iterator(thrust::make_tuple(std::get<0>(*personalization).begin(),
-                                                     std::get<1>(*personalization).begin())),
-        thrust::make_zip_iterator(thrust::make_tuple(std::get<0>(*personalization).end(),
-                                                     std::get<1>(*personalization).end())),
+        thrust::make_zip_iterator(cuda::std::make_tuple(std::get<0>(*personalization).begin(),
+                                                        std::get<1>(*personalization).begin())),
+        thrust::make_zip_iterator(cuda::std::make_tuple(std::get<0>(*personalization).end(),
+                                                        std::get<1>(*personalization).end())),
         [vertex_partition,
          pageranks = pageranks.data(),
          dangling_sum,
          personalization_sum,
          alpha] __device__(auto val) {
-          auto v     = thrust::get<0>(val);
-          auto value = thrust::get<1>(val);
+          auto v     = cuda::std::get<0>(val);
+          auto value = cuda::std::get<1>(val);
           *(pageranks + vertex_partition.local_vertex_partition_offset_from_vertex_nocheck(v)) +=
             (dangling_sum * alpha + static_cast<result_t>(1.0 - alpha)) *
             (value / personalization_sum);
@@ -322,8 +322,10 @@ centrality_algorithm_metadata_t pagerank(
     auto diff_sum = transform_reduce_v(
       handle,
       pull_graph_view,
-      thrust::make_zip_iterator(thrust::make_tuple(pageranks.begin(), old_pageranks.begin())),
-      [] __device__(auto, auto val) { return std::abs(thrust::get<0>(val) - thrust::get<1>(val)); },
+      thrust::make_zip_iterator(cuda::std::make_tuple(pageranks.begin(), old_pageranks.begin())),
+      [] __device__(auto, auto val) {
+        return std::abs(cuda::std::get<0>(val) - cuda::std::get<1>(val));
+      },
       result_t{0.0});
 
     iter++;

--- a/cpp/src/link_prediction/similarity_impl.cuh
+++ b/cpp/src/link_prediction/similarity_impl.cuh
@@ -110,15 +110,15 @@ rmm::device_uvector<weight_t> similarity(
             pair_first,
             pair_first + intersected_properties_a.size(),
             [] __device__(auto property_pair) {
-              auto prop_a = thrust::get<0>(property_pair);
-              auto prop_b = thrust::get<1>(property_pair);
-              return thrust::make_tuple(prop_a * prop_a, prop_b * prop_b, prop_a * prop_b);
+              auto prop_a = cuda::std::get<0>(property_pair);
+              auto prop_b = cuda::std::get<1>(property_pair);
+              return cuda::std::make_tuple(prop_a * prop_a, prop_b * prop_b, prop_a * prop_b);
             },
-            thrust::make_tuple(weight_t{0}, weight_t{0}, weight_t{0}),
+            cuda::std::make_tuple(weight_t{0}, weight_t{0}, weight_t{0}),
             [] __device__(auto lhs, auto rhs) {
-              return thrust::make_tuple(thrust::get<0>(lhs) + thrust::get<0>(rhs),
-                                        thrust::get<1>(lhs) + thrust::get<1>(rhs),
-                                        thrust::get<2>(lhs) + thrust::get<2>(rhs));
+              return cuda::std::make_tuple(cuda::std::get<0>(lhs) + cuda::std::get<0>(rhs),
+                                           cuda::std::get<1>(lhs) + cuda::std::get<1>(rhs),
+                                           cuda::std::get<2>(lhs) + cuda::std::get<2>(rhs));
             });
 
           return functor.compute_score(static_cast<weight_t>(sqrt(norm_a)),
@@ -143,16 +143,17 @@ rmm::device_uvector<weight_t> similarity(
               pair_first,
               pair_first + intersected_properties_a.size(),
               [] __device__(auto property_pair) {
-                auto prop_a = thrust::get<0>(property_pair);
-                auto prop_b = thrust::get<1>(property_pair);
-                return thrust::make_tuple(min(prop_a, prop_b), max(prop_a, prop_b), prop_a, prop_b);
+                auto prop_a = cuda::std::get<0>(property_pair);
+                auto prop_b = cuda::std::get<1>(property_pair);
+                return cuda::std::make_tuple(
+                  min(prop_a, prop_b), max(prop_a, prop_b), prop_a, prop_b);
               },
-              thrust::make_tuple(weight_t{0}, weight_t{0}, weight_t{0}, weight_t{0}),
+              cuda::std::make_tuple(weight_t{0}, weight_t{0}, weight_t{0}, weight_t{0}),
               [] __device__(auto lhs, auto rhs) {
-                return thrust::make_tuple(thrust::get<0>(lhs) + thrust::get<0>(rhs),
-                                          thrust::get<1>(lhs) + thrust::get<1>(rhs),
-                                          thrust::get<2>(lhs) + thrust::get<2>(rhs),
-                                          thrust::get<3>(lhs) + thrust::get<3>(rhs));
+                return cuda::std::make_tuple(cuda::std::get<0>(lhs) + cuda::std::get<0>(rhs),
+                                             cuda::std::get<1>(lhs) + cuda::std::get<1>(rhs),
+                                             cuda::std::get<2>(lhs) + cuda::std::get<2>(rhs),
+                                             cuda::std::get<3>(lhs) + cuda::std::get<3>(rhs));
               });
 
           weight_t sum_of_uniq_a = weight_a - sum_of_intersected_a;
@@ -408,11 +409,12 @@ all_pairs_similarity(raft::handle_t const& handle,
 
       auto new_size = thrust::distance(
         thrust::make_zip_iterator(v1.begin(), v2.begin()),
-        thrust::remove_if(
-          handle.get_thrust_policy(),
-          thrust::make_zip_iterator(v1.begin(), v2.begin()),
-          thrust::make_zip_iterator(v1.end(), v2.end()),
-          [] __device__(auto tuple) { return thrust::get<0>(tuple) == thrust::get<1>(tuple); }));
+        thrust::remove_if(handle.get_thrust_policy(),
+                          thrust::make_zip_iterator(v1.begin(), v2.begin()),
+                          thrust::make_zip_iterator(v1.end(), v2.end()),
+                          [] __device__(auto tuple) {
+                            return cuda::std::get<0>(tuple) == cuda::std::get<1>(tuple);
+                          }));
 
       v1.resize(new_size, handle.get_stream());
       v2.resize(new_size, handle.get_stream());
@@ -456,7 +458,7 @@ all_pairs_similarity(raft::handle_t const& handle,
                           thrust::make_zip_iterator(score.begin(), v1.begin(), v2.begin()),
                           thrust::make_zip_iterator(score.end(), v1.end(), v2.end()),
                           [similarity_threshold] __device__(auto tuple) {
-                            return thrust::get<0>(tuple) < similarity_threshold;
+                            return cuda::std::get<0>(tuple) < similarity_threshold;
                           }));
 
       score.resize(new_size, handle.get_stream());
@@ -598,11 +600,12 @@ all_pairs_similarity(raft::handle_t const& handle,
 
     auto new_size = thrust::distance(
       thrust::make_zip_iterator(v1.begin(), v2.begin()),
-      thrust::remove_if(
-        handle.get_thrust_policy(),
-        thrust::make_zip_iterator(v1.begin(), v2.begin()),
-        thrust::make_zip_iterator(v1.end(), v2.end()),
-        [] __device__(auto tuple) { return thrust::get<0>(tuple) == thrust::get<1>(tuple); }));
+      thrust::remove_if(handle.get_thrust_policy(),
+                        thrust::make_zip_iterator(v1.begin(), v2.begin()),
+                        thrust::make_zip_iterator(v1.end(), v2.end()),
+                        [] __device__(auto tuple) {
+                          return cuda::std::get<0>(tuple) == cuda::std::get<1>(tuple);
+                        }));
 
     v1.resize(new_size, handle.get_stream());
     v2.resize(new_size, handle.get_stream());

--- a/cpp/src/mtmg/vertex_pairs_result.cuh
+++ b/cpp/src/mtmg/vertex_pairs_result.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,7 +123,7 @@ std::
                       [v1_check = raft::device_span<vertex_t const>{
                          local_vertices.data(), local_vertices.size()}] __device__(auto tuple) {
                         return thrust::binary_search(
-                          thrust::seq, v1_check.begin(), v1_check.end(), thrust::get<0>(tuple));
+                          thrust::seq, v1_check.begin(), v1_check.end(), cuda::std::get<0>(tuple));
                       });
 
   v1.resize(

--- a/cpp/src/mtmg/vertex_result.cuh
+++ b/cpp/src/mtmg/vertex_result.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ rmm::device_uvector<result_t> vertex_result_view_t<result_t>::gather(
         [check = cugraph::detail::check_out_of_range_t<vertex_t>{
            vertex_partition_view.local_vertex_partition_range_first(),
            vertex_partition_view.local_vertex_partition_range_last()}] __device__(auto tuple) {
-          return check(thrust::get<0>(tuple));
+          return check(cuda::std::get<0>(tuple));
         }));
 
     local_vertices.resize(new_size, stream);

--- a/cpp/src/prims/detail/extract_transform_v_frontier_e.cuh
+++ b/cpp/src/prims/detail/extract_transform_v_frontier_e.cuh
@@ -41,6 +41,7 @@
 
 #include <cub/cub.cuh>
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/count.h>
@@ -49,7 +50,6 @@
 #include <thrust/functional.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/sort.h>
-#include <thrust/tuple.h>
 
 #include <algorithm>
 #include <cstdlib>
@@ -82,8 +82,8 @@ __device__ void push_buffer_element(BufferKeyOutputIterator buffer_key_output_fi
 
   static_assert(!std::is_same_v<output_key_t, void> || !std::is_same_v<output_value_t, void>);
   if constexpr (!std::is_same_v<output_key_t, void> && !std::is_same_v<output_value_t, void>) {
-    *(buffer_key_output_first + buffer_idx)   = thrust::get<0>(*e_op_result);
-    *(buffer_value_output_first + buffer_idx) = thrust::get<1>(*e_op_result);
+    *(buffer_key_output_first + buffer_idx)   = cuda::std::get<0>(*e_op_result);
+    *(buffer_value_output_first + buffer_idx) = cuda::std::get<1>(*e_op_result);
   } else if constexpr (!std::is_same_v<output_key_t, void>) {
     *(buffer_key_output_first + buffer_idx) = *e_op_result;
   } else {
@@ -694,7 +694,7 @@ extract_transform_v_frontier_e(raft::handle_t const& handle,
     std::is_same_v<e_op_result_t,
                    std::conditional_t<
                      !std::is_same_v<output_key_t, void> && !std::is_same_v<output_value_t, void>,
-                     cuda::std::optional<thrust::tuple<output_key_t, output_value_t>>,
+                     cuda::std::optional<cuda::std::tuple<output_key_t, output_value_t>>,
                      std::conditional_t<!std::is_same_v<output_key_t, void>,
                                         cuda::std::optional<output_key_t>,
                                         cuda::std::optional<output_value_t>>>>);

--- a/cpp/src/prims/detail/partition_v_frontier.cuh
+++ b/cpp/src/prims/detail/partition_v_frontier.cuh
@@ -31,6 +31,7 @@
 #include <cub/cub.cuh>
 #include <cuda/atomic>
 #include <cuda/functional>
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/iterator/constant_iterator.h>
@@ -38,7 +39,6 @@
 #include <thrust/remove.h>
 #include <thrust/sort.h>
 #include <thrust/tabulate.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <tuple>
@@ -115,8 +115,8 @@ partition_v_frontier_per_value_idx(
                    index_pair_first,
                    index_pair_last,
                    [num_values_per_key] __device__(size_t i) {
-                     return thrust::make_tuple(i / num_values_per_key,
-                                               static_cast<value_idx_t>(i % num_values_per_key));
+                     return cuda::std::make_tuple(i / num_values_per_key,
+                                                  static_cast<value_idx_t>(i % num_values_per_key));
                    });
 
   auto num_partitions = thresholds.size() / num_values_per_key + 1;
@@ -138,8 +138,8 @@ partition_v_frontier_per_value_idx(
        num_values_per_key,
        num_partitions,
        true_partition_idx = i] __device__(auto pair) {
-        auto key_idx   = thrust::get<0>(pair);
-        auto value_idx = thrust::get<1>(pair);
+        auto key_idx   = cuda::std::get<0>(pair);
+        auto value_idx = cuda::std::get<1>(pair);
         return *(frontier_value_first + key_idx * num_values_per_key + value_idx) <
                thresholds[value_idx * (num_partitions - 1) + true_partition_idx];
       });

--- a/cpp/src/prims/detail/per_v_transform_reduce_e.cuh
+++ b/cpp/src/prims/detail/per_v_transform_reduce_e.cuh
@@ -47,6 +47,7 @@
 #include <cub/cub.cuh>
 #include <cuda/functional>
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/distance.h>
 #include <thrust/execution_policy.h>
@@ -58,7 +59,6 @@
 #include <thrust/scatter.h>
 #include <thrust/set_operations.h>
 #include <thrust/transform_reduce.h>
-#include <thrust/tuple.h>
 #include <thrust/type_traits/integer_sequence.h>
 
 #include <numeric>
@@ -1006,8 +1006,8 @@ compute_selected_ranks_from_priorities(
                       offset_priority_pair_first + priorities.size(),
                       selected_ranks.begin(),
                       [root, subgroup_size, comm_rank, comm_size] __device__(auto pair) {
-                        auto offset   = thrust::get<0>(pair);
-                        auto priority = thrust::get<1>(pair);
+                        auto offset   = cuda::std::get<0>(pair);
+                        auto priority = cuda::std::get<1>(pair);
                         auto rank     = (priority == std::numeric_limits<priority_t>::max())
                                           ? comm_size
                                           : priority_to_rank<vertex_t, priority_t>(
@@ -1040,8 +1040,8 @@ compute_selected_ranks_from_priorities(
          subgroup_size,
          comm_rank,
          comm_size] __device__(auto pair) {
-          auto offset   = thrust::get<0>(pair);
-          auto priority = thrust::get<1>(pair);
+          auto offset   = cuda::std::get<0>(pair);
+          auto priority = cuda::std::get<1>(pair);
           auto rank     = (priority == std::numeric_limits<priority_t>::max())
                             ? comm_size
                             : priority_to_rank<vertex_t, priority_t>(
@@ -1067,7 +1067,7 @@ compute_selected_ranks_from_priorities(
              subgroup_size,
              comm_rank,
              comm_size] __device__(auto pair) {
-              auto offset   = thrust::get<1>(pair);
+              auto offset   = cuda::std::get<1>(pair);
               auto priority = priorities[offset];
               auto rank =
                 (priority == std::numeric_limits<priority_t>::max())
@@ -1076,8 +1076,8 @@ compute_selected_ranks_from_priorities(
                       priority, root, subgroup_size, comm_size, static_cast<vertex_t>(offset));
               if (rank == comm_rank) {
                 cuda::atomic_ref<uint32_t, cuda::thread_scope_device> word(
-                  keep_flags[packed_bool_offset(thrust::get<0>(pair))]);
-                word.fetch_or(packed_bool_mask(thrust::get<0>(pair)),
+                  keep_flags[packed_bool_offset(cuda::std::get<0>(pair))]);
+                word.fetch_or(packed_bool_mask(cuda::std::get<0>(pair)),
                               cuda::std::memory_order_relaxed);
               }
             });
@@ -1095,7 +1095,7 @@ compute_selected_ranks_from_priorities(
              subgroup_size,
              comm_rank,
              comm_size] __device__(auto pair) {
-              auto offset   = thrust::get<1>(pair);
+              auto offset   = cuda::std::get<1>(pair);
               auto priority = priorities[offset];
               auto rank =
                 (priority == std::numeric_limits<priority_t>::max())
@@ -1104,8 +1104,8 @@ compute_selected_ranks_from_priorities(
                       priority, root, subgroup_size, comm_size, static_cast<vertex_t>(offset));
               if (rank == comm_rank) {
                 cuda::atomic_ref<uint32_t, cuda::thread_scope_device> word(
-                  keep_flags[packed_bool_offset(thrust::get<0>(pair))]);
-                word.fetch_or(packed_bool_mask(thrust::get<0>(pair)),
+                  keep_flags[packed_bool_offset(cuda::std::get<0>(pair))]);
+                word.fetch_or(packed_bool_mask(cuda::std::get<0>(pair)),
                               cuda::std::memory_order_relaxed);
               }
             });

--- a/cpp/src/prims/detail/sample_and_compute_local_nbr_indices.cuh
+++ b/cpp/src/prims/detail/sample_and_compute_local_nbr_indices.cuh
@@ -38,6 +38,7 @@
 #include <cuda/atomic>
 #include <cuda/functional>
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/adjacent_difference.h>
 #include <thrust/copy.h>
 #include <thrust/count.h>
@@ -46,7 +47,6 @@
 #include <thrust/remove.h>
 #include <thrust/sort.h>
 #include <thrust/tabulate.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <optional>
@@ -121,8 +121,8 @@ struct convert_value_key_pair_to_shuffle_t {
   __device__ void operator()(size_t i) const
   {
     auto pair            = *(input_pair_first + i);
-    auto nbr_value       = thrust::get<0>(pair);
-    auto key_idx         = thrust::get<1>(pair);
+    auto nbr_value       = cuda::std::get<0>(pair);
+    auto key_idx         = cuda::std::get<1>(pair);
     auto local_nbr_value = nbr_value;
     int minor_comm_rank{-1};
     size_t intra_partition_offset{0};
@@ -140,7 +140,7 @@ struct convert_value_key_pair_to_shuffle_t {
       intra_partition_offset = counter.fetch_add(size_t{1}, cuda::std::memory_order_relaxed);
     }
     *(output_tuple_first + i) =
-      thrust::make_tuple(minor_comm_rank, intra_partition_offset, local_nbr_value, key_idx);
+      cuda::std::make_tuple(minor_comm_rank, intra_partition_offset, local_nbr_value, key_idx);
   }
 };
 
@@ -164,8 +164,8 @@ struct convert_per_type_value_key_pair_to_shuffle_t {
   {
     auto pair                     = *(input_pair_first + i);
     auto num_edge_types           = K_offsets.size() - 1;
-    auto per_type_nbr_value       = thrust::get<0>(pair);
-    auto idx                      = thrust::get<1>(pair);
+    auto per_type_nbr_value       = cuda::std::get<0>(pair);
+    auto idx                      = cuda::std::get<1>(pair);
     auto key_idx                  = idx / K_sum;
     auto type                     = static_cast<edge_type_t>(thrust::distance(
       K_offsets.begin() + 1,
@@ -187,7 +187,7 @@ struct convert_per_type_value_key_pair_to_shuffle_t {
       cuda::atomic_ref<size_t, cuda::thread_scope_device> counter(tx_counts[minor_comm_rank]);
       intra_partition_offset = counter.fetch_add(size_t{1}, cuda::std::memory_order_relaxed);
     }
-    *(output_tuple_first + i) = thrust::make_tuple(
+    *(output_tuple_first + i) = cuda::std::make_tuple(
       minor_comm_rank, intra_partition_offset, per_type_local_nbr_value, type, key_idx);
   }
 };
@@ -215,13 +215,13 @@ struct find_nth_valid_nbr_idx_t {
   EdgePartitionEdgeMaskWrapper edge_partition_e_mask;
   VertexIterator major_first{};
   raft::device_span<size_t const> major_idx_to_unique_major_idx{};
-  thrust::tuple<raft::device_span<size_t const>, raft::device_span<edge_t const>>
+  cuda::std::tuple<raft::device_span<size_t const>, raft::device_span<edge_t const>>
     unique_major_valid_local_nbr_count_inclusive_sums{};
 
-  __device__ edge_t operator()(thrust::tuple<edge_t, size_t> pair) const
+  __device__ edge_t operator()(cuda::std::tuple<edge_t, size_t> pair) const
   {
-    edge_t local_nbr_idx    = thrust::get<0>(pair);
-    size_t major_idx        = thrust::get<1>(pair);
+    edge_t local_nbr_idx    = cuda::std::get<0>(pair);
+    size_t major_idx        = cuda::std::get<1>(pair);
     size_t unique_major_idx = major_idx_to_unique_major_idx[major_idx];
     auto major              = *(major_first + major_idx);
     auto major_offset       = edge_partition.major_offset_from_major_nocheck(major);
@@ -249,11 +249,11 @@ struct find_nth_valid_nbr_idx_t {
         (*edge_partition_e_mask).value_first(), edge_offset, local_degree, local_nbr_idx + 1);
     } else {
       auto inclusive_sum_first =
-        thrust::get<1>(unique_major_valid_local_nbr_count_inclusive_sums).begin();
+        cuda::std::get<1>(unique_major_valid_local_nbr_count_inclusive_sums).begin();
       auto start_offset =
-        thrust::get<0>(unique_major_valid_local_nbr_count_inclusive_sums)[unique_major_idx];
+        cuda::std::get<0>(unique_major_valid_local_nbr_count_inclusive_sums)[unique_major_idx];
       auto end_offset =
-        thrust::get<0>(unique_major_valid_local_nbr_count_inclusive_sums)[unique_major_idx + 1];
+        cuda::std::get<0>(unique_major_valid_local_nbr_count_inclusive_sums)[unique_major_idx + 1];
       auto word_idx =
         static_cast<edge_t>(thrust::distance(inclusive_sum_first + start_offset,
                                              thrust::upper_bound(thrust::seq,
@@ -674,8 +674,8 @@ void sample_nbr_index_with_replacement(
      nbr_indices,
      K,
      invalid_idx = cugraph::invalid_edge_id_v<edge_t>] __device__(auto pair) {
-      auto i            = thrust::get<0>(pair);
-      auto r            = thrust::get<1>(pair);
+      auto i            = cuda::std::get<0>(pair);
+      auto r            = cuda::std::get<1>(pair);
       auto frontier_idx = frontier_indices ? (*frontier_indices)[i / K] : i / K;
       auto degree       = frontier_degrees[frontier_idx];
       auto sample_idx   = invalid_idx;
@@ -740,8 +740,8 @@ void sample_nbr_index_with_replacement(
        K_sum,
        invalid_idx = cugraph::invalid_edge_id_v<edge_t>] __device__(auto pair) {
         auto num_edge_types = static_cast<size_t>(K_offsets.size() - 1);
-        auto i              = thrust::get<0>(pair);
-        auto r              = thrust::get<1>(pair);
+        auto i              = cuda::std::get<0>(pair);
+        auto r              = cuda::std::get<1>(pair);
         auto idx            = thrust::distance(
           input_r_offsets.begin() + 1,
           thrust::upper_bound(thrust::seq, input_r_offsets.begin() + 1, input_r_offsets.end(), i));
@@ -768,8 +768,8 @@ void sample_nbr_index_with_replacement(
          K_sum,
          invalid_idx = cugraph::invalid_edge_id_v<edge_t>] __device__(auto pair) {
           auto num_edge_types = static_cast<edge_type_t>(K_offsets.size() - 1);
-          auto i              = thrust::get<0>(pair);
-          auto r              = thrust::get<1>(pair);
+          auto i              = cuda::std::get<0>(pair);
+          auto r              = cuda::std::get<1>(pair);
           auto frontier_idx   = i / K_sum;
           auto type           = static_cast<edge_type_t>(thrust::distance(
             K_offsets.begin() + 1,
@@ -978,8 +978,8 @@ void sample_nbr_index_without_replacement(
         cuda::proclaim_return_type<size_t>(
           [frontier_per_type_degrees, K_offsets] __device__(auto pair) {
             auto num_edge_types = static_cast<edge_type_t>(K_offsets.size() - 1);
-            auto frontier_idx   = thrust::get<0>(pair);
-            auto type           = thrust::get<1>(pair);
+            auto frontier_idx   = cuda::std::get<0>(pair);
+            auto type           = cuda::std::get<1>(pair);
             auto d =
               static_cast<size_t>(frontier_per_type_degrees[frontier_idx * num_edge_types + type]);
             auto K = K_offsets[type + 1] - K_offsets[type];
@@ -1206,13 +1206,13 @@ rmm::device_uvector<edge_t> compute_homogeneous_uniform_sampling_index_without_r
               // the new candidates to ensure that the previously selected neighbor indices will be
               // selected again
               if (sample_idx < unique_count) {  // re-select the previous ones
-                *(output_first + i) = thrust::make_tuple(
+                *(output_first + i) = cuda::std::make_tuple(
                   segment_sorted_tmp_nbr_indices[segment_idx * high_partition_oversampling_K +
                                                  sample_idx],
                   static_cast<int32_t>(sample_idx));
               } else {
                 *(output_first + i) =
-                  thrust::make_tuple(retry_nbr_indices[i], static_cast<int32_t>(sample_idx));
+                  cuda::std::make_tuple(retry_nbr_indices[i], static_cast<int32_t>(sample_idx));
               }
             });
         } else {
@@ -1291,9 +1291,10 @@ rmm::device_uvector<edge_t> compute_homogeneous_uniform_sampling_index_without_r
               size_t unique_count = 1;
               for (size_t j = 1; j < high_partition_oversampling_K; ++j) {
                 auto cur = *(input_pair_first + j);
-                if (thrust::get<0>(cur) ==
-                    thrust::get<0>(prev)) {  // update the sample index to the minimum
-                  thrust::get<1>(prev) = cuda::std::min(thrust::get<1>(prev), thrust::get<1>(cur));
+                if (cuda::std::get<0>(cur) ==
+                    cuda::std::get<0>(prev)) {  // update the sample index to the minimum
+                  cuda::std::get<1>(prev) =
+                    cuda::std::min(cuda::std::get<1>(prev), cuda::std::get<1>(cur));
                 } else {  // new unique neighbor index
                   *(output_pair_first + unique_count - 1) = prev;
                   ++unique_count;
@@ -1315,13 +1316,14 @@ rmm::device_uvector<edge_t> compute_homogeneous_uniform_sampling_index_without_r
                segment_sorted_tmp_sample_indices.begin())] __device__(size_t i) {
               auto pair_first = segment_sorted_pair_first + high_partition_oversampling_K * i;
               assert(high_partition_oversampling_K > 0);
-              thrust::tuple<edge_t, int32_t> prev = *pair_first;
-              size_t unique_count                 = 1;
+              cuda::std::tuple<edge_t, int32_t> prev = *pair_first;
+              size_t unique_count                    = 1;
               for (size_t j = 1; j < high_partition_oversampling_K; ++j) {
                 auto cur = *(pair_first + j);
-                if (thrust::get<0>(cur) ==
-                    thrust::get<0>(prev)) {  // update the sample index to the minimum
-                  thrust::get<1>(prev) = cuda::std::min(thrust::get<1>(prev), thrust::get<1>(cur));
+                if (cuda::std::get<0>(cur) ==
+                    cuda::std::get<0>(prev)) {  // update the sample index to the minimum
+                  cuda::std::get<1>(prev) =
+                    cuda::std::min(cuda::std::get<1>(prev), cuda::std::get<1>(cur));
                 } else {  // new unique neighbor index
                   *(pair_first + unique_count - 1) = prev;
                   ++unique_count;
@@ -1544,8 +1546,8 @@ rmm::device_uvector<edge_t> compute_heterogeneous_uniform_sampling_index_without
           frontier_partition_offsets[1] + keys_to_sort_per_iteration * i,
         cuda::proclaim_return_type<edge_t>(
           [frontier_per_type_degrees, num_edge_types] __device__(auto pair) {
-            return frontier_per_type_degrees[thrust::get<0>(pair) * num_edge_types +
-                                             thrust::get<1>(pair)];
+            return frontier_per_type_degrees[cuda::std::get<0>(pair) * num_edge_types +
+                                             cuda::std::get<1>(pair)];
           }));
       auto segment_frontier_type_first = frontier_edge_types.begin() +
                                          frontier_partition_offsets[1] +
@@ -1622,18 +1624,19 @@ rmm::device_uvector<edge_t> compute_heterogeneous_uniform_sampling_index_without
               auto sample_idx   = static_cast<edge_t>(i % high_partition_oversampling_K);
               auto unique_count = unique_counts[segment_idx];
               auto output_first = thrust::make_zip_iterator(
-                thrust::make_tuple(retry_per_type_nbr_indices, retry_sample_indices));
+                cuda::std::make_tuple(retry_per_type_nbr_indices, retry_sample_indices));
               // sample index for the previously selected neighbor indices should be smaller than
               // the new candidates to ensure that the previously selected neighbor indices will
               // be selected again
               if (sample_idx < unique_count) {  // re-select the previous ones
-                *(output_first + i) =
-                  thrust::make_tuple(segment_sorted_tmp_per_type_nbr_indices
-                                       [segment_idx * high_partition_oversampling_K + sample_idx],
-                                     static_cast<int32_t>(sample_idx));
+                *(output_first + i) = cuda::std::make_tuple(
+                  segment_sorted_tmp_per_type_nbr_indices[segment_idx *
+                                                            high_partition_oversampling_K +
+                                                          sample_idx],
+                  static_cast<int32_t>(sample_idx));
               } else {
-                *(output_first + i) = thrust::make_tuple(retry_per_type_nbr_indices[i],
-                                                         static_cast<int32_t>(sample_idx));
+                *(output_first + i) = cuda::std::make_tuple(retry_per_type_nbr_indices[i],
+                                                            static_cast<int32_t>(sample_idx));
               }
             });
         } else {
@@ -1699,8 +1702,8 @@ rmm::device_uvector<edge_t> compute_heterogeneous_uniform_sampling_index_without
              unique_counts = raft::device_span<edge_t>(unique_counts.data(), unique_counts.size()),
              retry_segment_indices           = (*retry_segment_indices).data(),
              retry_segment_sorted_pair_first = thrust::make_zip_iterator(
-               thrust::make_tuple((*retry_segment_sorted_per_type_nbr_indices).begin(),
-                                  (*retry_segment_sorted_sample_indices).begin())),
+               cuda::std::make_tuple((*retry_segment_sorted_per_type_nbr_indices).begin(),
+                                     (*retry_segment_sorted_sample_indices).begin())),
              segment_sorted_pair_first = thrust::make_zip_iterator(
                segment_sorted_tmp_per_type_nbr_indices.begin(),
                segment_sorted_tmp_sample_indices.begin())] __device__(size_t i) {
@@ -1714,9 +1717,10 @@ rmm::device_uvector<edge_t> compute_heterogeneous_uniform_sampling_index_without
               size_t unique_count = 1;
               for (size_t j = 1; j < high_partition_oversampling_K; ++j) {
                 auto cur = *(input_pair_first + j);
-                if (thrust::get<0>(cur) ==
-                    thrust::get<0>(prev)) {  // update the sample index to the minimum
-                  thrust::get<1>(prev) = cuda::std::min(thrust::get<1>(prev), thrust::get<1>(cur));
+                if (cuda::std::get<0>(cur) ==
+                    cuda::std::get<0>(prev)) {  // update the sample index to the minimum
+                  cuda::std::get<1>(prev) =
+                    cuda::std::min(cuda::std::get<1>(prev), cuda::std::get<1>(cur));
                 } else {  // new unique neighbor index
                   *(output_pair_first + unique_count - 1) = prev;
                   ++unique_count;
@@ -1738,13 +1742,14 @@ rmm::device_uvector<edge_t> compute_heterogeneous_uniform_sampling_index_without
                segment_sorted_tmp_sample_indices.begin())] __device__(size_t i) {
               auto pair_first = segment_sorted_pair_first + high_partition_oversampling_K * i;
               assert(high_partition_oversampling_K > 0);
-              thrust::tuple<edge_t, int32_t> prev = *pair_first;
-              size_t unique_count                 = 1;
+              cuda::std::tuple<edge_t, int32_t> prev = *pair_first;
+              size_t unique_count                    = 1;
               for (size_t j = 1; j < high_partition_oversampling_K; ++j) {
                 auto cur = *(pair_first + j);
-                if (thrust::get<0>(cur) ==
-                    thrust::get<0>(prev)) {  // update the sample index to the minimum
-                  thrust::get<1>(prev) = cuda::std::min(thrust::get<1>(prev), thrust::get<1>(cur));
+                if (cuda::std::get<0>(cur) ==
+                    cuda::std::get<0>(prev)) {  // update the sample index to the minimum
+                  cuda::std::get<1>(prev) =
+                    cuda::std::min(cuda::std::get<1>(prev), cuda::std::get<1>(cur));
                 } else {  // new unique neighbor index
                   *(pair_first + unique_count - 1) = prev;
                   ++unique_count;
@@ -1765,8 +1770,8 @@ rmm::device_uvector<edge_t> compute_heterogeneous_uniform_sampling_index_without
                               (*retry_segment_indices).end(),
                               [pair_first, K_offsets] __device__(auto segment_idx) {
                                 auto pair = *(pair_first + segment_idx);
-                                auto type = thrust::get<1>(pair);
-                                return thrust::get<0>(pair) >=
+                                auto type = cuda::std::get<1>(pair);
+                                return cuda::std::get<0>(pair) >=
                                        static_cast<edge_t>(K_offsets[type + 1] - K_offsets[type]);
                               });
           auto num_retry_segments = thrust::distance((*retry_segment_indices).begin(), last);
@@ -1781,8 +1786,8 @@ rmm::device_uvector<edge_t> compute_heterogeneous_uniform_sampling_index_without
             pair_first,
             pair_first + unique_counts.size(),
             [K_offsets] __device__(auto pair) {
-              auto count = thrust::get<0>(pair);
-              auto type  = thrust::get<1>(pair);
+              auto count = cuda::std::get<0>(pair);
+              auto type  = cuda::std::get<1>(pair);
               return count < static_cast<edge_t>(K_offsets[type + 1] - K_offsets[type]);
             });
           if (num_retry_segments > 0) {
@@ -2185,8 +2190,8 @@ void compute_heterogeneous_biased_sampling_index_without_replacement(
                                   input_frontier_edge_types.begin()),
         cuda::proclaim_return_type<size_t>(
           [input_per_type_degree_offsets, num_edge_types] __device__(auto pair) {
-            auto idx  = thrust::get<0>(pair);
-            auto type = thrust::get<1>(pair);
+            auto idx  = cuda::std::get<0>(pair);
+            auto type = cuda::std::get<1>(pair);
             return input_per_type_degree_offsets[idx * num_edge_types + type + 1] -
                    input_per_type_degree_offsets[idx * num_edge_types + type];
           }));
@@ -2601,9 +2606,9 @@ compute_aggregate_local_frontier_biases(raft::handle_t const& handle,
                       degrees = raft::device_span<size_t>(
                         aggregate_local_frontier_local_degrees.data(),
                         aggregate_local_frontier_local_degrees.size())] __device__(auto pair) {
-                       auto bias = thrust::get<0>(pair);
+                       auto bias = cuda::std::get<0>(pair);
                        if (bias == 0.0) {
-                         auto i   = thrust::get<1>(pair);
+                         auto i   = cuda::std::get<1>(pair);
                          auto idx = thrust::distance(
                            offsets.begin() + 1,
                            thrust::upper_bound(thrust::seq, offsets.begin() + 1, offsets.end(), i));
@@ -2625,7 +2630,7 @@ compute_aggregate_local_frontier_biases(raft::handle_t const& handle,
       thrust::remove_if(handle.get_thrust_policy(),
                         pair_first,
                         pair_first + aggregate_local_frontier_biases.size(),
-                        [] __device__(auto pair) { return thrust::get<0>(pair) == 0.0; });
+                        [] __device__(auto pair) { return cuda::std::get<0>(pair) == 0.0; });
     aggregate_local_frontier_biases.resize(thrust::distance(pair_first, pair_last),
                                            handle.get_stream());
     aggregate_local_frontier_nz_bias_indices.resize(thrust::distance(pair_first, pair_last),
@@ -2693,10 +2698,11 @@ compute_aggregate_local_frontier_bias_type_pairs(
       edge_src_value_input,
       edge_dst_value_input,
       view_concat(edge_value_input, edge_type_input),
-      cuda::proclaim_return_type<thrust::tuple<bias_t, edge_type_t>>(
+      cuda::proclaim_return_type<cuda::std::tuple<bias_t, edge_type_t>>(
         [bias_e_op] __device__(auto src, auto dst, auto src_val, auto dst_val, auto e_val) {
-          return thrust::make_tuple(bias_e_op(src, dst, src_val, dst_val, thrust::get<0>(e_val)),
-                                    thrust::get<1>(e_val));
+          return cuda::std::make_tuple(
+            bias_e_op(src, dst, src_val, dst_val, cuda::std::get<0>(e_val)),
+            cuda::std::get<1>(e_val));
         }),
 #if 1  // FIXME: better update shuffle_values to take host_span
       std::vector<size_t>(local_frontier_offsets.begin(), local_frontier_offsets.end() - 1),
@@ -2759,9 +2765,9 @@ compute_aggregate_local_frontier_bias_type_pairs(
                       degrees = raft::device_span<size_t>(
                         aggregate_local_frontier_local_degrees.data(),
                         aggregate_local_frontier_local_degrees.size())] __device__(auto pair) {
-                       auto bias = thrust::get<0>(pair);
+                       auto bias = cuda::std::get<0>(pair);
                        if (bias == 0.0) {
-                         auto i = thrust::get<1>(pair);
+                         auto i = cuda::std::get<1>(pair);
                          auto it =
                            thrust::upper_bound(thrust::seq, offsets.begin() + 1, offsets.end(), i);
                          auto idx = thrust::distance(offsets.begin() + 1, it);
@@ -2785,7 +2791,7 @@ compute_aggregate_local_frontier_bias_type_pairs(
       handle.get_thrust_policy(),
       triplet_first,
       triplet_first + std::get<0>(aggregate_local_frontier_bias_type_pairs).size(),
-      [] __device__(auto triplet) { return thrust::get<0>(triplet) == 0.0; });
+      [] __device__(auto triplet) { return cuda::std::get<0>(triplet) == 0.0; });
     std::get<0>(aggregate_local_frontier_bias_type_pairs)
       .resize(thrust::distance(triplet_first, triplet_last), handle.get_stream());
     std::get<1>(aggregate_local_frontier_bias_type_pairs)
@@ -2912,7 +2918,7 @@ shuffle_and_compute_local_nbr_values(
         raft::device_span<size_t const>(tx_displacements.data(), tx_displacements.size())}),
     minor_comm_ranks.begin(),
     thrust::make_zip_iterator(
-      thrust::make_tuple(tmp_sample_local_nbr_values.begin(), tmp_key_indices.begin())),
+      cuda::std::make_tuple(tmp_sample_local_nbr_values.begin(), tmp_key_indices.begin())),
     is_not_equal_t<int>{-1});
 
   sample_local_nbr_values = std::move(tmp_sample_local_nbr_values);
@@ -2924,7 +2930,7 @@ shuffle_and_compute_local_nbr_values(
   handle.sync_stream();
 
   pair_first = thrust::make_zip_iterator(
-    thrust::make_tuple(sample_local_nbr_values.begin(), key_indices.begin()));
+    cuda::std::make_tuple(sample_local_nbr_values.begin(), key_indices.begin()));
   auto [rx_value_buffer, rx_counts] =
     shuffle_values(minor_comm, pair_first, h_tx_counts, handle.get_stream());
 
@@ -3095,10 +3101,10 @@ rmm::device_uvector<edge_t> compute_local_nbr_indices_from_per_type_local_nbr_in
                1),
            num_edge_types,
            invalid_idx = cugraph::invalid_edge_id_v<edge_t>] __device__(auto triplet) {
-            auto per_type_local_nbr_idx = thrust::get<0>(triplet);
+            auto per_type_local_nbr_idx = cuda::std::get<0>(triplet);
             if (per_type_local_nbr_idx != invalid_idx) {
-              auto type              = thrust::get<1>(triplet);
-              auto key_idx           = thrust::get<2>(triplet);
+              auto type              = cuda::std::get<1>(triplet);
+              auto key_idx           = cuda::std::get<2>(triplet);
               auto unique_key_idx    = key_idx_to_unique_key_idx[key_idx];
               auto type_start_offset = static_cast<edge_t>(
                 unique_key_per_type_local_degree_offsets[unique_key_idx * num_edge_types + type] -
@@ -3128,9 +3134,9 @@ rmm::device_uvector<edge_t> compute_local_nbr_indices_from_per_type_local_nbr_in
          K_sum,
          invalid_idx = cugraph::invalid_edge_id_v<edge_t>] __device__(auto pair) {
           auto num_edge_types         = static_cast<edge_type_t>(K_offsets.size() - 1);
-          auto per_type_local_nbr_idx = thrust::get<0>(pair);
+          auto per_type_local_nbr_idx = cuda::std::get<0>(pair);
           if (per_type_local_nbr_idx != invalid_idx) {
-            auto i                 = thrust::get<1>(pair);
+            auto i                 = cuda::std::get<1>(pair);
             auto key_idx           = i / K_sum;
             auto unique_key_idx    = key_idx_to_unique_key_idx[key_idx];
             auto type              = static_cast<edge_type_t>(thrust::distance(
@@ -4156,8 +4162,8 @@ heterogeneous_biased_sample_without_replacement(
          K_sum,
          invalid_idx = cugraph::invalid_edge_id_v<edge_t>] __device__(auto pair) {
           auto num_edge_types  = static_cast<edge_type_t>(K_offsets.size() - 1);
-          auto idx             = thrust::get<0>(pair);
-          auto type            = thrust::get<1>(pair);
+          auto idx             = cuda::std::get<0>(pair);
+          auto type            = cuda::std::get<1>(pair);
           auto per_type_degree = frontier_per_type_degrees[idx * num_edge_types + type];
           thrust::sequence(
             thrust::seq,
@@ -4185,7 +4191,7 @@ heterogeneous_biased_sample_without_replacement(
       // aggregate frontier index type pairs with their degrees in the medium range
 
       auto aggregate_mid_local_frontier_index_type_pairs =
-        allocate_dataframe_buffer<thrust::tuple<size_t, edge_type_t>>(
+        allocate_dataframe_buffer<cuda::std::tuple<size_t, edge_type_t>>(
           mid_local_frontier_offsets.back(), handle.get_stream());
       device_allgatherv(
         minor_comm,
@@ -4222,8 +4228,8 @@ heterogeneous_biased_sample_without_replacement(
                    num_edge_types +
                  1),
              num_edge_types] __device__(auto pair) {
-              auto key_idx        = thrust::get<0>(pair);
-              auto type           = thrust::get<1>(pair);
+              auto key_idx        = cuda::std::get<0>(pair);
+              auto type           = cuda::std::get<1>(pair);
               auto unique_key_idx = key_idx_to_unique_key_idx[key_idx];
               return static_cast<edge_t>(
                 unique_key_per_type_local_degree_offsets[unique_key_idx * num_edge_types + type +
@@ -4360,8 +4366,8 @@ heterogeneous_biased_sample_without_replacement(
           [frontier_per_type_degrees = raft::device_span<edge_t>(frontier_per_type_degrees.data(),
                                                                  frontier_per_type_degrees.size()),
            num_edge_types] __device__(auto pair) {
-            return frontier_per_type_degrees[thrust::get<0>(pair) * num_edge_types +
-                                             thrust::get<1>(pair)];
+            return frontier_per_type_degrees[cuda::std::get<0>(pair) * num_edge_types +
+                                             cuda::std::get<1>(pair)];
           }));
       rmm::device_uvector<size_t> mid_frontier_per_type_degree_offsets(mid_frontier_size + 1,
                                                                        handle.get_stream());
@@ -4418,8 +4424,8 @@ heterogeneous_biased_sample_without_replacement(
         cuda::proclaim_return_type<size_t>(
           [K_offsets = raft::device_span<size_t const>(d_K_offsets.data(), d_K_offsets.size()),
            K_sum] __device__(auto pair) {
-            auto idx  = thrust::get<0>(pair);
-            auto type = thrust::get<1>(pair);
+            auto idx  = cuda::std::get<0>(pair);
+            auto type = cuda::std::get<1>(pair);
             return idx * K_sum + K_offsets[type];
           }));
 
@@ -4454,7 +4460,7 @@ heterogeneous_biased_sample_without_replacement(
       // aggregate frontier index & type pairs with their degrees in the high range
 
       auto aggregate_high_local_frontier_index_type_pairs =
-        allocate_dataframe_buffer<thrust::tuple<size_t, edge_type_t>>(
+        allocate_dataframe_buffer<cuda::std::tuple<size_t, edge_type_t>>(
           high_local_frontier_offsets.back(), handle.get_stream());
       device_allgatherv(
         minor_comm,
@@ -4749,8 +4755,8 @@ heterogeneous_biased_sample_without_replacement(
          K_sum,
          invalid_idx = cugraph::invalid_edge_id_v<edge_t>] __device__(auto pair) {
           auto num_edge_types  = static_cast<edge_type_t>(K_offsets.size() - 1);
-          auto idx             = thrust::get<0>(pair);
-          auto type            = thrust::get<1>(pair);
+          auto idx             = cuda::std::get<0>(pair);
+          auto type            = cuda::std::get<1>(pair);
           auto per_type_degree = frontier_per_type_degrees[idx * num_edge_types + type];
           thrust::sequence(
             thrust::seq,
@@ -4791,8 +4797,8 @@ heterogeneous_biased_sample_without_replacement(
         cuda::proclaim_return_type<size_t>(
           [K_offsets = raft::device_span<size_t const>(d_K_offsets.data(), d_K_offsets.size()),
            K_sum] __device__(auto pair) {
-            auto idx  = thrust::get<0>(pair);
-            auto type = thrust::get<1>(pair);
+            auto idx  = cuda::std::get<0>(pair);
+            auto type = cuda::std::get<1>(pair);
             return idx * K_sum + K_offsets[type];
           }));
 
@@ -4879,9 +4885,9 @@ rmm::device_uvector<edge_t> remap_local_nbr_indices(
              aggregate_local_frontier_unique_key_org_indices.data(),
              aggregate_local_frontier_unique_key_org_indices.size()),
            invalid_idx = cugraph::invalid_edge_id_v<edge_t>] __device__(auto pair) {
-            auto local_nbr_idx = thrust::get<0>(pair);
+            auto local_nbr_idx = cuda::std::get<0>(pair);
             if (local_nbr_idx != invalid_idx) {
-              auto key_idx        = thrust::get<1>(pair);
+              auto key_idx        = cuda::std::get<1>(pair);
               auto unique_key_idx = key_idx_to_unique_key_idx[key_idx];
               return aggregate_local_frontier_unique_key_org_indices
                 [unique_key_local_degree_offsets[unique_key_idx] + local_nbr_idx];
@@ -4912,9 +4918,9 @@ rmm::device_uvector<edge_t> remap_local_nbr_indices(
              aggregate_local_frontier_unique_key_org_indices.size()),
            K,
            invalid_idx = cugraph::invalid_edge_id_v<edge_t>] __device__(auto pair) {
-            auto local_nbr_idx = thrust::get<0>(pair);
+            auto local_nbr_idx = cuda::std::get<0>(pair);
             if (local_nbr_idx != invalid_idx) {
-              auto key_idx        = thrust::get<1>(pair) / K;
+              auto key_idx        = cuda::std::get<1>(pair) / K;
               auto unique_key_idx = key_idx_to_unique_key_idx[key_idx];
               return aggregate_local_frontier_unique_key_org_indices
                 [unique_key_local_degree_offsets[unique_key_idx] + local_nbr_idx];
@@ -5000,7 +5006,7 @@ rmm::device_uvector<typename GraphViewType::edge_type> convert_to_unmasked_local
         raft::device_span<size_t const>(
           aggregate_local_frontier_major_idx_to_unique_major_idx.data() + local_frontier_offsets[i],
           local_frontier_offsets[i + 1] - local_frontier_offsets[i]),
-        thrust::make_tuple(
+        cuda::std::make_tuple(
           raft::device_span<size_t const>(
             std::get<0>(local_frontier_unique_major_valid_local_nbr_count_inclusive_sums[i]).data(),
             std::get<0>(local_frontier_unique_major_valid_local_nbr_count_inclusive_sums[i])
@@ -5601,8 +5607,8 @@ homogeneous_biased_sample_and_compute_local_nbr_indices(
            unique_key_nz_bias_indices = raft::device_span<edge_t const>(
              aggregate_local_frontier_unique_key_nz_bias_indices.data(),
              aggregate_local_frontier_unique_key_nz_bias_indices.size())] __device__(auto pair) {
-            auto nz_bias_idx    = thrust::get<0>(pair);
-            auto key_idx        = thrust::get<1>(pair);
+            auto nz_bias_idx    = cuda::std::get<0>(pair);
+            auto key_idx        = cuda::std::get<1>(pair);
             auto unique_key_idx = key_idx_to_unique_key_idx[key_idx];
             return unique_key_nz_bias_indices[unique_key_local_degree_offsets[unique_key_idx] +
                                               nz_bias_idx];
@@ -5630,8 +5636,8 @@ homogeneous_biased_sample_and_compute_local_nbr_indices(
              aggregate_local_frontier_unique_key_nz_bias_indices.data(),
              aggregate_local_frontier_unique_key_nz_bias_indices.size()),
            K] __device__(auto pair) {
-            auto nz_bias_idx    = thrust::get<0>(pair);
-            auto key_idx        = thrust::get<1>(pair) / K;
+            auto nz_bias_idx    = cuda::std::get<0>(pair);
+            auto key_idx        = cuda::std::get<1>(pair) / K;
             auto unique_key_idx = key_idx_to_unique_key_idx[key_idx];
             return unique_key_nz_bias_indices[unique_key_local_degree_offsets[unique_key_idx] +
                                               nz_bias_idx];

--- a/cpp/src/prims/detail/transform_v_frontier_e.cuh
+++ b/cpp/src/prims/detail/transform_v_frontier_e.cuh
@@ -30,9 +30,9 @@
 #include <raft/core/handle.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/tuple.h>
 
 #include <type_traits>
 

--- a/cpp/src/prims/extract_transform_e.cuh
+++ b/cpp/src/prims/extract_transform_e.cuh
@@ -30,10 +30,10 @@
 
 #include <raft/core/handle.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/distance.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/remove.h>
-#include <thrust/tuple.h>
 
 #include <cstdint>
 #include <numeric>

--- a/cpp/src/prims/fill_edge_property.cuh
+++ b/cpp/src/prims/fill_edge_property.cuh
@@ -59,7 +59,7 @@ void fill_edge_property(raft::handle_t const& handle,
     if constexpr (cugraph::has_packed_bool_element<
                     std::remove_reference_t<decltype(value_firsts[i])>,
                     T>()) {
-      static_assert(std::is_arithmetic_v<T>, "unimplemented for thrust::tuple types.");
+      static_assert(std::is_arithmetic_v<T>, "unimplemented for cuda::std::tuple types.");
       auto packed_input = input ? packed_bool_full_mask() : packed_bool_empty_mask();
       auto rem          = edge_counts[i] % packed_bools_per_word();
       if (edge_partition_e_mask) {
@@ -69,9 +69,9 @@ void fill_edge_property(raft::handle_t const& handle,
                           input_first,
                           input_first + packed_bool_size(static_cast<size_t>(edge_counts[i] - rem)),
                           value_firsts[i],
-                          [packed_input] __device__(thrust::tuple<T, uint32_t> pair) {
-                            auto old_value = thrust::get<0>(pair);
-                            auto mask      = thrust::get<1>(pair);
+                          [packed_input] __device__(cuda::std::tuple<T, uint32_t> pair) {
+                            auto old_value = cuda::std::get<0>(pair);
+                            auto mask      = cuda::std::get<1>(pair);
                             return (old_value & ~mask) | (packed_input & mask);
                           });
         if (rem > 0) {
@@ -80,9 +80,9 @@ void fill_edge_property(raft::handle_t const& handle,
             input_first + packed_bool_size(static_cast<size_t>(edge_counts[i] - rem)),
             input_first + packed_bool_size(static_cast<size_t>(edge_counts[i])),
             value_firsts[i] + packed_bool_size(static_cast<size_t>(edge_counts[i] - rem)),
-            [packed_input, rem] __device__(thrust::tuple<T, uint32_t> pair) {
-              auto old_value = thrust::get<0>(pair);
-              auto mask      = thrust::get<1>(pair);
+            [packed_input, rem] __device__(cuda::std::tuple<T, uint32_t> pair) {
+              auto old_value = cuda::std::get<0>(pair);
+              auto mask      = cuda::std::get<1>(pair);
               return ((old_value & ~mask) | (packed_input & mask)) & packed_bool_partial_mask(rem);
             });
         }

--- a/cpp/src/prims/fill_edge_src_dst_property.cuh
+++ b/cpp/src/prims/fill_edge_src_dst_property.cuh
@@ -61,7 +61,7 @@ template <typename Iterator, typename T, std::size_t... Is>
 __device__ void fill_thrust_tuple(Iterator iter, size_t offset, T value, std::index_sequence<Is...>)
 {
   ((fill_thrust_tuple_element(
-     thrust::get<Is>(iter.get_iterator_tuple()), offset, thrust::get<Is>(value))),
+     cuda::std::get<Is>(iter.get_iterator_tuple()), offset, cuda::std::get<Is>(value))),
    ...);
 }
 
@@ -77,7 +77,7 @@ __device__ void fill_scalar_or_thrust_tuple(Iterator iter, size_t offset, T valu
   } else {
     if constexpr (cugraph::has_packed_bool_element<Iterator, T>) {
       fill_thrust_tuple(
-        iter, offset, value, std::make_index_sequence<thrust::tuple_size<T>::value>());
+        iter, offset, value, std::make_index_sequence<cuda::std::tuple_size<T>::value>());
     } else {
       *(iter + offset) = value;
     }
@@ -96,7 +96,7 @@ void fill_edge_major_property(raft::handle_t const& handle,
   static_assert(std::is_same_v<T, typename EdgeMajorPropertyOutputWrapper::value_type>);
   static_assert(!contains_packed_bool_element ||
                   std::is_arithmetic_v<typename EdgeMajorPropertyOutputWrapper::value_type>,
-                "unimplemented for thrust::tuple types with a packed bool element.");
+                "unimplemented for cuda::std::tuple types with a packed bool element.");
 
   auto keys         = edge_major_property_output.keys();
   auto value_firsts = edge_major_property_output.value_firsts();
@@ -142,7 +142,7 @@ void fill_edge_major_property(raft::handle_t const& handle,
   static_assert(std::is_same_v<T, typename EdgeMajorPropertyOutputWrapper::value_type>);
   static_assert(!contains_packed_bool_element ||
                   std::is_arithmetic_v<typename EdgeMajorPropertyOutputWrapper::value_type>,
-                "unimplemented for thrust::tuple types with a packed bool element.");
+                "unimplemented for cuda::std::tuple types with a packed bool element.");
 
   using vertex_t = typename GraphViewType::vertex_type;
   using edge_t   = typename GraphViewType::edge_type;
@@ -278,7 +278,7 @@ void fill_edge_minor_property(raft::handle_t const& handle,
   }
   auto value_first = edge_minor_property_output.value_first();
   if constexpr (contains_packed_bool_element) {
-    static_assert(std::is_arithmetic_v<T>, "unimplemented for thrust::tuple types.");
+    static_assert(std::is_arithmetic_v<T>, "unimplemented for cuda::std::tuple types.");
     auto packed_input = input ? packed_bool_full_mask() : packed_bool_empty_mask();
     thrust::fill_n(
       handle.get_thrust_policy(), value_first, packed_bool_size(num_buffer_elements), packed_input);

--- a/cpp/src/prims/per_v_pair_transform_dst_nbr_intersection.cuh
+++ b/cpp/src/prims/per_v_pair_transform_dst_nbr_intersection.cuh
@@ -33,6 +33,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/count.h>
@@ -47,7 +48,6 @@
 #include <thrust/reduce.h>
 #include <thrust/sort.h>
 #include <thrust/tabulate.h>
-#include <thrust/tuple.h>
 
 #include <type_traits>
 
@@ -66,7 +66,7 @@ struct compute_local_edge_partition_id_t {
 
   __device__ int operator()(size_t i) const
   {
-    auto major = thrust::get<0>(*(vertex_pair_first + i));
+    auto major = cuda::std::get<0>(*(vertex_pair_first + i));
     return static_cast<int>(
       thrust::distance(edge_partition_major_range_lasts.begin(),
                        thrust::upper_bound(thrust::seq,
@@ -83,7 +83,7 @@ struct compute_chunk_id_t {
 
   __device__ int operator()(size_t i) const
   {
-    return static_cast<int>(thrust::get<1>(*(vertex_pair_first + i)) % num_chunks);
+    return static_cast<int>(cuda::std::get<1>(*(vertex_pair_first + i)) % num_chunks);
   }
 };
 
@@ -128,8 +128,8 @@ struct call_intersection_op_t {
 
     auto index        = *(major_minor_pair_index_first + i);
     auto pair         = *(major_minor_pair_first + index);
-    auto major        = thrust::get<0>(pair);
-    auto minor        = thrust::get<1>(pair);
+    auto major        = cuda::std::get<0>(pair);
+    auto minor        = cuda::std::get<1>(pair);
     auto src          = GraphViewType::is_storage_transposed ? minor : major;
     auto dst          = GraphViewType::is_storage_transposed ? major : minor;
     auto intersection = raft::device_span<typename GraphViewType::vertex_type const>(

--- a/cpp/src/prims/per_v_random_select_transform_outgoing_e.cuh
+++ b/cpp/src/prims/per_v_random_select_transform_outgoing_e.cuh
@@ -35,6 +35,7 @@
 #include <cuda/atomic>
 #include <cuda/functional>
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/iterator/constant_iterator.h>
@@ -42,7 +43,6 @@
 #include <thrust/remove.h>
 #include <thrust/sort.h>
 #include <thrust/tabulate.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <optional>
@@ -72,9 +72,9 @@ template <typename edge_t, typename T>
 struct check_invalid_t {
   edge_t invalid_idx{};
 
-  __device__ bool operator()(thrust::tuple<edge_t, T> pair) const
+  __device__ bool operator()(cuda::std::tuple<edge_t, T> pair) const
   {
-    return thrust::get<0>(pair) == invalid_idx;
+    return cuda::std::get<0>(pair) == invalid_idx;
   }
 };
 
@@ -617,7 +617,7 @@ per_v_random_select_transform_e(raft::handle_t const& handle,
       sample_counts.resize(0, handle.get_stream());
       sample_counts.shrink_to_fit(handle.get_stream());
 
-      auto pair_first = thrust::make_zip_iterator(thrust::make_tuple(
+      auto pair_first = thrust::make_zip_iterator(cuda::std::make_tuple(
         sample_local_nbr_indices.begin(), get_dataframe_buffer_begin(sample_e_op_results)));
       auto pair_last =
         thrust::remove_if(handle.get_thrust_policy(),

--- a/cpp/src/prims/property_op_utils.cuh
+++ b/cpp/src/prims/property_op_utils.cuh
@@ -22,13 +22,13 @@
 #include <raft/core/device_span.hpp>
 
 #include <cub/cub.cuh>
+#include <cuda/std/tuple>
 #include <thrust/detail/type_traits/iterator/is_discard_iterator.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/detail/any_assign.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/memory.h>
-#include <thrust/tuple.h>
 
 #include <array>
 #include <type_traits>
@@ -127,21 +127,21 @@ template <typename T, template <typename> typename Op>
 struct property_op : public Op<T> {};
 
 template <typename... Args, template <typename> typename Op>
-struct property_op<thrust::tuple<Args...>, Op> {
-  using Type = thrust::tuple<Args...>;
+struct property_op<cuda::std::tuple<Args...>, Op> {
+  using Type = cuda::std::tuple<Args...>;
 
  private:
   template <typename T, std::size_t... Is>
   __host__ __device__ constexpr auto binary_op_impl(T& t1, T& t2, std::index_sequence<Is...>) const
   {
-    return thrust::make_tuple((Op<typename thrust::tuple_element<Is, Type>::type>()(
-      thrust::get<Is>(t1), thrust::get<Is>(t2)))...);
+    return cuda::std::make_tuple((Op<typename cuda::std::tuple_element<Is, Type>::type>()(
+      cuda::std::get<Is>(t1), cuda::std::get<Is>(t2)))...);
   }
 
  public:
   __host__ __device__ constexpr auto operator()(const Type& t1, const Type& t2) const
   {
-    return binary_op_impl(t1, t2, std::make_index_sequence<thrust::tuple_size<Type>::value>());
+    return binary_op_impl(t1, t2, std::make_index_sequence<cuda::std::tuple_size<Type>::value>());
   }
 };
 

--- a/cpp/src/prims/reduce_op.cuh
+++ b/cpp/src/prims/reduce_op.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,16 +37,18 @@ template <typename T, std::size_t... Is>
 __host__ __device__ std::enable_if_t<cugraph::is_thrust_tuple_of_arithmetic<T>::value, T>
 elementwise_thrust_min(T lhs, T rhs, std::index_sequence<Is...>)
 {
-  return thrust::make_tuple(
-    (thrust::get<Is>(lhs) < thrust::get<Is>(rhs) ? thrust::get<Is>(lhs) : thrust::get<Is>(rhs))...);
+  return cuda::std::make_tuple((cuda::std::get<Is>(lhs) < cuda::std::get<Is>(rhs)
+                                  ? cuda::std::get<Is>(lhs)
+                                  : cuda::std::get<Is>(rhs))...);
 }
 
 template <typename T, std::size_t... Is>
 __host__ __device__ std::enable_if_t<cugraph::is_thrust_tuple_of_arithmetic<T>::value, T>
 elementwise_thrust_max(T lhs, T rhs, std::index_sequence<Is...>)
 {
-  return thrust::make_tuple(
-    (thrust::get<Is>(lhs) < thrust::get<Is>(rhs) ? thrust::get<Is>(rhs) : thrust::get<Is>(lhs))...);
+  return cuda::std::make_tuple((cuda::std::get<Is>(lhs) < cuda::std::get<Is>(rhs)
+                                  ? cuda::std::get<Is>(rhs)
+                                  : cuda::std::get<Is>(lhs))...);
 }
 
 }  // namespace detail
@@ -107,7 +109,7 @@ struct minimum<T, std::enable_if_t<std::is_arithmetic_v<T>>> {
 };
 
 // Binary reduction operator selecting the minimum element of the two input arguments (using
-// operator <), a compatible raft comms op does not exist when T is a thrust::tuple type.
+// operator <), a compatible raft comms op does not exist when T is a cuda::std::tuple type.
 template <typename T>
 struct minimum<T, std::enable_if_t<cugraph::is_thrust_tuple_of_arithmetic<T>::value>> {
   using value_type                       = T;
@@ -144,7 +146,7 @@ struct elementwise_minimum {
   operator()(T const& lhs, T const& rhs) const
   {
     return detail::elementwise_thrust_min(
-      lhs, rhs, std::make_index_sequence<thrust::tuple_size<T>::value>());
+      lhs, rhs, std::make_index_sequence<cuda::std::tuple_size<T>::value>());
   }
 };
 
@@ -167,7 +169,7 @@ struct maximum<T, std::enable_if_t<std::is_arithmetic_v<T>>> {
 };
 
 // Binary reduction operator selecting the maximum element of the two input arguments (using
-// operator <), a compatible raft comms op does not exist when T is a thrust::tuple type.
+// operator <), a compatible raft comms op does not exist when T is a cuda::std::tuple type.
 template <typename T>
 struct maximum<T, std::enable_if_t<cugraph::is_thrust_tuple_of_arithmetic<T>::value>> {
   using value_type                       = T;
@@ -204,7 +206,7 @@ struct elementwise_maximum {
   operator()(T const& lhs, T const& rhs) const
   {
     return detail::elementwise_thrust_max(
-      lhs, rhs, std::make_index_sequence<thrust::tuple_size<T>::value>());
+      lhs, rhs, std::make_index_sequence<cuda::std::tuple_size<T>::value>());
   }
 };
 

--- a/cpp/src/prims/reduce_v.cuh
+++ b/cpp/src/prims/reduce_v.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ namespace cugraph {
  * @tparam GraphViewType Type of the passed non-owning graph object.
  * @tparam ReduceOp Type of the binary reduction operator.
  * @tparam VertexValueInputIterator Type of the iterator for vertex property values.
- * @tparam T Type of the initial value. T should be an arithmetic type or thrust::tuple of
+ * @tparam T Type of the initial value. T should be an arithmetic type or cuda::std::tuple of
  * arithmetic types.
  * @param handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator, and
  * handles to various CUDA libraries) to run graph algorithms.
@@ -184,7 +184,7 @@ T reduce_v(raft::handle_t const& handle,
  * @tparam GraphViewType Type of the passed non-owning graph object.
  * @tparam ReduceOp Type of the binary reduction operator.
  * @tparam VertexValueInputIterator Type of the iterator for vertex property values.
- * @tparam T Type of the initial value. T should be an arithmetic type or thrust::tuple of
+ * @tparam T Type of the initial value. T should be an arithmetic type or cuda::std::tuple of
  * arithmetic types.
  * @param handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator, and
  * handles to various CUDA libraries) to run graph algorithms.
@@ -217,7 +217,7 @@ T reduce_v(raft::handle_t const& handle,
  *
  * @tparam GraphViewType Type of the passed non-owning graph object.
  * @tparam VertexValueInputIterator Type of the iterator for vertex property values.
- * @tparam T Type of the initial value. T should be an arithmetic type or thrust::tuple of
+ * @tparam T Type of the initial value. T should be an arithmetic type or cuda::std::tuple of
  * arithmetic types.
  * @param handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator, and
  * handles to various CUDA libraries) to run graph algorithms.

--- a/cpp/src/prims/transform_e.cuh
+++ b/cpp/src/prims/transform_e.cuh
@@ -143,14 +143,14 @@ struct update_e_value_t {
   EdgeOp e_op{};
   EdgeValueOutputWrapper edge_partition_e_value_output{};
 
-  __device__ void operator()(thrust::tuple<typename GraphViewType::vertex_type,
-                                           typename GraphViewType::vertex_type> edge) const
+  __device__ void operator()(cuda::std::tuple<typename GraphViewType::vertex_type,
+                                              typename GraphViewType::vertex_type> edge) const
   {
     using vertex_t = typename GraphViewType::vertex_type;
     using edge_t   = typename GraphViewType::edge_type;
 
-    auto major = thrust::get<0>(edge);
-    auto minor = thrust::get<1>(edge);
+    auto major = cuda::std::get<0>(edge);
+    auto minor = cuda::std::get<1>(edge);
 
     auto major_offset = edge_partition.major_offset_from_major_nocheck(major);
     auto major_idx    = edge_partition.major_idx_from_major_nocheck(major);
@@ -330,7 +330,7 @@ void transform_e(raft::handle_t const& handle,
     auto num_edges = edge_partition.number_of_edges();
     if constexpr (edge_partition_e_output_device_view_t::has_packed_bool_element) {
       static_assert(edge_partition_e_output_device_view_t::is_packed_bool,
-                    "unimplemented for thrust::tuple types.");
+                    "unimplemented for cuda::std::tuple types.");
       if (edge_partition.number_of_edges() > edge_t{0}) {
         raft::grid_1d_thread_t update_grid(num_edges,
                                            detail::transform_e_kernel_block_size,
@@ -462,7 +462,7 @@ void transform_e(raft::handle_t const& handle,
   static_assert(GraphViewType::is_storage_transposed != EdgeBucketType::is_src_major);
   static_assert(EdgeBucketType::is_sorted_unique);
   static_assert(
-    std::is_same_v<typename EdgeBucketType::key_type, thrust::tuple<vertex_t, vertex_t>>);
+    std::is_same_v<typename EdgeBucketType::key_type, cuda::std::tuple<vertex_t, vertex_t>>);
 
   using edge_partition_src_input_device_view_t = std::conditional_t<
     std::is_same_v<typename EdgeSrcValueInputWrapper::value_type, cuda::std::nullopt_t>,
@@ -554,9 +554,9 @@ void transform_e(raft::handle_t const& handle,
           edge_first + edge_partition_offsets[i],
           edge_first + edge_partition_offsets[i + 1],
           [edge_partition,
-           edge_partition_e_mask] __device__(thrust::tuple<vertex_t, vertex_t> edge) {
-            auto major     = thrust::get<0>(edge);
-            auto minor     = thrust::get<1>(edge);
+           edge_partition_e_mask] __device__(cuda::std::tuple<vertex_t, vertex_t> edge) {
+            auto major     = cuda::std::get<0>(edge);
+            auto minor     = cuda::std::get<1>(edge);
             auto major_idx = edge_partition.major_idx_from_major_nocheck(major);
             if (!major_idx) { return true; }
             vertex_t const* indices{nullptr};

--- a/cpp/src/prims/transform_reduce_dst_nbr_intersection_of_e_endpoints_by_v.cuh
+++ b/cpp/src/prims/transform_reduce_dst_nbr_intersection_of_e_endpoints_by_v.cuh
@@ -33,6 +33,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/count.h>
@@ -47,7 +48,6 @@
 #include <thrust/reduce.h>
 #include <thrust/sort.h>
 #include <thrust/tabulate.h>
-#include <thrust/tuple.h>
 
 #include <type_traits>
 
@@ -59,9 +59,9 @@ template <typename vertex_t>
 struct compute_chunk_id_t {
   size_t num_chunks{};
 
-  __device__ int operator()(thrust::tuple<vertex_t, vertex_t> tup) const
+  __device__ int operator()(cuda::std::tuple<vertex_t, vertex_t> tup) const
   {
-    return static_cast<int>(thrust::get<1>(tup) % num_chunks);
+    return static_cast<int>(cuda::std::get<1>(tup) % num_chunks);
   }
 };
 
@@ -88,8 +88,8 @@ struct call_intersection_op_t {
   __device__ auto operator()(size_t i) const
   {
     auto pair         = *(major_minor_pair_first + i);
-    auto major        = thrust::get<0>(pair);
-    auto minor        = thrust::get<1>(pair);
+    auto major        = cuda::std::get<0>(pair);
+    auto minor        = cuda::std::get<1>(pair);
     auto major_offset = edge_partition.major_offset_from_major_nocheck(major);
     auto minor_offset = edge_partition.minor_offset_from_minor_nocheck(minor);
     auto src          = GraphViewType::is_storage_transposed ? minor : major;
@@ -169,10 +169,10 @@ struct accumulate_vertex_property_t {
   VertexValueOutputIterator vertex_value_output_first{};
   property_op<value_type, thrust::plus> vertex_property_add{};
 
-  __device__ void operator()(thrust::tuple<vertex_t, value_type> pair) const
+  __device__ void operator()(cuda::std::tuple<vertex_t, value_type> pair) const
   {
-    auto v        = thrust::get<0>(pair);
-    auto val      = thrust::get<1>(pair);
+    auto v        = cuda::std::get<0>(pair);
+    auto val      = cuda::std::get<1>(pair);
     auto v_offset = v - local_vertex_partition_range_first;
     *(vertex_value_output_first + v_offset) =
       vertex_property_add(*(vertex_value_output_first + v_offset), val);
@@ -187,8 +187,8 @@ struct accumulate_vertex_property_t {
  *
  * Iterate over every edge; intersect destination neighbor lists of source vertex & destination
  * vertex; invoke a user-provided functor per intersection, and reduce the functor output
- * values (thrust::tuple of three values having the same type: one for source, one for destination,
- * and one for every vertex in the intersection) per-vertex. We may add
+ * values (cuda::std::tuple of three values having the same type: one for source, one for
+ * destination, and one for every vertex in the intersection) per-vertex. We may add
  * transform_reduce_triplet_of_dst_nbr_intersection_of_e_endpoints_by_v in the future to allow
  * emitting different values for different vertices in the intersection of edge endpoints. This
  * function is inspired by thrust::transform_reduce().
@@ -214,7 +214,7 @@ struct accumulate_vertex_property_t {
  * destination property values). Use update_edge_dst_property to fill the wrapper.
  * @param intersection_op quinary operator takes edge source, edge destination, property values for
  * the source, property values for the destination, and a list of vertices in the intersection of
- * edge source & destination vertices' destination neighbors and returns a thrust::tuple of three
+ * edge source & destination vertices' destination neighbors and returns a cuda::std::tuple of three
  * values: one value per source vertex, one value for destination vertex, and one value for every
  * vertex in the intersection.
  * @param init Initial value to be added to the reduced @p intersection_op return values for each
@@ -325,7 +325,7 @@ void transform_reduce_dst_nbr_intersection_of_e_endpoints_by_v(
       segment_offsets);
 
     auto vertex_pair_first =
-      thrust::make_zip_iterator(thrust::make_tuple(majors.begin(), minors.begin()));
+      thrust::make_zip_iterator(cuda::std::make_tuple(majors.begin(), minors.begin()));
 
     // FIXME: Peak memory requirement is also dependent on the average minimum degree of the input
     // vertex pairs. We may need a more sophisticated mechanism to set max_chunk_size considering
@@ -378,9 +378,9 @@ void transform_reduce_dst_nbr_intersection_of_e_endpoints_by_v(
         allocate_dataframe_buffer<T>(this_chunk_size, handle.get_stream());
 
       auto triplet_first = thrust::make_zip_iterator(
-        thrust::make_tuple(get_dataframe_buffer_begin(src_value_buffer),
-                           get_dataframe_buffer_begin(dst_value_buffer),
-                           get_dataframe_buffer_begin(intersection_value_buffer)));
+        cuda::std::make_tuple(get_dataframe_buffer_begin(src_value_buffer),
+                              get_dataframe_buffer_begin(dst_value_buffer),
+                              get_dataframe_buffer_begin(intersection_value_buffer)));
       thrust::tabulate(handle.get_thrust_policy(),
                        triplet_first,
                        triplet_first + this_chunk_size,
@@ -409,7 +409,7 @@ void transform_reduce_dst_nbr_intersection_of_e_endpoints_by_v(
                      chunk_vertex_pair_first,
                      chunk_vertex_pair_first + this_chunk_size,
                      thrust::make_zip_iterator(
-                       thrust::make_tuple(chunk_majors.begin(), chunk_minors.begin())));
+                       cuda::std::make_tuple(chunk_majors.begin(), chunk_minors.begin())));
 
         auto [reduced_src_vertices, reduced_src_value_buffer] = detail::sort_and_reduce_by_vertices(
           handle,
@@ -531,7 +531,7 @@ void transform_reduce_dst_nbr_intersection_of_e_endpoints_by_v(
           handle, std::move(rx_reduced_vertices), std::move(rx_reduced_value_buffer));
       }
 
-      auto vertex_value_pair_first = thrust::make_zip_iterator(thrust::make_tuple(
+      auto vertex_value_pair_first = thrust::make_zip_iterator(cuda::std::make_tuple(
         reduced_vertices.begin(), get_dataframe_buffer_begin(reduced_value_buffer)));
       thrust::for_each(
         handle.get_thrust_policy(),

--- a/cpp/src/prims/transform_reduce_e.cuh
+++ b/cpp/src/prims/transform_reduce_e.cuh
@@ -36,13 +36,13 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/transform_reduce.h>
-#include <thrust/tuple.h>
 
 #include <cstdint>
 #include <type_traits>

--- a/cpp/src/prims/transform_reduce_e_by_src_dst_key.cuh
+++ b/cpp/src/prims/transform_reduce_e_by_src_dst_key.cuh
@@ -32,12 +32,12 @@
 #include <raft/core/handle.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/sort.h>
-#include <thrust/tuple.h>
 
 #include <type_traits>
 
@@ -838,8 +838,8 @@ transform_reduce_e_by_src_dst_key(raft::handle_t const& handle,
  * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
  * @return std::tuple Tuple of rmm::device_uvector<typename GraphView::vertex_type> and
  * rmm::device_uvector<T> (if T is arithmetic scalar) or a tuple of rmm::device_uvector objects (if
- * T is a thrust::tuple type of arithmetic scalar types, one rmm::device_uvector object per scalar
- * type).
+ * T is a cuda::std::tuple type of arithmetic scalar types, one rmm::device_uvector object per
+ * scalar type).
  */
 template <typename GraphViewType,
           typename EdgeSrcValueInputWrapper,
@@ -926,8 +926,8 @@ auto transform_reduce_e_by_src_key(raft::handle_t const& handle,
  * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
  * @return std::tuple Tuple of rmm::device_uvector<typename GraphView::vertex_type> and
  * rmm::device_uvector<T> (if T is arithmetic scalar) or a tuple of rmm::device_uvector objects (if
- * T is a thrust::tuple type of arithmetic scalar types, one rmm::device_uvector object per scalar
- * type).
+ * T is a cuda::std::tuple type of arithmetic scalar types, one rmm::device_uvector object per
+ * scalar type).
  */
 template <typename GraphViewType,
           typename EdgeSrcValueInputWrapper,

--- a/cpp/src/prims/update_edge_src_dst_property.cuh
+++ b/cpp/src/prims/update_edge_src_dst_property.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,7 +126,7 @@ void update_edge_major_property(raft::handle_t const& handle,
                                      typename EdgeMajorPropertyOutputWrapper::value_type>();
   static_assert(!contains_packed_bool_element ||
                   std::is_arithmetic_v<typename EdgeMajorPropertyOutputWrapper::value_type>,
-                "unimplemented for thrust::tuple types with a packed bool element.");
+                "unimplemented for cuda::std::tuple types with a packed bool element.");
 
   auto edge_partition_value_firsts = edge_major_property_output.value_firsts();
   if constexpr (GraphViewType::is_multi_gpu) {
@@ -276,7 +276,7 @@ void update_edge_major_property(raft::handle_t const& handle,
                                      typename EdgeMajorPropertyOutputWrapper::value_type>();
   static_assert(!contains_packed_bool_element ||
                   std::is_arithmetic_v<typename EdgeMajorPropertyOutputWrapper::value_type>,
-                "unimplemented for thrust::tuple types with a packed bool element.");
+                "unimplemented for cuda::std::tuple types with a packed bool element.");
 
   using vertex_t = typename GraphViewType::vertex_type;
   using edge_t   = typename GraphViewType::edge_type;
@@ -461,7 +461,7 @@ void update_edge_minor_property(raft::handle_t const& handle,
                                      typename EdgeMinorPropertyOutputWrapper::value_type>();
   static_assert(!contains_packed_bool_element ||
                   std::is_arithmetic_v<typename EdgeMinorPropertyOutputWrapper::value_type>,
-                "unimplemented for thrust::tuple types with a packed bool element.");
+                "unimplemented for cuda::std::tuple types with a packed bool element.");
 
   auto edge_partition_value_first = edge_minor_property_output.value_first();
   if constexpr (GraphViewType::is_multi_gpu) {
@@ -703,7 +703,7 @@ void update_edge_minor_property(raft::handle_t const& handle,
                                      typename EdgeMinorPropertyOutputWrapper::value_type>();
   static_assert(!contains_packed_bool_element ||
                   std::is_arithmetic_v<typename EdgeMinorPropertyOutputWrapper::value_type>,
-                "unimplemented for thrust::tuple types with a packed bool element.");
+                "unimplemented for cuda::std::tuple types with a packed bool element.");
 
   using vertex_t = typename GraphViewType::vertex_type;
   using edge_t   = typename GraphViewType::edge_type;

--- a/cpp/src/prims/update_v_frontier.cuh
+++ b/cpp/src/prims/update_v_frontier.cuh
@@ -24,13 +24,13 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/distance.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/remove.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <algorithm>
 #include <cstdlib>
@@ -56,20 +56,20 @@ struct update_v_frontier_call_v_op_t {
   VertexOp v_op{};
   vertex_t local_vertex_partition_range_first{};
 
-  __device__ uint8_t operator()(thrust::tuple<key_t, payload_t> pair) const
+  __device__ uint8_t operator()(cuda::std::tuple<key_t, payload_t> pair) const
   {
-    auto key     = thrust::get<0>(pair);
-    auto payload = thrust::get<1>(pair);
+    auto key     = cuda::std::get<0>(pair);
+    auto payload = cuda::std::get<1>(pair);
     auto v_offset =
       thrust_tuple_get_or_identity<key_t, 0>(key) - local_vertex_partition_range_first;
     auto v_val       = *(vertex_value_input_first + v_offset);
     auto v_op_result = v_op(key, v_val, payload);
-    if (thrust::get<1>(v_op_result)) {
-      *(vertex_value_output_first + v_offset) = *(thrust::get<1>(v_op_result));
+    if (cuda::std::get<1>(v_op_result)) {
+      *(vertex_value_output_first + v_offset) = *(cuda::std::get<1>(v_op_result));
     }
-    if (thrust::get<0>(v_op_result)) {
-      assert(*(thrust::get<0>(v_op_result)) < std::numeric_limits<uint8_t>::max());
-      return static_cast<uint8_t>(*(thrust::get<0>(v_op_result)));
+    if (cuda::std::get<0>(v_op_result)) {
+      assert(*(cuda::std::get<0>(v_op_result)) < std::numeric_limits<uint8_t>::max());
+      return static_cast<uint8_t>(*(cuda::std::get<0>(v_op_result)));
     } else {
       return std::numeric_limits<uint8_t>::max();
     }
@@ -98,12 +98,12 @@ struct update_v_frontier_call_v_op_t<vertex_t,
       thrust_tuple_get_or_identity<key_t, 0>(key) - local_vertex_partition_range_first;
     auto v_val       = *(vertex_value_input_first + v_offset);
     auto v_op_result = v_op(key, v_val);
-    if (thrust::get<1>(v_op_result)) {
-      *(vertex_value_output_first + v_offset) = *(thrust::get<1>(v_op_result));
+    if (cuda::std::get<1>(v_op_result)) {
+      *(vertex_value_output_first + v_offset) = *(cuda::std::get<1>(v_op_result));
     }
-    if (thrust::get<0>(v_op_result)) {
-      assert(*(thrust::get<0>(v_op_result)) < std::numeric_limits<uint8_t>::max());
-      return static_cast<uint8_t>(*(thrust::get<0>(v_op_result)));
+    if (cuda::std::get<0>(v_op_result)) {
+      assert(*(cuda::std::get<0>(v_op_result)) < std::numeric_limits<uint8_t>::max());
+      return static_cast<uint8_t>(*(cuda::std::get<0>(v_op_result)));
     } else {
       return std::numeric_limits<uint8_t>::max();
     }
@@ -114,9 +114,9 @@ struct update_v_frontier_call_v_op_t<vertex_t,
 // after if constexpr else statement that involves device lambda (bug report submitted)
 template <typename key_t>
 struct check_invalid_bucket_idx_t {
-  __device__ bool operator()(thrust::tuple<uint8_t, key_t> pair)
+  __device__ bool operator()(cuda::std::tuple<uint8_t, key_t> pair)
   {
-    return thrust::get<0>(pair) == std::numeric_limits<uint8_t>::max();
+    return cuda::std::get<0>(pair) == std::numeric_limits<uint8_t>::max();
   }
 };
 
@@ -211,7 +211,7 @@ void update_v_frontier(raft::handle_t const& handle,
     rmm::device_uvector<uint8_t> bucket_indices(size_dataframe_buffer(key_buffer),
                                                 handle.get_stream());
 
-    auto key_payload_pair_first = thrust::make_zip_iterator(thrust::make_tuple(
+    auto key_payload_pair_first = thrust::make_zip_iterator(cuda::std::make_tuple(
       get_dataframe_buffer_begin(key_buffer), get_dataframe_buffer_begin(payload_buffer)));
     thrust::transform(handle.get_thrust_policy(),
                       key_payload_pair_first,
@@ -232,7 +232,7 @@ void update_v_frontier(raft::handle_t const& handle,
     shrink_to_fit_dataframe_buffer(payload_buffer, handle.get_stream());
 
     auto bucket_key_pair_first = thrust::make_zip_iterator(
-      thrust::make_tuple(bucket_indices.begin(), get_dataframe_buffer_begin(key_buffer)));
+      cuda::std::make_tuple(bucket_indices.begin(), get_dataframe_buffer_begin(key_buffer)));
     bucket_indices.resize(
       thrust::distance(bucket_key_pair_first,
                        thrust::remove_if(handle.get_thrust_policy(),
@@ -351,7 +351,7 @@ void update_v_frontier(raft::handle_t const& handle,
                                                   graph_view.local_vertex_partition_range_first()});
 
     auto bucket_key_pair_first = thrust::make_zip_iterator(
-      thrust::make_tuple(bucket_indices.begin(), get_dataframe_buffer_begin(key_buffer)));
+      cuda::std::make_tuple(bucket_indices.begin(), get_dataframe_buffer_begin(key_buffer)));
     bucket_indices.resize(
       thrust::distance(bucket_key_pair_first,
                        thrust::remove_if(handle.get_thrust_policy(),

--- a/cpp/src/sampling/detail/check_edge_bias_values.cuh
+++ b/cpp/src/sampling/detail/check_edge_bias_values.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/count.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 

--- a/cpp/src/sampling/detail/gather_one_hop_edgelist_impl.cuh
+++ b/cpp/src/sampling/detail/gather_one_hop_edgelist_impl.cuh
@@ -31,7 +31,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/optional>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 namespace cugraph {
 namespace detail {
@@ -45,49 +45,49 @@ struct return_edges_with_properties_e_op {
                                       EdgeProperties edge_properties) const
   {
     static_assert(std::is_same_v<key_t, vertex_t> ||
-                  std::is_same_v<key_t, thrust::tuple<vertex_t, int32_t>>);
+                  std::is_same_v<key_t, cuda::std::tuple<vertex_t, int32_t>>);
 
     // FIXME: A solution using thrust_tuple_cat would be more flexible here
     if constexpr (std::is_same_v<key_t, vertex_t>) {
       vertex_t src{optionally_tagged_src};
 
       if constexpr (std::is_same_v<EdgeProperties, cuda::std::nullopt_t>) {
-        return cuda::std::make_optional(thrust::make_tuple(src, dst));
+        return cuda::std::make_optional(cuda::std::make_tuple(src, dst));
       } else if constexpr (std::is_arithmetic<EdgeProperties>::value) {
-        return cuda::std::make_optional(thrust::make_tuple(src, dst, edge_properties));
+        return cuda::std::make_optional(cuda::std::make_tuple(src, dst, edge_properties));
       } else if constexpr (cugraph::is_thrust_tuple_of_arithmetic<EdgeProperties>::value &&
-                           (thrust::tuple_size<EdgeProperties>::value == 2)) {
-        return cuda::std::make_optional(thrust::make_tuple(
-          src, dst, thrust::get<0>(edge_properties), thrust::get<1>(edge_properties)));
+                           (cuda::std::tuple_size<EdgeProperties>::value == 2)) {
+        return cuda::std::make_optional(cuda::std::make_tuple(
+          src, dst, cuda::std::get<0>(edge_properties), cuda::std::get<1>(edge_properties)));
       } else if constexpr (cugraph::is_thrust_tuple_of_arithmetic<EdgeProperties>::value &&
-                           (thrust::tuple_size<EdgeProperties>::value == 3)) {
-        return cuda::std::make_optional(thrust::make_tuple(src,
-                                                           dst,
-                                                           thrust::get<0>(edge_properties),
-                                                           thrust::get<1>(edge_properties),
-                                                           thrust::get<2>(edge_properties)));
+                           (cuda::std::tuple_size<EdgeProperties>::value == 3)) {
+        return cuda::std::make_optional(cuda::std::make_tuple(src,
+                                                              dst,
+                                                              cuda::std::get<0>(edge_properties),
+                                                              cuda::std::get<1>(edge_properties),
+                                                              cuda::std::get<2>(edge_properties)));
       }
-    } else if constexpr (std::is_same_v<key_t, thrust::tuple<vertex_t, int32_t>>) {
-      vertex_t src{thrust::get<0>(optionally_tagged_src)};
-      int32_t label{thrust::get<1>(optionally_tagged_src)};
+    } else if constexpr (std::is_same_v<key_t, cuda::std::tuple<vertex_t, int32_t>>) {
+      vertex_t src{cuda::std::get<0>(optionally_tagged_src)};
+      int32_t label{cuda::std::get<1>(optionally_tagged_src)};
 
-      src = thrust::get<0>(optionally_tagged_src);
+      src = cuda::std::get<0>(optionally_tagged_src);
       if constexpr (std::is_same_v<EdgeProperties, cuda::std::nullopt_t>) {
-        return cuda::std::make_optional(thrust::make_tuple(src, dst, label));
+        return cuda::std::make_optional(cuda::std::make_tuple(src, dst, label));
       } else if constexpr (std::is_arithmetic<EdgeProperties>::value) {
-        return cuda::std::make_optional(thrust::make_tuple(src, dst, edge_properties, label));
+        return cuda::std::make_optional(cuda::std::make_tuple(src, dst, edge_properties, label));
       } else if constexpr (cugraph::is_thrust_tuple_of_arithmetic<EdgeProperties>::value &&
-                           (thrust::tuple_size<EdgeProperties>::value == 2)) {
-        return cuda::std::make_optional(thrust::make_tuple(
-          src, dst, thrust::get<0>(edge_properties), thrust::get<1>(edge_properties), label));
+                           (cuda::std::tuple_size<EdgeProperties>::value == 2)) {
+        return cuda::std::make_optional(cuda::std::make_tuple(
+          src, dst, cuda::std::get<0>(edge_properties), cuda::std::get<1>(edge_properties), label));
       } else if constexpr (cugraph::is_thrust_tuple_of_arithmetic<EdgeProperties>::value &&
-                           (thrust::tuple_size<EdgeProperties>::value == 3)) {
-        return cuda::std::make_optional(thrust::make_tuple(src,
-                                                           dst,
-                                                           thrust::get<0>(edge_properties),
-                                                           thrust::get<1>(edge_properties),
-                                                           thrust::get<2>(edge_properties),
-                                                           label));
+                           (cuda::std::tuple_size<EdgeProperties>::value == 3)) {
+        return cuda::std::make_optional(cuda::std::make_tuple(src,
+                                                              dst,
+                                                              cuda::std::get<0>(edge_properties),
+                                                              cuda::std::get<1>(edge_properties),
+                                                              cuda::std::get<2>(edge_properties),
+                                                              label));
       }
     }
   }

--- a/cpp/src/sampling/detail/prepare_next_frontier_impl.cuh
+++ b/cpp/src/sampling/detail/prepare_next_frontier_impl.cuh
@@ -29,8 +29,8 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/sort.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <optional>

--- a/cpp/src/sampling/detail/remove_visited_vertices_from_frontier_sg_v32_e32.cu
+++ b/cpp/src/sampling/detail/remove_visited_vertices_from_frontier_sg_v32_e32.cu
@@ -20,9 +20,9 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/remove.h>
-#include <thrust/tuple.h>
 
 #include <optional>
 

--- a/cpp/src/sampling/detail/remove_visited_vertices_from_frontier_sg_v64_e64.cu
+++ b/cpp/src/sampling/detail/remove_visited_vertices_from_frontier_sg_v64_e64.cu
@@ -20,9 +20,9 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/remove.h>
-#include <thrust/tuple.h>
 
 #include <optional>
 

--- a/cpp/src/sampling/detail/sample_edges.cuh
+++ b/cpp/src/sampling/detail/sample_edges.cuh
@@ -30,8 +30,8 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/sort.h>
-#include <thrust/tuple.h>
 
 namespace cugraph {
 namespace detail {
@@ -47,20 +47,20 @@ struct sample_edges_op_t {
   {
     // FIXME: A solution using thrust_tuple_cat would be more flexible here
     if constexpr (std::is_same_v<EdgeProperties, cuda::std::nullopt_t>) {
-      return thrust::make_tuple(src, dst);
+      return cuda::std::make_tuple(src, dst);
     } else if constexpr (std::is_arithmetic<EdgeProperties>::value) {
-      return thrust::make_tuple(src, dst, edge_properties);
+      return cuda::std::make_tuple(src, dst, edge_properties);
     } else if constexpr (cugraph::is_thrust_tuple_of_arithmetic<EdgeProperties>::value &&
-                         (thrust::tuple_size<EdgeProperties>::value == 2)) {
-      return thrust::make_tuple(
-        src, dst, thrust::get<0>(edge_properties), thrust::get<1>(edge_properties));
+                         (cuda::std::tuple_size<EdgeProperties>::value == 2)) {
+      return cuda::std::make_tuple(
+        src, dst, cuda::std::get<0>(edge_properties), cuda::std::get<1>(edge_properties));
     } else if constexpr (cugraph::is_thrust_tuple_of_arithmetic<EdgeProperties>::value &&
-                         (thrust::tuple_size<EdgeProperties>::value == 3)) {
-      return thrust::make_tuple(src,
-                                dst,
-                                thrust::get<0>(edge_properties),
-                                thrust::get<1>(edge_properties),
-                                thrust::get<2>(edge_properties));
+                         (cuda::std::tuple_size<EdgeProperties>::value == 3)) {
+      return cuda::std::make_tuple(src,
+                                   dst,
+                                   cuda::std::get<0>(edge_properties),
+                                   cuda::std::get<1>(edge_properties),
+                                   cuda::std::get<2>(edge_properties));
     }
   }
 };
@@ -148,7 +148,7 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t, weight_t, edge_t, edge_type_t>>{
+              std::optional<cuda::std::tuple<vertex_t, vertex_t, weight_t, edge_t, edge_type_t>>{
                 std::nullopt},
               false);
         } else {
@@ -165,7 +165,7 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t, weight_t, edge_t, edge_type_t>>{
+              std::optional<cuda::std::tuple<vertex_t, vertex_t, weight_t, edge_t, edge_type_t>>{
                 std::nullopt},
               false);
         }
@@ -187,7 +187,7 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t, weight_t, edge_t>>{std::nullopt},
+              std::optional<cuda::std::tuple<vertex_t, vertex_t, weight_t, edge_t>>{std::nullopt},
               false);
         } else {
           std::forward_as_tuple(sample_offsets, std::tie(majors, minors, weights, edge_ids)) =
@@ -202,7 +202,7 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t, weight_t, edge_t>>{std::nullopt},
+              std::optional<cuda::std::tuple<vertex_t, vertex_t, weight_t, edge_t>>{std::nullopt},
               false);
         }
       }
@@ -225,7 +225,8 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t, weight_t, edge_type_t>>{std::nullopt},
+              std::optional<cuda::std::tuple<vertex_t, vertex_t, weight_t, edge_type_t>>{
+                std::nullopt},
               false);
         } else {
           std::forward_as_tuple(sample_offsets, std::tie(majors, minors, weights, edge_types)) =
@@ -240,7 +241,8 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t, weight_t, edge_type_t>>{std::nullopt},
+              std::optional<cuda::std::tuple<vertex_t, vertex_t, weight_t, edge_type_t>>{
+                std::nullopt},
               false);
         }
       } else {
@@ -261,7 +263,7 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t, weight_t>>{std::nullopt},
+              std::optional<cuda::std::tuple<vertex_t, vertex_t, weight_t>>{std::nullopt},
               false);
         } else {
           std::forward_as_tuple(sample_offsets, std::tie(majors, minors, weights)) =
@@ -276,7 +278,7 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t, weight_t>>{std::nullopt},
+              std::optional<cuda::std::tuple<vertex_t, vertex_t, weight_t>>{std::nullopt},
               false);
         }
       }
@@ -301,7 +303,8 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t, edge_t, edge_type_t>>{std::nullopt},
+              std::optional<cuda::std::tuple<vertex_t, vertex_t, edge_t, edge_type_t>>{
+                std::nullopt},
               false);
         } else {
           std::forward_as_tuple(sample_offsets, std::tie(majors, minors, edge_ids, edge_types)) =
@@ -316,7 +319,8 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t, edge_t, edge_type_t>>{std::nullopt},
+              std::optional<cuda::std::tuple<vertex_t, vertex_t, edge_t, edge_type_t>>{
+                std::nullopt},
               false);
         }
       } else {
@@ -337,7 +341,7 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t, edge_t>>{std::nullopt},
+              std::optional<cuda::std::tuple<vertex_t, vertex_t, edge_t>>{std::nullopt},
               false);
         } else {
           std::forward_as_tuple(sample_offsets, std::tie(majors, minors, edge_ids)) =
@@ -352,7 +356,7 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t, edge_t>>{std::nullopt},
+              std::optional<cuda::std::tuple<vertex_t, vertex_t, edge_t>>{std::nullopt},
               false);
         }
       }
@@ -375,7 +379,7 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t, edge_type_t>>{std::nullopt},
+              std::optional<cuda::std::tuple<vertex_t, vertex_t, edge_type_t>>{std::nullopt},
               false);
         } else {
           std::forward_as_tuple(sample_offsets, std::tie(majors, minors, edge_types)) =
@@ -390,7 +394,7 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t, edge_type_t>>{std::nullopt},
+              std::optional<cuda::std::tuple<vertex_t, vertex_t, edge_type_t>>{std::nullopt},
               false);
         }
       } else {
@@ -411,7 +415,7 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t>>{std::nullopt},
+              std::optional<cuda::std::tuple<vertex_t, vertex_t>>{std::nullopt},
               false);
         } else {
           std::forward_as_tuple(sample_offsets, std::tie(majors, minors)) =
@@ -426,7 +430,7 @@ sample_edges(raft::handle_t const& handle,
               rng_state,
               fanout,
               with_replacement,
-              std::optional<thrust::tuple<vertex_t, vertex_t>>{std::nullopt},
+              std::optional<cuda::std::tuple<vertex_t, vertex_t>>{std::nullopt},
               false);
         }
       }

--- a/cpp/src/sampling/random_walks.cuh
+++ b/cpp/src/sampling/random_walks.cuh
@@ -30,6 +30,7 @@
 
 #include <cuda/functional>
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/count.h>
@@ -49,7 +50,6 @@
 #include <thrust/scatter.h>
 #include <thrust/transform.h>
 #include <thrust/transform_scan.h>
-#include <thrust/tuple.h>
 
 #include <cassert>
 #include <cstdlib>  // FIXME: requirement for temporary std::getenv()
@@ -210,7 +210,7 @@ struct col_indx_extract_t {
       d_v_col_indx.begin(),                                 // input2
       out_degs_,                                            // stencil
       thrust::make_zip_iterator(
-        thrust::make_tuple(d_v_next_vertices.begin(), d_v_next_weights.begin())),  // output
+        cuda::std::make_tuple(d_v_next_vertices.begin(), d_v_next_weights.begin())),  // output
       [max_depth         = max_depth_,
        ptr_d_sizes       = sizes_,
        ptr_d_coalesced_v = original::raw_const_ptr(d_coalesced_src_v),
@@ -224,7 +224,7 @@ struct col_indx_extract_t {
 
         auto weight_value = (values ? (*values)[start_row + col_indx]
                                     : weight_t{1});  // account for un-weighted graphs
-        return thrust::make_tuple(col_indices[start_row + col_indx], weight_value);
+        return cuda::std::make_tuple(col_indices[start_row + col_indx], weight_value);
       },
       [] __device__(auto crt_out_deg) { return crt_out_deg > 0; });
   }
@@ -270,8 +270,8 @@ struct col_indx_extract_t {
                        auto opt_tpl_vn_wn = sampler(src_v, rnd_val, prev_v, path_indx, start_path);
 
                        if (opt_tpl_vn_wn.has_value()) {
-                         auto src_vertex = thrust::get<0>(*opt_tpl_vn_wn);
-                         auto crt_weight = thrust::get<1>(*opt_tpl_vn_wn);
+                         auto src_vertex = cuda::std::get<0>(*opt_tpl_vn_wn);
+                         auto crt_weight = cuda::std::get<1>(*opt_tpl_vn_wn);
 
                          ptr_coalesced_v[start_v_pos + 1] = src_vertex;
                          ptr_coalesced_w[start_w_pos]     = crt_weight;
@@ -969,9 +969,10 @@ struct coo_convertor_t {
       handle_.get_thrust_policy(),
       valid_src_indx.begin(),
       valid_src_indx.end(),
-      thrust::make_zip_iterator(thrust::make_tuple(d_src_v.begin(), d_dst_v.begin())),  // start_zip
+      thrust::make_zip_iterator(
+        cuda::std::make_tuple(d_src_v.begin(), d_dst_v.begin())),  // start_zip
       [ptr_d_vertex = original::raw_const_ptr(d_coalesced_v)] __device__(auto indx) {
-        return thrust::make_tuple(ptr_d_vertex[indx], ptr_d_vertex[indx + 1]);
+        return cuda::std::make_tuple(ptr_d_vertex[indx], ptr_d_vertex[indx + 1]);
       });
 
     return std::make_tuple(std::move(d_src_v), std::move(d_dst_v));

--- a/cpp/src/sampling/random_walks_impl.cuh
+++ b/cpp/src/sampling/random_walks_impl.cuh
@@ -60,10 +60,10 @@ struct sample_edges_op_t {
   }
 
   template <typename W = weight_t>
-  __device__ std::enable_if_t<!std::is_same_v<W, void>, thrust::tuple<vertex_t, W>> operator()(
+  __device__ std::enable_if_t<!std::is_same_v<W, void>, cuda::std::tuple<vertex_t, W>> operator()(
     vertex_t, vertex_t dst, cuda::std::nullopt_t, cuda::std::nullopt_t, W w) const
   {
-    return thrust::make_tuple(dst, w);
+    return cuda::std::make_tuple(dst, w);
   }
 };
 
@@ -78,10 +78,10 @@ struct biased_random_walk_e_bias_op_t {
 
 template <typename vertex_t, typename weight_t>
 struct biased_sample_edges_op_t {
-  __device__ thrust::tuple<vertex_t, weight_t> operator()(
+  __device__ cuda::std::tuple<vertex_t, weight_t> operator()(
     vertex_t, vertex_t dst, weight_t, cuda::std::nullopt_t, weight_t weight) const
   {
-    return thrust::make_tuple(dst, weight);
+    return cuda::std::make_tuple(dst, weight);
   }
 };
 
@@ -97,14 +97,14 @@ struct node2vec_random_walk_e_bias_op_t {
   // Unweighted Bias Operator
   template <typename W = weight_t>
   __device__ std::enable_if_t<std::is_same_v<W, void>, bias_t> operator()(
-    thrust::tuple<vertex_t, vertex_t> tagged_src,
+    cuda::std::tuple<vertex_t, vertex_t> tagged_src,
     vertex_t dst,
     cuda::std::nullopt_t,
     cuda::std::nullopt_t,
     cuda::std::nullopt_t) const
   {
     //  Check tag (prev vert) for destination
-    if (dst == thrust::get<1>(tagged_src)) { return 1.0 / p_; }
+    if (dst == cuda::std::get<1>(tagged_src)) { return 1.0 / p_; }
     //  Search zipped vertices for tagged src
     auto lower_itr = thrust::lower_bound(
       thrust::seq,
@@ -124,14 +124,14 @@ struct node2vec_random_walk_e_bias_op_t {
   //  Weighted Bias Operator
   template <typename W = weight_t>
   __device__ std::enable_if_t<!std::is_same_v<W, void>, bias_t> operator()(
-    thrust::tuple<vertex_t, vertex_t> tagged_src,
+    cuda::std::tuple<vertex_t, vertex_t> tagged_src,
     vertex_t dst,
     cuda::std::nullopt_t,
     cuda::std::nullopt_t,
     W) const
   {
     //  Check tag (prev vert) for destination
-    if (dst == thrust::get<1>(tagged_src)) { return 1.0 / p_; }
+    if (dst == cuda::std::get<1>(tagged_src)) { return 1.0 / p_; }
     //  Search zipped vertices for tagged src
     auto lower_itr = thrust::lower_bound(
       thrust::seq,
@@ -153,7 +153,7 @@ template <typename vertex_t, typename weight_t>
 struct node2vec_sample_edges_op_t {
   template <typename W = weight_t>
   __device__ std::enable_if_t<std::is_same_v<W, void>, vertex_t> operator()(
-    thrust::tuple<vertex_t, vertex_t> tagged_src,
+    cuda::std::tuple<vertex_t, vertex_t> tagged_src,
     vertex_t dst,
     cuda::std::nullopt_t,
     cuda::std::nullopt_t,
@@ -163,14 +163,14 @@ struct node2vec_sample_edges_op_t {
   }
 
   template <typename W = weight_t>
-  __device__ std::enable_if_t<!std::is_same_v<W, void>, thrust::tuple<vertex_t, W>> operator()(
-    thrust::tuple<vertex_t, vertex_t> tagged_src,
+  __device__ std::enable_if_t<!std::is_same_v<W, void>, cuda::std::tuple<vertex_t, W>> operator()(
+    cuda::std::tuple<vertex_t, vertex_t> tagged_src,
     vertex_t dst,
     cuda::std::nullopt_t,
     cuda::std::nullopt_t,
     W w) const
   {
-    return thrust::make_tuple(dst, w);
+    return cuda::std::make_tuple(dst, w);
   }
 };
 
@@ -217,7 +217,7 @@ struct uniform_selector {
           size_t{1},
           true,
           std::make_optional(
-            thrust::make_tuple(cugraph::invalid_vertex_id<vertex_t>::value, weight_t{0.0})));
+            cuda::std::make_tuple(cugraph::invalid_vertex_id<vertex_t>::value, weight_t{0.0})));
 
       minors  = std::move(std::get<0>(sample_e_op_results));
       weights = std::move(std::get<1>(sample_e_op_results));
@@ -292,8 +292,8 @@ struct biased_selector {
       rng_state_,
       size_t{1},
       true,
-      std::make_optional(
-        thrust::make_tuple(vertex_t{cugraph::invalid_vertex_id<vertex_t>::value}, weight_t{0.0})));
+      std::make_optional(cuda::std::make_tuple(
+        vertex_t{cugraph::invalid_vertex_id<vertex_t>::value}, weight_t{0.0})));
 
     //  Return results
     return std::make_tuple(std::move(std::get<0>(sample_e_op_results)),
@@ -472,7 +472,7 @@ struct node2vec_selector {
           rng_state_,
           size_t{1},
           true,
-          std::make_optional(thrust::make_tuple(
+          std::make_optional(cuda::std::make_tuple(
             vertex_t{cugraph::invalid_vertex_id<vertex_t>::value}, weight_t{0.0})));
       minors  = std::move(std::get<0>(sample_e_op_results));
       weights = std::move(std::get<1>(sample_e_op_results));
@@ -631,7 +631,9 @@ random_walk_impl(raft::handle_t const& handle,
                cugraph::detail::compute_gpu_id_from_int_vertex_t<vertex_t>{
                  {vertex_partition_range_lasts.begin(), vertex_partition_range_lasts.size()},
                  major_comm_size,
-                 minor_comm_size}] __device__(auto val) { return key_func(thrust::get<0>(val)); },
+                 minor_comm_size}] __device__(auto val) {
+              return key_func(cuda::std::get<0>(val));
+            },
             handle.get_stream());
       } else {
         // Shuffle vertices to correct GPU to compute random indices
@@ -647,7 +649,9 @@ random_walk_impl(raft::handle_t const& handle,
                cugraph::detail::compute_gpu_id_from_int_vertex_t<vertex_t>{
                  {vertex_partition_range_lasts.begin(), vertex_partition_range_lasts.size()},
                  major_comm_size,
-                 minor_comm_size}] __device__(auto val) { return key_func(thrust::get<0>(val)); },
+                 minor_comm_size}] __device__(auto val) {
+              return key_func(cuda::std::get<0>(val));
+            },
             handle.get_stream());
       }
     }
@@ -849,7 +853,7 @@ random_walk_impl(raft::handle_t const& handle,
               handle.get_comms(),
               current_iter,
               current_iter + current_vertices.size(),
-              [] __device__(auto val) { return thrust::get<2>(val); },
+              [] __device__(auto val) { return cuda::std::get<2>(val); },
               handle.get_stream());
         } else {
           auto current_iter = thrust::make_zip_iterator(current_vertices.begin(),
@@ -864,7 +868,7 @@ random_walk_impl(raft::handle_t const& handle,
               handle.get_comms(),
               current_iter,
               current_iter + current_vertices.size(),
-              [] __device__(auto val) { return thrust::get<1>(val); },
+              [] __device__(auto val) { return cuda::std::get<1>(val); },
               handle.get_stream());
         }
       } else {
@@ -880,7 +884,7 @@ random_walk_impl(raft::handle_t const& handle,
               handle.get_comms(),
               current_iter,
               current_iter + current_vertices.size(),
-              [] __device__(auto val) { return thrust::get<2>(val); },
+              [] __device__(auto val) { return cuda::std::get<2>(val); },
               handle.get_stream());
         } else {
           auto current_iter = thrust::make_zip_iterator(
@@ -892,7 +896,7 @@ random_walk_impl(raft::handle_t const& handle,
               handle.get_comms(),
               current_iter,
               current_iter + current_vertices.size(),
-              [] __device__(auto val) { return thrust::get<1>(val); },
+              [] __device__(auto val) { return cuda::std::get<1>(val); },
               handle.get_stream());
         }
       }
@@ -908,9 +912,9 @@ random_walk_impl(raft::handle_t const& handle,
                         result_wgts  = result_weights->data(),
                         level,
                         max_length] __device__(auto tuple) {
-                         vertex_t v                                       = thrust::get<0>(tuple);
-                         weight_t w                                       = thrust::get<1>(tuple);
-                         size_t pos                                       = thrust::get<2>(tuple);
+                         vertex_t v = cuda::std::get<0>(tuple);
+                         weight_t w = cuda::std::get<1>(tuple);
+                         size_t pos = cuda::std::get<2>(tuple);
                          result_verts[pos * (max_length + 1) + level + 1] = v;
                          result_wgts[pos * max_length + level]            = w;
                        });
@@ -920,8 +924,8 @@ random_walk_impl(raft::handle_t const& handle,
         thrust::make_zip_iterator(current_vertices.begin(), current_position.begin()),
         thrust::make_zip_iterator(current_vertices.end(), current_position.end()),
         [result_verts = result_vertices.data(), level, max_length] __device__(auto tuple) {
-          vertex_t v                                       = thrust::get<0>(tuple);
-          size_t pos                                       = thrust::get<1>(tuple);
+          vertex_t v                                       = cuda::std::get<0>(tuple);
+          size_t pos                                       = cuda::std::get<1>(tuple);
           result_verts[pos * (max_length + 1) + level + 1] = v;
         });
     }

--- a/cpp/src/structure/create_graph_from_edgelist_impl.cuh
+++ b/cpp/src/structure/create_graph_from_edgelist_impl.cuh
@@ -32,6 +32,7 @@
 
 #include <raft/core/handle.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/count.h>
@@ -40,7 +41,6 @@
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/sort.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <cstdint>
@@ -58,16 +58,16 @@ struct check_edge_t {
   vertex_t const* sorted_valid_minor_range_first{nullptr};
   vertex_t const* sorted_valid_minor_range_last{nullptr};
 
-  __device__ bool operator()(thrust::tuple<vertex_t, vertex_t> const& e) const
+  __device__ bool operator()(cuda::std::tuple<vertex_t, vertex_t> const& e) const
   {
     return !thrust::binary_search(thrust::seq,
                                   sorted_valid_major_range_first,
                                   sorted_valid_major_range_last,
-                                  thrust::get<0>(e)) ||
+                                  cuda::std::get<0>(e)) ||
            !thrust::binary_search(thrust::seq,
                                   sorted_valid_minor_range_first,
                                   sorted_valid_minor_range_last,
-                                  thrust::get<1>(e));
+                                  cuda::std::get<1>(e));
   }
 };
 
@@ -158,7 +158,7 @@ void expensive_check_edgelist(raft::handle_t const& handle,
     }
 
     auto edge_first = thrust::make_zip_iterator(
-      thrust::make_tuple(edgelist_majors.begin(), edgelist_minors.begin()));
+      cuda::std::make_tuple(edgelist_majors.begin(), edgelist_minors.begin()));
     CUGRAPH_EXPECTS(
       thrust::count_if(handle.get_thrust_policy(),
                        edge_first,
@@ -205,7 +205,7 @@ void expensive_check_edgelist(raft::handle_t const& handle,
       }
 
       auto edge_first = thrust::make_zip_iterator(
-        thrust::make_tuple(edgelist_majors.begin(), edgelist_minors.begin()));
+        cuda::std::make_tuple(edgelist_majors.begin(), edgelist_minors.begin()));
       CUGRAPH_EXPECTS(
         thrust::count_if(handle.get_thrust_policy(),
                          edge_first,
@@ -226,7 +226,7 @@ void expensive_check_edgelist(raft::handle_t const& handle,
                    sorted_vertices.begin());
       thrust::sort(handle.get_thrust_policy(), sorted_vertices.begin(), sorted_vertices.end());
       auto edge_first = thrust::make_zip_iterator(
-        thrust::make_tuple(edgelist_majors.begin(), edgelist_minors.begin()));
+        cuda::std::make_tuple(edgelist_majors.begin(), edgelist_minors.begin()));
       CUGRAPH_EXPECTS(
         thrust::count_if(handle.get_thrust_policy(),
                          edge_first,
@@ -281,10 +281,10 @@ bool check_symmetric(raft::handle_t const& handle,
   if (org_srcs.size() != symmetrized_srcs.size()) { return false; }
 
   auto org_edge_first =
-    thrust::make_zip_iterator(thrust::make_tuple(org_srcs.begin(), org_dsts.begin()));
+    thrust::make_zip_iterator(cuda::std::make_tuple(org_srcs.begin(), org_dsts.begin()));
   thrust::sort(handle.get_thrust_policy(), org_edge_first, org_edge_first + org_srcs.size());
   auto symmetrized_edge_first = thrust::make_zip_iterator(
-    thrust::make_tuple(symmetrized_srcs.begin(), symmetrized_dsts.begin()));
+    cuda::std::make_tuple(symmetrized_srcs.begin(), symmetrized_dsts.begin()));
   thrust::sort(handle.get_thrust_policy(),
                symmetrized_edge_first,
                symmetrized_edge_first + symmetrized_srcs.size());
@@ -308,7 +308,7 @@ bool check_no_parallel_edge(raft::handle_t const& handle,
     handle.get_thrust_policy(), edgelist_dsts.begin(), edgelist_dsts.end(), org_dsts.begin());
 
   auto org_edge_first =
-    thrust::make_zip_iterator(thrust::make_tuple(org_srcs.begin(), org_dsts.begin()));
+    thrust::make_zip_iterator(cuda::std::make_tuple(org_srcs.begin(), org_dsts.begin()));
   thrust::sort(handle.get_thrust_policy(), org_edge_first, org_edge_first + org_srcs.size());
   return thrust::unique(
            handle.get_thrust_policy(), org_edge_first, org_edge_first + edgelist_srcs.size()) ==

--- a/cpp/src/structure/decompress_to_edgelist_impl.cuh
+++ b/cpp/src/structure/decompress_to_edgelist_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,11 +30,11 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/sort.h>
-#include <thrust/tuple.h>
 
 #include <algorithm>
 #include <optional>
@@ -172,10 +172,10 @@ decompress_to_edgelist_impl(
         if (edgelist_ids) {
           if (edgelist_types) {
             auto zip_itr =
-              thrust::make_zip_iterator(thrust::make_tuple(major_ptrs[i],
-                                                           (*edgelist_weights).data() + cur_size,
-                                                           (*edgelist_ids).data() + cur_size,
-                                                           (*edgelist_types).data() + cur_size));
+              thrust::make_zip_iterator(cuda::std::make_tuple(major_ptrs[i],
+                                                              (*edgelist_weights).data() + cur_size,
+                                                              (*edgelist_ids).data() + cur_size,
+                                                              (*edgelist_types).data() + cur_size));
 
             thrust::sort_by_key(handle.get_thrust_policy(),
                                 minor_ptrs[i],
@@ -184,9 +184,9 @@ decompress_to_edgelist_impl(
 
           } else {
             auto zip_itr =
-              thrust::make_zip_iterator(thrust::make_tuple(major_ptrs[i],
-                                                           (*edgelist_weights).data() + cur_size,
-                                                           (*edgelist_ids).data() + cur_size));
+              thrust::make_zip_iterator(cuda::std::make_tuple(major_ptrs[i],
+                                                              (*edgelist_weights).data() + cur_size,
+                                                              (*edgelist_ids).data() + cur_size));
 
             thrust::sort_by_key(handle.get_thrust_policy(),
                                 minor_ptrs[i],
@@ -196,9 +196,9 @@ decompress_to_edgelist_impl(
         } else {
           if (edgelist_types) {
             auto zip_itr =
-              thrust::make_zip_iterator(thrust::make_tuple(major_ptrs[i],
-                                                           (*edgelist_weights).data() + cur_size,
-                                                           (*edgelist_types).data() + cur_size));
+              thrust::make_zip_iterator(cuda::std::make_tuple(major_ptrs[i],
+                                                              (*edgelist_weights).data() + cur_size,
+                                                              (*edgelist_types).data() + cur_size));
 
             thrust::sort_by_key(handle.get_thrust_policy(),
                                 minor_ptrs[i],
@@ -207,7 +207,7 @@ decompress_to_edgelist_impl(
 
           } else {
             auto zip_itr = thrust::make_zip_iterator(
-              thrust::make_tuple(major_ptrs[i], (*edgelist_weights).data() + cur_size));
+              cuda::std::make_tuple(major_ptrs[i], (*edgelist_weights).data() + cur_size));
 
             thrust::sort_by_key(handle.get_thrust_policy(),
                                 minor_ptrs[i],
@@ -219,9 +219,9 @@ decompress_to_edgelist_impl(
         if (edgelist_ids) {
           if (edgelist_types) {
             auto zip_itr =
-              thrust::make_zip_iterator(thrust::make_tuple(major_ptrs[i],
-                                                           (*edgelist_ids).data() + cur_size,
-                                                           (*edgelist_types).data() + cur_size));
+              thrust::make_zip_iterator(cuda::std::make_tuple(major_ptrs[i],
+                                                              (*edgelist_ids).data() + cur_size,
+                                                              (*edgelist_types).data() + cur_size));
 
             thrust::sort_by_key(handle.get_thrust_policy(),
                                 minor_ptrs[i],
@@ -230,7 +230,7 @@ decompress_to_edgelist_impl(
 
           } else {
             auto zip_itr = thrust::make_zip_iterator(
-              thrust::make_tuple(major_ptrs[i], (*edgelist_ids).data() + cur_size));
+              cuda::std::make_tuple(major_ptrs[i], (*edgelist_ids).data() + cur_size));
 
             thrust::sort_by_key(handle.get_thrust_policy(),
                                 minor_ptrs[i],
@@ -240,7 +240,7 @@ decompress_to_edgelist_impl(
         } else {
           if (edgelist_types) {
             auto zip_itr = thrust::make_zip_iterator(
-              thrust::make_tuple(major_ptrs[i], (*edgelist_types).data() + cur_size));
+              cuda::std::make_tuple(major_ptrs[i], (*edgelist_types).data() + cur_size));
 
             thrust::sort_by_key(handle.get_thrust_policy(),
                                 minor_ptrs[i],

--- a/cpp/src/structure/detail/structure_utils.cuh
+++ b/cpp/src/structure/detail/structure_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,7 +113,7 @@ std::tuple<rmm::device_uvector<edge_t>, rmm::device_uvector<vertex_t>> compress_
                                                                                    : invalid_vertex;
                     });
 
-  auto pair_first = thrust::make_zip_iterator(thrust::make_tuple(
+  auto pair_first = thrust::make_zip_iterator(cuda::std::make_tuple(
     dcs_nzd_vertices.begin(), offsets.begin() + (major_hypersparse_first - major_range_first)));
   CUGRAPH_EXPECTS(
     dcs_nzd_vertices.size() < static_cast<size_t>(std::numeric_limits<int32_t>::max()),
@@ -123,7 +123,7 @@ std::tuple<rmm::device_uvector<edge_t>, rmm::device_uvector<vertex_t>> compress_
                                                              pair_first,
                                                              pair_first + dcs_nzd_vertices.size(),
                                                              [] __device__(auto pair) {
-                                                               return thrust::get<0>(pair) ==
+                                                               return cuda::std::get<0>(pair) ==
                                                                       invalid_vertex;
                                                              })),
                           stream_view);
@@ -186,7 +186,7 @@ sort_and_compress_edgelist(
       detail::mem_frugal_partition(pair_first,
                                    pair_first + edgelist_minors.size(),
                                    get_dataframe_buffer_begin(edgelist_values),
-                                   thrust_tuple_get<thrust::tuple<vertex_t, vertex_t>, 0>{},
+                                   thrust_tuple_get<cuda::std::tuple<vertex_t, vertex_t>, 0>{},
                                    pivot,
                                    stream_view);
     thrust::sort_by_key(rmm::exec_policy(stream_view),
@@ -287,19 +287,19 @@ sort_and_compress_edgelist(rmm::device_uvector<vertex_t>&& edgelist_srcs,
       auto second_half_first =
         detail::mem_frugal_partition(pair_first,
                                      pair_first + edgelist_major_offsets.size(),
-                                     thrust_tuple_get<thrust::tuple<uint32_t, vertex_t>, 0>{},
+                                     thrust_tuple_get<cuda::std::tuple<uint32_t, vertex_t>, 0>{},
                                      pivots[1],
                                      stream_view);
       auto second_quarter_first =
         detail::mem_frugal_partition(pair_first,
                                      second_half_first,
-                                     thrust_tuple_get<thrust::tuple<uint32_t, vertex_t>, 0>{},
+                                     thrust_tuple_get<cuda::std::tuple<uint32_t, vertex_t>, 0>{},
                                      pivots[0],
                                      stream_view);
       auto last_quarter_first =
         detail::mem_frugal_partition(second_half_first,
                                      pair_first + edgelist_major_offsets.size(),
-                                     thrust_tuple_get<thrust::tuple<uint32_t, vertex_t>, 0>{},
+                                     thrust_tuple_get<cuda::std::tuple<uint32_t, vertex_t>, 0>{},
                                      pivots[2],
                                      stream_view);
       thrust::sort(rmm::exec_policy(stream_view), pair_first, second_quarter_first);
@@ -330,19 +330,19 @@ sort_and_compress_edgelist(rmm::device_uvector<vertex_t>&& edgelist_srcs,
       auto second_half_first =
         detail::mem_frugal_partition(edge_first,
                                      edge_first + edgelist_majors.size(),
-                                     thrust_tuple_get<thrust::tuple<vertex_t, vertex_t>, 0>{},
+                                     thrust_tuple_get<cuda::std::tuple<vertex_t, vertex_t>, 0>{},
                                      pivots[1],
                                      stream_view);
       auto second_quarter_first =
         detail::mem_frugal_partition(edge_first,
                                      second_half_first,
-                                     thrust_tuple_get<thrust::tuple<vertex_t, vertex_t>, 0>{},
+                                     thrust_tuple_get<cuda::std::tuple<vertex_t, vertex_t>, 0>{},
                                      pivots[0],
                                      stream_view);
       auto last_quarter_first =
         detail::mem_frugal_partition(second_half_first,
                                      edge_first + edgelist_majors.size(),
-                                     thrust_tuple_get<thrust::tuple<vertex_t, vertex_t>, 0>{},
+                                     thrust_tuple_get<cuda::std::tuple<vertex_t, vertex_t>, 0>{},
                                      pivots[2],
                                      stream_view);
       thrust::sort(rmm::exec_policy(stream_view), edge_first, second_quarter_first);

--- a/cpp/src/structure/graph_impl.cuh
+++ b/cpp/src/structure/graph_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cub/cub.cuh>
+#include <cuda/std/tuple>
 #include <thrust/adjacent_difference.h>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
@@ -53,7 +54,6 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <algorithm>
@@ -72,10 +72,10 @@ struct out_of_range_t {
   vertex_t minor_range_first{};
   vertex_t minor_range_last{};
 
-  __device__ bool operator()(thrust::tuple<vertex_t, vertex_t> t) const
+  __device__ bool operator()(cuda::std::tuple<vertex_t, vertex_t> t) const
   {
-    auto major = thrust::get<0>(t);
-    auto minor = thrust::get<1>(t);
+    auto major = cuda::std::get<0>(t);
+    auto minor = cuda::std::get<1>(t);
     return (major < major_range_first) || (major >= major_range_last) ||
            (minor < minor_range_first) || (minor >= minor_range_last);
   }

--- a/cpp/src/structure/graph_view_impl.cuh
+++ b/cpp/src/structure/graph_view_impl.cuh
@@ -39,6 +39,7 @@
 
 #include <cuda/functional>
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/count.h>
 #include <thrust/extrema.h>
@@ -52,7 +53,6 @@
 #include <thrust/tabulate.h>
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
-#include <thrust/tuple.h>
 
 #include <algorithm>
 #include <cstdint>
@@ -853,8 +853,8 @@ graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu, std::enable_if_t<mul
                       thrust::make_permutation_iterator(
                         ret.begin(), edge_indices.begin() + edge_partition_offsets[i]),
                       [edge_partition, edge_partition_e_mask] __device__(auto e) {
-                        auto major     = thrust::get<0>(e);
-                        auto minor     = thrust::get<1>(e);
+                        auto major     = cuda::std::get<0>(e);
+                        auto minor     = cuda::std::get<1>(e);
                         auto major_idx = edge_partition.major_idx_from_major_nocheck(major);
                         if (major_idx) {
                           vertex_t const* indices{nullptr};
@@ -924,8 +924,8 @@ graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu, std::enable_if_t<!mu
     edge_first + edge_srcs.size(),
     ret.begin(),
     [edge_partition, edge_partition_e_mask] __device__(auto e) {
-      auto major        = thrust::get<0>(e);
-      auto minor        = thrust::get<1>(e);
+      auto major        = cuda::std::get<0>(e);
+      auto minor        = cuda::std::get<1>(e);
       auto major_offset = edge_partition.major_offset_from_major_nocheck(major);
       vertex_t const* indices{nullptr};
       edge_t local_edge_offset{};
@@ -999,8 +999,8 @@ graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu, std::enable_if_t<mul
       thrust::make_permutation_iterator(ret.begin(),
                                         edge_indices.begin() + edge_partition_offsets[i]),
       [edge_partition, edge_partition_e_mask] __device__(auto e) {
-        auto major     = thrust::get<0>(e);
-        auto minor     = thrust::get<1>(e);
+        auto major     = cuda::std::get<0>(e);
+        auto minor     = cuda::std::get<1>(e);
         auto major_idx = edge_partition.major_idx_from_major_nocheck(major);
         if (major_idx) {
           vertex_t const* indices{nullptr};
@@ -1069,8 +1069,8 @@ graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu, std::enable_if_t<!mu
     edge_first + edge_srcs.size(),
     ret.begin(),
     [edge_partition, edge_partition_e_mask] __device__(auto e) {
-      auto major        = thrust::get<0>(e);
-      auto minor        = thrust::get<1>(e);
+      auto major        = cuda::std::get<0>(e);
+      auto minor        = cuda::std::get<1>(e);
       auto major_offset = edge_partition.major_offset_from_major_nocheck(major);
       vertex_t const* indices{nullptr};
       edge_t local_edge_offset{};

--- a/cpp/src/structure/induced_subgraph_impl.cuh
+++ b/cpp/src/structure/induced_subgraph_impl.cuh
@@ -35,6 +35,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/count.h>
@@ -48,7 +49,6 @@
 #include <thrust/scan.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 
@@ -58,48 +58,48 @@ namespace detail {
 
 template <typename vertex_t, typename weight_t, typename property_t>
 struct induced_subgraph_weighted_edge_op {
-  using return_type = cuda::std::optional<thrust::tuple<vertex_t, vertex_t, weight_t, size_t>>;
+  using return_type = cuda::std::optional<cuda::std::tuple<vertex_t, vertex_t, weight_t, size_t>>;
 
   raft::device_span<size_t const> dst_subgraph_offsets;
   raft::device_span<vertex_t const> dst_subgraph_vertices;
 
-  return_type __device__ operator()(thrust::tuple<vertex_t, size_t> tagged_src,
+  return_type __device__ operator()(cuda::std::tuple<vertex_t, size_t> tagged_src,
                                     vertex_t dst,
                                     property_t sv,
                                     property_t dv,
                                     weight_t wgt) const
   {
-    size_t subgraph = thrust::get<1>(tagged_src);
+    size_t subgraph = cuda::std::get<1>(tagged_src);
     return thrust::binary_search(thrust::seq,
                                  dst_subgraph_vertices.data() + dst_subgraph_offsets[subgraph],
                                  dst_subgraph_vertices.data() + dst_subgraph_offsets[subgraph + 1],
                                  dst)
              ? cuda::std::make_optional(
-                 thrust::make_tuple(thrust::get<0>(tagged_src), dst, wgt, subgraph))
+                 cuda::std::make_tuple(cuda::std::get<0>(tagged_src), dst, wgt, subgraph))
              : cuda::std::nullopt;
   }
 };
 
 template <typename vertex_t, typename property_t>
 struct induced_subgraph_unweighted_edge_op {
-  using return_type = cuda::std::optional<thrust::tuple<vertex_t, vertex_t, size_t>>;
+  using return_type = cuda::std::optional<cuda::std::tuple<vertex_t, vertex_t, size_t>>;
 
   raft::device_span<size_t const> dst_subgraph_offsets;
   raft::device_span<vertex_t const> dst_subgraph_vertices;
 
-  return_type __device__ operator()(thrust::tuple<vertex_t, size_t> tagged_src,
+  return_type __device__ operator()(cuda::std::tuple<vertex_t, size_t> tagged_src,
                                     vertex_t dst,
                                     property_t sv,
                                     property_t dv,
                                     cuda::std::nullopt_t) const
   {
-    size_t subgraph = thrust::get<1>(tagged_src);
+    size_t subgraph = cuda::std::get<1>(tagged_src);
     return thrust::binary_search(thrust::seq,
                                  dst_subgraph_vertices.data() + dst_subgraph_offsets[subgraph],
                                  dst_subgraph_vertices.data() + dst_subgraph_offsets[subgraph + 1],
                                  dst)
              ? cuda::std::make_optional(
-                 thrust::make_tuple(thrust::get<0>(tagged_src), dst, subgraph))
+                 cuda::std::make_tuple(cuda::std::get<0>(tagged_src), dst, subgraph))
              : cuda::std::nullopt;
   }
 };

--- a/cpp/src/structure/relabel_impl.cuh
+++ b/cpp/src/structure/relabel_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/polymorphic_allocator.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/distance.h>
@@ -38,7 +39,6 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <algorithm>
@@ -103,14 +103,14 @@ void relabel(raft::handle_t const& handle,
                      std::get<1>(old_new_label_pairs) + num_label_pairs,
                      label_pair_new_labels.begin());
         auto pair_first = thrust::make_zip_iterator(
-          thrust::make_tuple(label_pair_old_labels.begin(), label_pair_new_labels.begin()));
+          cuda::std::make_tuple(label_pair_old_labels.begin(), label_pair_new_labels.begin()));
         std::forward_as_tuple(std::tie(rx_label_pair_old_labels, rx_label_pair_new_labels),
                               std::ignore) =
           groupby_gpu_id_and_shuffle_values(
             handle.get_comms(),
             pair_first,
             pair_first + num_label_pairs,
-            [key_func] __device__(auto val) { return key_func(thrust::get<0>(val)); },
+            [key_func] __device__(auto val) { return key_func(cuda::std::get<0>(val)); },
             handle.get_stream());
       }
 

--- a/cpp/src/structure/remove_multi_edges_impl.cuh
+++ b/cpp/src/structure/remove_multi_edges_impl.cuh
@@ -30,11 +30,11 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/cstddef>
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/distance.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/sort.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <cuco/hash_functions.cuh>
@@ -50,11 +50,11 @@ template <typename vertex_t>
 struct hash_src_dst_pair {
   int32_t num_groups;
 
-  int32_t __device__ operator()(thrust::tuple<vertex_t, vertex_t> t) const
+  int32_t __device__ operator()(cuda::std::tuple<vertex_t, vertex_t> t) const
   {
     vertex_t pair[2];
-    pair[0] = thrust::get<0>(t);
-    pair[1] = thrust::get<1>(t);
+    pair[0] = cuda::std::get<0>(t);
+    pair[1] = cuda::std::get<1>(t);
     cuco::murmurhash3_32<vertex_t*> hash_func{};
     return hash_func.compute_hash(reinterpret_cast<cuda::std::byte*>(pair), 2 * sizeof(vertex_t)) %
            num_groups;

--- a/cpp/src/structure/remove_self_loops_impl.cuh
+++ b/cpp/src/structure/remove_self_loops_impl.cuh
@@ -21,11 +21,11 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/count.h>
 #include <thrust/distance.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/remove.h>
-#include <thrust/tuple.h>
 
 #include <algorithm>
 #include <optional>

--- a/cpp/src/structure/renumber_edgelist_impl.cuh
+++ b/cpp/src/structure/renumber_edgelist_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/polymorphic_allocator.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/count.h>
@@ -48,7 +49,6 @@
 #include <thrust/merge.h>
 #include <thrust/reduce.h>
 #include <thrust/sort.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <cuco/hash_functions.cuh>
@@ -67,12 +67,12 @@ struct check_edge_src_and_dst_t {
   raft::device_span<vertex_t const> sorted_majors{};
   raft::device_span<vertex_t const> sorted_minors{};
 
-  __device__ bool operator()(thrust::tuple<vertex_t, vertex_t> e) const
+  __device__ bool operator()(cuda::std::tuple<vertex_t, vertex_t> e) const
   {
     return !thrust::binary_search(
-             thrust::seq, sorted_majors.begin(), sorted_majors.end(), thrust::get<0>(e)) ||
+             thrust::seq, sorted_majors.begin(), sorted_majors.end(), cuda::std::get<0>(e)) ||
            !thrust::binary_search(
-             thrust::seq, sorted_minors.begin(), sorted_minors.end(), thrust::get<1>(e));
+             thrust::seq, sorted_minors.begin(), sorted_minors.end(), cuda::std::get<1>(e));
   }
 };
 
@@ -106,13 +106,13 @@ struct search_and_increment_degree_t {
   vertex_t num_vertices{0};
   edge_t* degrees{nullptr};
 
-  __device__ void operator()(thrust::tuple<vertex_t, edge_t> vertex_degree_pair) const
+  __device__ void operator()(cuda::std::tuple<vertex_t, edge_t> vertex_degree_pair) const
   {
     auto it = thrust::lower_bound(thrust::seq,
                                   sorted_vertices,
                                   sorted_vertices + num_vertices,
-                                  thrust::get<0>(vertex_degree_pair));
-    *(degrees + thrust::distance(sorted_vertices, it)) += thrust::get<1>(vertex_degree_pair);
+                                  cuda::std::get<0>(vertex_degree_pair));
+    *(degrees + thrust::distance(sorted_vertices, it)) += cuda::std::get<1>(vertex_degree_pair);
   }
 };
 
@@ -763,7 +763,7 @@ void expensive_check_edgelist(
 
     for (size_t i = 0; i < edgelist_majors.size(); ++i) {
       auto edge_first =
-        thrust::make_zip_iterator(thrust::make_tuple(edgelist_majors[i], edgelist_minors[i]));
+        thrust::make_zip_iterator(cuda::std::make_tuple(edgelist_majors[i], edgelist_minors[i]));
       CUGRAPH_EXPECTS(
         thrust::count_if(
           handle.get_thrust_policy(),
@@ -781,7 +781,8 @@ void expensive_check_edgelist(
            local_edge_partition_id_key_func =
              detail::compute_local_edge_partition_id_from_ext_edge_endpoints_t<vertex_t>{
                comm_size, major_comm_size, minor_comm_size}] __device__(auto edge) {
-            return (gpu_id_key_func(thrust::get<0>(edge), thrust::get<1>(edge)) != comm_rank) ||
+            return (gpu_id_key_func(cuda::std::get<0>(edge), cuda::std::get<1>(edge)) !=
+                    comm_rank) ||
                    (local_edge_partition_id_key_func(edge) != i);
           }) == 0,
         "Invalid input argument: edgelist_majors & edgelist_minors should be "
@@ -854,7 +855,7 @@ void expensive_check_edgelist(
         }
 
         auto edge_first =
-          thrust::make_zip_iterator(thrust::make_tuple(edgelist_majors[i], edgelist_minors[i]));
+          thrust::make_zip_iterator(cuda::std::make_tuple(edgelist_majors[i], edgelist_minors[i]));
 
         CUGRAPH_EXPECTS(
           thrust::count_if(
@@ -876,7 +877,7 @@ void expensive_check_edgelist(
 
     if (sorted_local_vertices) {
       auto edge_first =
-        thrust::make_zip_iterator(thrust::make_tuple(edgelist_majors[0], edgelist_minors[0]));
+        thrust::make_zip_iterator(cuda::std::make_tuple(edgelist_majors[0], edgelist_minors[0]));
       CUGRAPH_EXPECTS(
         thrust::count_if(handle.get_thrust_policy(),
                          edge_first,

--- a/cpp/src/structure/renumber_utils_impl.cuh
+++ b/cpp/src/structure/renumber_utils_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/polymorphic_allocator.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/count.h>
@@ -39,7 +40,6 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 namespace cugraph {
@@ -432,13 +432,14 @@ void renumber_ext_vertices(raft::handle_t const& handle,
     rmm::device_uvector<bool> contains(num_vertices, handle.get_stream());
     renumber_map_view.contains(
       vertices, vertices + num_vertices, contains.begin(), handle.get_stream());
-    auto vc_pair_first = thrust::make_zip_iterator(thrust::make_tuple(vertices, contains.begin()));
+    auto vc_pair_first =
+      thrust::make_zip_iterator(cuda::std::make_tuple(vertices, contains.begin()));
     CUGRAPH_EXPECTS(thrust::count_if(handle.get_thrust_policy(),
                                      vc_pair_first,
                                      vc_pair_first + num_vertices,
                                      [] __device__(auto pair) {
-                                       auto v = thrust::get<0>(pair);
-                                       auto c = thrust::get<1>(pair);
+                                       auto v = cuda::std::get<0>(pair);
+                                       auto c = cuda::std::get<1>(pair);
                                        return v == invalid_vertex_id<vertex_t>::value
                                                 ? (c == true)
                                                 : (c == false);
@@ -485,13 +486,14 @@ void renumber_local_ext_vertices(raft::handle_t const& handle,
     rmm::device_uvector<bool> contains(num_vertices, handle.get_stream());
     renumber_map_view.contains(
       vertices, vertices + num_vertices, contains.begin(), handle.get_stream());
-    auto vc_pair_first = thrust::make_zip_iterator(thrust::make_tuple(vertices, contains.begin()));
+    auto vc_pair_first =
+      thrust::make_zip_iterator(cuda::std::make_tuple(vertices, contains.begin()));
     CUGRAPH_EXPECTS(thrust::count_if(handle.get_thrust_policy(),
                                      vc_pair_first,
                                      vc_pair_first + num_vertices,
                                      [] __device__(auto pair) {
-                                       auto v = thrust::get<0>(pair);
-                                       auto c = thrust::get<1>(pair);
+                                       auto v = cuda::std::get<0>(pair);
+                                       auto c = cuda::std::get<1>(pair);
                                        return v == invalid_vertex_id<vertex_t>::value
                                                 ? (c == true)
                                                 : (c == false);

--- a/cpp/src/structure/symmetrize_edgelist_impl.cuh
+++ b/cpp/src/structure/symmetrize_edgelist_impl.cuh
@@ -23,6 +23,7 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/distance.h>
 #include <thrust/for_each.h>
@@ -36,7 +37,6 @@
 #include <thrust/set_operations.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <algorithm>
 #include <optional>
@@ -48,11 +48,13 @@ namespace {
 // compare after flipping major & minor
 template <typename vertex_t, typename weight_t>
 struct compare_upper_triangular_edges_as_lower_triangular_t {
-  __device__ bool operator()(thrust::tuple<vertex_t, vertex_t, weight_t> const& lhs,
-                             thrust::tuple<vertex_t, vertex_t, weight_t> const& rhs) const
+  __device__ bool operator()(cuda::std::tuple<vertex_t, vertex_t, weight_t> const& lhs,
+                             cuda::std::tuple<vertex_t, vertex_t, weight_t> const& rhs) const
   {
-    return thrust::make_tuple(thrust::get<1>(lhs), thrust::get<0>(lhs), thrust::get<2>(lhs)) <
-           thrust::make_tuple(thrust::get<1>(rhs), thrust::get<0>(rhs), thrust::get<2>(rhs));
+    return cuda::std::make_tuple(
+             cuda::std::get<1>(lhs), cuda::std::get<0>(lhs), cuda::std::get<2>(lhs)) <
+           cuda::std::make_tuple(
+             cuda::std::get<1>(rhs), cuda::std::get<0>(rhs), cuda::std::get<2>(rhs));
   }
 };
 
@@ -61,21 +63,21 @@ struct compare_upper_triangular_edges_as_lower_triangular_t {
 // upper triangular edges
 template <typename vertex_t, typename weight_t>
 struct compare_lower_and_upper_triangular_edges_t {
-  __device__ bool operator()(thrust::tuple<vertex_t, vertex_t, weight_t> const& lhs,
-                             thrust::tuple<vertex_t, vertex_t, weight_t> const& rhs) const
+  __device__ bool operator()(cuda::std::tuple<vertex_t, vertex_t, weight_t> const& lhs,
+                             cuda::std::tuple<vertex_t, vertex_t, weight_t> const& rhs) const
   {
-    auto lhs_in_lower = thrust::get<0>(lhs) > thrust::get<1>(lhs);
-    auto rhs_in_lower = thrust::get<0>(rhs) > thrust::get<1>(rhs);
-    return thrust::make_tuple(
-             lhs_in_lower ? thrust::get<0>(lhs) : thrust::get<1>(lhs),
-             lhs_in_lower ? thrust::get<1>(lhs) : thrust::get<0>(lhs),
+    auto lhs_in_lower = cuda::std::get<0>(lhs) > cuda::std::get<1>(lhs);
+    auto rhs_in_lower = cuda::std::get<0>(rhs) > cuda::std::get<1>(rhs);
+    return cuda::std::make_tuple(
+             lhs_in_lower ? cuda::std::get<0>(lhs) : cuda::std::get<1>(lhs),
+             lhs_in_lower ? cuda::std::get<1>(lhs) : cuda::std::get<0>(lhs),
              !lhs_in_lower,  // lower triangular edges comes before upper triangular edges
-             thrust::get<2>(lhs)) <
-           thrust::make_tuple(
-             rhs_in_lower ? thrust::get<0>(rhs) : thrust::get<1>(rhs),
-             rhs_in_lower ? thrust::get<1>(rhs) : thrust::get<0>(rhs),
+             cuda::std::get<2>(lhs)) <
+           cuda::std::make_tuple(
+             rhs_in_lower ? cuda::std::get<0>(rhs) : cuda::std::get<1>(rhs),
+             rhs_in_lower ? cuda::std::get<1>(rhs) : cuda::std::get<0>(rhs),
              !rhs_in_lower,  // lower triangular edges comes before upper triangular edges
-             thrust::get<2>(rhs));
+             cuda::std::get<2>(rhs));
   }
 };
 
@@ -96,9 +98,10 @@ struct symmetrize_op_t {
     auto max_run_length = lower_run_length < upper_run_length ? upper_run_length : lower_run_length;
     for (size_t i = 0; i < max_run_length; ++i) {
       if (i < min_run_length) {
-        thrust::get<2>(*(edge_first + i)) = (thrust::get<2>(*(edge_first + i)) +
-                                             thrust::get<2>(*(edge_first + lower_run_length + i))) /
-                                            weight_t{2};  // average
+        cuda::std::get<2>(*(edge_first + i)) =
+          (cuda::std::get<2>(*(edge_first + i)) +
+           cuda::std::get<2>(*(edge_first + lower_run_length + i))) /
+          weight_t{2};  // average
         *(include_first + i)                    = true;
         *(include_first + lower_run_length + i) = false;
       } else {
@@ -127,12 +130,12 @@ struct update_edge_weights_and_flags_t {
     } else {
       auto cur       = *(edge_first + i);
       auto prev      = *(edge_first + (i - 1));
-      auto cur_pair  = thrust::get<0>(cur) > thrust::get<1>(cur)
-                         ? thrust::make_tuple(thrust::get<0>(cur), thrust::get<1>(cur))
-                         : thrust::make_tuple(thrust::get<1>(cur), thrust::get<0>(cur));
-      auto prev_pair = thrust::get<0>(prev) > thrust::get<1>(prev)
-                         ? thrust::make_tuple(thrust::get<0>(prev), thrust::get<1>(prev))
-                         : thrust::make_tuple(thrust::get<1>(prev), thrust::get<0>(prev));
+      auto cur_pair  = cuda::std::get<0>(cur) > cuda::std::get<1>(cur)
+                         ? cuda::std::make_tuple(cuda::std::get<0>(cur), cuda::std::get<1>(cur))
+                         : cuda::std::make_tuple(cuda::std::get<1>(cur), cuda::std::get<0>(cur));
+      auto prev_pair = cuda::std::get<0>(prev) > cuda::std::get<1>(prev)
+                         ? cuda::std::make_tuple(cuda::std::get<0>(prev), cuda::std::get<1>(prev))
+                         : cuda::std::make_tuple(cuda::std::get<1>(prev), cuda::std::get<0>(prev));
       first_in_run   = cur_pair != prev_pair;
     }
 
@@ -140,13 +143,14 @@ struct update_edge_weights_and_flags_t {
       auto first = *(edge_first + i);
       size_t lower_run_length{0};
       size_t upper_run_length{0};
-      auto pair_first = thrust::get<0>(first) > thrust::get<1>(first)
-                          ? thrust::make_tuple(thrust::get<0>(first), thrust::get<1>(first))
-                          : thrust::make_tuple(thrust::get<1>(first), thrust::get<0>(first));
+      auto pair_first =
+        cuda::std::get<0>(first) > cuda::std::get<1>(first)
+          ? cuda::std::make_tuple(cuda::std::get<0>(first), cuda::std::get<1>(first))
+          : cuda::std::make_tuple(cuda::std::get<1>(first), cuda::std::get<0>(first));
       while (i + lower_run_length < num_edges) {
         auto cur = *(edge_first + i + lower_run_length);
-        if ((thrust::get<0>(cur) > thrust::get<1>(cur)) &&
-            (thrust::make_tuple(thrust::get<0>(cur), thrust::get<1>(cur)) == pair_first)) {
+        if ((cuda::std::get<0>(cur) > cuda::std::get<1>(cur)) &&
+            (cuda::std::make_tuple(cuda::std::get<0>(cur), cuda::std::get<1>(cur)) == pair_first)) {
           ++lower_run_length;
         } else {
           break;
@@ -154,8 +158,8 @@ struct update_edge_weights_and_flags_t {
       }
       while (i + lower_run_length + upper_run_length < num_edges) {
         auto cur = *(edge_first + i + lower_run_length + upper_run_length);
-        if ((thrust::get<0>(cur) < thrust::get<1>(cur)) &&
-            (thrust::make_tuple(thrust::get<1>(cur), thrust::get<0>(cur)) == pair_first)) {
+        if ((cuda::std::get<0>(cur) < cuda::std::get<1>(cur)) &&
+            (cuda::std::make_tuple(cuda::std::get<1>(cur), cuda::std::get<0>(cur)) == pair_first)) {
           ++upper_run_length;
         } else {
           break;
@@ -169,11 +173,12 @@ struct update_edge_weights_and_flags_t {
 
 template <typename vertex_t>
 struct to_lower_triangular_t {
-  __device__ thrust::tuple<vertex_t, vertex_t> operator()(thrust::tuple<vertex_t, vertex_t> e) const
+  __device__ cuda::std::tuple<vertex_t, vertex_t> operator()(
+    cuda::std::tuple<vertex_t, vertex_t> e) const
   {
-    return thrust::get<0>(e) > thrust::get<1>(e)
+    return cuda::std::get<0>(e) > cuda::std::get<1>(e)
              ? e
-             : thrust::make_tuple(thrust::get<1>(e), thrust::get<0>(e));
+             : cuda::std::make_tuple(cuda::std::get<1>(e), cuda::std::get<0>(e));
   }
 };
 
@@ -231,7 +236,7 @@ merge_lower_triangular(raft::handle_t const& handle,
   merged_minors.resize(merged_majors.size(), handle.get_stream());
   merged_properties.resize(merged_majors.size(), handle.get_stream());
   auto merged_first = thrust::make_zip_iterator(
-    thrust::make_tuple(merged_majors.begin(), merged_minors.begin(), merged_properties.begin()));
+    cuda::std::make_tuple(merged_majors.begin(), merged_minors.begin(), merged_properties.begin()));
   thrust::merge(handle.get_thrust_policy(),
                 lower_triangular_edge_first,
                 lower_triangular_edge_first + lower_triangular_majors.size(),
@@ -269,7 +274,7 @@ merge_lower_triangular(raft::handle_t const& handle,
                      thrust::remove_if(handle.get_thrust_policy(),
                                        merged_edge_and_flag_first,
                                        merged_edge_and_flag_first + merged_majors.size(),
-                                       [] __device__(auto t) { return !thrust::get<3>(t); })),
+                                       [] __device__(auto t) { return !cuda::std::get<3>(t); })),
     handle.get_stream());
   merged_majors.shrink_to_fit(handle.get_stream());
   merged_minors.resize(merged_majors.size(), handle.get_stream());
@@ -303,12 +308,12 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> merge_l
   rmm::device_uvector<vertex_t> merged_minors(0, handle.get_stream());
 
   auto lower_triangular_edge_first = thrust::make_zip_iterator(
-    thrust::make_tuple(lower_triangular_majors.begin(), lower_triangular_minors.begin()));
+    cuda::std::make_tuple(lower_triangular_majors.begin(), lower_triangular_minors.begin()));
   thrust::sort(handle.get_thrust_policy(),
                lower_triangular_edge_first,
                lower_triangular_edge_first + lower_triangular_majors.size());
-  auto upper_triangular_edge_first = thrust::make_zip_iterator(
-    thrust::make_tuple(upper_triangular_minors.begin(), upper_triangular_majors.begin()));  // flip
+  auto upper_triangular_edge_first = thrust::make_zip_iterator(cuda::std::make_tuple(
+    upper_triangular_minors.begin(), upper_triangular_majors.begin()));  // flip
   thrust::sort(handle.get_thrust_policy(),
                upper_triangular_edge_first,
                upper_triangular_edge_first + upper_triangular_majors.size());
@@ -319,7 +324,7 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> merge_l
                        handle.get_stream());
   merged_minors.resize(merged_majors.size(), handle.get_stream());
   auto merged_first =
-    thrust::make_zip_iterator(thrust::make_tuple(merged_majors.begin(), merged_minors.begin()));
+    thrust::make_zip_iterator(cuda::std::make_tuple(merged_majors.begin(), merged_minors.begin()));
   auto merged_last =
     reciprocal
       ? thrust::set_intersection(handle.get_thrust_policy(),
@@ -389,14 +394,14 @@ symmetrize_edgelist(raft::handle_t const& handle,
   size_t num_diagonal_edges{0};
 
   auto lower_triangular_compare = [] __device__(auto e) {
-    auto major = thrust::get<0>(e);
-    auto minor = thrust::get<1>(e);
+    auto major = cuda::std::get<0>(e);
+    auto minor = cuda::std::get<1>(e);
     return major > minor;
   };
 
   auto diagonal_compare = [] __device__(auto e) {
-    auto major = thrust::get<0>(e);
-    auto minor = thrust::get<1>(e);
+    auto major = cuda::std::get<0>(e);
+    auto minor = cuda::std::get<1>(e);
     return major == minor;
   };
 

--- a/cpp/src/traversal/bfs_impl.cuh
+++ b/cpp/src/traversal/bfs_impl.cuh
@@ -32,6 +32,7 @@
 #include <raft/core/handle.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/fill.h>
@@ -43,7 +44,6 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/set_operations.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <limits>
 #include <type_traits>
@@ -534,11 +534,11 @@ void bfs(raft::handle_t const& handle,
         auto aggregate_m_u = m_u;
         if constexpr (GraphViewType::is_multi_gpu) {
           auto tmp      = host_scalar_allreduce(handle.get_comms(),
-                                           thrust::make_tuple(m_f, m_u),
+                                           cuda::std::make_tuple(m_f, m_u),
                                            raft::comms::op_t::SUM,
                                            handle.get_stream());
-          aggregate_m_f = thrust::get<0>(tmp);
-          aggregate_m_u = thrust::get<1>(tmp);
+          aggregate_m_f = cuda::std::get<0>(tmp);
+          aggregate_m_u = cuda::std::get<1>(tmp);
         }
         if ((aggregate_m_f * direction_optimizing_alpha > aggregate_m_u) &&
             (next_aggregate_frontier_size >= cur_aggregate_frontier_size)) {
@@ -686,11 +686,11 @@ void bfs(raft::handle_t const& handle,
       if constexpr (GraphViewType::is_multi_gpu) {
         auto tmp = host_scalar_allreduce(
           handle.get_comms(),
-          thrust::make_tuple(next_aggregate_frontier_size, aggregate_nzd_unvisited_vertices),
+          cuda::std::make_tuple(next_aggregate_frontier_size, aggregate_nzd_unvisited_vertices),
           raft::comms::op_t::SUM,
           handle.get_stream());
-        next_aggregate_frontier_size     = thrust::get<0>(tmp);
-        aggregate_nzd_unvisited_vertices = thrust::get<1>(tmp);
+        next_aggregate_frontier_size     = cuda::std::get<0>(tmp);
+        aggregate_nzd_unvisited_vertices = cuda::std::get<1>(tmp);
       }
 
       if (next_aggregate_frontier_size == 0) { break; }

--- a/cpp/src/traversal/k_hop_nbrs_impl.cuh
+++ b/cpp/src/traversal/k_hop_nbrs_impl.cuh
@@ -31,13 +31,13 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/count.h>
 #include <thrust/fill.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
 
 #include <limits>
 #include <type_traits>
@@ -48,13 +48,13 @@ namespace {
 
 template <typename vertex_t>
 struct e_op_t {
-  __device__ cuda::std::optional<size_t> operator()(thrust::tuple<vertex_t, size_t> tagged_src,
+  __device__ cuda::std::optional<size_t> operator()(cuda::std::tuple<vertex_t, size_t> tagged_src,
                                                     vertex_t,
                                                     cuda::std::nullopt_t,
                                                     cuda::std::nullopt_t,
                                                     cuda::std::nullopt_t) const
   {
-    return thrust::get<1>(tagged_src);
+    return cuda::std::get<1>(tagged_src);
   }
 };
 

--- a/cpp/src/traversal/od_shortest_distances_impl.cuh
+++ b/cpp/src/traversal/od_shortest_distances_impl.cuh
@@ -38,6 +38,7 @@
 #include <raft/util/integer_utils.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/fill.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -45,7 +46,6 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/set_operations.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <limits>
 
@@ -60,10 +60,10 @@ template <typename vertex_t, typename tag_t, typename key_t>
 struct aggregate_vi_t {
   tag_t num_origins{};
 
-  __device__ key_t operator()(thrust::tuple<vertex_t, tag_t> tup) const
+  __device__ key_t operator()(cuda::std::tuple<vertex_t, tag_t> tup) const
   {
-    return (static_cast<key_t>(thrust::get<0>(tup)) * static_cast<key_t>(num_origins)) +
-           static_cast<key_t>(thrust::get<1>(tup));
+    return (static_cast<key_t>(cuda::std::get<0>(tup)) * static_cast<key_t>(num_origins)) +
+           static_cast<key_t>(cuda::std::get<1>(tup));
   }
 };
 
@@ -71,9 +71,9 @@ template <typename vertex_t, typename tag_t, typename key_t>
 struct split_vi_t {
   tag_t num_origins{};
 
-  __device__ thrust::tuple<vertex_t, tag_t> operator()(key_t aggregated_vi) const
+  __device__ cuda::std::tuple<vertex_t, tag_t> operator()(key_t aggregated_vi) const
   {
-    return thrust::make_tuple(
+    return cuda::std::make_tuple(
       static_cast<vertex_t>(aggregated_vi / static_cast<key_t>(num_origins)),
       static_cast<tag_t>(aggregated_vi % static_cast<key_t>(num_origins)));
   }
@@ -133,8 +133,8 @@ struct e_op_t {
   weight_t cutoff{};
   weight_t invalid_distance{};
 
-  __device__ cuda::std::optional<thrust::tuple<tag_t, weight_t>> operator()(
-    thrust::tuple<vertex_t, tag_t> tagged_src,
+  __device__ cuda::std::optional<cuda::std::tuple<tag_t, weight_t>> operator()(
+    cuda::std::tuple<vertex_t, tag_t> tagged_src,
     vertex_t dst,
     cuda::std::nullopt_t,
     cuda::std::nullopt_t,
@@ -144,14 +144,14 @@ struct e_op_t {
 
     auto src_val = key_to_dist_map.find(aggregator(tagged_src));
     assert(src_val != invalid_distance);
-    auto origin_idx   = thrust::get<1>(tagged_src);
+    auto origin_idx   = cuda::std::get<1>(tagged_src);
     auto new_distance = src_val + w;
     auto threshold    = cutoff;
-    auto dst_val      = key_to_dist_map.find(aggregator(thrust::make_tuple(dst, origin_idx)));
+    auto dst_val      = key_to_dist_map.find(aggregator(cuda::std::make_tuple(dst, origin_idx)));
     if (dst_val != invalid_distance) { threshold = dst_val < threshold ? dst_val : threshold; }
     return (new_distance < threshold)
-             ? cuda::std::optional<thrust::tuple<tag_t, weight_t>>{thrust::make_tuple(origin_idx,
-                                                                                      new_distance)}
+             ? cuda::std::optional<cuda::std::tuple<tag_t, weight_t>>{cuda::std::make_tuple(
+                 origin_idx, new_distance)}
              : cuda::std::nullopt;
   }
 };
@@ -163,14 +163,14 @@ struct insert_nbr_key_t {
   detail::key_cuco_store_insert_device_view_t<detail::key_cuco_store_view_t<key_t>> key_set{};
   aggregate_vi_t<vertex_t, tag_t, key_t> aggregator{};
 
-  __device__ void operator()(thrust::tuple<vertex_t, tag_t> vi)
+  __device__ void operator()(cuda::std::tuple<vertex_t, tag_t> vi)
   {
-    auto v   = thrust::get<0>(vi);
-    auto idx = thrust::get<1>(vi);
+    auto v   = cuda::std::get<0>(vi);
+    auto idx = cuda::std::get<1>(vi);
 
     for (edge_t nbr_offset = offsets[v]; nbr_offset < offsets[v + 1]; ++nbr_offset) {
       auto nbr = indices[nbr_offset];
-      key_set.insert(aggregator(thrust::make_tuple(nbr, idx)));
+      key_set.insert(aggregator(cuda::std::make_tuple(nbr, idx)));
     }
   }
 };
@@ -180,10 +180,10 @@ struct keep_t {
   weight_t old_near_far_threshold{};
   detail::key_cuco_store_contains_device_view_t<detail::key_cuco_store_view_t<key_t>> key_set{};
 
-  __device__ bool operator()(thrust::tuple<key_t, weight_t> pair) const
+  __device__ bool operator()(cuda::std::tuple<key_t, weight_t> pair) const
   {
-    return (thrust::get<1>(pair) >= old_near_far_threshold) ||
-           (key_set.contains(thrust::get<0>(pair)));
+    return (cuda::std::get<1>(pair) >= old_near_far_threshold) ||
+           (key_set.contains(cuda::std::get<0>(pair)));
   }
 };
 
@@ -632,8 +632,8 @@ rmm::device_uvector<weight_t> od_shortest_distances(
     rmm::device_uvector<weight_t> distance_buffer(0, handle.get_stream());
     {
       // use detail space functions as sort_by_key with key = key_t is faster than key =
-      // thrust::tuple<vertex_t, od_idx_t> and we need to convert thrust::tuple<vertex_t, od_idx_t>
-      // to key_t anyways for post processing
+      // cuda::std::tuple<vertex_t, od_idx_t> and we need to convert cuda::std::tuple<vertex_t,
+      // od_idx_t> to key_t anyways for post processing
 
       auto e_op = e_op_t<vertex_t, od_idx_t, key_t, weight_t, GraphViewType::is_multi_gpu>{
         detail::kv_cuco_store_find_device_view_t(key_to_dist_map.view()),
@@ -641,7 +641,7 @@ rmm::device_uvector<weight_t> od_shortest_distances(
         cutoff,
         invalid_distance};
       detail::transform_reduce_v_frontier_call_e_op_t<
-        thrust::tuple<vertex_t, od_idx_t>,
+        cuda::std::tuple<vertex_t, od_idx_t>,
         weight_t,
         vertex_t,
         cuda::std::nullopt_t,
@@ -651,16 +651,17 @@ rmm::device_uvector<weight_t> od_shortest_distances(
         e_op_wrapper{e_op};
 
       auto new_frontier_tagged_vertex_buffer =
-        allocate_dataframe_buffer<thrust::tuple<vertex_t, od_idx_t>>(0, handle.get_stream());
+        allocate_dataframe_buffer<cuda::std::tuple<vertex_t, od_idx_t>>(0, handle.get_stream());
       std::tie(new_frontier_tagged_vertex_buffer, distance_buffer) =
-        detail::extract_transform_v_frontier_e<false, thrust::tuple<vertex_t, od_idx_t>, weight_t>(
-          handle,
-          graph_view,
-          vertex_frontier.bucket(bucket_idx_near),
-          edge_src_dummy_property_t{}.view(),
-          edge_dst_dummy_property_t{}.view(),
-          edge_weight_view,
-          e_op_wrapper);
+        detail::extract_transform_v_frontier_e<false,
+                                               cuda::std::tuple<vertex_t, od_idx_t>,
+                                               weight_t>(handle,
+                                                         graph_view,
+                                                         vertex_frontier.bucket(bucket_idx_near),
+                                                         edge_src_dummy_property_t{}.view(),
+                                                         edge_dst_dummy_property_t{}.view(),
+                                                         edge_weight_view,
+                                                         e_op_wrapper);
 
       new_frontier_keys.resize(size_dataframe_buffer(new_frontier_tagged_vertex_buffer),
                                handle.get_stream());
@@ -801,9 +802,9 @@ rmm::device_uvector<weight_t> od_shortest_distances(
                                  thrust::upper_bound(thrust::seq,
                                                      split_thresholds.begin(),
                                                      split_thresholds.end(),
-                                                     thrust::get<1>(pair))));
+                                                     cuda::std::get<1>(pair))));
             },
-            [] __device__(auto pair) { return thrust::get<0>(pair); },
+            [] __device__(auto pair) { return cuda::std::get<0>(pair); },
             raft::device_span<size_t>(d_counters.data(), d_counters.size()));
 
         std::vector<size_t> h_counters(d_counters.size());

--- a/cpp/src/traversal/sssp_impl.cuh
+++ b/cpp/src/traversal/sssp_impl.cuh
@@ -33,12 +33,12 @@
 #include <raft/util/cudart_utils.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/fill.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <limits>
 
@@ -52,7 +52,7 @@ struct e_op_t {
   weight_t const* distances{};
   weight_t cutoff{};
 
-  __device__ cuda::std::optional<thrust::tuple<weight_t, vertex_t>> operator()(
+  __device__ cuda::std::optional<cuda::std::tuple<weight_t, vertex_t>> operator()(
     vertex_t src, vertex_t dst, weight_t src_val, cuda::std::nullopt_t, weight_t w) const
   {
     auto push         = true;
@@ -65,7 +65,7 @@ struct e_op_t {
       threshold         = old_distance < threshold ? old_distance : threshold;
     }
     if (new_distance >= threshold) { push = false; }
-    return push ? cuda::std::optional<thrust::tuple<weight_t, vertex_t>>{thrust::make_tuple(
+    return push ? cuda::std::optional<cuda::std::tuple<weight_t, vertex_t>>{cuda::std::make_tuple(
                     new_distance, src)}
                 : cuda::std::nullopt;
   }
@@ -122,7 +122,7 @@ void sssp(raft::handle_t const& handle,
   auto constexpr invalid_distance = std::numeric_limits<weight_t>::max();
   auto constexpr invalid_vertex   = invalid_vertex_id<vertex_t>::value;
 
-  auto val_first = thrust::make_zip_iterator(thrust::make_tuple(distances, predecessor_first));
+  auto val_first = thrust::make_zip_iterator(cuda::std::make_tuple(distances, predecessor_first));
   thrust::transform(
     handle.get_thrust_policy(),
     thrust::make_counting_iterator(push_graph_view.local_vertex_partition_range_first()),
@@ -131,7 +131,7 @@ void sssp(raft::handle_t const& handle,
     [source_vertex] __device__(auto val) {
       auto distance = invalid_distance;
       if (val == source_vertex) { distance = weight_t{0.0}; }
-      return thrust::make_tuple(distance, invalid_vertex);
+      return cuda::std::make_tuple(distance, invalid_vertex);
     });
 
   if (num_edges == 0) { return; }
@@ -147,9 +147,9 @@ void sssp(raft::handle_t const& handle,
     edge_dst_dummy_property_t{}.view(),
     edge_weight_view,
     [] __device__(vertex_t, vertex_t, auto, auto, weight_t w) {
-      return thrust::make_tuple(weight_t{1.0}, w);
+      return cuda::std::make_tuple(weight_t{1.0}, w);
     },
-    thrust::make_tuple(weight_t{0.0}, weight_t{0.0}));
+    cuda::std::make_tuple(weight_t{0.0}, weight_t{0.0}));
   average_vertex_degree /= static_cast<weight_t>(num_vertices);
   average_edge_weight /= static_cast<weight_t>(num_edges);
   auto delta =
@@ -208,7 +208,7 @@ void sssp(raft::handle_t const& handle,
         edge_weight_view,
         e_op_t<vertex_t, weight_t, GraphViewType::is_multi_gpu>{
           vertex_partition, distances, cutoff},
-        reduce_op::minimum<thrust::tuple<weight_t, vertex_t>>());
+        reduce_op::minimum<cuda::std::tuple<weight_t, vertex_t>>());
 
     update_v_frontier(
       handle,
@@ -218,15 +218,15 @@ void sssp(raft::handle_t const& handle,
       vertex_frontier,
       std::vector<size_t>{bucket_idx_next_near, bucket_idx_far},
       distances,
-      thrust::make_zip_iterator(thrust::make_tuple(distances, predecessor_first)),
+      thrust::make_zip_iterator(cuda::std::make_tuple(distances, predecessor_first)),
       [near_far_threshold] __device__(auto v, auto v_val, auto pushed_val) {
-        auto new_dist = thrust::get<0>(pushed_val);
+        auto new_dist = cuda::std::get<0>(pushed_val);
         auto update   = (new_dist < v_val);
-        return thrust::make_tuple(
+        return cuda::std::make_tuple(
           update ? cuda::std::optional<size_t>{new_dist < near_far_threshold ? bucket_idx_next_near
                                                                              : bucket_idx_far}
                  : cuda::std::nullopt,
-          update ? cuda::std::optional<thrust::tuple<weight_t, vertex_t>>{pushed_val}
+          update ? cuda::std::optional<cuda::std::tuple<weight_t, vertex_t>>{pushed_val}
                  : cuda::std::nullopt);
       });
 

--- a/cpp/src/utilities/collect_comm.cuh
+++ b/cpp/src/utilities/collect_comm.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/polymorphic_allocator.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/adjacent_difference.h>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
@@ -41,7 +42,6 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <iterator>
@@ -113,14 +113,14 @@ dataframe_buffer_type_t<typename KVStoreViewType::value_type> collect_values_for
                                                               false,
                                                               stream_view);
   } else {
-    auto kv_pair_first = thrust::make_zip_iterator(
-      thrust::make_tuple(unique_keys.begin(), get_dataframe_buffer_begin(values_for_unique_keys)));
+    auto kv_pair_first = thrust::make_zip_iterator(cuda::std::make_tuple(
+      unique_keys.begin(), get_dataframe_buffer_begin(values_for_unique_keys)));
     auto valid_kv_pair_last =
       thrust::remove_if(rmm::exec_policy(stream_view),
                         kv_pair_first,
                         kv_pair_first + unique_keys.size(),
                         [invalid_value = kv_store_view.invalid_value()] __device__(auto pair) {
-                          return thrust::get<1>(pair) == invalid_value;
+                          return cuda::std::get<1>(pair) == invalid_value;
                         });  // remove (k,v) pairs with unmatched keys (it is invalid to insert a
                              // (k,v) pair with v = empty_key_sentinel)
     auto num_valid_pairs = static_cast<size_t>(thrust::distance(kv_pair_first, valid_kv_pair_last));

--- a/cpp/src/utilities/error_check_utils.cuh
+++ b/cpp/src/utilities/error_check_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,10 +44,10 @@ struct is_invalid_input_vertex_pair_t {
   vertex_t edge_partition_minor_range_first{};
   vertex_t edge_partition_minor_range_last{};
 
-  __device__ bool operator()(thrust::tuple<vertex_t, vertex_t> pair) const
+  __device__ bool operator()(cuda::std::tuple<vertex_t, vertex_t> pair) const
   {
-    auto major = thrust::get<0>(pair);
-    auto minor = thrust::get<1>(pair);
+    auto major = cuda::std::get<0>(pair);
+    auto minor = cuda::std::get<1>(pair);
     if (!is_valid_vertex(num_vertices, major) || !is_valid_vertex(num_vertices, minor)) {
       return true;
     }

--- a/cpp/src/utilities/shuffle_vertex_pairs.cuh
+++ b/cpp/src/utilities/shuffle_vertex_pairs.cuh
@@ -25,9 +25,9 @@
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
 
+#include <cuda/std/tuple>
 #include <thrust/gather.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 
@@ -119,7 +119,7 @@ shuffle_vertex_pairs_with_values_by_gpu_id_impl(
     d_tx_value_counts = cugraph::groupby_and_count(
       thrust::make_zip_iterator(majors.begin(), minors.begin()),
       thrust::make_zip_iterator(majors.end(), minors.end()),
-      [func] __device__(auto val) { return func(thrust::get<0>(val), thrust::get<1>(val)); },
+      [func] __device__(auto val) { return func(cuda::std::get<0>(val), cuda::std::get<1>(val)); },
       comm_size,
       mem_frugal_threshold,
       handle.get_stream());
@@ -128,7 +128,9 @@ shuffle_vertex_pairs_with_values_by_gpu_id_impl(
       d_tx_value_counts = cugraph::groupby_and_count(
         thrust::make_zip_iterator(majors.begin(), minors.begin(), weights->begin()),
         thrust::make_zip_iterator(majors.end(), minors.end(), weights->end()),
-        [func] __device__(auto val) { return func(thrust::get<0>(val), thrust::get<1>(val)); },
+        [func] __device__(auto val) {
+          return func(cuda::std::get<0>(val), cuda::std::get<1>(val));
+        },
         comm_size,
         mem_frugal_threshold,
         handle.get_stream());
@@ -136,7 +138,9 @@ shuffle_vertex_pairs_with_values_by_gpu_id_impl(
       d_tx_value_counts = cugraph::groupby_and_count(
         thrust::make_zip_iterator(majors.begin(), minors.begin(), edge_ids->begin()),
         thrust::make_zip_iterator(majors.end(), minors.end(), edge_ids->end()),
-        [func] __device__(auto val) { return func(thrust::get<0>(val), thrust::get<1>(val)); },
+        [func] __device__(auto val) {
+          return func(cuda::std::get<0>(val), cuda::std::get<1>(val));
+        },
         comm_size,
         mem_frugal_threshold,
         handle.get_stream());
@@ -144,7 +148,9 @@ shuffle_vertex_pairs_with_values_by_gpu_id_impl(
       d_tx_value_counts = cugraph::groupby_and_count(
         thrust::make_zip_iterator(majors.begin(), minors.begin(), edge_types->begin()),
         thrust::make_zip_iterator(majors.end(), minors.end(), edge_types->end()),
-        [func] __device__(auto val) { return func(thrust::get<0>(val), thrust::get<1>(val)); },
+        [func] __device__(auto val) {
+          return func(cuda::std::get<0>(val), cuda::std::get<1>(val));
+        },
         comm_size,
         mem_frugal_threshold,
         handle.get_stream());
@@ -152,7 +158,9 @@ shuffle_vertex_pairs_with_values_by_gpu_id_impl(
       d_tx_value_counts = cugraph::groupby_and_count(
         thrust::make_zip_iterator(majors.begin(), minors.begin(), edge_start_times->begin()),
         thrust::make_zip_iterator(majors.end(), minors.end(), edge_start_times->end()),
-        [func] __device__(auto val) { return func(thrust::get<0>(val), thrust::get<1>(val)); },
+        [func] __device__(auto val) {
+          return func(cuda::std::get<0>(val), cuda::std::get<1>(val));
+        },
         comm_size,
         mem_frugal_threshold,
         handle.get_stream());
@@ -160,7 +168,9 @@ shuffle_vertex_pairs_with_values_by_gpu_id_impl(
       d_tx_value_counts = cugraph::groupby_and_count(
         thrust::make_zip_iterator(majors.begin(), minors.begin(), edge_end_times->begin()),
         thrust::make_zip_iterator(majors.end(), minors.end(), edge_end_times->end()),
-        [func] __device__(auto val) { return func(thrust::get<0>(val), thrust::get<1>(val)); },
+        [func] __device__(auto val) {
+          return func(cuda::std::get<0>(val), cuda::std::get<1>(val));
+        },
         comm_size,
         mem_frugal_threshold,
         handle.get_stream());
@@ -173,7 +183,7 @@ shuffle_vertex_pairs_with_values_by_gpu_id_impl(
     d_tx_value_counts = cugraph::groupby_and_count(
       thrust::make_zip_iterator(majors.begin(), minors.begin(), property_position.begin()),
       thrust::make_zip_iterator(majors.end(), minors.end(), property_position.end()),
-      [func] __device__(auto val) { return func(thrust::get<0>(val), thrust::get<1>(val)); },
+      [func] __device__(auto val) { return func(cuda::std::get<0>(val), cuda::std::get<1>(val)); },
       comm_size,
       mem_frugal_threshold,
       handle.get_stream());

--- a/cpp/src/utilities/shuffle_vertex_pairs_mg_v32_e32.cu
+++ b/cpp/src/utilities/shuffle_vertex_pairs_mg_v32_e32.cu
@@ -23,8 +23,8 @@
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 

--- a/cpp/src/utilities/shuffle_vertex_pairs_mg_v64_e64.cu
+++ b/cpp/src/utilities/shuffle_vertex_pairs_mg_v64_e64.cu
@@ -23,8 +23,8 @@
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 

--- a/cpp/src/utilities/shuffle_vertices.cuh
+++ b/cpp/src/utilities/shuffle_vertices.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 #include <cugraph/detail/shuffle_wrappers.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
 
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <tuple>
 

--- a/cpp/src/utilities/shuffle_vertices_mg_v32_fp.cu
+++ b/cpp/src/utilities/shuffle_vertices_mg_v32_fp.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #include <cugraph/detail/shuffle_wrappers.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
 
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <tuple>
 

--- a/cpp/src/utilities/shuffle_vertices_mg_v32_integral.cu
+++ b/cpp/src/utilities/shuffle_vertices_mg_v32_integral.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #include <cugraph/detail/shuffle_wrappers.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
 
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <tuple>
 

--- a/cpp/src/utilities/shuffle_vertices_mg_v64_fp.cu
+++ b/cpp/src/utilities/shuffle_vertices_mg_v64_fp.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #include <cugraph/detail/shuffle_wrappers.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
 
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <tuple>
 

--- a/cpp/src/utilities/shuffle_vertices_mg_v64_integral.cu
+++ b/cpp/src/utilities/shuffle_vertices_mg_v64_integral.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #include <cugraph/detail/shuffle_wrappers.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
 
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <tuple>
 

--- a/cpp/tests/community/egonet_validate.cu
+++ b/cpp/tests/community/egonet_validate.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ egonet_reference(
                                     d_reference_wgt->begin() + old_size),
           [frontier_begin = frontier.begin(),
            frontier_end   = frontier.end()] __device__(auto tuple) {
-            vertex_t src = thrust::get<0>(tuple);
+            vertex_t src = cuda::std::get<0>(tuple);
             return thrust::binary_search(thrust::seq, frontier_begin, frontier_end, src);
           });
       } else {
@@ -133,7 +133,7 @@ egonet_reference(
                                                   d_reference_dst.begin() + old_size),
                         [frontier_begin = frontier.begin(),
                          frontier_end   = frontier.end()] __device__(auto tuple) {
-                          vertex_t src = thrust::get<0>(tuple);
+                          vertex_t src = cuda::std::get<0>(tuple);
                           return thrust::binary_search(
                             thrust::seq, frontier_begin, frontier_end, src);
                         });
@@ -173,8 +173,8 @@ egonet_reference(
          frontier_end   = frontier.end(),
          visited_begin  = visited.begin(),
          visited_end    = visited.end()] __device__(auto tuple) {
-          vertex_t src = thrust::get<0>(tuple);
-          vertex_t dst = thrust::get<1>(tuple);
+          vertex_t src = cuda::std::get<0>(tuple);
+          vertex_t dst = cuda::std::get<1>(tuple);
           return thrust::binary_search(thrust::seq, frontier_begin, frontier_end, src) &&
                  thrust::binary_search(thrust::seq, visited_begin, visited_end, dst);
         });
@@ -198,8 +198,8 @@ egonet_reference(
            frontier_end   = frontier.end(),
            visited_begin  = visited.begin(),
            visited_end    = visited.end()] __device__(auto tuple) {
-            vertex_t src = thrust::get<0>(tuple);
-            vertex_t dst = thrust::get<1>(tuple);
+            vertex_t src = cuda::std::get<0>(tuple);
+            vertex_t dst = cuda::std::get<1>(tuple);
             return thrust::binary_search(thrust::seq, frontier_begin, frontier_end, src) &&
                    thrust::binary_search(thrust::seq, visited_begin, visited_end, dst);
           });
@@ -214,8 +214,8 @@ egonet_reference(
            frontier_end   = frontier.end(),
            visited_begin  = visited.begin(),
            visited_end    = visited.end()] __device__(auto tuple) {
-            vertex_t src = thrust::get<0>(tuple);
-            vertex_t dst = thrust::get<1>(tuple);
+            vertex_t src = cuda::std::get<0>(tuple);
+            vertex_t dst = cuda::std::get<1>(tuple);
             return thrust::binary_search(thrust::seq, frontier_begin, frontier_end, src) &&
                    thrust::binary_search(thrust::seq, visited_begin, visited_end, dst);
           });
@@ -297,12 +297,12 @@ void egonet_validate(raft::handle_t const& handle,
                                                           d_cugraph_egonet_wgt->begin()) +
                                   h_offsets[i],
                                 [] __device__(auto left, auto right) {
-                                  auto l0 = thrust::get<0>(left);
-                                  auto l1 = thrust::get<1>(left);
-                                  auto l2 = thrust::get<2>(left);
-                                  auto r0 = thrust::get<0>(right);
-                                  auto r1 = thrust::get<1>(right);
-                                  auto r2 = thrust::get<2>(right);
+                                  auto l0 = cuda::std::get<0>(left);
+                                  auto l1 = cuda::std::get<1>(left);
+                                  auto l2 = cuda::std::get<2>(left);
+                                  auto r0 = cuda::std::get<0>(right);
+                                  auto r1 = cuda::std::get<1>(right);
+                                  auto r2 = cuda::std::get<2>(right);
                                   if (!((l0 == r0) && (l1 == r1) && (l2 == r2)))
                                     printf("edge mismatch: (%d,%d,%g) != (%d,%d,%g)\n",
                                            (int)l0,
@@ -338,10 +338,10 @@ void egonet_validate(raft::handle_t const& handle,
         thrust::make_zip_iterator(d_cugraph_egonet_src.begin(), d_cugraph_egonet_dst.begin()) +
           h_offsets[i],
         [] __device__(auto left, auto right) {
-          auto l0 = thrust::get<0>(left);
-          auto l1 = thrust::get<1>(left);
-          auto r0 = thrust::get<0>(right);
-          auto r1 = thrust::get<1>(right);
+          auto l0 = cuda::std::get<0>(left);
+          auto l1 = cuda::std::get<1>(left);
+          auto r0 = cuda::std::get<0>(right);
+          auto r1 = cuda::std::get<1>(right);
           if (!((l0 == r0) && (l1 == r1)))
             printf("edge mismatch: (%d,%d) != (%d,%d)\n", (int)l0, (int)l1, (int)r0, (int)r1);
           return (l0 == r0) && (l1 == r1);

--- a/cpp/tests/components/mg_vertex_coloring_test.cu
+++ b/cpp/tests/components/mg_vertex_coloring_test.cu
@@ -185,14 +185,14 @@ class Tests_MGGraphColoring
       {
         thrust::for_each(
           thrust::host,
-          thrust::make_zip_iterator(thrust::make_tuple(
+          thrust::make_zip_iterator(cuda::std::make_tuple(
             h_colors.begin(), h_vertices_in_this_proces.begin(), h_color_conflicts.begin())),
-          thrust::make_zip_iterator(thrust::make_tuple(
+          thrust::make_zip_iterator(cuda::std::make_tuple(
             h_colors.end(), h_vertices_in_this_proces.end(), h_color_conflicts.end())),
           [](auto color_vetex_and_conflict_flag) {
-            auto color         = thrust::get<0>(color_vetex_and_conflict_flag);
-            auto v             = thrust::get<1>(color_vetex_and_conflict_flag);
-            auto conflict_flag = thrust::get<2>(color_vetex_and_conflict_flag);
+            auto color         = cuda::std::get<0>(color_vetex_and_conflict_flag);
+            auto v             = cuda::std::get<1>(color_vetex_and_conflict_flag);
+            auto conflict_flag = cuda::std::get<2>(color_vetex_and_conflict_flag);
             ASSERT_TRUE(conflict_flag == 0)
               << v << " got same color as one of its neighbor" << std::endl;
           });

--- a/cpp/tests/components/vertex_coloring_test.cu
+++ b/cpp/tests/components/vertex_coloring_test.cu
@@ -159,14 +159,14 @@ class Tests_SGGraphColoring
       if (nr_conflicts >= 0) {
         thrust::for_each(
           thrust::host,
-          thrust::make_zip_iterator(thrust::make_tuple(
+          thrust::make_zip_iterator(cuda::std::make_tuple(
             h_colors.begin(), h_vertices_in_this_proces.begin(), h_color_conflict_flags.begin())),
-          thrust::make_zip_iterator(thrust::make_tuple(
+          thrust::make_zip_iterator(cuda::std::make_tuple(
             h_colors.end(), h_vertices_in_this_proces.end(), h_color_conflict_flags.end())),
           [](auto color_vetex_and_conflict_flag) {
-            auto color         = thrust::get<0>(color_vetex_and_conflict_flag);
-            auto v             = thrust::get<1>(color_vetex_and_conflict_flag);
-            auto conflict_flag = thrust::get<2>(color_vetex_and_conflict_flag);
+            auto color         = cuda::std::get<0>(color_vetex_and_conflict_flag);
+            auto v             = cuda::std::get<1>(color_vetex_and_conflict_flag);
+            auto conflict_flag = cuda::std::get<2>(color_vetex_and_conflict_flag);
             ASSERT_TRUE(conflict_flag == 0)
               << v << " got same color as one of its neighbor" << std::endl;
           });

--- a/cpp/tests/cores/k_core_validate.cu
+++ b/cpp/tests/cores/k_core_validate.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,8 +81,8 @@ void check_correctness(
                      thrust::make_zip_iterator(graph_src.begin(), graph_dst.begin()),
                      thrust::make_zip_iterator(graph_src.end(), graph_dst.end()),
                      [k, d_core_numbers = core_numbers.data()] __device__(auto tuple) {
-                       vertex_t src = thrust::get<0>(tuple);
-                       vertex_t dst = thrust::get<1>(tuple);
+                       vertex_t src = cuda::std::get<0>(tuple);
+                       vertex_t dst = cuda::std::get<1>(tuple);
                        return ((d_core_numbers[src] >= k) && (d_core_numbers[dst] >= k));
                      });
 

--- a/cpp/tests/generators/erdos_renyi_test.cpp
+++ b/cpp/tests/generators/erdos_renyi_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,10 @@
 #include <cugraph/graph.hpp>
 #include <cugraph/graph_generators.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/sort.h>
-#include <thrust/tuple.h>
 
 #include <gtest/gtest.h>
 
@@ -39,13 +39,13 @@ void test_symmetric(std::vector<vertex_t>& h_src_v, std::vector<vertex_t>& h_dst
   std::copy(h_dst_v.begin(), h_dst_v.end(), reverse_src_v.begin());
 
   thrust::sort(thrust::host,
-               thrust::make_zip_iterator(thrust::make_tuple(h_src_v.begin(), h_dst_v.begin())),
-               thrust::make_zip_iterator(thrust::make_tuple(h_src_v.end(), h_dst_v.end())));
+               thrust::make_zip_iterator(cuda::std::make_tuple(h_src_v.begin(), h_dst_v.begin())),
+               thrust::make_zip_iterator(cuda::std::make_tuple(h_src_v.end(), h_dst_v.end())));
 
   thrust::sort(
     thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(reverse_src_v.begin(), reverse_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(reverse_src_v.end(), reverse_dst_v.end())));
+    thrust::make_zip_iterator(cuda::std::make_tuple(reverse_src_v.begin(), reverse_dst_v.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(reverse_src_v.end(), reverse_dst_v.end())));
 
   EXPECT_EQ(reverse_src_v, h_src_v);
   EXPECT_EQ(reverse_dst_v, h_dst_v);

--- a/cpp/tests/generators/generators_test.cpp
+++ b/cpp/tests/generators/generators_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,10 @@
 
 #include <cugraph/graph_generators.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/sort.h>
-#include <thrust/tuple.h>
 
 #include <random>
 
@@ -73,16 +73,17 @@ TEST_F(GeneratorsTest, Mesh2DGraphTest)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(
-    thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
-      expected_src_v.size());
+  thrust::sort(thrust::host,
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
+                 expected_src_v.size());
 
   thrust::sort(
     thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
       actual_src_v.size());
 
   EXPECT_EQ(expected_src_v, actual_src_v);
@@ -124,16 +125,17 @@ TEST_F(GeneratorsTest, Mesh3DGraphTest)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(
-    thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
-      expected_src_v.size());
+  thrust::sort(thrust::host,
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
+                 expected_src_v.size());
 
   thrust::sort(
     thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
       actual_src_v.size());
 
   EXPECT_EQ(expected_src_v, actual_src_v);
@@ -159,16 +161,17 @@ TEST_F(GeneratorsTest, CompleteGraphTestTriangles)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(
-    thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
-      expected_src_v.size());
+  thrust::sort(thrust::host,
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
+                 expected_src_v.size());
 
   thrust::sort(
     thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
       actual_src_v.size());
 
   EXPECT_EQ(expected_src_v, actual_src_v);
@@ -198,16 +201,17 @@ TEST_F(GeneratorsTest, CompleteGraphTest5)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(
-    thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
-      expected_src_v.size());
+  thrust::sort(thrust::host,
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
+                 expected_src_v.size());
 
   thrust::sort(
     thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
       actual_src_v.size());
 
   EXPECT_EQ(expected_src_v, actual_src_v);
@@ -237,16 +241,17 @@ TEST_F(GeneratorsTest, LineGraphTestSymmetric)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(
-    thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
-      expected_src_v.size());
+  thrust::sort(thrust::host,
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
+                 expected_src_v.size());
 
   thrust::sort(
     thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
       actual_src_v.size());
 
   EXPECT_EQ(expected_src_v, actual_src_v);
@@ -286,16 +291,17 @@ TEST_F(GeneratorsTest, Mesh2DGraphTestSymmetric)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(
-    thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
-      expected_src_v.size());
+  thrust::sort(thrust::host,
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
+                 expected_src_v.size());
 
   thrust::sort(
     thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
       actual_src_v.size());
 
   EXPECT_EQ(expected_src_v, actual_src_v);
@@ -359,16 +365,17 @@ TEST_F(GeneratorsTest, Mesh3DGraphTestSymmetric)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(
-    thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
-      expected_src_v.size());
+  thrust::sort(thrust::host,
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
+                 expected_src_v.size());
 
   thrust::sort(
     thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
       actual_src_v.size());
 
   EXPECT_EQ(expected_src_v, actual_src_v);
@@ -400,16 +407,17 @@ TEST_F(GeneratorsTest, CompleteGraphTestTrianglesSymmetric)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(
-    thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
-      expected_src_v.size());
+  thrust::sort(thrust::host,
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
+                 expected_src_v.size());
 
   thrust::sort(
     thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
       actual_src_v.size());
 
   EXPECT_EQ(expected_src_v, actual_src_v);
@@ -447,16 +455,17 @@ TEST_F(GeneratorsTest, CompleteGraphTest5Symmetric)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(
-    thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
-      expected_src_v.size());
+  thrust::sort(thrust::host,
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
+                 expected_src_v.size());
 
   thrust::sort(
     thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
       actual_src_v.size());
 
   EXPECT_EQ(expected_src_v, actual_src_v);
@@ -507,16 +516,17 @@ TEST_F(GeneratorsTest, CombineGraphsTest)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(
-    thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
-      expected_src_v.size());
+  thrust::sort(thrust::host,
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
+                 expected_src_v.size());
 
   thrust::sort(
     thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
       actual_src_v.size());
 
   EXPECT_EQ(expected_src_v, actual_src_v);
@@ -570,16 +580,17 @@ TEST_F(GeneratorsTest, CombineGraphsOffsetsTest)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(
-    thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
-      expected_src_v.size());
+  thrust::sort(thrust::host,
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())),
+               thrust::make_zip_iterator(
+                 cuda::std::make_tuple(expected_src_v.begin(), expected_dst_v.begin())) +
+                 expected_src_v.size());
 
   thrust::sort(
     thrust::host,
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
-    thrust::make_zip_iterator(thrust::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(actual_src_v.begin(), actual_dst_v.begin())) +
       actual_src_v.size());
 
   EXPECT_EQ(expected_src_v, actual_src_v);

--- a/cpp/tests/link_prediction/similarity_compare.cpp
+++ b/cpp/tests/link_prediction/similarity_compare.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,11 +50,11 @@ void weighted_similarity_compare(
   auto& [graph_src, graph_dst, graph_wgt] = edge_list;
   auto& [v1, v2]                          = vertex_pairs;
 
-  auto compare_pairs = [](thrust::tuple<vertex_t, vertex_t, weight_t> lhs,
-                          thrust::tuple<vertex_t, vertex_t, weight_t> rhs) {
-    return ((thrust::get<0>(lhs) < thrust::get<0>(rhs)) ||
-            ((thrust::get<0>(lhs) == thrust::get<0>(rhs)) &&
-             (thrust::get<1>(lhs) < thrust::get<1>(rhs))));
+  auto compare_pairs = [](cuda::std::tuple<vertex_t, vertex_t, weight_t> lhs,
+                          cuda::std::tuple<vertex_t, vertex_t, weight_t> rhs) {
+    return ((cuda::std::get<0>(lhs) < cuda::std::get<0>(rhs)) ||
+            ((cuda::std::get<0>(lhs) == cuda::std::get<0>(rhs)) &&
+             (cuda::std::get<1>(lhs) < cuda::std::get<1>(rhs))));
   };
 
   std::sort(thrust::make_zip_iterator(graph_src.begin(), graph_dst.begin(), (*graph_wgt).begin()),
@@ -70,10 +70,10 @@ void weighted_similarity_compare(
   std::for_each(
     thrust::make_zip_iterator(graph_src.begin(), graph_dst.begin(), (*graph_wgt).begin()),
     thrust::make_zip_iterator(graph_src.end(), graph_dst.end(), (*graph_wgt).end()),
-    [&weighted_vertex_degrees](thrust::tuple<vertex_t, vertex_t, weight_t> src_dst_wgt) {
-      auto src = thrust::get<0>(src_dst_wgt);
-      auto dst = thrust::get<1>(src_dst_wgt);
-      auto wgt = thrust::get<2>(src_dst_wgt);
+    [&weighted_vertex_degrees](cuda::std::tuple<vertex_t, vertex_t, weight_t> src_dst_wgt) {
+      auto src = cuda::std::get<0>(src_dst_wgt);
+      auto dst = cuda::std::get<1>(src_dst_wgt);
+      auto wgt = cuda::std::get<2>(src_dst_wgt);
 
       weighted_vertex_degrees[src] += wgt / weight_t{2};
       weighted_vertex_degrees[dst] += wgt / weight_t{2};
@@ -99,9 +99,9 @@ void weighted_similarity_compare(
      &graph_src,
      &graph_dst,
      &graph_wgt_first](auto tuple) {
-      auto v1    = thrust::get<0>(tuple);
-      auto v2    = thrust::get<1>(tuple);
-      auto score = thrust::get<2>(tuple);
+      auto v1    = cuda::std::get<0>(tuple);
+      auto v2    = cuda::std::get<1>(tuple);
+      auto score = cuda::std::get<2>(tuple);
 
       auto v1_begin =
         std::distance(graph_src.begin(), std::lower_bound(graph_src.begin(), graph_src.end(), v1));
@@ -177,9 +177,11 @@ void weighted_similarity_compare(
           thrust::make_zip_iterator(intersected_weights_v1.begin(), intersected_weights_v2.begin()),
           thrust::make_zip_iterator(intersected_weights_v1.end(), intersected_weights_v2.end()),
           [&min_weight_v1_intersect_v2,
-           &max_weight_v1_intersect_v2](thrust::tuple<weight_t, weight_t> w1_w2) {
-            min_weight_v1_intersect_v2 += std::min(thrust::get<0>(w1_w2), thrust::get<1>(w1_w2));
-            max_weight_v1_intersect_v2 += std::max(thrust::get<0>(w1_w2), thrust::get<1>(w1_w2));
+           &max_weight_v1_intersect_v2](cuda::std::tuple<weight_t, weight_t> w1_w2) {
+            min_weight_v1_intersect_v2 +=
+              std::min(cuda::std::get<0>(w1_w2), cuda::std::get<1>(w1_w2));
+            max_weight_v1_intersect_v2 +=
+              std::max(cuda::std::get<0>(w1_w2), cuda::std::get<1>(w1_w2));
           });
 
         max_weight_v1_intersect_v2 += (sum_of_uniq_weights_v1 + sum_of_uniq_weights_v2);
@@ -197,9 +199,9 @@ void weighted_similarity_compare(
         std::for_each(
           thrust::make_zip_iterator(intersected_weights_v1.begin(), intersected_weights_v2.begin()),
           thrust::make_zip_iterator(intersected_weights_v1.end(), intersected_weights_v2.end()),
-          [&norm_v1, &norm_v2, &v1_dot_v2](thrust::tuple<weight_t, weight_t> w1_w2) {
-            auto x = thrust::get<0>(w1_w2);
-            auto y = thrust::get<1>(w1_w2);
+          [&norm_v1, &norm_v2, &v1_dot_v2](cuda::std::tuple<weight_t, weight_t> w1_w2) {
+            auto x = cuda::std::get<0>(w1_w2);
+            auto y = cuda::std::get<1>(w1_w2);
 
             norm_v1 += x * x;
             norm_v2 += y * y;
@@ -226,11 +228,11 @@ void similarity_compare(
   auto& [graph_src, graph_dst, graph_wgt] = edge_list;
   auto& [v1, v2]                          = vertex_pairs;
 
-  auto compare_pairs = [](thrust::tuple<vertex_t, vertex_t> lhs,
-                          thrust::tuple<vertex_t, vertex_t> rhs) {
-    return ((thrust::get<0>(lhs) < thrust::get<0>(rhs)) ||
-            ((thrust::get<0>(lhs) == thrust::get<0>(rhs)) &&
-             (thrust::get<1>(lhs) < thrust::get<1>(rhs))));
+  auto compare_pairs = [](cuda::std::tuple<vertex_t, vertex_t> lhs,
+                          cuda::std::tuple<vertex_t, vertex_t> rhs) {
+    return ((cuda::std::get<0>(lhs) < cuda::std::get<0>(rhs)) ||
+            ((cuda::std::get<0>(lhs) == cuda::std::get<0>(rhs)) &&
+             (cuda::std::get<1>(lhs) < cuda::std::get<1>(rhs))));
   };
 
   std::sort(thrust::make_zip_iterator(graph_src.begin(), graph_dst.begin()),
@@ -251,9 +253,9 @@ void similarity_compare(
     thrust::make_zip_iterator(v1.end(), v2.end(), similarity_score.end()),
     [compare_functor, test_functor, &vertex_degrees, &graph_src, &graph_dst, &graph_wgt](
       auto tuple) {
-      auto v1    = thrust::get<0>(tuple);
-      auto v2    = thrust::get<1>(tuple);
-      auto score = thrust::get<2>(tuple);
+      auto v1    = cuda::std::get<0>(tuple);
+      auto v2    = cuda::std::get<1>(tuple);
+      auto score = cuda::std::get<2>(tuple);
 
       auto v1_begin =
         std::distance(graph_src.begin(), std::lower_bound(graph_src.begin(), graph_src.end(), v1));

--- a/cpp/tests/link_prediction/weighted_similarity_test.cpp
+++ b/cpp/tests/link_prediction/weighted_similarity_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,8 +110,8 @@ class Tests_Similarity
         std::for_each(thrust::make_zip_iterator(src.begin(), dst.begin()),
                       thrust::make_zip_iterator(src.end(), dst.end()),
                       [&one_hop_v1, &one_hop_v2, seed](auto t) {
-                        auto u = thrust::get<0>(t);
-                        auto v = thrust::get<1>(t);
+                        auto u = cuda::std::get<0>(t);
+                        auto v = cuda::std::get<1>(t);
                         if (u == seed) {
                           one_hop_v1.push_back(u);
                           one_hop_v2.push_back(v);
@@ -122,13 +122,13 @@ class Tests_Similarity
       std::for_each(thrust::make_zip_iterator(one_hop_v1.begin(), one_hop_v2.begin()),
                     thrust::make_zip_iterator(one_hop_v1.end(), one_hop_v2.end()),
                     [&](auto t1) {
-                      auto seed     = thrust::get<0>(t1);
-                      auto neighbor = thrust::get<1>(t1);
+                      auto seed     = cuda::std::get<0>(t1);
+                      auto neighbor = cuda::std::get<1>(t1);
                       std::for_each(thrust::make_zip_iterator(src.begin(), dst.begin()),
                                     thrust::make_zip_iterator(src.end(), dst.end()),
                                     [&](auto t2) {
-                                      auto u = thrust::get<0>(t2);
-                                      auto v = thrust::get<1>(t2);
+                                      auto u = cuda::std::get<0>(t2);
+                                      auto v = cuda::std::get<1>(t2);
                                       if (u == neighbor) {
                                         h_v1.push_back(seed);
                                         h_v2.push_back(v);
@@ -142,8 +142,8 @@ class Tests_Similarity
       auto end_iter = std::unique(thrust::make_zip_iterator(h_v1.begin(), h_v2.begin()),
                                   thrust::make_zip_iterator(h_v1.end(), h_v2.end()),
                                   [](auto t1, auto t2) {
-                                    return (thrust::get<0>(t1) == thrust::get<0>(t2)) &&
-                                           (thrust::get<1>(t1) == thrust::get<1>(t2));
+                                    return (cuda::std::get<0>(t1) == cuda::std::get<0>(t2)) &&
+                                           (cuda::std::get<1>(t1) == cuda::std::get<1>(t2));
                                   });
 
       h_v1.resize(

--- a/cpp/tests/mtmg/multi_node_threaded_test.cu
+++ b/cpp/tests/mtmg/multi_node_threaded_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -392,8 +392,8 @@ class Tests_Multithreaded
                         thrust::make_zip_iterator(std::get<0>(t1).begin(), std::get<1>(t1).begin()),
                         thrust::make_zip_iterator(std::get<0>(t1).end(), std::get<1>(t1).end()),
                         [h_sg_pageranks, compare_functor, h_sg_renumber_map](auto t2) {
-                          vertex_t v  = thrust::get<0>(t2);
-                          weight_t pr = thrust::get<1>(t2);
+                          vertex_t v  = cuda::std::get<0>(t2);
+                          weight_t pr = cuda::std::get<1>(t2);
 
                           auto pos =
                             std::find(h_sg_renumber_map->begin(), h_sg_renumber_map->end(), v);

--- a/cpp/tests/mtmg/threaded_test.cu
+++ b/cpp/tests/mtmg/threaded_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -407,8 +407,8 @@ class Tests_Multithreaded
             thrust::make_zip_iterator(std::get<0>(t1).begin(), std::get<1>(t1).begin()),
             thrust::make_zip_iterator(std::get<0>(t1).end(), std::get<1>(t1).end()),
             [&h_sg_pageranks, compare_functor, &h_sg_renumber_map](auto t2) {
-              vertex_t v  = thrust::get<0>(t2);
-              weight_t pr = thrust::get<1>(t2);
+              vertex_t v  = cuda::std::get<0>(t2);
+              weight_t pr = cuda::std::get<1>(t2);
 
               auto pos    = std::find(h_sg_renumber_map->begin(), h_sg_renumber_map->end(), v);
               auto offset = std::distance(h_sg_renumber_map->begin(), pos);

--- a/cpp/tests/mtmg/threaded_test_jaccard.cu
+++ b/cpp/tests/mtmg/threaded_test_jaccard.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -419,8 +419,9 @@ class Tests_Multithreaded
         thrust::make_zip_iterator(h_sg_v1.begin(), h_sg_v2.begin(), h_sg_similarities.begin()),
         thrust::make_zip_iterator(h_sg_v1.end(), h_sg_v2.end(), h_sg_similarities.end()),
         [&sg_results](auto tuple) {
-          sg_results.insert(std::make_pair(
-            std::make_tuple(thrust::get<0>(tuple), thrust::get<1>(tuple)), thrust::get<2>(tuple)));
+          sg_results.insert(
+            std::make_pair(std::make_tuple(cuda::std::get<0>(tuple), cuda::std::get<1>(tuple)),
+                           cuda::std::get<2>(tuple)));
         });
 
       std::for_each(
@@ -433,9 +434,9 @@ class Tests_Multithreaded
             thrust::make_zip_iterator(
               std::get<0>(t1).end(), std::get<1>(t1).end(), std::get<2>(t1).end()),
             [&sg_results, compare_functor](auto t2) {
-              vertex_t v1      = thrust::get<0>(t2);
-              vertex_t v2      = thrust::get<1>(t2);
-              weight_t jaccard = thrust::get<2>(t2);
+              vertex_t v1      = cuda::std::get<0>(t2);
+              vertex_t v2      = cuda::std::get<1>(t2);
+              weight_t jaccard = cuda::std::get<2>(t2);
 
               auto pos = sg_results.find(std::make_tuple(v1, v2));
 

--- a/cpp/tests/mtmg/threaded_test_louvain.cu
+++ b/cpp/tests/mtmg/threaded_test_louvain.cu
@@ -453,8 +453,8 @@ class Tests_Multithreaded
             thrust::make_zip_iterator(std::get<0>(t1).begin(), std::get<1>(t1).begin()),
             thrust::make_zip_iterator(std::get<0>(t1).end(), std::get<1>(t1).end()),
             [&h_sg_clusters, &h_cluster_map, &h_renumber_map, &h_cluster_reverse_map](auto t2) {
-              vertex_t v = thrust::get<0>(t2);
-              vertex_t c = thrust::get<1>(t2);
+              vertex_t v = cuda::std::get<0>(t2);
+              vertex_t c = cuda::std::get<1>(t2);
 
               auto pos    = std::find(h_renumber_map.begin(), h_renumber_map.end(), v);
               auto offset = std::distance(h_renumber_map.begin(), pos);

--- a/cpp/tests/prims/mg_count_if_e.cu
+++ b/cpp/tests/prims/mg_count_if_e.cu
@@ -38,12 +38,12 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/count.h>
 #include <thrust/distance.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <cuco/hash_functions.cuh>
 
@@ -204,14 +204,14 @@ using Tests_MGCountIfE_Rmat = Tests_MGCountIfE<cugraph::test::Rmat_Usecase>;
 TEST_P(Tests_MGCountIfE_File, CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, false>(std::get<0>(param),
-                                                                              std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, false>(
+    std::get<0>(param), std::get<1>(param));
 }
 
 TEST_P(Tests_MGCountIfE_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, false>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, false>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -219,7 +219,7 @@ TEST_P(Tests_MGCountIfE_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 TEST_P(Tests_MGCountIfE_Rmat, CheckInt64Int64FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int64_t, int64_t, float, thrust::tuple<int, float>, false>(
+  run_current_test<int64_t, int64_t, float, cuda::std::tuple<int, float>, false>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -227,14 +227,14 @@ TEST_P(Tests_MGCountIfE_Rmat, CheckInt64Int64FloatTupleIntFloatTransposeFalse)
 TEST_P(Tests_MGCountIfE_File, CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, true>(std::get<0>(param),
-                                                                             std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, true>(std::get<0>(param),
+                                                                                std::get<1>(param));
 }
 
 TEST_P(Tests_MGCountIfE_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, true>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, true>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -242,7 +242,7 @@ TEST_P(Tests_MGCountIfE_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 TEST_P(Tests_MGCountIfE_Rmat, CheckInt64Int64FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int64_t, int64_t, float, thrust::tuple<int, float>, true>(
+  run_current_test<int64_t, int64_t, float, cuda::std::tuple<int, float>, true>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }

--- a/cpp/tests/prims/mg_extract_transform_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_e.cu
@@ -41,6 +41,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/equal.h>
@@ -49,7 +50,6 @@
 #include <thrust/sort.h>
 #include <thrust/tabulate.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <cuco/hash_functions.cuh>
 
@@ -62,12 +62,12 @@
 template <typename vertex_t, typename property_t, typename output_payload_t>
 struct e_op_t {
   static_assert(std::is_same_v<output_payload_t, int32_t> ||
-                std::is_same_v<output_payload_t, thrust::tuple<float, int32_t>>);
+                std::is_same_v<output_payload_t, cuda::std::tuple<float, int32_t>>);
 
   using return_type =
     cuda::std::optional<std::conditional_t<std::is_arithmetic_v<output_payload_t>,
-                                           thrust::tuple<vertex_t, vertex_t, int32_t>,
-                                           thrust::tuple<vertex_t, vertex_t, float, int32_t>>>;
+                                           cuda::std::tuple<vertex_t, vertex_t, int32_t>,
+                                           cuda::std::tuple<vertex_t, vertex_t, float, int32_t>>>;
 
   __device__ return_type operator()(
     vertex_t src, vertex_t dst, property_t src_val, property_t dst_val, cuda::std::nullopt_t) const
@@ -75,11 +75,11 @@ struct e_op_t {
     auto output_payload = static_cast<output_payload_t>(1);
     if (src_val < dst_val) {
       if constexpr (std::is_arithmetic_v<output_payload_t>) {
-        return thrust::make_tuple(src, dst, output_payload);
+        return cuda::std::make_tuple(src, dst, output_payload);
       } else {
-        static_assert(thrust::tuple_size<output_payload_t>::value == size_t{2});
-        return thrust::make_tuple(
-          src, dst, thrust::get<0>(output_payload), thrust::get<1>(output_payload));
+        static_assert(cuda::std::tuple_size<output_payload_t>::value == size_t{2});
+        return cuda::std::make_tuple(
+          src, dst, cuda::std::get<0>(output_payload), cuda::std::get<1>(output_payload));
       }
     } else {
       return cuda::std::nullopt;
@@ -115,7 +115,7 @@ class Tests_MGExtractTransformE
     static_assert(std::is_same_v<output_payload_t, void> ||
                   cugraph::is_arithmetic_or_thrust_tuple_of_arithmetic<output_payload_t>::value);
     if constexpr (cugraph::is_thrust_tuple<output_payload_t>::value) {
-      static_assert(thrust::tuple_size<output_payload_t>::value == size_t{2});
+      static_assert(cuda::std::tuple_size<output_payload_t>::value == size_t{2});
     }
 
     HighResTimer hr_timer{};
@@ -295,14 +295,14 @@ TEST_P(Tests_MGExtractTransformE_Rmat, CheckInt32Int32FloatVoidInt32)
 TEST_P(Tests_MGExtractTransformE_File, CheckInt32Int32FloatVoidTupleFloatInt32)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<float, int32_t>>(std::get<0>(param),
-                                                                           std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<float, int32_t>>(std::get<0>(param),
+                                                                              std::get<1>(param));
 }
 
 TEST_P(Tests_MGExtractTransformE_Rmat, CheckInt32Int32FloatVoidTupleFloatInt32)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<float, int32_t>>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<float, int32_t>>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -324,14 +324,14 @@ TEST_P(Tests_MGExtractTransformE_Rmat, CheckInt32Int32FloatInt32Int32)
 TEST_P(Tests_MGExtractTransformE_File, CheckInt32Int32FloatInt32TupleFloatInt32)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<float, int32_t>>(std::get<0>(param),
-                                                                           std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<float, int32_t>>(std::get<0>(param),
+                                                                              std::get<1>(param));
 }
 
 TEST_P(Tests_MGExtractTransformE_Rmat, CheckInt32Int32FloatInt32TupleFloatInt32)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<float, int32_t>>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<float, int32_t>>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }

--- a/cpp/tests/prims/mg_extract_transform_v_frontier_outgoing_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_v_frontier_outgoing_e.cu
@@ -40,6 +40,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/equal.h>
@@ -48,7 +49,6 @@
 #include <thrust/sort.h>
 #include <thrust/tabulate.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <cuco/hash_functions.cuh>
 
@@ -61,18 +61,18 @@
 template <typename key_t, typename vertex_t, typename property_t, typename output_payload_t>
 struct e_op_t {
   static_assert(std::is_same_v<key_t, vertex_t> ||
-                std::is_same_v<key_t, thrust::tuple<vertex_t, int32_t>>);
+                std::is_same_v<key_t, cuda::std::tuple<vertex_t, int32_t>>);
   static_assert(std::is_same_v<output_payload_t, int32_t> ||
-                std::is_same_v<output_payload_t, thrust::tuple<float, int32_t>>);
+                std::is_same_v<output_payload_t, cuda::std::tuple<float, int32_t>>);
 
   using return_type = cuda::std::optional<typename std::conditional_t<
     std::is_same_v<key_t, vertex_t>,
     std::conditional_t<std::is_arithmetic_v<output_payload_t>,
-                       thrust::tuple<vertex_t, vertex_t, int32_t>,
-                       thrust::tuple<vertex_t, vertex_t, float, int32_t>>,
+                       cuda::std::tuple<vertex_t, vertex_t, int32_t>,
+                       cuda::std::tuple<vertex_t, vertex_t, float, int32_t>>,
     std::conditional_t<std::is_arithmetic_v<output_payload_t>,
-                       thrust::tuple<vertex_t, int32_t, vertex_t, int32_t>,
-                       thrust::tuple<vertex_t, int32_t, vertex_t, float, int32_t>>>>;
+                       cuda::std::tuple<vertex_t, int32_t, vertex_t, int32_t>,
+                       cuda::std::tuple<vertex_t, int32_t, vertex_t, float, int32_t>>>>;
 
   __device__ return_type operator()(key_t optionally_tagged_src,
                                     vertex_t dst,
@@ -84,28 +84,28 @@ struct e_op_t {
     if (src_val < dst_val) {
       if constexpr (std::is_same_v<key_t, vertex_t>) {
         if constexpr (std::is_arithmetic_v<output_payload_t>) {
-          return thrust::make_tuple(optionally_tagged_src, dst, output_payload);
+          return cuda::std::make_tuple(optionally_tagged_src, dst, output_payload);
         } else {
-          static_assert(thrust::tuple_size<output_payload_t>::value == size_t{2});
-          return thrust::make_tuple(optionally_tagged_src,
-                                    dst,
-                                    thrust::get<0>(output_payload),
-                                    thrust::get<1>(output_payload));
+          static_assert(cuda::std::tuple_size<output_payload_t>::value == size_t{2});
+          return cuda::std::make_tuple(optionally_tagged_src,
+                                       dst,
+                                       cuda::std::get<0>(output_payload),
+                                       cuda::std::get<1>(output_payload));
         }
       } else {
-        static_assert(thrust::tuple_size<key_t>::value == size_t{2});
+        static_assert(cuda::std::tuple_size<key_t>::value == size_t{2});
         if constexpr (std::is_arithmetic_v<output_payload_t>) {
-          return thrust::make_tuple(thrust::get<0>(optionally_tagged_src),
-                                    thrust::get<1>(optionally_tagged_src),
-                                    dst,
-                                    output_payload);
+          return cuda::std::make_tuple(cuda::std::get<0>(optionally_tagged_src),
+                                       cuda::std::get<1>(optionally_tagged_src),
+                                       dst,
+                                       output_payload);
         } else {
-          static_assert(thrust::tuple_size<output_payload_t>::value == size_t{2});
-          return thrust::make_tuple(thrust::get<0>(optionally_tagged_src),
-                                    thrust::get<1>(optionally_tagged_src),
-                                    dst,
-                                    thrust::get<0>(output_payload),
-                                    thrust::get<1>(output_payload));
+          static_assert(cuda::std::tuple_size<output_payload_t>::value == size_t{2});
+          return cuda::std::make_tuple(cuda::std::get<0>(optionally_tagged_src),
+                                       cuda::std::get<1>(optionally_tagged_src),
+                                       dst,
+                                       cuda::std::get<0>(output_payload),
+                                       cuda::std::get<1>(output_payload));
         }
       }
     } else {
@@ -144,13 +144,13 @@ class Tests_MGExtractTransformVFrontierOutgoingE
     using result_t    = int32_t;
 
     using key_t =
-      std::conditional_t<std::is_same_v<tag_t, void>, vertex_t, thrust::tuple<vertex_t, tag_t>>;
+      std::conditional_t<std::is_same_v<tag_t, void>, vertex_t, cuda::std::tuple<vertex_t, tag_t>>;
 
     static_assert(std::is_same_v<tag_t, void> || std::is_arithmetic_v<tag_t>);
     static_assert(std::is_same_v<output_payload_t, void> ||
                   cugraph::is_arithmetic_or_thrust_tuple_of_arithmetic<output_payload_t>::value);
     if constexpr (cugraph::is_thrust_tuple<output_payload_t>::value) {
-      static_assert(thrust::tuple_size<output_payload_t>::value == size_t{2});
+      static_assert(cuda::std::tuple_size<output_payload_t>::value == size_t{2});
     }
 
     HighResTimer hr_timer{};
@@ -215,7 +215,7 @@ class Tests_MGExtractTransformVFrontierOutgoingE
                        [mg_renumber_map_labels = (*d_mg_renumber_map_labels).data(),
                         local_vertex_partition_range_first =
                           mg_graph_view.local_vertex_partition_range_first()] __device__(size_t i) {
-                         return thrust::make_tuple(
+                         return cuda::std::make_tuple(
                            static_cast<vertex_t>(local_vertex_partition_range_first + i),
                            static_cast<tag_t>(*(mg_renumber_map_labels + i) % size_t{10}));
                        });
@@ -330,7 +330,7 @@ class Tests_MGExtractTransformVFrontierOutgoingE
                            cugraph::get_dataframe_buffer_begin(sg_key_buffer),
                            cugraph::get_dataframe_buffer_end(sg_key_buffer),
                            [] __device__(size_t i) {
-                             return thrust::make_tuple(
+                             return cuda::std::make_tuple(
                                static_cast<vertex_t>(i),
                                static_cast<tag_t>(static_cast<vertex_t>(i) % size_t{10}));
                            });
@@ -395,14 +395,14 @@ TEST_P(Tests_MGExtractTransformVFrontierOutgoingE_Rmat, CheckInt32Int32FloatVoid
 TEST_P(Tests_MGExtractTransformVFrontierOutgoingE_File, CheckInt32Int32FloatVoidTupleFloatInt32)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, void, thrust::tuple<float, int32_t>>(
+  run_current_test<int32_t, int32_t, float, void, cuda::std::tuple<float, int32_t>>(
     std::get<0>(param), std::get<1>(param));
 }
 
 TEST_P(Tests_MGExtractTransformVFrontierOutgoingE_Rmat, CheckInt32Int32FloatVoidTupleFloatInt32)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, void, thrust::tuple<float, int32_t>>(
+  run_current_test<int32_t, int32_t, float, void, cuda::std::tuple<float, int32_t>>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -425,14 +425,14 @@ TEST_P(Tests_MGExtractTransformVFrontierOutgoingE_Rmat, CheckInt32Int32FloatInt3
 TEST_P(Tests_MGExtractTransformVFrontierOutgoingE_File, CheckInt32Int32FloatInt32TupleFloatInt32)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, int32_t, thrust::tuple<float, int32_t>>(
+  run_current_test<int32_t, int32_t, float, int32_t, cuda::std::tuple<float, int32_t>>(
     std::get<0>(param), std::get<1>(param));
 }
 
 TEST_P(Tests_MGExtractTransformVFrontierOutgoingE_Rmat, CheckInt32Int32FloatInt32TupleFloatInt32)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, int32_t, thrust::tuple<float, int32_t>>(
+  run_current_test<int32_t, int32_t, float, int32_t, cuda::std::tuple<float, int32_t>>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }

--- a/cpp/tests/prims/mg_per_v_pair_transform_dst_nbr_weighted_intersection.cu
+++ b/cpp/tests/prims/mg_per_v_pair_transform_dst_nbr_weighted_intersection.cu
@@ -41,8 +41,8 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/tuple.h>
 
 #include <gtest/gtest.h>
 
@@ -50,7 +50,7 @@
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 struct intersection_op_t {
-  __device__ thrust::tuple<weight_t, weight_t> operator()(
+  __device__ cuda::std::tuple<weight_t, weight_t> operator()(
     vertex_t a,
     vertex_t b,
     weight_t weight_a /* weighted out degree */,
@@ -78,7 +78,7 @@ struct intersection_op_t {
 
     max_weight_a_intersect_b += sum_of_uniq_a + sum_of_uniq_b;
 
-    return thrust::make_tuple(min_weight_a_intersect_b, max_weight_a_intersect_b);
+    return cuda::std::make_tuple(min_weight_a_intersect_b, max_weight_a_intersect_b);
   }
 };
 
@@ -155,7 +155,7 @@ class Tests_MGPerVPairTransformDstNbrIntersection
       vertex_t{0});  // the code below to generate vertex pairs is invalid for an empty graph.
 
     auto mg_vertex_pair_buffer =
-      cugraph::allocate_dataframe_buffer<thrust::tuple<vertex_t, vertex_t>>(
+      cugraph::allocate_dataframe_buffer<cuda::std::tuple<vertex_t, vertex_t>>(
         prims_usecase.num_vertex_pairs / comm_size +
           (static_cast<size_t>(comm_rank) < prims_usecase.num_vertex_pairs % comm_size ? 1 : 0),
         handle_->get_stream());
@@ -169,7 +169,7 @@ class Tests_MGPerVPairTransformDstNbrIntersection
           hash_func{};  // use hash_func to generate arbitrary vertex pairs
         auto v0 = static_cast<vertex_t>(hash_func(i + comm_rank) % num_vertices);
         auto v1 = static_cast<vertex_t>(hash_func(i + num_vertices + comm_rank) % num_vertices);
-        return thrust::make_tuple(v0, v1);
+        return cuda::std::make_tuple(v0, v1);
       });
 
     auto h_vertex_partition_range_lasts = mg_graph_view.vertex_partition_range_lasts();
@@ -196,8 +196,9 @@ class Tests_MGPerVPairTransformDstNbrIntersection
                  std::nullopt,
                  h_vertex_partition_range_lasts);
 
-    auto mg_result_buffer = cugraph::allocate_dataframe_buffer<thrust::tuple<weight_t, weight_t>>(
-      cugraph::size_dataframe_buffer(mg_vertex_pair_buffer), handle_->get_stream());
+    auto mg_result_buffer =
+      cugraph::allocate_dataframe_buffer<cuda::std::tuple<weight_t, weight_t>>(
+        cugraph::size_dataframe_buffer(mg_vertex_pair_buffer), handle_->get_stream());
     auto mg_out_weight_sums = compute_out_weight_sums(*handle_, mg_graph_view, mg_edge_weight_view);
 
     if (cugraph::test::g_perf) {
@@ -240,7 +241,7 @@ class Tests_MGPerVPairTransformDstNbrIntersection
         h_vertex_partition_range_lasts);
 
       auto mg_aggregate_vertex_pair_buffer =
-        cugraph::allocate_dataframe_buffer<thrust::tuple<vertex_t, vertex_t>>(
+        cugraph::allocate_dataframe_buffer<cuda::std::tuple<vertex_t, vertex_t>>(
           0, handle_->get_stream());
       std::get<0>(mg_aggregate_vertex_pair_buffer) =
         cugraph::test::device_gatherv(*handle_,
@@ -252,7 +253,7 @@ class Tests_MGPerVPairTransformDstNbrIntersection
                                       std::get<1>(mg_vertex_pair_buffer).size());
 
       auto mg_aggregate_result_buffer =
-        cugraph::allocate_dataframe_buffer<thrust::tuple<weight_t, weight_t>>(
+        cugraph::allocate_dataframe_buffer<cuda::std::tuple<weight_t, weight_t>>(
           0, handle_->get_stream());
       std::get<0>(mg_aggregate_result_buffer) = cugraph::test::device_gatherv(
         *handle_, std::get<0>(mg_result_buffer).data(), std::get<0>(mg_result_buffer).size());
@@ -282,7 +283,7 @@ class Tests_MGPerVPairTransformDstNbrIntersection
       if (handle_->get_comms().get_rank() == 0) {
         auto sg_graph_view = sg_graph.view();
         auto sg_result_buffer =
-          cugraph::allocate_dataframe_buffer<thrust::tuple<weight_t, weight_t>>(
+          cugraph::allocate_dataframe_buffer<cuda::std::tuple<weight_t, weight_t>>(
             cugraph::size_dataframe_buffer(mg_aggregate_vertex_pair_buffer), handle_->get_stream());
 
         rmm::device_uvector<weight_t> sg_out_weight_sums =
@@ -301,11 +302,11 @@ class Tests_MGPerVPairTransformDstNbrIntersection
         auto threshold_ratio     = weight_t{1e-4};
         auto threshold_magnitude = std::numeric_limits<weight_t>::min();
         auto nearly_equal = [threshold_ratio, threshold_magnitude] __device__(auto lhs, auto rhs) {
-          return (fabs(thrust::get<0>(lhs) - thrust::get<0>(rhs)) <
-                  max(max(thrust::get<0>(lhs), thrust::get<0>(rhs)) * threshold_ratio,
+          return (fabs(cuda::std::get<0>(lhs) - cuda::std::get<0>(rhs)) <
+                  max(max(cuda::std::get<0>(lhs), cuda::std::get<0>(rhs)) * threshold_ratio,
                       threshold_magnitude)) &&
-                 (fabs(thrust::get<1>(lhs) - thrust::get<1>(rhs)) <
-                  max(max(thrust::get<1>(lhs), thrust::get<1>(rhs)) * threshold_ratio,
+                 (fabs(cuda::std::get<1>(lhs) - cuda::std::get<1>(rhs)) <
+                  max(max(cuda::std::get<1>(lhs), cuda::std::get<1>(rhs)) * threshold_ratio,
                       threshold_magnitude));
         };
         bool valid = thrust::equal(handle_->get_thrust_policy(),

--- a/cpp/tests/prims/mg_per_v_random_select_transform_outgoing_e.cu
+++ b/cpp/tests/prims/mg_per_v_random_select_transform_outgoing_e.cu
@@ -42,9 +42,9 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/adjacent_difference.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/tuple.h>
 
 #include <gtest/gtest.h>
 
@@ -61,7 +61,7 @@ struct e_bias_op_t {
 
 template <typename vertex_t, typename weight_t, typename edge_type_t, typename property_t>
 struct e_op_t {
-  using result_t = decltype(cugraph::thrust_tuple_cat(thrust::tuple<vertex_t, vertex_t>{},
+  using result_t = decltype(cugraph::thrust_tuple_cat(cuda::std::tuple<vertex_t, vertex_t>{},
                                                       cugraph::to_thrust_tuple(property_t{}),
                                                       cugraph::to_thrust_tuple(property_t{}),
                                                       cugraph::to_thrust_tuple(edge_type_t{})));
@@ -73,16 +73,16 @@ struct e_op_t {
                                  cuda::std::nullopt_t) const
   {
     if constexpr (cugraph::is_thrust_tuple_of_arithmetic<property_t>::value) {
-      static_assert(thrust::tuple_size<property_t>::value == size_t{2});
-      return thrust::make_tuple(src,
-                                dst,
-                                thrust::get<0>(src_prop),
-                                thrust::get<1>(src_prop),
-                                thrust::get<0>(dst_prop),
-                                thrust::get<1>(dst_prop),
-                                edge_type_t{0});
+      static_assert(cuda::std::tuple_size<property_t>::value == size_t{2});
+      return cuda::std::make_tuple(src,
+                                   dst,
+                                   cuda::std::get<0>(src_prop),
+                                   cuda::std::get<1>(src_prop),
+                                   cuda::std::get<0>(dst_prop),
+                                   cuda::std::get<1>(dst_prop),
+                                   edge_type_t{0});
     } else {
-      return thrust::make_tuple(src, dst, src_prop, dst_prop, edge_type_t{0});
+      return cuda::std::make_tuple(src, dst, src_prop, dst_prop, edge_type_t{0});
     }
   }
 
@@ -90,16 +90,16 @@ struct e_op_t {
     vertex_t src, vertex_t dst, property_t src_prop, property_t dst_prop, edge_type_t type) const
   {
     if constexpr (cugraph::is_thrust_tuple_of_arithmetic<property_t>::value) {
-      static_assert(thrust::tuple_size<property_t>::value == size_t{2});
-      return thrust::make_tuple(src,
-                                dst,
-                                thrust::get<0>(src_prop),
-                                thrust::get<1>(src_prop),
-                                thrust::get<0>(dst_prop),
-                                thrust::get<1>(dst_prop),
-                                type);
+      static_assert(cuda::std::tuple_size<property_t>::value == size_t{2});
+      return cuda::std::make_tuple(src,
+                                   dst,
+                                   cuda::std::get<0>(src_prop),
+                                   cuda::std::get<1>(src_prop),
+                                   cuda::std::get<0>(dst_prop),
+                                   cuda::std::get<1>(dst_prop),
+                                   type);
     } else {
-      return thrust::make_tuple(src, dst, src_prop, dst_prop, type);
+      return cuda::std::make_tuple(src, dst, src_prop, dst_prop, type);
     }
   }
 };
@@ -231,16 +231,16 @@ class Tests_MGPerVRandomSelectTransformOutgoingE
       .insert(cugraph::get_dataframe_buffer_begin(mg_vertex_buffer),
               cugraph::get_dataframe_buffer_end(mg_vertex_buffer));
 
-    using result_t = decltype(cugraph::thrust_tuple_cat(thrust::tuple<vertex_t, vertex_t>{},
+    using result_t = decltype(cugraph::thrust_tuple_cat(cuda::std::tuple<vertex_t, vertex_t>{},
                                                         cugraph::to_thrust_tuple(property_t{}),
                                                         cugraph::to_thrust_tuple(property_t{}),
                                                         cugraph::to_thrust_tuple(edge_type_t{})));
 
     std::optional<result_t> invalid_value{std::nullopt};
     if (prims_usecase.use_invalid_value) {
-      invalid_value                  = result_t{};
-      thrust::get<0>(*invalid_value) = cugraph::invalid_vertex_id<vertex_t>::value;
-      thrust::get<1>(*invalid_value) = cugraph::invalid_vertex_id<vertex_t>::value;
+      invalid_value                     = result_t{};
+      cuda::std::get<0>(*invalid_value) = cugraph::invalid_vertex_id<vertex_t>::value;
+      cuda::std::get<1>(*invalid_value) = cugraph::invalid_vertex_id<vertex_t>::value;
     }
 
     if (cugraph::test::g_perf) {
@@ -559,7 +559,8 @@ class Tests_MGPerVRandomSelectTransformOutgoingE
                 }
                 for (auto offset = offset_first; offset < offset_last; ++offset) {
                   auto e_op_result = *(sample_e_op_result_first + offset);
-                  auto type = thrust::get<thrust::tuple_size<result_t>::value - 1>(e_op_result);
+                  auto type =
+                    cuda::std::get<cuda::std::tuple_size<result_t>::value - 1>(e_op_result);
                   if (type >= c * array_size &&
                       type < cuda::std::min((c + 1) * array_size, num_edge_types)) {
                     ++per_type_sample_counts[type - c * array_size];
@@ -612,8 +613,8 @@ class Tests_MGPerVRandomSelectTransformOutgoingE
 
             for (size_t j = offset_first; j < offset_last; ++j) {
               auto e_op_result  = *(sample_e_op_result_first + j);
-              auto sg_src       = thrust::get<0>(e_op_result);
-              auto sg_dst       = thrust::get<1>(e_op_result);
+              auto sg_src       = cuda::std::get<0>(e_op_result);
+              auto sg_dst       = cuda::std::get<1>(e_op_result);
               auto sg_nbr_first = sg_indices + *(sg_graph_offsets + sg_src);
               auto sg_nbr_last  = sg_indices + *(sg_graph_offsets + (sg_src + vertex_t{1}));
               auto sg_nbr_bias_first =
@@ -647,22 +648,22 @@ class Tests_MGPerVRandomSelectTransformOutgoingE
               property_t src_val{};
               property_t dst_val{};
               if constexpr (cugraph::is_thrust_tuple_of_arithmetic<property_t>::value) {
-                src_val =
-                  thrust::make_tuple(thrust::get<2>(e_op_result), thrust::get<3>(e_op_result));
-                dst_val =
-                  thrust::make_tuple(thrust::get<4>(e_op_result), thrust::get<5>(e_op_result));
+                src_val = cuda::std::make_tuple(cuda::std::get<2>(e_op_result),
+                                                cuda::std::get<3>(e_op_result));
+                dst_val = cuda::std::make_tuple(cuda::std::get<4>(e_op_result),
+                                                cuda::std::get<5>(e_op_result));
               } else {
-                src_val = thrust::get<2>(e_op_result);
-                dst_val = thrust::get<3>(e_op_result);
+                src_val = cuda::std::get<2>(e_op_result);
+                dst_val = cuda::std::get<3>(e_op_result);
               }
               if (src_val != property_transform(sg_src)) { return true; }
               if (dst_val != property_transform(sg_dst)) { return true; }
 
               if (!with_replacement) {
                 auto sg_dst_first =
-                  thrust::get<1>(sample_e_op_result_first.get_iterator_tuple()) + offset_first;
+                  cuda::std::get<1>(sample_e_op_result_first.get_iterator_tuple()) + offset_first;
                 auto sg_dst_last =
-                  thrust::get<1>(sample_e_op_result_first.get_iterator_tuple()) + offset_last;
+                  cuda::std::get<1>(sample_e_op_result_first.get_iterator_tuple()) + offset_last;
                 auto dst_count = thrust::count(thrust::seq, sg_dst_first, sg_dst_last, sg_dst);
                 auto lower_it =
                   thrust::lower_bound(thrust::seq,
@@ -710,14 +711,14 @@ using Tests_MGPerVRandomSelectTransformOutgoingE_Rmat =
 TEST_P(Tests_MGPerVRandomSelectTransformOutgoingE_File, CheckInt32Int32FloatTupleIntFloat)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>>(std::get<0>(param),
-                                                                       std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>>(std::get<0>(param),
+                                                                          std::get<1>(param));
 }
 
 TEST_P(Tests_MGPerVRandomSelectTransformOutgoingE_Rmat, CheckInt32Int32FloatTupleIntFloat)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -725,7 +726,7 @@ TEST_P(Tests_MGPerVRandomSelectTransformOutgoingE_Rmat, CheckInt32Int32FloatTupl
 TEST_P(Tests_MGPerVRandomSelectTransformOutgoingE_Rmat, CheckInt64Int64FloatTupleIntFloat)
 {
   auto param = GetParam();
-  run_current_test<int64_t, int64_t, float, thrust::tuple<int, float>>(
+  run_current_test<int64_t, int64_t, float, cuda::std::tuple<int, float>>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }

--- a/cpp/tests/prims/mg_per_v_transform_reduce_dst_key_aggregated_outgoing_e.cu
+++ b/cpp/tests/prims/mg_per_v_transform_reduce_dst_key_aggregated_outgoing_e.cu
@@ -41,13 +41,13 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/count.h>
 #include <thrust/distance.h>
 #include <thrust/equal.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <cuco/hash_functions.cuh>
 
@@ -164,13 +164,13 @@ class Tests_MGPerVTransformReduceDstKeyAggregatedOutgoingE
         *handle_, mg_kv_store_keys, key_prop_hash_bin_count);
 
     static_assert(std::is_same_v<result_t, int> ||
-                  std::is_same_v<result_t, thrust::tuple<int, float>>);
+                  std::is_same_v<result_t, cuda::std::tuple<int, float>>);
     result_t invalid_value{};
     if constexpr (std::is_same_v<result_t, int>) {
       invalid_value = std::numeric_limits<int>::max();
     } else {
       invalid_value =
-        thrust::make_tuple(std::numeric_limits<int>::max(), std::numeric_limits<float>::max());
+        cuda::std::make_tuple(std::numeric_limits<int>::max(), std::numeric_limits<float>::max());
     }
     cugraph::kv_store_t<vertex_t, result_t, false> mg_kv_store(
       mg_kv_store_keys.begin(),
@@ -333,7 +333,7 @@ class Tests_MGPerVTransformReduceDstKeyAggregatedOutgoingE
               mg_graph_view.local_vertex_partition_range(),
               std::optional<raft::device_span<vertex_t const>>{std::nullopt},
               std::optional<raft::device_span<vertex_t const>>{std::nullopt},
-              raft::device_span<typename thrust::tuple_element<0, result_t>::type const>(
+              raft::device_span<typename cuda::std::tuple_element<0, result_t>::type const>(
                 std::get<0>(mg_results[i]).data(), std::get<0>(mg_results[i]).size()));
 
           std::tie(std::ignore, std::get<1>(mg_aggregate_results)) =
@@ -344,7 +344,7 @@ class Tests_MGPerVTransformReduceDstKeyAggregatedOutgoingE
               mg_graph_view.local_vertex_partition_range(),
               std::optional<raft::device_span<vertex_t const>>{std::nullopt},
               std::optional<raft::device_span<vertex_t const>>{std::nullopt},
-              raft::device_span<typename thrust::tuple_element<1, result_t>::type const>(
+              raft::device_span<typename cuda::std::tuple_element<1, result_t>::type const>(
                 std::get<1>(mg_results[i]).data(), std::get<1>(mg_results[i]).size()));
         }
 
@@ -503,15 +503,15 @@ TEST_P(Tests_MGPerVTransformReduceDstKeyAggregatedOutgoingE_File,
        CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>>(std::get<0>(param),
-                                                                       std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>>(std::get<0>(param),
+                                                                          std::get<1>(param));
 }
 
 TEST_P(Tests_MGPerVTransformReduceDstKeyAggregatedOutgoingE_Rmat,
        CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -520,7 +520,7 @@ TEST_P(Tests_MGPerVTransformReduceDstKeyAggregatedOutgoingE_Rmat,
        CheckInt64Int64FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int64_t, int64_t, float, thrust::tuple<int, float>>(
+  run_current_test<int64_t, int64_t, float, cuda::std::tuple<int, float>>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }

--- a/cpp/tests/prims/mg_per_v_transform_reduce_incoming_outgoing_e.cu
+++ b/cpp/tests/prims/mg_per_v_transform_reduce_incoming_outgoing_e.cu
@@ -41,13 +41,13 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/count.h>
 #include <thrust/distance.h>
 #include <thrust/equal.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <cuco/hash_functions.cuh>
 
@@ -320,7 +320,7 @@ class Tests_MGPerVTransformReduceIncomingOutgoingE
               mg_graph_view.local_vertex_partition_range(),
               std::optional<raft::device_span<vertex_t const>>{std::nullopt},
               std::optional<raft::device_span<vertex_t const>>{std::nullopt},
-              raft::device_span<typename thrust::tuple_element<0, result_t>::type const>(
+              raft::device_span<typename cuda::std::tuple_element<0, result_t>::type const>(
                 std::get<0>(mg_in_results[i]).data(), std::get<0>(mg_in_results[i]).size()));
 
           std::tie(std::ignore, std::get<1>(mg_aggregate_in_results)) =
@@ -331,7 +331,7 @@ class Tests_MGPerVTransformReduceIncomingOutgoingE
               mg_graph_view.local_vertex_partition_range(),
               std::optional<raft::device_span<vertex_t const>>{std::nullopt},
               std::optional<raft::device_span<vertex_t const>>{std::nullopt},
-              raft::device_span<typename thrust::tuple_element<1, result_t>::type const>(
+              raft::device_span<typename cuda::std::tuple_element<1, result_t>::type const>(
                 std::get<1>(mg_in_results[i]).data(), std::get<1>(mg_in_results[i]).size()));
 
           std::tie(std::ignore, std::get<0>(mg_aggregate_out_results)) =
@@ -342,7 +342,7 @@ class Tests_MGPerVTransformReduceIncomingOutgoingE
               mg_graph_view.local_vertex_partition_range(),
               std::optional<raft::device_span<vertex_t const>>{std::nullopt},
               std::optional<raft::device_span<vertex_t const>>{std::nullopt},
-              raft::device_span<typename thrust::tuple_element<0, result_t>::type const>(
+              raft::device_span<typename cuda::std::tuple_element<0, result_t>::type const>(
                 std::get<0>(mg_out_results[i]).data(), std::get<0>(mg_out_results[i]).size()));
 
           std::tie(std::ignore, std::get<1>(mg_aggregate_out_results)) =
@@ -353,7 +353,7 @@ class Tests_MGPerVTransformReduceIncomingOutgoingE
               mg_graph_view.local_vertex_partition_range(),
               std::optional<raft::device_span<vertex_t const>>{std::nullopt},
               std::optional<raft::device_span<vertex_t const>>{std::nullopt},
-              raft::device_span<typename thrust::tuple_element<1, result_t>::type const>(
+              raft::device_span<typename cuda::std::tuple_element<1, result_t>::type const>(
                 std::get<1>(mg_out_results[i]).data(), std::get<1>(mg_out_results[i]).size()));
         }
 
@@ -484,15 +484,15 @@ TEST_P(Tests_MGPerVTransformReduceIncomingOutgoingE_File,
        CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, false>(std::get<0>(param),
-                                                                              std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, false>(
+    std::get<0>(param), std::get<1>(param));
 }
 
 TEST_P(Tests_MGPerVTransformReduceIncomingOutgoingE_Rmat,
        CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, false>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, false>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -501,7 +501,7 @@ TEST_P(Tests_MGPerVTransformReduceIncomingOutgoingE_Rmat,
        CheckInt64Int64FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int64_t, int64_t, float, thrust::tuple<int, float>, false>(
+  run_current_test<int64_t, int64_t, float, cuda::std::tuple<int, float>, false>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -510,15 +510,15 @@ TEST_P(Tests_MGPerVTransformReduceIncomingOutgoingE_File,
        CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, true>(std::get<0>(param),
-                                                                             std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, true>(std::get<0>(param),
+                                                                                std::get<1>(param));
 }
 
 TEST_P(Tests_MGPerVTransformReduceIncomingOutgoingE_Rmat,
        CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, true>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, true>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -527,7 +527,7 @@ TEST_P(Tests_MGPerVTransformReduceIncomingOutgoingE_Rmat,
        CheckInt64Int64FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int64_t, int64_t, float, thrust::tuple<int, float>, true>(
+  run_current_test<int64_t, int64_t, float, cuda::std::tuple<int, float>, true>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }

--- a/cpp/tests/prims/mg_reduce_v.cu
+++ b/cpp/tests/prims/mg_reduce_v.cu
@@ -36,13 +36,13 @@
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/distance.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <cuco/hash_functions.cuh>
 
@@ -233,14 +233,14 @@ using Tests_MGReduceV_Rmat = Tests_MGReduceV<cugraph::test::Rmat_Usecase>;
 TEST_P(Tests_MGReduceV_File, CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int32_t, float>, false>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int32_t, float>, false>(
     std::get<0>(param), std::get<1>(param));
 }
 
 TEST_P(Tests_MGReduceV_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int32_t, float>, false>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int32_t, float>, false>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -248,14 +248,14 @@ TEST_P(Tests_MGReduceV_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 TEST_P(Tests_MGReduceV_File, CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int32_t, float>, true>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int32_t, float>, true>(
     std::get<0>(param), std::get<1>(param));
 }
 
 TEST_P(Tests_MGReduceV_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int32_t, float>, true>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int32_t, float>, true>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }

--- a/cpp/tests/prims/mg_transform_e.cu
+++ b/cpp/tests/prims/mg_transform_e.cu
@@ -38,10 +38,10 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/count.h>
 #include <thrust/distance.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
 
 #include <cuco/hash_functions.cuh>
 
@@ -135,21 +135,22 @@ class Tests_MGTransformE
         std::optional<cugraph::edge_property_view_t<edge_t, int32_t const*>>{std::nullopt},
         std::optional<raft::device_span<vertex_t const>>{std::nullopt});
       auto edge_first = thrust::make_zip_iterator(
-        thrust::make_tuple(store_transposed ? dsts.begin() : srcs.begin(),
-                           store_transposed ? srcs.begin() : dsts.begin()));
-      srcs.resize(thrust::distance(
-                    edge_first,
-                    thrust::remove_if(handle_->get_thrust_policy(),
-                                      edge_first,
-                                      edge_first + srcs.size(),
-                                      [] __device__(thrust::tuple<vertex_t, vertex_t> e) {
-                                        return ((thrust::get<0>(e) + thrust::get<1>(e)) % 2) != 0;
-                                      })),
-                  handle_->get_stream());
+        cuda::std::make_tuple(store_transposed ? dsts.begin() : srcs.begin(),
+                              store_transposed ? srcs.begin() : dsts.begin()));
+      srcs.resize(
+        thrust::distance(edge_first,
+                         thrust::remove_if(handle_->get_thrust_policy(),
+                                           edge_first,
+                                           edge_first + srcs.size(),
+                                           [] __device__(cuda::std::tuple<vertex_t, vertex_t> e) {
+                                             return ((cuda::std::get<0>(e) + cuda::std::get<1>(e)) %
+                                                     2) != 0;
+                                           })),
+        handle_->get_stream());
       dsts.resize(srcs.size(), handle_->get_stream());
       edge_first = thrust::make_zip_iterator(
-        thrust::make_tuple(store_transposed ? dsts.begin() : srcs.begin(),
-                           store_transposed ? srcs.begin() : dsts.begin()));
+        cuda::std::make_tuple(store_transposed ? dsts.begin() : srcs.begin(),
+                              store_transposed ? srcs.begin() : dsts.begin()));
       thrust::sort(handle_->get_thrust_policy(), edge_first, edge_first + srcs.size());
 
       edge_list.insert(srcs.begin(),
@@ -268,14 +269,14 @@ using Tests_MGTransformE_Rmat = Tests_MGTransformE<cugraph::test::Rmat_Usecase>;
 TEST_P(Tests_MGTransformE_File, CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, false>(std::get<0>(param),
-                                                                              std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, false>(
+    std::get<0>(param), std::get<1>(param));
 }
 
 TEST_P(Tests_MGTransformE_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, false>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, false>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -283,7 +284,7 @@ TEST_P(Tests_MGTransformE_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 TEST_P(Tests_MGTransformE_Rmat, CheckInt64Int64FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int64_t, int64_t, float, thrust::tuple<int, float>, false>(
+  run_current_test<int64_t, int64_t, float, cuda::std::tuple<int, float>, false>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -291,14 +292,14 @@ TEST_P(Tests_MGTransformE_Rmat, CheckInt64Int64FloatTupleIntFloatTransposeFalse)
 TEST_P(Tests_MGTransformE_File, CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, true>(std::get<0>(param),
-                                                                             std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, true>(std::get<0>(param),
+                                                                                std::get<1>(param));
 }
 
 TEST_P(Tests_MGTransformE_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, true>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, true>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -306,7 +307,7 @@ TEST_P(Tests_MGTransformE_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 TEST_P(Tests_MGTransformE_Rmat, CheckInt64Int64FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int64_t, int64_t, float, thrust::tuple<int, float>, true>(
+  run_current_test<int64_t, int64_t, float, cuda::std::tuple<int, float>, true>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }

--- a/cpp/tests/prims/mg_transform_reduce_dst_nbr_intersection_of_e_endpoints_by_v.cu
+++ b/cpp/tests/prims/mg_transform_reduce_dst_nbr_intersection_of_e_endpoints_by_v.cu
@@ -40,8 +40,8 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/tuple.h>
 
 #include <gtest/gtest.h>
 
@@ -49,14 +49,14 @@
 
 template <typename vertex_t, typename edge_t>
 struct intersection_op_t {
-  __device__ thrust::tuple<edge_t, edge_t, edge_t> operator()(
+  __device__ cuda::std::tuple<edge_t, edge_t, edge_t> operator()(
     vertex_t v0,
     vertex_t v1,
     edge_t v0_prop,
     edge_t v1_prop,
     raft::device_span<vertex_t const> intersection) const
   {
-    return thrust::make_tuple(
+    return cuda::std::make_tuple(
       v0_prop + v1_prop, v0_prop + v1_prop, static_cast<edge_t>(intersection.size()));
   }
 };

--- a/cpp/tests/prims/mg_transform_reduce_e.cu
+++ b/cpp/tests/prims/mg_transform_reduce_e.cu
@@ -39,12 +39,12 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/count.h>
 #include <thrust/distance.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <cuco/hash_functions.cuh>
 
@@ -220,14 +220,14 @@ using Tests_MGTransformReduceE_Rmat = Tests_MGTransformReduceE<cugraph::test::Rm
 TEST_P(Tests_MGTransformReduceE_File, CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, false>(std::get<0>(param),
-                                                                              std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, false>(
+    std::get<0>(param), std::get<1>(param));
 }
 
 TEST_P(Tests_MGTransformReduceE_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, false>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, false>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -235,7 +235,7 @@ TEST_P(Tests_MGTransformReduceE_Rmat, CheckInt32Int32FloatTupleIntFloatTranspose
 TEST_P(Tests_MGTransformReduceE_Rmat, CheckInt64Int64FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int64_t, int64_t, float, thrust::tuple<int, float>, false>(
+  run_current_test<int64_t, int64_t, float, cuda::std::tuple<int, float>, false>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -243,14 +243,14 @@ TEST_P(Tests_MGTransformReduceE_Rmat, CheckInt64Int64FloatTupleIntFloatTranspose
 TEST_P(Tests_MGTransformReduceE_File, CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, true>(std::get<0>(param),
-                                                                             std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, true>(std::get<0>(param),
+                                                                                std::get<1>(param));
 }
 
 TEST_P(Tests_MGTransformReduceE_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, true>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, true>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -258,7 +258,7 @@ TEST_P(Tests_MGTransformReduceE_Rmat, CheckInt32Int32FloatTupleIntFloatTranspose
 TEST_P(Tests_MGTransformReduceE_Rmat, CheckInt64Int64FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int64_t, int64_t, float, thrust::tuple<int, float>, true>(
+  run_current_test<int64_t, int64_t, float, cuda::std::tuple<int, float>, true>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }

--- a/cpp/tests/prims/mg_transform_reduce_e_by_src_dst_key.cu
+++ b/cpp/tests/prims/mg_transform_reduce_e_by_src_dst_key.cu
@@ -40,12 +40,12 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/count.h>
 #include <thrust/distance.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <cuco/hash_functions.cuh>
 
@@ -347,14 +347,14 @@ using Tests_MGTransformReduceEBySrcDstKey_Rmat =
 TEST_P(Tests_MGTransformReduceEBySrcDstKey_File, CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, false>(std::get<0>(param),
-                                                                              std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, false>(
+    std::get<0>(param), std::get<1>(param));
 }
 
 TEST_P(Tests_MGTransformReduceEBySrcDstKey_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, false>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, false>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -362,7 +362,7 @@ TEST_P(Tests_MGTransformReduceEBySrcDstKey_Rmat, CheckInt32Int32FloatTupleIntFlo
 TEST_P(Tests_MGTransformReduceEBySrcDstKey_Rmat, CheckInt64Int64FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int64_t, int64_t, float, thrust::tuple<int, float>, false>(
+  run_current_test<int64_t, int64_t, float, cuda::std::tuple<int, float>, false>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -370,14 +370,14 @@ TEST_P(Tests_MGTransformReduceEBySrcDstKey_Rmat, CheckInt64Int64FloatTupleIntFlo
 TEST_P(Tests_MGTransformReduceEBySrcDstKey_File, CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, true>(std::get<0>(param),
-                                                                             std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, true>(std::get<0>(param),
+                                                                                std::get<1>(param));
 }
 
 TEST_P(Tests_MGTransformReduceEBySrcDstKey_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, true>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, true>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -385,7 +385,7 @@ TEST_P(Tests_MGTransformReduceEBySrcDstKey_Rmat, CheckInt32Int32FloatTupleIntFlo
 TEST_P(Tests_MGTransformReduceEBySrcDstKey_Rmat, CheckInt64Int64FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int64_t, int64_t, float, thrust::tuple<int, float>, true>(
+  run_current_test<int64_t, int64_t, float, cuda::std::tuple<int, float>, true>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }

--- a/cpp/tests/prims/mg_transform_reduce_v.cu
+++ b/cpp/tests/prims/mg_transform_reduce_v.cu
@@ -36,10 +36,10 @@
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/count.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/tuple.h>
 
 #include <cuco/hash_functions.cuh>
 
@@ -237,14 +237,14 @@ using Tests_MGTransformReduceV_Rmat = Tests_MGTransformReduceV<cugraph::test::Rm
 TEST_P(Tests_MGTransformReduceV_File, CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, false>(std::get<0>(param),
-                                                                              std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, false>(
+    std::get<0>(param), std::get<1>(param));
 }
 
 TEST_P(Tests_MGTransformReduceV_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, false>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, false>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -252,7 +252,7 @@ TEST_P(Tests_MGTransformReduceV_Rmat, CheckInt32Int32FloatTupleIntFloatTranspose
 TEST_P(Tests_MGTransformReduceV_Rmat, CheckInt64Int64FloatTupleIntFloatTransposeFalse)
 {
   auto param = GetParam();
-  run_current_test<int64_t, int64_t, float, thrust::tuple<int, float>, false>(
+  run_current_test<int64_t, int64_t, float, cuda::std::tuple<int, float>, false>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -260,14 +260,14 @@ TEST_P(Tests_MGTransformReduceV_Rmat, CheckInt64Int64FloatTupleIntFloatTranspose
 TEST_P(Tests_MGTransformReduceV_File, CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, true>(std::get<0>(param),
-                                                                             std::get<1>(param));
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, true>(std::get<0>(param),
+                                                                                std::get<1>(param));
 }
 
 TEST_P(Tests_MGTransformReduceV_Rmat, CheckInt32Int32FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int32_t, int32_t, float, thrust::tuple<int, float>, true>(
+  run_current_test<int32_t, int32_t, float, cuda::std::tuple<int, float>, true>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }
@@ -275,7 +275,7 @@ TEST_P(Tests_MGTransformReduceV_Rmat, CheckInt32Int32FloatTupleIntFloatTranspose
 TEST_P(Tests_MGTransformReduceV_Rmat, CheckInt64Int64FloatTupleIntFloatTransposeTrue)
 {
   auto param = GetParam();
-  run_current_test<int64_t, int64_t, float, thrust::tuple<int, float>, true>(
+  run_current_test<int64_t, int64_t, float, cuda::std::tuple<int, float>, true>(
     std::get<0>(param),
     cugraph::test::override_Rmat_Usecase_with_cmd_line_arguments(std::get<1>(param)));
 }

--- a/cpp/tests/prims/result_compare.cuh
+++ b/cpp/tests/prims/result_compare.cuh
@@ -20,8 +20,8 @@
 #include <raft/core/handle.hpp>
 
 #include <cuda/std/optional>
+#include <cuda/std/tuple>
 #include <thrust/equal.h>
-#include <thrust/tuple.h>
 
 #include <algorithm>
 #include <cmath>
@@ -60,8 +60,8 @@ struct comparator {
         t1,
         std::is_floating_point_v<T> ? cuda::std::optional<T>{threshold_ratio} : cuda::std::nullopt);
     } else {
-      auto val0 = thrust::get<0>(t0);
-      auto val1 = thrust::get<0>(t1);
+      auto val0 = cuda::std::get<0>(t0);
+      auto val1 = cuda::std::get<0>(t1);
       auto passed =
         detail::compare_arithmetic_scalar(val0,
                                           val1,
@@ -70,9 +70,9 @@ struct comparator {
                                             : cuda::std::nullopt);
       if (!passed) return false;
 
-      if constexpr (thrust::tuple_size<T>::value >= 2) {
-        auto val0 = thrust::get<1>(t0);
-        auto val1 = thrust::get<1>(t1);
+      if constexpr (cuda::std::tuple_size<T>::value >= 2) {
+        auto val0 = cuda::std::get<1>(t0);
+        auto val1 = cuda::std::get<1>(t1);
         auto passed =
           detail::compare_arithmetic_scalar(val0,
                                             val1,
@@ -81,7 +81,7 @@ struct comparator {
                                               : cuda::std::nullopt);
         if (!passed) return false;
       }
-      if constexpr (thrust::tuple_size<T>::value >= 3) {
+      if constexpr (cuda::std::tuple_size<T>::value >= 3) {
         assert(false);  // should not be reached.
       }
       return true;
@@ -91,10 +91,10 @@ struct comparator {
 
 struct scalar_result_compare {
   template <typename... Args>
-  auto operator()(thrust::tuple<Args...> t1, thrust::tuple<Args...> t2)
+  auto operator()(cuda::std::tuple<Args...> t1, cuda::std::tuple<Args...> t2)
   {
-    using type = thrust::tuple<Args...>;
-    return equality_impl(t1, t2, std::make_index_sequence<thrust::tuple_size<type>::value>());
+    using type = cuda::std::tuple<Args...>;
+    return equality_impl(t1, t2, std::make_index_sequence<cuda::std::tuple_size<type>::value>());
   }
 
   template <typename T>
@@ -108,7 +108,8 @@ struct scalar_result_compare {
   template <typename T, std::size_t... I>
   auto equality_impl(T t1, T t2, std::index_sequence<I...>)
   {
-    return (... && (scalar_result_compare::operator()(thrust::get<I>(t1), thrust::get<I>(t2))));
+    return (... &&
+            (scalar_result_compare::operator()(cuda::std::get<I>(t1), cuda::std::get<I>(t2))));
   }
 };
 
@@ -121,8 +122,8 @@ struct vector_result_compare {
   auto operator()(std::tuple<rmm::device_uvector<Args>...> const& t1,
                   std::tuple<rmm::device_uvector<Args>...> const& t2)
   {
-    using type = thrust::tuple<Args...>;
-    return equality_impl(t1, t2, std::make_index_sequence<thrust::tuple_size<type>::value>());
+    using type = cuda::std::tuple<Args...>;
+    return equality_impl(t1, t2, std::make_index_sequence<cuda::std::tuple_size<type>::value>());
   }
 
   template <typename T>

--- a/cpp/tests/sampling/detail/sampling_post_processing_validate.cu
+++ b/cpp/tests/sampling/detail/sampling_post_processing_validate.cu
@@ -439,8 +439,8 @@ bool compare_heterogeneous_edgelist(
           r_edge_id = (*edge_ids)[r_idx];
         }
 
-        return thrust::make_tuple(l_edge_type, l_hop, l_src, l_dst, l_weight, l_edge_id) <
-               thrust::make_tuple(r_edge_type, r_hop, r_src, r_dst, r_weight, r_edge_id);
+        return cuda::std::make_tuple(l_edge_type, l_hop, l_src, l_dst, l_weight, l_edge_id) <
+               cuda::std::make_tuple(r_edge_type, r_hop, r_src, r_dst, r_weight, r_edge_id);
       });
 
     for (size_t j = 0; j < num_edge_types; ++j) {
@@ -704,8 +704,8 @@ bool compare_heterogeneous_edgelist(
               r_edge_id = (*edge_ids)[r_idx];
             }
 
-            return thrust::make_tuple(l_src, l_dst, l_weight, l_edge_id) <
-                   thrust::make_tuple(r_src, r_dst, r_weight, r_edge_id);
+            return cuda::std::make_tuple(l_src, l_dst, l_weight, l_edge_id) <
+                   cuda::std::make_tuple(r_src, r_dst, r_weight, r_edge_id);
           });
       }
 
@@ -1027,7 +1027,7 @@ bool check_vertex_renumber_map_invariants(
       thrust::sort(
         handle.get_thrust_policy(), pair_first, pair_first + this_label_unique_majors.size());
       this_label_unique_majors.resize(thrust::distance(this_label_unique_majors.begin(),
-                                                       thrust::get<0>(thrust::unique_by_key(
+                                                       cuda::std::get<0>(thrust::unique_by_key(
                                                          handle.get_thrust_policy(),
                                                          this_label_unique_majors.begin(),
                                                          this_label_unique_majors.end(),
@@ -1069,7 +1069,7 @@ bool check_vertex_renumber_map_invariants(
       thrust::sort(
         handle.get_thrust_policy(), pair_first, pair_first + this_label_unique_minors.size());
       this_label_unique_minors.resize(thrust::distance(this_label_unique_minors.begin(),
-                                                       thrust::get<0>(thrust::unique_by_key(
+                                                       cuda::std::get<0>(thrust::unique_by_key(
                                                          handle.get_thrust_policy(),
                                                          this_label_unique_minors.begin(),
                                                          this_label_unique_minors.end(),
@@ -1155,13 +1155,14 @@ bool check_vertex_renumber_map_invariants(
                                   thrust::upper_bound(thrust::seq,
                                                       vertex_type_offsets.begin() + 1,
                                                       vertex_type_offsets.end(),
-                                                      thrust::get<0>(pair)));
+                                                      cuda::std::get<0>(pair)));
                                 return static_cast<size_t>(thrust::distance(
                                          vertex_type_offsets.begin() + 1,
                                          thrust::upper_bound(thrust::seq,
                                                              vertex_type_offsets.begin() + 1,
                                                              vertex_type_offsets.end(),
-                                                             thrust::get<0>(pair)))) == vertex_type;
+                                                             cuda::std::get<0>(pair)))) ==
+                                       vertex_type;
                               })),
             handle.get_stream());
           (*this_type_unique_major_hops)
@@ -1172,21 +1173,21 @@ bool check_vertex_renumber_map_invariants(
           output_pair_first = thrust::make_zip_iterator(this_type_unique_minors.begin(),
                                                         (*this_type_unique_minor_hops).begin());
           this_type_unique_minors.resize(
-            thrust::distance(
-              output_pair_first,
-              thrust::copy_if(handle.get_thrust_policy(),
-                              input_pair_first,
-                              input_pair_first + this_label_unique_minors.size(),
-                              output_pair_first,
-                              [vertex_type_offsets = *vertex_type_offsets,
-                               vertex_type         = j] __device__(auto pair) {
-                                return static_cast<size_t>(thrust::distance(
-                                         vertex_type_offsets.begin() + 1,
-                                         thrust::upper_bound(thrust::seq,
-                                                             vertex_type_offsets.begin() + 1,
-                                                             vertex_type_offsets.end(),
-                                                             thrust::get<0>(pair)))) == vertex_type;
-                              })),
+            thrust::distance(output_pair_first,
+                             thrust::copy_if(handle.get_thrust_policy(),
+                                             input_pair_first,
+                                             input_pair_first + this_label_unique_minors.size(),
+                                             output_pair_first,
+                                             [vertex_type_offsets = *vertex_type_offsets,
+                                              vertex_type         = j] __device__(auto pair) {
+                                               return static_cast<size_t>(thrust::distance(
+                                                        vertex_type_offsets.begin() + 1,
+                                                        thrust::upper_bound(
+                                                          thrust::seq,
+                                                          vertex_type_offsets.begin() + 1,
+                                                          vertex_type_offsets.end(),
+                                                          cuda::std::get<0>(pair)))) == vertex_type;
+                                             })),
             handle.get_stream());
           (*this_type_unique_minor_hops)
             .resize(this_type_unique_minors.size(), handle.get_stream());
@@ -1232,7 +1233,7 @@ bool check_vertex_renumber_map_invariants(
         merged_vertices.resize(
           thrust::distance(
             merged_vertices.begin(),
-            thrust::get<0>(thrust::unique_by_key(
+            cuda::std::get<0>(thrust::unique_by_key(
               handle.get_thrust_policy(),
               merged_vertices.begin(),
               merged_vertices.end(),
@@ -1282,7 +1283,7 @@ bool check_vertex_renumber_map_invariants(
                               renumbered_merged_vertex_first,
                               thrust::make_discard_iterator(),
                               min_vertices.begin(),
-                              thrust::equal_to<thrust::tuple<int32_t, int8_t>>{},
+                              thrust::equal_to<cuda::std::tuple<int32_t, int8_t>>{},
                               thrust::minimum<vertex_t>{});
         thrust::reduce_by_key(handle.get_thrust_policy(),
                               sort_key_first,
@@ -1290,7 +1291,7 @@ bool check_vertex_renumber_map_invariants(
                               renumbered_merged_vertex_first,
                               thrust::make_discard_iterator(),
                               max_vertices.begin(),
-                              thrust::equal_to<thrust::tuple<int32_t, int8_t>>{},
+                              thrust::equal_to<cuda::std::tuple<int32_t, int8_t>>{},
                               thrust::maximum<vertex_t>{});
 
         auto num_violations =
@@ -1537,12 +1538,12 @@ bool check_edge_id_renumber_map_invariants(
         auto key_first = thrust::make_zip_iterator((*this_label_unique_key_edge_types).begin(),
                                                    this_label_unique_key_edge_ids.begin());
         this_label_unique_key_edge_ids.resize(
-          thrust::distance(
-            key_first,
-            thrust::get<0>(thrust::unique_by_key(handle.get_thrust_policy(),
-                                                 key_first,
-                                                 key_first + this_label_unique_key_edge_ids.size(),
-                                                 (*this_label_unique_key_hops).begin()))),
+          thrust::distance(key_first,
+                           cuda::std::get<0>(thrust::unique_by_key(
+                             handle.get_thrust_policy(),
+                             key_first,
+                             key_first + this_label_unique_key_edge_ids.size(),
+                             (*this_label_unique_key_hops).begin()))),
           handle.get_stream());
         (*this_label_unique_key_edge_types)
           .resize(this_label_unique_key_edge_ids.size(), handle.get_stream());
@@ -1573,10 +1574,10 @@ bool check_edge_id_renumber_map_invariants(
         this_label_unique_key_edge_ids.resize(
           thrust::distance(
             this_label_unique_key_edge_ids.begin(),
-            thrust::get<0>(thrust::unique_by_key(handle.get_thrust_policy(),
-                                                 this_label_unique_key_edge_ids.begin(),
-                                                 this_label_unique_key_edge_ids.end(),
-                                                 (*this_label_unique_key_hops).begin()))),
+            cuda::std::get<0>(thrust::unique_by_key(handle.get_thrust_policy(),
+                                                    this_label_unique_key_edge_ids.begin(),
+                                                    this_label_unique_key_edge_ids.end(),
+                                                    (*this_label_unique_key_hops).begin()))),
           handle.get_stream());
         (*this_label_unique_key_hops)
           .resize(this_label_unique_key_edge_ids.size(), handle.get_stream());

--- a/cpp/tests/sampling/random_walks_check.cuh
+++ b/cpp/tests/sampling/random_walks_check.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,8 @@ void random_walks_validate(
           //    should add a check to verify that degree(src) == 0
           if (d != cugraph::invalid_vertex_id<vertex_t>::value) {
             auto iter = thrust::make_zip_iterator(src, dst);
-            auto pos  = thrust::find(thrust::seq, iter, iter + num_edges, thrust::make_tuple(s, d));
+            auto pos =
+              thrust::find(thrust::seq, iter, iter + num_edges, cuda::std::make_tuple(s, d));
 
             if (pos != (iter + num_edges)) {
               auto index = thrust::distance(iter, pos);
@@ -138,7 +139,8 @@ void random_walks_validate(
           //    should add a check to verify that degree(src) == 0
           if (d != cugraph::invalid_vertex_id<vertex_t>::value) {
             auto iter = thrust::make_zip_iterator(src, dst);
-            auto pos  = thrust::find(thrust::seq, iter, iter + num_edges, thrust::make_tuple(s, d));
+            auto pos =
+              thrust::find(thrust::seq, iter, iter + num_edges, cuda::std::make_tuple(s, d));
 
             if (pos == (iter + num_edges)) printf("edge (%d,%d) NOT FOUND\n", (int)s, (int)d);
 

--- a/cpp/tests/structure/induced_subgraph_validate.cu
+++ b/cpp/tests/structure/induced_subgraph_validate.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,12 +94,12 @@ void induced_subgraph_validate(
                                               d_cugraph_subgraph_edgelist_minors.begin(),
                                               d_cugraph_subgraph_edgelist_weights->begin()),
                     [] __device__(auto left, auto right) {
-                      auto l0 = thrust::get<0>(left);
-                      auto l1 = thrust::get<1>(left);
-                      auto l2 = thrust::get<2>(left);
-                      auto r0 = thrust::get<0>(right);
-                      auto r1 = thrust::get<1>(right);
-                      auto r2 = thrust::get<2>(right);
+                      auto l0 = cuda::std::get<0>(left);
+                      auto l1 = cuda::std::get<1>(left);
+                      auto l2 = cuda::std::get<2>(left);
+                      auto r0 = cuda::std::get<0>(right);
+                      auto r1 = cuda::std::get<1>(right);
+                      auto r2 = cuda::std::get<2>(right);
                       return (l0 == r0) && (l1 == r1) && (l2 == r2);
                     }))
       << "Extracted subgraph edges do not match with the edges extracted by the reference "
@@ -129,10 +129,10 @@ void induced_subgraph_validate(
                     thrust::make_zip_iterator(d_cugraph_subgraph_edgelist_majors.begin(),
                                               d_cugraph_subgraph_edgelist_minors.begin()),
                     [] __device__(auto left, auto right) {
-                      auto l0 = thrust::get<0>(left);
-                      auto l1 = thrust::get<1>(left);
-                      auto r0 = thrust::get<0>(right);
-                      auto r1 = thrust::get<1>(right);
+                      auto l0 = cuda::std::get<0>(left);
+                      auto l1 = cuda::std::get<1>(left);
+                      auto r0 = cuda::std::get<0>(right);
+                      auto r1 = cuda::std::get<1>(right);
                       return (l0 == r0) && (l1 == r1);
                     }))
       << "Extracted subgraph edges do not match with the edges extracted by the reference "

--- a/cpp/tests/utilities/csv_file_utilities.cu
+++ b/cpp/tests/utilities/csv_file_utilities.cu
@@ -97,9 +97,9 @@ bool check_symmetric(raft::handle_t const& handle,
 
   if (edgelist_weights) {
     auto org_first = thrust::make_zip_iterator(
-      thrust::make_tuple(org_srcs.begin(), org_dsts.begin(), (*org_weights).begin()));
+      cuda::std::make_tuple(org_srcs.begin(), org_dsts.begin(), (*org_weights).begin()));
     thrust::sort(handle.get_thrust_policy(), org_first, org_first + org_srcs.size());
-    auto symmetrized_first = thrust::make_zip_iterator(thrust::make_tuple(
+    auto symmetrized_first = thrust::make_zip_iterator(cuda::std::make_tuple(
       symmetrized_srcs.begin(), symmetrized_dsts.begin(), (*symmetrized_weights).begin()));
     thrust::sort(
       handle.get_thrust_policy(), symmetrized_first, symmetrized_first + symmetrized_srcs.size());
@@ -107,10 +107,10 @@ bool check_symmetric(raft::handle_t const& handle,
       handle.get_thrust_policy(), org_first, org_first + org_srcs.size(), symmetrized_first);
   } else {
     auto org_first =
-      thrust::make_zip_iterator(thrust::make_tuple(org_srcs.begin(), org_dsts.begin()));
+      thrust::make_zip_iterator(cuda::std::make_tuple(org_srcs.begin(), org_dsts.begin()));
     thrust::sort(handle.get_thrust_policy(), org_first, org_first + org_srcs.size());
     auto symmetrized_first = thrust::make_zip_iterator(
-      thrust::make_tuple(symmetrized_srcs.begin(), symmetrized_dsts.begin()));
+      cuda::std::make_tuple(symmetrized_srcs.begin(), symmetrized_dsts.begin()));
     thrust::sort(
       handle.get_thrust_policy(), symmetrized_first, symmetrized_first + symmetrized_srcs.size());
     return thrust::equal(
@@ -234,7 +234,7 @@ read_edgelist_from_csv_file(raft::handle_t const& handle,
       comm_size, major_comm_size, minor_comm_size};
     size_t number_of_local_edges{};
     if (d_edgelist_weights) {
-      auto edge_first       = thrust::make_zip_iterator(thrust::make_tuple(
+      auto edge_first       = thrust::make_zip_iterator(cuda::std::make_tuple(
         d_edgelist_srcs.begin(), d_edgelist_dsts.begin(), (*d_edgelist_weights).begin()));
       number_of_local_edges = thrust::distance(
         edge_first,
@@ -243,14 +243,14 @@ read_edgelist_from_csv_file(raft::handle_t const& handle,
           edge_first,
           edge_first + d_edgelist_srcs.size(),
           [store_transposed, comm_rank, key_func = edge_key_func] __device__(auto e) {
-            auto major = thrust::get<0>(e);
-            auto minor = thrust::get<1>(e);
+            auto major = cuda::std::get<0>(e);
+            auto minor = cuda::std::get<1>(e);
             return store_transposed ? key_func(minor, major) != comm_rank
                                     : key_func(major, minor) != comm_rank;
           }));
     } else {
       auto edge_first = thrust::make_zip_iterator(
-        thrust::make_tuple(d_edgelist_srcs.begin(), d_edgelist_dsts.begin()));
+        cuda::std::make_tuple(d_edgelist_srcs.begin(), d_edgelist_dsts.begin()));
       number_of_local_edges = thrust::distance(
         edge_first,
         thrust::remove_if(
@@ -258,8 +258,8 @@ read_edgelist_from_csv_file(raft::handle_t const& handle,
           edge_first,
           edge_first + d_edgelist_srcs.size(),
           [store_transposed, comm_rank, key_func = edge_key_func] __device__(auto e) {
-            auto major = thrust::get<0>(e);
-            auto minor = thrust::get<1>(e);
+            auto major = cuda::std::get<0>(e);
+            auto minor = cuda::std::get<1>(e);
             return store_transposed ? key_func(minor, major) != comm_rank
                                     : key_func(major, minor) != comm_rank;
           }));

--- a/cpp/tests/utilities/matrix_market_file_utilities.cu
+++ b/cpp/tests/utilities/matrix_market_file_utilities.cu
@@ -25,11 +25,11 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/distance.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/remove.h>
 #include <thrust/sequence.h>
-#include <thrust/tuple.h>
 
 #include <cstdint>
 
@@ -346,7 +346,7 @@ read_edgelist_from_matrix_market_file(raft::handle_t const& handle,
       comm_size, major_comm_size, minor_comm_size};
     size_t number_of_local_edges{};
     if (d_edgelist_weights) {
-      auto edge_first       = thrust::make_zip_iterator(thrust::make_tuple(
+      auto edge_first       = thrust::make_zip_iterator(cuda::std::make_tuple(
         d_edgelist_srcs.begin(), d_edgelist_dsts.begin(), (*d_edgelist_weights).begin()));
       number_of_local_edges = thrust::distance(
         edge_first,
@@ -355,14 +355,14 @@ read_edgelist_from_matrix_market_file(raft::handle_t const& handle,
           edge_first,
           edge_first + d_edgelist_srcs.size(),
           [store_transposed, comm_rank, key_func = edge_key_func] __device__(auto e) {
-            auto major = thrust::get<0>(e);
-            auto minor = thrust::get<1>(e);
+            auto major = cuda::std::get<0>(e);
+            auto minor = cuda::std::get<1>(e);
             return store_transposed ? key_func(minor, major) != comm_rank
                                     : key_func(major, minor) != comm_rank;
           }));
     } else {
       auto edge_first = thrust::make_zip_iterator(
-        thrust::make_tuple(d_edgelist_srcs.begin(), d_edgelist_dsts.begin()));
+        cuda::std::make_tuple(d_edgelist_srcs.begin(), d_edgelist_dsts.begin()));
       number_of_local_edges = thrust::distance(
         edge_first,
         thrust::remove_if(
@@ -370,8 +370,8 @@ read_edgelist_from_matrix_market_file(raft::handle_t const& handle,
           edge_first,
           edge_first + d_edgelist_srcs.size(),
           [store_transposed, comm_rank, key_func = edge_key_func] __device__(auto e) {
-            auto major = thrust::get<0>(e);
-            auto minor = thrust::get<1>(e);
+            auto major = cuda::std::get<0>(e);
+            auto minor = cuda::std::get<1>(e);
             return store_transposed ? key_func(minor, major) != comm_rank
                                     : key_func(major, minor) != comm_rank;
           }));

--- a/cpp/tests/utilities/property_generator_kernels.cuh
+++ b/cpp/tests/utilities/property_generator_kernels.cuh
@@ -20,7 +20,7 @@
 #include "utilities/property_generator_utilities.hpp"
 
 #include <cuda/std/optional>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <cuco/hash_functions.cuh>
 
@@ -35,8 +35,8 @@ namespace detail {
 template <typename TupleType, typename T, std::size_t... Is>
 __host__ __device__ auto make_type_casted_tuple_from_scalar(T val, std::index_sequence<Is...>)
 {
-  return thrust::make_tuple(
-    static_cast<typename thrust::tuple_element<Is, TupleType>::type>(val)...);
+  return cuda::std::make_tuple(
+    static_cast<typename cuda::std::tuple_element<Is, TupleType>::type>(val)...);
 }
 
 template <typename property_t, typename T>
@@ -45,7 +45,7 @@ __host__ __device__ auto make_property_value(T val)
   property_t ret{};
   if constexpr (cugraph::is_thrust_tuple_of_arithmetic<property_t>::value) {
     ret = make_type_casted_tuple_from_scalar<property_t>(
-      val, std::make_index_sequence<thrust::tuple_size<property_t>::value>{});
+      val, std::make_index_sequence<cuda::std::tuple_size<property_t>::value>{});
   } else {
     ret = static_cast<property_t>(val);
   }

--- a/cpp/tests/utilities/property_generator_utilities_impl.cuh
+++ b/cpp/tests/utilities/property_generator_utilities_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,11 +29,11 @@
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/distance.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <cuco/hash_functions.cuh>
 

--- a/cpp/tests/utilities/property_generator_utilities_mg.cu
+++ b/cpp/tests/utilities/property_generator_utilities_mg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,25 +22,25 @@ template struct generate<cugraph::graph_view_t<int32_t, int32_t, false, true>, b
 template struct generate<cugraph::graph_view_t<int32_t, int32_t, false, true>, int32_t>;
 template struct generate<cugraph::graph_view_t<int32_t, int32_t, false, true>, int64_t>;
 template struct generate<cugraph::graph_view_t<int32_t, int32_t, false, true>,
-                         thrust::tuple<int, float>>;
+                         cuda::std::tuple<int, float>>;
 
 template struct generate<cugraph::graph_view_t<int32_t, int32_t, true, true>, bool>;
 template struct generate<cugraph::graph_view_t<int32_t, int32_t, true, true>, int32_t>;
 template struct generate<cugraph::graph_view_t<int32_t, int32_t, true, true>, int64_t>;
 template struct generate<cugraph::graph_view_t<int32_t, int32_t, true, true>,
-                         thrust::tuple<int, float>>;
+                         cuda::std::tuple<int, float>>;
 
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, false, true>, bool>;
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, false, true>, int32_t>;
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, false, true>, int64_t>;
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, false, true>,
-                         thrust::tuple<int, float>>;
+                         cuda::std::tuple<int, float>>;
 
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, true, true>, bool>;
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, true, true>, int32_t>;
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, true, true>, int64_t>;
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, true, true>,
-                         thrust::tuple<int, float>>;
+                         cuda::std::tuple<int, float>>;
 
 }  // namespace test
 }  // namespace cugraph

--- a/cpp/tests/utilities/property_generator_utilities_sg.cu
+++ b/cpp/tests/utilities/property_generator_utilities_sg.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,25 +22,25 @@ template struct generate<cugraph::graph_view_t<int32_t, int32_t, false, false>, 
 template struct generate<cugraph::graph_view_t<int32_t, int32_t, false, false>, int32_t>;
 template struct generate<cugraph::graph_view_t<int32_t, int32_t, false, false>, int64_t>;
 template struct generate<cugraph::graph_view_t<int32_t, int32_t, false, false>,
-                         thrust::tuple<int, float>>;
+                         cuda::std::tuple<int, float>>;
 
 template struct generate<cugraph::graph_view_t<int32_t, int32_t, true, false>, bool>;
 template struct generate<cugraph::graph_view_t<int32_t, int32_t, true, false>, int32_t>;
 template struct generate<cugraph::graph_view_t<int32_t, int32_t, true, false>, int64_t>;
 template struct generate<cugraph::graph_view_t<int32_t, int32_t, true, false>,
-                         thrust::tuple<int, float>>;
+                         cuda::std::tuple<int, float>>;
 
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, false, false>, bool>;
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, false, false>, int32_t>;
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, false, false>, int64_t>;
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, false, false>,
-                         thrust::tuple<int, float>>;
+                         cuda::std::tuple<int, float>>;
 
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, true, false>, bool>;
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, true, false>, int32_t>;
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, true, false>, int64_t>;
 template struct generate<cugraph::graph_view_t<int64_t, int64_t, true, false>,
-                         thrust::tuple<int, float>>;
+                         cuda::std::tuple<int, float>>;
 
 }  // namespace test
 }  // namespace cugraph

--- a/cpp/tests/utilities/thrust_wrapper.cu
+++ b/cpp/tests/utilities/thrust_wrapper.cu
@@ -21,6 +21,7 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/distance.h>
 #include <thrust/extrema.h>
@@ -33,7 +34,6 @@
 #include <thrust/sort.h>
 #include <thrust/tabulate.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 namespace cugraph {
@@ -197,14 +197,14 @@ sort_by_key<int64_t, int64_t>(raft::handle_t const& handle,
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     std::tuple<rmm::device_uvector<int32_t>, rmm::device_uvector<float>>>
-sort_by_key<int32_t, thrust::tuple<int32_t, float>>(
+sort_by_key<int32_t, cuda::std::tuple<int32_t, float>>(
   raft::handle_t const& handle,
   rmm::device_uvector<int32_t> const& keys,
   std::tuple<rmm::device_uvector<int32_t>, rmm::device_uvector<float>> const& values);
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     std::tuple<rmm::device_uvector<int32_t>, rmm::device_uvector<float>>>
-sort_by_key<int64_t, thrust::tuple<int32_t, float>>(
+sort_by_key<int64_t, cuda::std::tuple<int32_t, float>>(
   raft::handle_t const& handle,
   rmm::device_uvector<int64_t> const& keys,
   std::tuple<rmm::device_uvector<int32_t>, rmm::device_uvector<float>> const& values);
@@ -578,7 +578,7 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> remove_
       handle.get_thrust_policy(),
       thrust::make_zip_iterator(v1.begin(), v2.begin()),
       thrust::make_zip_iterator(v1.end(), v2.end()),
-      [] __device__(auto tuple) { return thrust::get<0>(tuple) == thrust::get<1>(tuple); }));
+      [] __device__(auto tuple) { return cuda::std::get<0>(tuple) == cuda::std::get<1>(tuple); }));
 
   v1.resize(new_size, handle.get_stream());
   v2.resize(new_size, handle.get_stream());

--- a/cpp/tests/utilities/validation_utilities.cu
+++ b/cpp/tests/utilities/validation_utilities.cu
@@ -427,14 +427,14 @@ size_t count_intersection(raft::handle_t const& handle,
 #else
         auto lb = thrust::distance(
           src.begin(),
-          thrust::lower_bound(thrust::seq, src.begin(), src.end(), thrust::get<0>(tuple)));
+          thrust::lower_bound(thrust::seq, src.begin(), src.end(), cuda::std::get<0>(tuple)));
         auto ub = thrust::distance(
           src.begin(),
-          thrust::upper_bound(thrust::seq, src.begin(), src.end(), thrust::get<0>(tuple)));
+          thrust::upper_bound(thrust::seq, src.begin(), src.end(), cuda::std::get<0>(tuple)));
 
-        if (src.data()[lb] == thrust::get<0>(tuple)) {
+        if (src.data()[lb] == cuda::std::get<0>(tuple)) {
           return thrust::binary_search(
-            thrust::seq, dst.begin() + lb, dst.begin() + ub, thrust::get<1>(tuple))
+            thrust::seq, dst.begin() + lb, dst.begin() + ub, cuda::std::get<1>(tuple))
               ? size_t{1}
               : size_t{0};
         } else {
@@ -462,7 +462,7 @@ size_t count_edges_on_wrong_int_gpu(raft::handle_t const& handle,
        handle.get_subcomm(cugraph::partition_manager::major_comm_name()).get_size(),
        handle.get_subcomm(cugraph::partition_manager::minor_comm_name())
          .get_size()}] __device__(auto e) {
-      return (gpu_id_key_func(thrust::get<0>(e), thrust::get<1>(e)) != comm_rank);
+      return (gpu_id_key_func(cuda::std::get<0>(e), cuda::std::get<1>(e)) != comm_rank);
     });
 }
 


### PR DESCRIPTION
The latter is more or less deprecated and we want to move towards standard types