### PR TITLE
Silence compiler warnings about host device destructor

### DIFF
--- a/cpp/include/cugraph/edge_property.hpp
+++ b/cpp/include/cugraph/edge_property.hpp
@@ -52,6 +52,9 @@ class edge_property_view_t {
   {
   }
 
+  // nvcc 12.5 sometimes deduces this as a host device function, just defining it fixes that
+  ~edge_property_view_t() {}
+
   std::vector<ValueIterator> const& value_firsts() const { return edge_partition_value_firsts_; }
 
   std::vector<edge_t> const& edge_counts() const { return edge_partition_edge_counts_; }


### PR DESCRIPTION
We are seeing spurious compiler warnings like

> error: calling a __host__ function("std::vector<...> ::~vector()") from a __host__ __device__ function("cugraph::edge_property_view_t<...> ::~edge_property_view_t") is not allowed

This is clearly a compiler bug that has been fixed but affects 12.5 which is what runs in CI

Example [here](https://github.com/NVIDIA/cccl/actions/runs/13720179287/job/38373997200?pr=3953#step:6:12629)