### PR TITLE
remove_multi_edges bug fix.

### DIFF
--- a/cpp/include/cugraph/graph_functions.hpp
+++ b/cpp/include/cugraph/graph_functions.hpp
@@ -1261,7 +1261,7 @@ remove_self_loops(raft::handle_t const& handle,
  * edgelist_edge_types.has_value() | @p edgelist_edge_start_times.has_value() | @p
  * edgelist_edge_end_times.has_value()is true. If each edge has more than one property values, edge
  * property values are compared in the order of weight (if valid), edge ID (if valid), edge type (if
- * vlaid), edge start time (if valid) and edge end time (if valid). Setting this to true incurs
+ * valid), edge start time (if valid) and edge end time (if valid). Setting this to true incurs
  * performance overhead as this requires more comparisons.
  * @return Tuple of vectors storing edge sources, destinations, optional weights, optional edge ids,
  * optional edge types, optional edge start times and optional edge end times.

--- a/cpp/include/cugraph/graph_functions.hpp
+++ b/cpp/include/cugraph/graph_functions.hpp
@@ -1258,8 +1258,11 @@ remove_self_loops(raft::handle_t const& handle,
  * @param keep_min_value_edge Flag indicating whether to keep an arbitrary edge (false) or the
  * minimum value edge (true) among the edges in a multi-edge. Relevant only if @p
  * edgelist_weights.has_value() | @p edgelist_edge_ids.has_value() | @p
- * edgelist_edge_types.has_value() is true. Setting this to true incurs performance overhead as this
- * requires more comparisons.
+ * edgelist_edge_types.has_value() | @p edgelist_edge_start_times.has_value() | @p
+ * edgelist_edge_end_times.has_value()is true. If each edge has more than one property values, edge
+ * property values are compared in the order of weight (if valid), edge ID (if valid), edge type (if
+ * vlaid), edge start time (if valid) and edge end time (if valid). Setting this to true incurs
+ * performance overhead as this requires more comparisons.
  * @return Tuple of vectors storing edge sources, destinations, optional weights, optional edge ids,
  * optional edge types, optional edge start times and optional edge end times.
  */


### PR DESCRIPTION
`remove_multi_edges` functions takes `keep_min_edge_value`.

This is set to true when removing multi-edges in a symmetric edge list (which will be used to create an undirected graph) to ensure that the edge list remain symmetric (including edge values).

The existing implementation doesn't work properly if # edge properties > 1.

The existing implementation sorts (src, dst, edge index) and keeps the edge with the minimum index among the multi-edges between src & dst.  This doesn't guarantee that the same (src, dst, edge value) will be selected in both directions.

This PR fixes this bug.