### PR TITLE
Updates call to `as_column` for new requirement on `dtype` arg

### DIFF
--- a/python/cugraph/cugraph/utilities/utils.py
+++ b/python/cugraph/cugraph/utilities/utils.py
@@ -479,7 +479,7 @@ def create_list_series_from_2d_ar(ar, index):
     n_rows, n_cols = ar.shape
     data = as_column(ar.flatten())
     offset_col = as_column(
-        cp.arange(start=0, stop=len(data) + 1, step=n_cols), dtype="int32"
+        cp.arange(start=0, stop=len(data) + 1, step=n_cols), dtype=cp.dtype(cp.int32)
     )
     mask_col = cp.full(shape=n_rows, fill_value=True)
     mask = as_column(mask_col).as_mask()


### PR DESCRIPTION
`as_column` previously allowed a string describing the dtype (ex. `"int32"`), but the latest version requires a dtype object (ex. `cp.dtype(cp.int32)`)