### PR TITLE
add cugraph-notebook-codeowners to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,4 +36,4 @@ dependencies.yaml        @rapidsai/packaging-codeowners
 pyproject.toml           @rapidsai/packaging-codeowners
 
 # notebooks code owners
-*.ipynb @cugraph-notebook-codeowners
+*.ipynb @rapidsai/cugraph-notebook-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,3 +34,6 @@ CMakeLists.txt     @rapidsai/cugraph-cmake-codeowners
 dependencies.yaml        @rapidsai/packaging-codeowners
 /build.sh                @rapidsai/packaging-codeowners
 pyproject.toml           @rapidsai/packaging-codeowners
+
+# notebooks code owners
+*.ipynb @cugraph-notebook-codeowners


### PR DESCRIPTION
Makes all `.ipynb` files reviewable by `@cugraph-notebook-codeowners`