### PR TITLE
CUDF changed API to assume the dtype is already converted to a cudf type

### DIFF
--- a/python/cugraph/cugraph/structure/hypergraph.py
+++ b/python/cugraph/cugraph/structure/hypergraph.py
@@ -40,7 +40,7 @@ from cugraph.structure.graph_classes import Graph
 from cugraph.structure.symmetrize import symmetrize
 
 
-_str_dtype = np.dtype("str")
+_str_dtype = cudf.dtype("str")
 
 
 def hypergraph(


### PR DESCRIPTION
Switch from np.dtype to cudf.dtype to accommodate a cudf change.