### PR TITLE
temporarily increase the timeout for nightly test failures

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,6 +56,9 @@ jobs:
         uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:
           repo: cugraph
+          # TODO: remove this once upstream issues in RAFT are resolved on 11.4.
+          # The limit was temporarily increased to unblock work.
+          max_days_without_success: 30
   changed-files:
     secrets: inherit
     needs: telemetry-setup


### PR DESCRIPTION
This mimics a change in cuML which will allow time to resolve the issue that we think is going on in RAFT that is causing PR merging to be blocked.