### PR TITLE
Fix spectral clustering tests

### DIFF
--- a/cpp/src/community/legacy/spectral_clustering.cu
+++ b/cpp/src/community/legacy/spectral_clustering.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,15 +89,16 @@ void balancedCutClustering_impl(legacy::GraphCSRView<vertex_t, edge_t, weight_t>
   using index_type = vertex_t;
   using value_type = weight_t;
 
-  raft::spectral::matrix::sparse_matrix_t<index_type, value_type> const r_csr_m{handle, graph};
+  raft::spectral::matrix::sparse_matrix_t<index_type, value_type, std::int32_t> const r_csr_m{
+    handle, graph};
 
-  raft::spectral::eigen_solver_config_t<index_type, value_type> eig_cfg{
+  raft::spectral::eigen_solver_config_t<index_type, value_type, std::int32_t> eig_cfg{
     n_eig_vects, evs_max_it, restartIter_lanczos, evs_tol, reorthog, seed1};
-  raft::spectral::lanczos_solver_t<index_type, value_type> eig_solver{eig_cfg};
+  raft::spectral::lanczos_solver_t<index_type, value_type, std::int32_t> eig_solver{eig_cfg};
 
-  raft::spectral::cluster_solver_config_t<index_type, value_type> clust_cfg{
+  raft::spectral::cluster_solver_config_t<index_type, value_type, std::int32_t> clust_cfg{
     n_clusters, kmean_max_it, kmean_tol, seed2};
-  raft::spectral::kmeans_solver_t<index_type, value_type> cluster_solver{clust_cfg};
+  raft::spectral::kmeans_solver_t<index_type, value_type, std::int32_t> cluster_solver{clust_cfg};
 
   raft::spectral::partition(
     handle, r_csr_m, eig_solver, cluster_solver, clustering, eig_vals, eig_vects);
@@ -159,15 +160,16 @@ void spectralModularityMaximization_impl(
   using index_type = vertex_t;
   using value_type = weight_t;
 
-  raft::spectral::matrix::sparse_matrix_t<index_type, value_type> const r_csr_m{handle, graph};
+  raft::spectral::matrix::sparse_matrix_t<index_type, value_type, std::int32_t> const r_csr_m{
+    handle, graph};
 
-  raft::spectral::eigen_solver_config_t<index_type, value_type> eig_cfg{
+  raft::spectral::eigen_solver_config_t<index_type, value_type, std::int32_t> eig_cfg{
     n_eig_vects, evs_max_it, restartIter_lanczos, evs_tol, reorthog, seed1};
-  raft::spectral::lanczos_solver_t<index_type, value_type> eig_solver{eig_cfg};
+  raft::spectral::lanczos_solver_t<index_type, value_type, std::int32_t> eig_solver{eig_cfg};
 
-  raft::spectral::cluster_solver_config_t<index_type, value_type> clust_cfg{
+  raft::spectral::cluster_solver_config_t<index_type, value_type, std::int32_t> clust_cfg{
     n_clusters, kmean_max_it, kmean_tol, seed2};
-  raft::spectral::kmeans_solver_t<index_type, value_type> cluster_solver{clust_cfg};
+  raft::spectral::kmeans_solver_t<index_type, value_type, std::int32_t> cluster_solver{clust_cfg};
 
   // not returned...
   // auto result =
@@ -191,7 +193,8 @@ void analyzeModularityClustering_impl(legacy::GraphCSRView<vertex_t, edge_t, wei
   using index_type = vertex_t;
   using value_type = weight_t;
 
-  raft::spectral::matrix::sparse_matrix_t<index_type, value_type> const r_csr_m{handle, graph};
+  raft::spectral::matrix::sparse_matrix_t<index_type, value_type, std::int32_t> const r_csr_m{
+    handle, graph};
 
   weight_t mod;
   raft::spectral::analyzeModularity(handle, r_csr_m, n_clusters, clustering, mod);
@@ -217,7 +220,8 @@ void analyzeBalancedCut_impl(legacy::GraphCSRView<vertex_t, edge_t, weight_t> co
   using index_type = vertex_t;
   using value_type = weight_t;
 
-  raft::spectral::matrix::sparse_matrix_t<index_type, value_type> const r_csr_m{handle, graph};
+  raft::spectral::matrix::sparse_matrix_t<index_type, value_type, std::int32_t> const r_csr_m{
+    handle, graph};
 
   raft::spectral::analyzePartition(handle, r_csr_m, n_clusters, clustering, edge_cut, cost);
 


### PR DESCRIPTION
raft has changed their API slightly to allow for larger arrays.

We need to properly pass the index size otherwise we end up with type conflicts.

NOTE: I was a tiny bit lazy and just passed the previous default. We might get around with specifying less but ... :shrug: