### PR TITLE
Optimize check for vertex existence

### DIFF
--- a/cpp/include/cugraph/detail/utility_wrappers.hpp
+++ b/cpp/include/cugraph/detail/utility_wrappers.hpp
@@ -117,6 +117,22 @@ void transform_increment_ints(raft::device_span<value_t> values,
 
 /**
  * @ingroup utility_wrappers_cpp
+ * @brief    Update a value in a device span to 0 if it matches the target_value or 1
+ *
+ * @tparam      value_t      type of the value to operate on. Must be either int32_t or int64_t.
+ *
+ * @param[out]  values       device span to update
+ * @param[in]   target_value        value to be querried
+ * @param[in]   stream_view  stream view
+ *
+ */
+template <typename value_t>
+void transform_binary(raft::device_span<value_t> values,
+                      value_t target_value,
+                      raft::handle_t const& handle);
+
+/**
+ * @ingroup utility_wrappers_cpp
  * @brief    Fill a buffer with a sequence of values
  *
  * Fills the buffer with the sequence:

--- a/cpp/include/cugraph/detail/utility_wrappers.hpp
+++ b/cpp/include/cugraph/detail/utility_wrappers.hpp
@@ -118,18 +118,20 @@ void transform_increment_ints(raft::device_span<value_t> values,
 
 /**
  * @ingroup utility_wrappers_cpp
- * @brief    Update a value in a device span to 0 if it matches the target_value or 1
+ * @brief    Update the values of device span to 0 if it matches the compare value or 1
  *
  * @tparam      value_t      type of the value to operate on. Must be either int32_t or int64_t.
  *
- * @param[out]  values       device span to update
- * @param[in]   target_value        value to be querried
+ * @param[out]  values       device span with the values to compare
+ * @param[out]  result       device span with the result of the comparison
+ * @param[in]   compare      value to be querriedm in the values array
  * @param[in]   stream_view  stream view
  *
  */
 template <typename value_t>
-void transform_binary(raft::device_span<value_t> values,
-                      value_t target_value,
+void transform_not_equal(raft::device_span<value_t> values,
+                      raft::device_span<bool> result,
+                      value_t compare,
                       raft::handle_t const& handle);
 
 /**

--- a/cpp/include/cugraph/detail/utility_wrappers.hpp
+++ b/cpp/include/cugraph/detail/utility_wrappers.hpp
@@ -269,5 +269,21 @@ size_t count_values(raft::handle_t const& handle,
                     raft::device_span<data_t const> span,
                     data_t value);
 
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief Verify if a value appears in a span
+ *
+ * @tparam data_t type of data in span
+ * @param handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator, and
+ * handles to various CUDA libraries) to run graph algorithms.
+ * @param span The span of data to compare
+ * @param value The value to count
+ * @return true if found, false if not found
+ */
+template <typename data_t>
+size_t has_vertex(raft::handle_t const& handle,
+                  raft::device_span<data_t const> span,
+                  data_t value);
+
 }  // namespace detail
 }  // namespace cugraph

--- a/cpp/include/cugraph/detail/utility_wrappers.hpp
+++ b/cpp/include/cugraph/detail/utility_wrappers.hpp
@@ -269,21 +269,5 @@ size_t count_values(raft::handle_t const& handle,
                     raft::device_span<data_t const> span,
                     data_t value);
 
-/**
- * @ingroup utility_wrappers_cpp
- * @brief Verify if a value appears in a span
- *
- * @tparam data_t type of data in span
- * @param handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator, and
- * handles to various CUDA libraries) to run graph algorithms.
- * @param span The span of data to compare
- * @param value The value to count
- * @return true if found, false if not found
- */
-template <typename data_t>
-size_t has_vertex(raft::handle_t const& handle,
-                  raft::device_span<data_t const> span,
-                  data_t value);
-
 }  // namespace detail
 }  // namespace cugraph

--- a/cpp/include/cugraph/detail/utility_wrappers.hpp
+++ b/cpp/include/cugraph/detail/utility_wrappers.hpp
@@ -130,9 +130,9 @@ void transform_increment_ints(raft::device_span<value_t> values,
  */
 template <typename value_t>
 void transform_not_equal(raft::device_span<value_t> values,
-                      raft::device_span<bool> result,
-                      value_t compare,
-                      raft::handle_t const& handle);
+                         raft::device_span<bool> result,
+                         value_t compare,
+                         raft::handle_t const& handle);
 
 /**
  * @ingroup utility_wrappers_cpp

--- a/cpp/include/cugraph/detail/utility_wrappers.hpp
+++ b/cpp/include/cugraph/detail/utility_wrappers.hpp
@@ -132,7 +132,7 @@ template <typename value_t>
 void transform_not_equal(raft::device_span<value_t> values,
                          raft::device_span<bool> result,
                          value_t compare,
-                         raft::handle_t const& handle);
+                         rmm::cuda_stream_view const& stream_view);
 
 /**
  * @ingroup utility_wrappers_cpp

--- a/cpp/include/cugraph_c/graph_functions.h
+++ b/cpp/include/cugraph_c/graph_functions.h
@@ -110,7 +110,7 @@ cugraph_error_code_t cugraph_two_hop_neighbors(
  * @param [in]  vertex         Vertex to be queried
  * @param [in]  do_expensive_check
  *                             A flag to run expensive checks for input arguments (if set to true)
- * @param [out] result         Opaque pointer to resulting queried vertex
+ * @param [out] result         Opaque pointer to resulting queried vertices
  * @param [out] error          Pointer to an error object storing details of any error.  Will
  *                             be populated if error code is not CUGRAPH_SUCCESS
  * @return error code
@@ -119,7 +119,7 @@ cugraph_error_code_t cugraph_has_vertex(const cugraph_resource_handle_t* handle,
                                         cugraph_graph_t* graph,
                                         cugraph_type_erased_device_array_view_t* vertices,
                                         bool_t do_expensive_check,
-                                        bool_t* result,
+                                        cugraph_type_erased_device_array_t** result,
                                         cugraph_error_t** error);
 
 /**

--- a/cpp/include/cugraph_c/graph_functions.h
+++ b/cpp/include/cugraph_c/graph_functions.h
@@ -107,7 +107,7 @@ cugraph_error_code_t cugraph_two_hop_neighbors(
  *
  * @param [in]  handle         Handle for accessing resources
  * @param [in]  graph          Pointer to graph
- * @param [in]  vertex         Vertex to be queried
+ * @param [in]  vertices       Vertices to be queried
  * @param [in]  do_expensive_check
  *                             A flag to run expensive checks for input arguments (if set to true)
  * @param [out] result         Opaque pointer to resulting queried vertices

--- a/cpp/include/cugraph_c/graph_functions.h
+++ b/cpp/include/cugraph_c/graph_functions.h
@@ -102,7 +102,6 @@ cugraph_error_code_t cugraph_two_hop_neighbors(
   cugraph_vertex_pairs_t** result,
   cugraph_error_t** error);
 
-
 /**
  * @brief      Verify if a vertex exists in the graph
  *
@@ -116,13 +115,12 @@ cugraph_error_code_t cugraph_two_hop_neighbors(
  *                             be populated if error code is not CUGRAPH_SUCCESS
  * @return error code
  */
-cugraph_error_code_t cugraph_has_vertex(
-  const cugraph_resource_handle_t* handle,
-  cugraph_graph_t* graph,
-  const int vertex,
-  bool_t do_expensive_check,
-  bool_t* result,
-  cugraph_error_t** error);
+cugraph_error_code_t cugraph_has_vertex(const cugraph_resource_handle_t* handle,
+                                        cugraph_graph_t* graph,
+                                        const int vertex,
+                                        bool_t do_expensive_check,
+                                        bool_t* result,
+                                        cugraph_error_t** error);
 
 /**
  * @brief       Opaque induced subgraph type

--- a/cpp/include/cugraph_c/graph_functions.h
+++ b/cpp/include/cugraph_c/graph_functions.h
@@ -102,6 +102,28 @@ cugraph_error_code_t cugraph_two_hop_neighbors(
   cugraph_vertex_pairs_t** result,
   cugraph_error_t** error);
 
+
+/**
+ * @brief      Verify if a vertex exists in the graph
+ *
+ * @param [in]  handle         Handle for accessing resources
+ * @param [in]  graph          Pointer to graph
+ * @param [in]  vertex         Vertex to be queried
+ * @param [in]  do_expensive_check
+ *                             A flag to run expensive checks for input arguments (if set to true)
+ * @param [out] result         Opaque pointer to resulting queried vertex
+ * @param [out] error          Pointer to an error object storing details of any error.  Will
+ *                             be populated if error code is not CUGRAPH_SUCCESS
+ * @return error code
+ */
+cugraph_error_code_t cugraph_has_vertex(
+  const cugraph_resource_handle_t* handle,
+  cugraph_graph_t* graph,
+  const int vertex,
+  bool_t do_expensive_check,
+  bool_t* result,
+  cugraph_error_t** error);
+
 /**
  * @brief       Opaque induced subgraph type
  *

--- a/cpp/include/cugraph_c/graph_functions.h
+++ b/cpp/include/cugraph_c/graph_functions.h
@@ -117,7 +117,7 @@ cugraph_error_code_t cugraph_two_hop_neighbors(
  */
 cugraph_error_code_t cugraph_has_vertex(const cugraph_resource_handle_t* handle,
                                         cugraph_graph_t* graph,
-                                        const int vertex,
+                                        cugraph_type_erased_device_array_view_t* vertices,
                                         bool_t do_expensive_check,
                                         bool_t* result,
                                         cugraph_error_t** error);

--- a/cpp/src/c_api/graph_functions.cpp
+++ b/cpp/src/c_api/graph_functions.cpp
@@ -132,7 +132,6 @@ struct two_hop_neighbors_functor : public cugraph::c_api::abstract_functor {
             bool multi_gpu>
   void operator()()
   {
-    printf("\nin two_hop_neighbors \n");
     if constexpr (!cugraph::is_candidate<vertex_t, edge_t, weight_t>::value) {
       unsupported();
     } else {

--- a/cpp/src/c_api/graph_functions.cpp
+++ b/cpp/src/c_api/graph_functions.cpp
@@ -321,8 +321,9 @@ struct has_vertex_functor : public cugraph::c_api::abstract_functor {
         raft::device_span<vertex_t>{vertices.data(), vertices.size()},
         cugraph::invalid_vertex_id<vertex_t>::value,
         handle_.get_stream());
-      
-      result_ = new cugraph::c_api::cugraph_type_erased_device_array_t(vertices, graph_->vertex_type_);
+
+      result_ =
+        new cugraph::c_api::cugraph_type_erased_device_array_t(vertices, graph_->vertex_type_);
     }
   }
 };

--- a/cpp/src/c_api/graph_functions.cpp
+++ b/cpp/src/c_api/graph_functions.cpp
@@ -291,13 +291,6 @@ struct has_vertex_functor : public cugraph::c_api::abstract_functor {
     if constexpr (!cugraph::is_candidate<vertex_t, edge_t, weight_t>::value) {
       unsupported();
     } else {
-      if constexpr (store_transposed) { // FIXME: Do we enforce store_transposed == false ?
-        error_code_ = cugraph::c_api::
-          transpose_storage<vertex_t, edge_t, weight_t, store_transposed, multi_gpu>(
-            handle_, graph_, error_.get());
-        if (error_code_ != CUGRAPH_SUCCESS) return;
-      }
-
       auto graph =
         reinterpret_cast<cugraph::graph_t<vertex_t, edge_t, false, multi_gpu>*>(graph_->graph_);
 
@@ -305,16 +298,6 @@ struct has_vertex_functor : public cugraph::c_api::abstract_functor {
       auto number_map = reinterpret_cast<rmm::device_uvector<vertex_t>*>(graph_->number_map_);
 
       rmm::device_uvector<vertex_t> vertex_array(1, handle_.get_stream());
-
-
-      //vertex.resize(vertex_->size_, handle_.get_stream());
-      #if 0
-      raft::copy(vertex.data(),
-                  vertex_->as_type<vertex_t const>(),
-                  vertex_->size_,
-                  handle_.get_stream());
-      #endif
-
 
       cugraph::detail::sequence_fill(handle_.get_stream(),
                                      vertex_array.data(),
@@ -345,7 +328,6 @@ struct has_vertex_functor : public cugraph::c_api::abstract_functor {
       }
 
       if (invalid_count == 0) {
-        //result_ = static_cast<bool>(true);
         result_ = bool_t::TRUE;
       }
 

--- a/cpp/src/c_api/graph_functions.cpp
+++ b/cpp/src/c_api/graph_functions.cpp
@@ -275,7 +275,8 @@ struct has_vertex_functor : public cugraph::c_api::abstract_functor {
     : abstract_functor(),
       handle_(*reinterpret_cast<cugraph::c_api::cugraph_resource_handle_t const*>(handle)->handle_),
       graph_(reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(graph)),
-      vertices_(reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t*>(vertices)),
+      vertices_(
+        reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t*>(vertices)),
       do_expensive_check_(do_expensive_check)
   {
   }
@@ -319,14 +320,12 @@ struct has_vertex_functor : public cugraph::c_api::abstract_functor {
         graph_view.local_vertex_partition_range_last(),
         do_expensive_check_);
 
-      cugraph::detail::transform_binary(raft::device_span<vertex_t>{vertices.data(),
-                                                                  vertices.size()},
-                                        cugraph::invalid_vertex_id<vertex_t>::value,
-                                        handle_.get_stream()
-                                        );
+      cugraph::detail::transform_binary(
+        raft::device_span<vertex_t>{vertices.data(), vertices.size()},
+        cugraph::invalid_vertex_id<vertex_t>::value,
+        handle_.get_stream());
 
-
-      #if 0
+#if 0
       size_t invalid_count = cugraph::detail::count_values(
         handle_,
         raft::device_span<vertex_t const>{vertices.data(), vertices.size()},
@@ -338,7 +337,7 @@ struct has_vertex_functor : public cugraph::c_api::abstract_functor {
       }
 
       if (invalid_count == 0) { result_ = bool_t::TRUE; }
-      #endif
+#endif
     }
   }
 };
@@ -421,14 +420,14 @@ extern "C" cugraph_error_code_t cugraph_count_multi_edges(const cugraph_resource
   return cugraph::c_api::run_algorithm(graph, functor, result, error);
 }
 
-extern "C" cugraph_error_code_t cugraph_has_vertex(const cugraph_resource_handle_t* handle,
-                                                   cugraph_graph_t* graph,
-                                                   cugraph_type_erased_device_array_view_t* vertices,
-                                                   bool_t do_expensive_check,
-                                                   bool_t* result,
-                                                   cugraph_error_t** error)
+extern "C" cugraph_error_code_t cugraph_has_vertex(
+  const cugraph_resource_handle_t* handle,
+  cugraph_graph_t* graph,
+  cugraph_type_erased_device_array_view_t* vertices,
+  bool_t do_expensive_check,
+  bool_t* result,
+  cugraph_error_t** error)
 {
-
   CAPI_EXPECTS(
     reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(graph)->vertex_type_ ==
       reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(vertices)

--- a/cpp/src/c_api/graph_functions.cpp
+++ b/cpp/src/c_api/graph_functions.cpp
@@ -310,7 +310,7 @@ struct has_vertex_functor : public cugraph::c_api::abstract_functor {
         graph_view.local_vertex_partition_range_first(),
         graph_view.local_vertex_partition_range_last(),
         do_expensive_check_);
-      
+
       rmm::device_uvector<bool> vertex_check(vertices.size(), handle_.get_stream());
 
       cugraph::detail::transform_not_equal(
@@ -319,8 +319,8 @@ struct has_vertex_functor : public cugraph::c_api::abstract_functor {
         cugraph::invalid_vertex_id<vertex_t>::value,
         handle_.get_stream());
 
-      result_ =
-        new cugraph::c_api::cugraph_type_erased_device_array_t(vertex_check, cugraph_data_type_id_t::BOOL);
+      result_ = new cugraph::c_api::cugraph_type_erased_device_array_t(
+        vertex_check, cugraph_data_type_id_t::BOOL);
     }
   }
 };

--- a/cpp/src/c_api/graph_functions.cpp
+++ b/cpp/src/c_api/graph_functions.cpp
@@ -157,20 +157,10 @@ struct two_hop_neighbors_functor : public cugraph::c_api::abstract_functor {
                    start_vertices_->as_type<vertex_t const>(),
                    start_vertices_->size_,
                    handle_.get_stream());
-        
-        raft::print_device_vector("b_start_vertices", start_vertices.data(), start_vertices.size(), std::cout);
 
         if constexpr (multi_gpu) {
           start_vertices = cugraph::shuffle_ext_vertices(handle_, std::move(start_vertices));
         }
-
-        raft::print_device_vector("number_map", number_map->data(), number_map->size(), std::cout);
-
-
-        printf("range first = %d", graph_view.local_vertex_partition_range_first());
-        printf("range last = %d", graph_view.local_vertex_partition_range_last());
-
-        printf("\n");
 
         cugraph::renumber_ext_vertices<vertex_t, multi_gpu>(
           handle_,
@@ -180,8 +170,6 @@ struct two_hop_neighbors_functor : public cugraph::c_api::abstract_functor {
           graph_view.local_vertex_partition_range_first(),
           graph_view.local_vertex_partition_range_last(),
           do_expensive_check_);
-      
-      raft::print_device_vector("a_start_vertices", start_vertices.data(), start_vertices.size(), std::cout);
 
       } else {
         start_vertices.resize(graph_view.local_vertex_partition_range_size(), handle_.get_stream());

--- a/cpp/src/c_api/graph_functions.cpp
+++ b/cpp/src/c_api/graph_functions.cpp
@@ -299,10 +299,8 @@ struct has_vertex_functor : public cugraph::c_api::abstract_functor {
 
       rmm::device_uvector<vertex_t> vertex_array(1, handle_.get_stream());
 
-      cugraph::detail::sequence_fill(handle_.get_stream(),
-                                     vertex_array.data(),
-                                     vertex_array.size(),
-                                     vertex_t(vertex_));
+      cugraph::detail::sequence_fill(
+        handle_.get_stream(), vertex_array.data(), vertex_array.size(), vertex_t(vertex_));
 
       if constexpr (multi_gpu) {
         vertex_array = cugraph::shuffle_ext_vertices(handle_, std::move(vertex_array));
@@ -327,10 +325,7 @@ struct has_vertex_functor : public cugraph::c_api::abstract_functor {
           handle_.get_comms(), invalid_count, raft::comms::op_t::SUM, handle_.get_stream());
       }
 
-      if (invalid_count == 0) {
-        result_ = bool_t::TRUE;
-      }
-
+      if (invalid_count == 0) { result_ = bool_t::TRUE; }
     }
   }
 };
@@ -413,13 +408,12 @@ extern "C" cugraph_error_code_t cugraph_count_multi_edges(const cugraph_resource
   return cugraph::c_api::run_algorithm(graph, functor, result, error);
 }
 
-extern "C" cugraph_error_code_t cugraph_has_vertex(
-  const cugraph_resource_handle_t* handle,
-  cugraph_graph_t* graph,
-  const int vertex,
-  bool_t do_expensive_check,
-  bool_t* result,
-  cugraph_error_t** error)
+extern "C" cugraph_error_code_t cugraph_has_vertex(const cugraph_resource_handle_t* handle,
+                                                   cugraph_graph_t* graph,
+                                                   const int vertex,
+                                                   bool_t do_expensive_check,
+                                                   bool_t* result,
+                                                   cugraph_error_t** error)
 {
   has_vertex_functor functor(handle, graph, vertex, do_expensive_check);
 

--- a/cpp/src/c_api/graph_sg.cpp
+++ b/cpp/src/c_api/graph_sg.cpp
@@ -263,8 +263,6 @@ struct create_graph_functor : public cugraph::c_api::abstract_functor {
       std::optional<rmm::device_uvector<edge_time_t>> dummy_start_times{std::nullopt};
       std::optional<rmm::device_uvector<edge_time_t>> dummy_end_times{std::nullopt};
 
-        
-
       std::tie(*graph,
                new_edge_weights,
                new_edge_ids,
@@ -294,20 +292,19 @@ struct create_graph_functor : public cugraph::c_api::abstract_functor {
       if (renumber_) {
         *number_map = std::move(new_number_map.value());
       } else {
-
         number_map->resize(graph->number_of_vertices(), handle_.get_stream());
         cugraph::detail::sequence_fill(handle_.get_stream(),
                                        number_map->data(),
                                        number_map->size(),
                                        graph->view().local_vertex_partition_range_first());
-        
+
         if (vertices_) {
           vertex_list = rmm::device_uvector<vertex_t>(vertices_->size_, handle_.get_stream());
           raft::copy<vertex_t>(vertex_list->data(),
-                             vertices_->as_type<vertex_t>(),
-                             vertices_->size_,
-                             handle_.get_stream());
-          
+                               vertices_->as_type<vertex_t>(),
+                               vertices_->size_,
+                               handle_.get_stream());
+
           auto is_consecutive = cugraph::detail::is_equal(
             handle_.get_stream(),
             raft::device_span<vertex_t>{vertex_list->data(), vertex_list->size()},
@@ -319,8 +316,6 @@ struct create_graph_functor : public cugraph::c_api::abstract_functor {
               "Vertex list must be numbered consecutively from 0 when 'renumber' is 'false'");
             return;
           }
-        
-        
         }
       }
 

--- a/cpp/src/c_api/graph_sg.cpp
+++ b/cpp/src/c_api/graph_sg.cpp
@@ -268,31 +268,26 @@ struct create_graph_functor : public cugraph::c_api::abstract_functor {
       if (!renumber_) {
         raft::copy<vertex_t>(
           vertices.data(), edgelist_srcs.data(), edgelist_srcs.size(), handle_.get_stream());
-        
-        cugraph::detail::sort_ints(
-          handle_.get_stream(),
-          raft::device_span<vertex_t>{vertices.data(), vertices.size()});
-        
+
+        cugraph::detail::sort_ints(handle_.get_stream(),
+                                   raft::device_span<vertex_t>{vertices.data(), vertices.size()});
+
         size_t unique_vertices_size = cugraph::detail::unique_ints(
-          handle_.get_stream(),
-          raft::device_span<vertex_t>{vertices.data(), vertices.size()});
+          handle_.get_stream(), raft::device_span<vertex_t>{vertices.data(), vertices.size()});
 
         vertices.resize(unique_vertices_size + edgelist_dsts.size(), handle_.get_stream());
 
-        raft::copy<vertex_t>(
-          vertices.data() + unique_vertices_size,
-          edgelist_dsts.data(),
-          edgelist_dsts.size(),
-          handle_.get_stream());
+        raft::copy<vertex_t>(vertices.data() + unique_vertices_size,
+                             edgelist_dsts.data(),
+                             edgelist_dsts.size(),
+                             handle_.get_stream());
 
-        cugraph::detail::sort_ints(
-          handle_.get_stream(),
-          raft::device_span<vertex_t>{vertices.data(), vertices.size()});
-        
+        cugraph::detail::sort_ints(handle_.get_stream(),
+                                   raft::device_span<vertex_t>{vertices.data(), vertices.size()});
+
         unique_vertices_size = cugraph::detail::unique_ints(
-          handle_.get_stream(),
-          raft::device_span<vertex_t>{vertices.data(), vertices.size()});
-        
+          handle_.get_stream(), raft::device_span<vertex_t>{vertices.data(), vertices.size()});
+
         vertices.resize(unique_vertices_size, handle_.get_stream());
       }
 
@@ -334,16 +329,16 @@ struct create_graph_functor : public cugraph::c_api::abstract_functor {
                                        graph->view().local_vertex_partition_range_first());
 
         auto is_consecutive = cugraph::detail::is_equal(
-                                handle_.get_stream(),
-                                raft::device_span<vertex_t>{vertices.data(), vertices.size()},
-                                raft::device_span<vertex_t>{number_map->data(), number_map->size()}
-                              );
-        
+          handle_.get_stream(),
+          raft::device_span<vertex_t>{vertices.data(), vertices.size()},
+          raft::device_span<vertex_t>{number_map->data(), number_map->size()});
+
         if (!is_consecutive) {
-          mark_error(CUGRAPH_INVALID_INPUT, "Vertex list must be numbered consecutively from 0 when 'renumber' is 'false'");
+          mark_error(
+            CUGRAPH_INVALID_INPUT,
+            "Vertex list must be numbered consecutively from 0 when 'renumber' is 'false'");
           return;
         }
-      
       }
 
       if (new_edge_weights) { *edge_weights = std::move(new_edge_weights.value()); }

--- a/cpp/src/c_api/graph_sg.cpp
+++ b/cpp/src/c_api/graph_sg.cpp
@@ -300,7 +300,6 @@ struct create_graph_functor : public cugraph::c_api::abstract_functor {
 
         vertices.resize(unique_edgelist_srcs_size + unique_edgelist_dsts_size,
                         handle_.get_stream());
-        vertices.shrink_to_fit(handle_.get_stream());
 
         raft::copy<vertex_t>(vertices.data() + unique_edgelist_srcs_size,
                              tmp_edgelist_dsts.data(),
@@ -365,8 +364,6 @@ struct create_graph_functor : public cugraph::c_api::abstract_functor {
             "Vertex list must be numbered consecutively from 0 when 'renumber' is 'false'");
           return;
         }
-
-        *number_map = std::move(vertices);
       }
 
       if (new_edge_weights) { *edge_weights = std::move(new_edge_weights.value()); }

--- a/cpp/src/c_api/graph_sg.cpp
+++ b/cpp/src/c_api/graph_sg.cpp
@@ -279,30 +279,29 @@ struct create_graph_functor : public cugraph::c_api::abstract_functor {
 
         vertices.shrink_to_fit(handle_.get_stream());
 
-        rmm::device_uvector<vertex_t> tmp_edgelist_dsts(
-          edgelist_dsts.size(), handle_.get_stream());
-        
+        rmm::device_uvector<vertex_t> tmp_edgelist_dsts(edgelist_dsts.size(), handle_.get_stream());
+
         raft::copy<vertex_t>(tmp_edgelist_dsts.data(),
                              edgelist_dsts.data(),
                              edgelist_dsts.size(),
                              handle_.get_stream());
-        
-        cugraph::detail::sort_ints(handle_.get_stream(),
-                                   raft::device_span<vertex_t>{
-                                    tmp_edgelist_dsts.data(), tmp_edgelist_dsts.size()});
-        
+
+        cugraph::detail::sort_ints(
+          handle_.get_stream(),
+          raft::device_span<vertex_t>{tmp_edgelist_dsts.data(), tmp_edgelist_dsts.size()});
+
         size_t unique_edgelist_dsts_size = cugraph::detail::unique_ints(
           handle_.get_stream(),
           raft::device_span<vertex_t>{tmp_edgelist_dsts.data(), tmp_edgelist_dsts.size()});
-        
-        
+
         tmp_edgelist_dsts.resize(unique_edgelist_dsts_size, handle_.get_stream());
 
         tmp_edgelist_dsts.shrink_to_fit(handle_.get_stream());
 
-        vertices.resize(unique_edgelist_srcs_size + unique_edgelist_dsts_size, handle_.get_stream());
+        vertices.resize(unique_edgelist_srcs_size + unique_edgelist_dsts_size,
+                        handle_.get_stream());
         vertices.shrink_to_fit(handle_.get_stream());
-        
+
         raft::copy<vertex_t>(vertices.data() + unique_edgelist_srcs_size,
                              tmp_edgelist_dsts.data(),
                              tmp_edgelist_dsts.size(),

--- a/cpp/src/detail/utility_wrappers_32.cu
+++ b/cpp/src/detail/utility_wrappers_32.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/detail/utility_wrappers_32.cu
+++ b/cpp/src/detail/utility_wrappers_32.cu
@@ -81,8 +81,9 @@ template void transform_increment_ints(raft::device_span<int32_t> values,
                                        int32_t value,
                                        rmm::cuda_stream_view const& stream_view);
 
-template void transform_binary(raft::device_span<int32_t> values,
-                               int32_t target_value,
+template void transform_not_equal(raft::device_span<int32_t> values,
+                               raft::device_span<bool> result,
+                               int32_t compare,
                                raft::handle_t const& handle);
 
 template void stride_fill(rmm::cuda_stream_view const& stream_view,

--- a/cpp/src/detail/utility_wrappers_32.cu
+++ b/cpp/src/detail/utility_wrappers_32.cu
@@ -82,9 +82,9 @@ template void transform_increment_ints(raft::device_span<int32_t> values,
                                        rmm::cuda_stream_view const& stream_view);
 
 template void transform_not_equal(raft::device_span<int32_t> values,
-                               raft::device_span<bool> result,
-                               int32_t compare,
-                               raft::handle_t const& handle);
+                                  raft::device_span<bool> result,
+                                  int32_t compare,
+                                  raft::handle_t const& handle);
 
 template void stride_fill(rmm::cuda_stream_view const& stream_view,
                           int32_t* d_value,

--- a/cpp/src/detail/utility_wrappers_32.cu
+++ b/cpp/src/detail/utility_wrappers_32.cu
@@ -81,6 +81,10 @@ template void transform_increment_ints(raft::device_span<int32_t> values,
                                        int32_t value,
                                        rmm::cuda_stream_view const& stream_view);
 
+template void transform_binary(raft::device_span<int32_t> values,
+                               int32_t target_value,
+                               raft::handle_t const& handle);
+
 template void stride_fill(rmm::cuda_stream_view const& stream_view,
                           int32_t* d_value,
                           size_t size,

--- a/cpp/src/detail/utility_wrappers_32.cu
+++ b/cpp/src/detail/utility_wrappers_32.cu
@@ -84,7 +84,7 @@ template void transform_increment_ints(raft::device_span<int32_t> values,
 template void transform_not_equal(raft::device_span<int32_t> values,
                                   raft::device_span<bool> result,
                                   int32_t compare,
-                                  raft::handle_t const& handle);
+                                  rmm::cuda_stream_view const& stream_view);
 
 template void stride_fill(rmm::cuda_stream_view const& stream_view,
                           int32_t* d_value,

--- a/cpp/src/detail/utility_wrappers_64.cu
+++ b/cpp/src/detail/utility_wrappers_64.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/detail/utility_wrappers_64.cu
+++ b/cpp/src/detail/utility_wrappers_64.cu
@@ -82,7 +82,7 @@ template void transform_increment_ints(raft::device_span<int64_t> values,
 template void transform_not_equal(raft::device_span<int64_t> values,
                                   raft::device_span<bool> result,
                                   int64_t compare,
-                                  raft::handle_t const& handle);
+                                  rmm::cuda_stream_view const& stream_view);
 
 template void stride_fill(rmm::cuda_stream_view const& stream_view,
                           int64_t* d_value,

--- a/cpp/src/detail/utility_wrappers_64.cu
+++ b/cpp/src/detail/utility_wrappers_64.cu
@@ -79,6 +79,10 @@ template void transform_increment_ints(raft::device_span<int64_t> values,
                                        int64_t value,
                                        rmm::cuda_stream_view const& stream_view);
 
+template void transform_binary(raft::device_span<int64_t> values,
+                               int64_t target_value,
+                               raft::handle_t const& handle);
+
 template void stride_fill(rmm::cuda_stream_view const& stream_view,
                           int64_t* d_value,
                           size_t size,

--- a/cpp/src/detail/utility_wrappers_64.cu
+++ b/cpp/src/detail/utility_wrappers_64.cu
@@ -80,9 +80,9 @@ template void transform_increment_ints(raft::device_span<int64_t> values,
                                        rmm::cuda_stream_view const& stream_view);
 
 template void transform_not_equal(raft::device_span<int64_t> values,
-                               raft::device_span<bool> result,
-                               int64_t compare,
-                               raft::handle_t const& handle);
+                                  raft::device_span<bool> result,
+                                  int64_t compare,
+                                  raft::handle_t const& handle);
 
 template void stride_fill(rmm::cuda_stream_view const& stream_view,
                           int64_t* d_value,

--- a/cpp/src/detail/utility_wrappers_64.cu
+++ b/cpp/src/detail/utility_wrappers_64.cu
@@ -79,8 +79,9 @@ template void transform_increment_ints(raft::device_span<int64_t> values,
                                        int64_t value,
                                        rmm::cuda_stream_view const& stream_view);
 
-template void transform_binary(raft::device_span<int64_t> values,
-                               int64_t target_value,
+template void transform_not_equal(raft::device_span<int64_t> values,
+                               raft::device_span<bool> result,
+                               int64_t compare,
                                raft::handle_t const& handle);
 
 template void stride_fill(rmm::cuda_stream_view const& stream_view,

--- a/cpp/src/detail/utility_wrappers_impl.cuh
+++ b/cpp/src/detail/utility_wrappers_impl.cuh
@@ -102,17 +102,17 @@ void transform_increment_ints(raft::device_span<value_t> values,
 }
 
 template <typename value_t>
-void transform_binary(raft::device_span<value_t> values,
-                      value_t target_value,
+void transform_not_equal(raft::device_span<value_t> values,
+                      raft::device_span<bool> result,
+                      value_t compare,
                       raft::handle_t const& handle)
 {
   thrust::transform(handle.get_thrust_policy(),
                     values.begin(),
                     values.end(),
-                    values.begin(),
-                    cuda::proclaim_return_type<value_t>([target_value] __device__(value_t value) {
-                      return target_value == value ? static_cast<value_t>(0)
-                                                   : static_cast<value_t>(1);
+                    result.begin(),
+                    cuda::proclaim_return_type<bool>([compare] __device__(value_t value) {
+                      return compare != value;
                     }));
 }
 

--- a/cpp/src/detail/utility_wrappers_impl.cuh
+++ b/cpp/src/detail/utility_wrappers_impl.cuh
@@ -33,6 +33,7 @@
 #include <thrust/remove.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
+#include <thrust/binary_search.h>
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
 #include <thrust/tuple.h>
@@ -183,6 +184,14 @@ size_t count_values(raft::handle_t const& handle,
                     data_t value)
 {
   return thrust::count(handle.get_thrust_policy(), span.begin(), span.end(), value);
+}
+
+template <typename data_t>
+bool binary_search(raft::handle_t const& handle,
+                   raft::device_span<data_t const> span,
+                   data_t value)
+{
+  return thrust::binary_search(handle.get_thrust_policy(), span.begin(), span.end(), value);
 }
 
 }  // namespace detail

--- a/cpp/src/detail/utility_wrappers_impl.cuh
+++ b/cpp/src/detail/utility_wrappers_impl.cuh
@@ -33,7 +33,6 @@
 #include <thrust/remove.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
-#include <thrust/binary_search.h>
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
 #include <thrust/tuple.h>
@@ -184,14 +183,6 @@ size_t count_values(raft::handle_t const& handle,
                     data_t value)
 {
   return thrust::count(handle.get_thrust_policy(), span.begin(), span.end(), value);
-}
-
-template <typename data_t>
-bool binary_search(raft::handle_t const& handle,
-                   raft::device_span<data_t const> span,
-                   data_t value)
-{
-  return thrust::binary_search(handle.get_thrust_policy(), span.begin(), span.end(), value);
 }
 
 }  // namespace detail

--- a/cpp/src/detail/utility_wrappers_impl.cuh
+++ b/cpp/src/detail/utility_wrappers_impl.cuh
@@ -111,7 +111,8 @@ void transform_binary(raft::device_span<value_t> values,
                     values.end(),
                     values.begin(),
                     cuda::proclaim_return_type<value_t>([target_value] __device__(value_t value) {
-                      return target_value == value ? static_cast<value_t>(0) : static_cast<value_t>(1);
+                      return target_value == value ? static_cast<value_t>(0)
+                                                   : static_cast<value_t>(1);
                     }));
 }
 

--- a/cpp/src/detail/utility_wrappers_impl.cuh
+++ b/cpp/src/detail/utility_wrappers_impl.cuh
@@ -103,17 +103,16 @@ void transform_increment_ints(raft::device_span<value_t> values,
 
 template <typename value_t>
 void transform_not_equal(raft::device_span<value_t> values,
-                      raft::device_span<bool> result,
-                      value_t compare,
-                      raft::handle_t const& handle)
+                         raft::device_span<bool> result,
+                         value_t compare,
+                         raft::handle_t const& handle)
 {
   thrust::transform(handle.get_thrust_policy(),
                     values.begin(),
                     values.end(),
                     result.begin(),
-                    cuda::proclaim_return_type<bool>([compare] __device__(value_t value) {
-                      return compare != value;
-                    }));
+                    cuda::proclaim_return_type<bool>(
+                      [compare] __device__(value_t value) { return compare != value; }));
 }
 
 template <typename value_t>

--- a/cpp/src/detail/utility_wrappers_impl.cuh
+++ b/cpp/src/detail/utility_wrappers_impl.cuh
@@ -102,6 +102,20 @@ void transform_increment_ints(raft::device_span<value_t> values,
 }
 
 template <typename value_t>
+void transform_binary(raft::device_span<value_t> values,
+                      value_t target_value,
+                      raft::handle_t const& handle)
+{
+  thrust::transform(handle.get_thrust_policy(),
+                    values.begin(),
+                    values.end(),
+                    values.begin(),
+                    cuda::proclaim_return_type<value_t>([target_value] __device__(value_t value) {
+                      return target_value == value ? static_cast<value_t>(0) : static_cast<value_t>(1);
+                    }));
+}
+
+template <typename value_t>
 void stride_fill(rmm::cuda_stream_view const& stream_view,
                  value_t* d_value,
                  size_t size,

--- a/cpp/src/detail/utility_wrappers_impl.cuh
+++ b/cpp/src/detail/utility_wrappers_impl.cuh
@@ -105,9 +105,9 @@ template <typename value_t>
 void transform_not_equal(raft::device_span<value_t> values,
                          raft::device_span<bool> result,
                          value_t compare,
-                         raft::handle_t const& handle)
+                         rmm::cuda_stream_view const& stream_view)
 {
-  thrust::transform(handle.get_thrust_policy(),
+  thrust::transform(rmm::exec_policy(stream_view),
                     values.begin(),
                     values.end(),
                     result.begin(),

--- a/python/cugraph/cugraph/dask/traversal/bfs.py
+++ b/python/cugraph/cugraph/dask/traversal/bfs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cugraph/cugraph/dask/traversal/bfs.py
+++ b/python/cugraph/cugraph/dask/traversal/bfs.py
@@ -149,10 +149,6 @@ def bfs(input_graph, start, depth_limit=None, return_distances=True, check_start
             else:
                 start = start.astype(vertex_dtype[0])
 
-        is_valid_vertex = input_graph.has_node(start)
-        if not is_valid_vertex:
-            raise ValueError("At least one start vertex provided was invalid")
-
     if input_graph.renumbered:
         if isinstance(start, dask_cudf.DataFrame):
             tmp_col_names = start.columns

--- a/python/cugraph/cugraph/dask/traversal/sssp.py
+++ b/python/cugraph/cugraph/dask/traversal/sssp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cugraph/cugraph/dask/traversal/sssp.py
+++ b/python/cugraph/cugraph/dask/traversal/sssp.py
@@ -110,14 +110,6 @@ def sssp(input_graph, source, cutoff=None, check_source=True):
 
     client = default_client()
 
-    def check_valid_vertex(G, source):
-        is_valid_vertex = G.has_node(source)
-        if not is_valid_vertex:
-            raise ValueError("Invalid source vertex")
-
-    if check_source:
-        check_valid_vertex(input_graph, source)
-
     if cutoff is None:
         cutoff = cupy.inf
 

--- a/python/cugraph/cugraph/traversal/bfs.py
+++ b/python/cugraph/cugraph/traversal/bfs.py
@@ -47,41 +47,6 @@ def _ensure_args(G, start, i_start, directed):
         if directed is not None:
             raise TypeError("'directed' cannot be specified for a " "Graph-type input")
 
-        # ensure start vertex is valid
-        invalid_vertex_err = ValueError("A provided vertex was not valid")
-        if is_nx_graph_type(G_type):
-            if start not in G:
-                raise invalid_vertex_err
-        else:
-            if not isinstance(start, cudf.DataFrame):
-                if not isinstance(start, dask_cudf.DataFrame):
-                    vertex_dtype = G.nodes().dtype
-                    start = cudf.DataFrame(
-                        {"starts": cudf.Series(start, dtype=vertex_dtype)}
-                    )
-
-            if G.is_renumbered():
-                validlen = len(
-                    G.renumber_map.to_internal_vertex_id(start, start.columns).dropna()
-                )
-                if validlen < len(start):
-                    raise invalid_vertex_err
-            else:
-                el = G.edgelist.edgelist_df[["src", "dst"]]
-                col = start.columns[0]
-                null_l = (
-                    el.merge(start[col].rename("src"), on="src", how="right")
-                    .dst.isnull()
-                    .sum()
-                )
-                null_r = (
-                    el.merge(start[col].rename("dst"), on="dst", how="right")
-                    .src.isnull()
-                    .sum()
-                )
-                if null_l + null_r > 0:
-                    raise invalid_vertex_err
-
     if directed is None:
         directed = True
 

--- a/python/cugraph/cugraph/traversal/bfs.py
+++ b/python/cugraph/cugraph/traversal/bfs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/traversal/sssp.py
+++ b/python/cugraph/cugraph/traversal/sssp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/cugraph/cugraph/traversal/sssp.py
+++ b/python/cugraph/cugraph/traversal/sssp.py
@@ -63,8 +63,6 @@ def _ensure_args(
         )
         if is_nx_graph_type(G_type) and source not in G:
             raise invalid_vertex_err
-        elif indices is None and not G.has_node(source):
-            raise invalid_vertex_err
 
         directed = False
 

--- a/python/pylibcugraph/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/pylibcugraph/CMakeLists.txt
@@ -74,6 +74,7 @@ set(cython_sources
     edge_id_lookup_table.pyx
     decompress_to_edgelist.pyx
     renumber_arbitrary_edgelist.pyx
+    has_vertex.pyx
 )
 set(linked_libraries cugraph::cugraph;cugraph::cugraph_c)
 

--- a/python/pylibcugraph/pylibcugraph/__init__.py
+++ b/python/pylibcugraph/pylibcugraph/__init__.py
@@ -145,6 +145,8 @@ from pylibcugraph.decompress_to_edgelist import decompress_to_edgelist
 
 from pylibcugraph.renumber_arbitrary_edgelist import renumber_arbitrary_edgelist
 
+from pylibcugraph.has_vertex import has_vertex
+
 
 from pylibcugraph import exceptions
 

--- a/python/pylibcugraph/pylibcugraph/_cugraph_c/graph_functions.pxd
+++ b/python/pylibcugraph/pylibcugraph/_cugraph_c/graph_functions.pxd
@@ -308,3 +308,15 @@ cdef extern from "cugraph_c/graph_functions.h":
             cugraph_edgelist_t** result,
             cugraph_error_t** error
         )
+    
+    ###########################################################################
+
+    # has_vertex
+    cdef cugraph_error_code_t cugraph_has_vertex(
+        const cugraph_resource_handle_t* handle,
+        const cugraph_graph_t* graph,
+        const int vertex,
+        bool_t do_expensive_check,
+        bool_t* result,
+        cugraph_error_t** error)
+

--- a/python/pylibcugraph/pylibcugraph/_cugraph_c/graph_functions.pxd
+++ b/python/pylibcugraph/pylibcugraph/_cugraph_c/graph_functions.pxd
@@ -36,6 +36,7 @@ from pylibcugraph._cugraph_c.graph cimport cugraph_graph_t
 from pylibcugraph._cugraph_c.array cimport (
     cugraph_type_erased_device_array_view_t,
     cugraph_type_erased_host_array_view_t,
+    cugraph_type_erased_device_array_t,
 )
 
 cdef extern from "cugraph_c/graph_functions.h":
@@ -317,5 +318,5 @@ cdef extern from "cugraph_c/graph_functions.h":
         const cugraph_graph_t* graph,
         cugraph_type_erased_device_array_view_t* vertices,
         bool_t do_expensive_check,
-        bool_t* result,
+        cugraph_type_erased_device_array_t** result,
         cugraph_error_t** error)

--- a/python/pylibcugraph/pylibcugraph/_cugraph_c/graph_functions.pxd
+++ b/python/pylibcugraph/pylibcugraph/_cugraph_c/graph_functions.pxd
@@ -308,7 +308,7 @@ cdef extern from "cugraph_c/graph_functions.h":
             cugraph_edgelist_t** result,
             cugraph_error_t** error
         )
-    
+
     ###########################################################################
 
     # has_vertex
@@ -319,4 +319,3 @@ cdef extern from "cugraph_c/graph_functions.h":
         bool_t do_expensive_check,
         bool_t* result,
         cugraph_error_t** error)
-

--- a/python/pylibcugraph/pylibcugraph/_cugraph_c/graph_functions.pxd
+++ b/python/pylibcugraph/pylibcugraph/_cugraph_c/graph_functions.pxd
@@ -315,7 +315,7 @@ cdef extern from "cugraph_c/graph_functions.h":
     cdef cugraph_error_code_t cugraph_has_vertex(
         const cugraph_resource_handle_t* handle,
         const cugraph_graph_t* graph,
-        const int vertex,
+        cugraph_type_erased_device_array_view_t* vertices,
         bool_t do_expensive_check,
         bool_t* result,
         cugraph_error_t** error)

--- a/python/pylibcugraph/pylibcugraph/bfs.pyx
+++ b/python/pylibcugraph/pylibcugraph/bfs.pyx
@@ -20,6 +20,7 @@ from libc.stdint cimport uintptr_t
 from libc.stdint cimport int32_t
 from libc.limits cimport INT_MAX
 
+from pylibcugraph import has_vertex
 from pylibcugraph.resource_handle cimport ResourceHandle
 from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_bfs,
@@ -147,7 +148,7 @@ def bfs(ResourceHandle handle, _GPUGraph graph,
     assert_CAI_type(sources, "sources")
 
     # Check if sources are valid
-    if not all(pylibcugraph.has_vertex(handle, graph, sources, do_expensive_check)):
+    if not all(has_vertex(handle, graph, sources, do_expensive_check)):
         raise ValueError(
             f"one or more vertices are invalid. Call the method 'has_vertex' ",
             f"to identify the invalid vertices")

--- a/python/pylibcugraph/pylibcugraph/bfs.pyx
+++ b/python/pylibcugraph/pylibcugraph/bfs.pyx
@@ -20,7 +20,7 @@ from libc.stdint cimport uintptr_t
 from libc.stdint cimport int32_t
 from libc.limits cimport INT_MAX
 
-from pylibcugraph import has_vertex
+from pylibcugraph.has_vertex import has_vertex
 from pylibcugraph.resource_handle cimport ResourceHandle
 from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_bfs,
@@ -30,7 +30,6 @@ from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_paths_result_get_distances,
     cugraph_paths_result_free,
 )
-from pylibcugraph import has_vertex
 from pylibcugraph._cugraph_c.array cimport (
     cugraph_type_erased_device_array_view_t,
     cugraph_type_erased_device_array_view_create,

--- a/python/pylibcugraph/pylibcugraph/bfs.pyx
+++ b/python/pylibcugraph/pylibcugraph/bfs.pyx
@@ -20,7 +20,6 @@ from libc.stdint cimport uintptr_t
 from libc.stdint cimport int32_t
 from libc.limits cimport INT_MAX
 
-import pylibcugraph
 from pylibcugraph.resource_handle cimport ResourceHandle
 from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_bfs,

--- a/python/pylibcugraph/pylibcugraph/bfs.pyx
+++ b/python/pylibcugraph/pylibcugraph/bfs.pyx
@@ -20,6 +20,7 @@ from libc.stdint cimport uintptr_t
 from libc.stdint cimport int32_t
 from libc.limits cimport INT_MAX
 
+import pylibcugraph
 from pylibcugraph.resource_handle cimport ResourceHandle
 from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_bfs,
@@ -29,6 +30,7 @@ from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_paths_result_get_distances,
     cugraph_paths_result_free,
 )
+from pylibcugraph import has_vertex
 from pylibcugraph._cugraph_c.array cimport (
     cugraph_type_erased_device_array_view_t,
     cugraph_type_erased_device_array_view_create,
@@ -145,6 +147,10 @@ def bfs(ResourceHandle handle, _GPUGraph graph,
 
     assert_CAI_type(sources, "sources")
 
+    # Check if sources are valid
+    for v in sources.values_host:
+        if not pylibcugraph.has_vertex(handle, graph, v, do_expensive_check):
+            raise ValueError(f"vertex {v} is not valid.")
     if depth_limit <= 0:
         depth_limit = INT_MAX - 1
 

--- a/python/pylibcugraph/pylibcugraph/bfs.pyx
+++ b/python/pylibcugraph/pylibcugraph/bfs.pyx
@@ -148,9 +148,10 @@ def bfs(ResourceHandle handle, _GPUGraph graph,
     assert_CAI_type(sources, "sources")
 
     # Check if sources are valid
-    for v in sources.values_host:
-        if not pylibcugraph.has_vertex(handle, graph, v, do_expensive_check):
-            raise ValueError(f"vertex {v} is not valid.")
+    if not all(pylibcugraph.has_vertex(handle, graph, sources, do_expensive_check)):
+        raise ValueError(
+            f"one or more vertices are invalid. Call the method 'has_vertex' ",
+            f"to identify the invalid vertices")
     if depth_limit <= 0:
         depth_limit = INT_MAX - 1
 

--- a/python/pylibcugraph/pylibcugraph/graphs.pxd
+++ b/python/pylibcugraph/pylibcugraph/graphs.pxd
@@ -18,11 +18,14 @@ from pylibcugraph._cugraph_c.graph cimport (
     cugraph_graph_t,
     cugraph_type_erased_device_array_view_t,
 )
+from pylibcugraph._cugraph_c.types cimport (
+    cugraph_data_type_id_t)
 
 
 # Base class allowing functions to accept either SGGraph or MGGraph
 # This is not visible in python
 cdef class _GPUGraph:
+    cdef cugraph_data_type_id_t vertex_type
     cdef cugraph_graph_t* c_graph_ptr
     cdef cugraph_type_erased_device_array_view_t* edge_id_view_ptr
     cdef cugraph_type_erased_device_array_view_t** edge_id_view_ptr_ptr

--- a/python/pylibcugraph/pylibcugraph/graphs.pxd
+++ b/python/pylibcugraph/pylibcugraph/graphs.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/pylibcugraph/pylibcugraph/graphs.pyx
+++ b/python/pylibcugraph/pylibcugraph/graphs.pyx
@@ -428,8 +428,13 @@ cdef class MGGraph(_GPUGraph):
                     srcs_view_ptr_ptr = \
                         <cugraph_type_erased_device_array_view_t **>malloc(
                             num_arrays * sizeof(cugraph_type_erased_device_array_view_t*))
+
                 srcs_view_ptr_ptr[i] = \
                     create_cugraph_type_erased_device_array_view_from_py_obj(src_array[i])
+                
+                if i == 0:
+                    self.vertex_type = cugraph_type_erased_device_array_view_type(
+                        srcs_view_ptr_ptr[0])
 
             if dst_array[i] is not None:
                 if i == 0:

--- a/python/pylibcugraph/pylibcugraph/graphs.pyx
+++ b/python/pylibcugraph/pylibcugraph/graphs.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -200,7 +200,7 @@ cdef class SGGraph(_GPUGraph):
             create_cugraph_type_erased_device_array_view_from_py_obj(
                 vertices_array
             )
-        
+
         self.vertex_type = cugraph_type_erased_device_array_view_type(
             srcs_or_offsets_view_ptr)
 

--- a/python/pylibcugraph/pylibcugraph/graphs.pyx
+++ b/python/pylibcugraph/pylibcugraph/graphs.pyx
@@ -29,6 +29,9 @@ from pylibcugraph._cugraph_c.graph cimport (
     cugraph_graph_create_sg_from_csr,
     cugraph_graph_free,
 )
+from pylibcugraph._cugraph_c.array cimport (
+    cugraph_type_erased_device_array_view_type,
+)
 from pylibcugraph.resource_handle cimport (
     ResourceHandle,
 )
@@ -197,6 +200,13 @@ cdef class SGGraph(_GPUGraph):
             create_cugraph_type_erased_device_array_view_from_py_obj(
                 vertices_array
             )
+        
+        self.vertex_type = cugraph_type_erased_device_array_view_type(
+            srcs_or_offsets_view_ptr)
+
+        print("vertex_type = ", self.vertex_type)
+        #self.vertex_type = "int32"
+
         self.weights_view_ptr = create_cugraph_type_erased_device_array_view_from_py_obj(
                 weight_array
             )

--- a/python/pylibcugraph/pylibcugraph/graphs.pyx
+++ b/python/pylibcugraph/pylibcugraph/graphs.pyx
@@ -431,7 +431,7 @@ cdef class MGGraph(_GPUGraph):
 
                 srcs_view_ptr_ptr[i] = \
                     create_cugraph_type_erased_device_array_view_from_py_obj(src_array[i])
-                
+
                 if i == 0:
                     self.vertex_type = cugraph_type_erased_device_array_view_type(
                         srcs_view_ptr_ptr[0])

--- a/python/pylibcugraph/pylibcugraph/graphs.pyx
+++ b/python/pylibcugraph/pylibcugraph/graphs.pyx
@@ -204,9 +204,6 @@ cdef class SGGraph(_GPUGraph):
         self.vertex_type = cugraph_type_erased_device_array_view_type(
             srcs_or_offsets_view_ptr)
 
-        print("vertex_type = ", self.vertex_type)
-        #self.vertex_type = "int32"
-
         self.weights_view_ptr = create_cugraph_type_erased_device_array_view_from_py_obj(
                 weight_array
             )

--- a/python/pylibcugraph/pylibcugraph/has_vertex.pyx
+++ b/python/pylibcugraph/pylibcugraph/has_vertex.pyx
@@ -104,5 +104,4 @@ def has_vertex(ResourceHandle resource_handle,
 
     cupy_has_vertex = copy_to_cupy_array(c_resource_handle_ptr, result_view_ptr)
 
-
     return cupy_has_vertex

--- a/python/pylibcugraph/pylibcugraph/has_vertex.pyx
+++ b/python/pylibcugraph/pylibcugraph/has_vertex.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -75,7 +75,7 @@ def has_vertex(ResourceHandle resource_handle,
     cdef cugraph_resource_handle_t* c_resource_handle_ptr = \
         resource_handle.c_resource_handle_ptr
     cdef cugraph_graph_t* c_graph_ptr = graph.c_graph_ptr
-    
+
     cdef bool_t result;
     cdef cugraph_error_code_t error_code
     cdef cugraph_error_t* error_ptr

--- a/python/pylibcugraph/pylibcugraph/has_vertex.pyx
+++ b/python/pylibcugraph/pylibcugraph/has_vertex.pyx
@@ -26,7 +26,9 @@ from pylibcugraph._cugraph_c.error cimport (
     cugraph_error_t,
 )
 from pylibcugraph._cugraph_c.array cimport (
+    cugraph_type_erased_device_array_t,
     cugraph_type_erased_device_array_view_t,
+    cugraph_type_erased_device_array_view
 )
 from pylibcugraph._cugraph_c.graph_functions cimport (
     cugraph_has_vertex
@@ -43,6 +45,7 @@ from pylibcugraph.graphs cimport (
 from pylibcugraph.utils cimport (
     assert_success,
     assert_CAI_type,
+    copy_to_cupy_array,
     create_cugraph_type_erased_device_array_view_from_py_obj
 )
 
@@ -82,7 +85,7 @@ def has_vertex(ResourceHandle resource_handle,
             create_cugraph_type_erased_device_array_view_from_py_obj(
                 vertices)
 
-    cdef bool_t result;
+    cdef cugraph_type_erased_device_array_t* result_ptr
     cdef cugraph_error_code_t error_code
     cdef cugraph_error_t* error_ptr
 
@@ -90,9 +93,16 @@ def has_vertex(ResourceHandle resource_handle,
                                     c_graph_ptr,
                                     vertices_view_ptr,
                                     do_expensive_check,
-                                    &result,
+                                    &result_ptr,
                                     &error_ptr)
     assert_success(error_code, error_ptr, "has_vertex")
 
+    cdef cugraph_type_erased_device_array_view_t* \
+        result_view_ptr = \
+            cugraph_type_erased_device_array_view(
+                result_ptr)
 
-    return True if result else False
+    cupy_has_vertex = copy_to_cupy_array(c_resource_handle_ptr, result_view_ptr)
+
+
+    return cupy_has_vertex

--- a/python/pylibcugraph/pylibcugraph/has_vertex.pyx
+++ b/python/pylibcugraph/pylibcugraph/has_vertex.pyx
@@ -1,0 +1,92 @@
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Have cython use python 3 syntax
+# cython: language_level = 3
+
+
+from pylibcugraph._cugraph_c.types cimport (
+    bool_t,
+)
+from pylibcugraph._cugraph_c.resource_handle cimport (
+    cugraph_resource_handle_t,
+)
+from pylibcugraph._cugraph_c.error cimport (
+    cugraph_error_code_t,
+    cugraph_error_t,
+)
+from pylibcugraph._cugraph_c.array cimport (
+    cugraph_type_erased_device_array_view_t,
+    cugraph_type_erased_device_array_view_free,
+)
+from pylibcugraph._cugraph_c.graph_functions cimport (
+    cugraph_has_vertex
+)
+from pylibcugraph._cugraph_c.graph cimport (
+    cugraph_graph_t,
+)
+from pylibcugraph.resource_handle cimport (
+    ResourceHandle,
+)
+from pylibcugraph.graphs cimport (
+    _GPUGraph,
+)
+from pylibcugraph.utils cimport (
+    assert_success,
+    copy_to_cupy_array,
+    create_cugraph_type_erased_device_array_view_from_py_obj
+)
+
+
+def has_vertex(ResourceHandle resource_handle,
+               _GPUGraph graph,
+               vertex,
+               bool_t do_expensive_check):
+    """
+        Verify if a vertex exists in the graph
+
+        Parameters
+        ----------
+        resource_handle : ResourceHandle
+            Handle to the underlying device resources needed for referencing data
+            and running algorithms.
+
+        graph : SGGraph or MGGraph
+            The input graph, for either Single or Multi-GPU operations.
+
+        vertex : int
+                 vertex to be queried
+
+        Returns
+        -------
+        Return 'True' if the vertex exists in the graph or 'False'
+    """
+
+    cdef cugraph_resource_handle_t* c_resource_handle_ptr = \
+        resource_handle.c_resource_handle_ptr
+    cdef cugraph_graph_t* c_graph_ptr = graph.c_graph_ptr
+    
+    cdef bool_t result;
+    cdef cugraph_error_code_t error_code
+    cdef cugraph_error_t* error_ptr
+
+    error_code = cugraph_has_vertex(c_resource_handle_ptr,
+                                    c_graph_ptr,
+                                    vertex,
+                                    do_expensive_check,
+                                    &result,
+                                    &error_ptr)
+    assert_success(error_code, error_ptr, "has_vertex")
+
+
+    return True if result else False

--- a/python/pylibcugraph/pylibcugraph/has_vertex.pyx
+++ b/python/pylibcugraph/pylibcugraph/has_vertex.pyx
@@ -71,8 +71,28 @@ def has_vertex(ResourceHandle resource_handle,
 
         Returns
         -------
-        Return 'True' if the vertex exists in the graph or 'False'
-    """
+        Return a device array of bool where 'True' is indicative of a vertex existance
+        and 'False' otherwise.
+
+        Examples
+        --------
+        >>> import pylibcugraph, cupy, numpy
+        >>> srcs = cupy.asarray([0, 1, 1, 2, 2, 2, 3, 3, 4], dtype=numpy.int32)
+        >>> dsts = cupy.asarray([1, 3, 4, 0, 1, 3, 4, 5, 5], dtype=numpy.int32)
+        >>> weights = cupy.asarray(
+        ...     [0.1, 2.1, 1.1, 5.1, 3.1, 4.1, 7.2, 3.2, 6.1], dtype=numpy.float32)
+        >>> source_vertices = cupy.asarray([0, 1], dtype=numpy.int32)
+        >>> resource_handle = pylibcugraph.ResourceHandle()
+        >>> graph_props = pylibcugraph.GraphProperties(
+        ...     is_symmetric=False, is_multigraph=False)
+        >>> G = pylibcugraph.SGGraph(
+        ...     resource_handle, graph_props, srcs, dsts, weight_array=weights,
+        ...     store_transposed=False, renumber=False, do_expensive_check=False)
+        >>> vertices = cupy.asarray([0, 1, 2, 6], dtype=numpy.int32)
+        >>> result = pylibcugraph.has_vertex(resource_handle, G, vertices False)
+        >>> result
+        [ True  True  True False]
+        """
 
     assert_CAI_type(vertices, "vertices")
 

--- a/python/pylibcugraph/pylibcugraph/sssp.pyx
+++ b/python/pylibcugraph/pylibcugraph/sssp.pyx
@@ -51,6 +51,7 @@ from pylibcugraph.graphs cimport (
 from pylibcugraph.utils cimport (
     assert_success,
     copy_to_cupy_array,
+    get_numpy_type_from_c_type,
 )
 
 
@@ -128,8 +129,12 @@ def sssp(ResourceHandle resource_handle,
     array([-1, -1,  1,  2], dtype=int32)
     """
 
+    vertex_type = get_numpy_type_from_c_type(graph.vertex_type)
+
+    cp_source = cupy.asarray([source], dtype=vertex_type)
+
     # Check if sources are valid
-    if not pylibcugraph.has_vertex(resource_handle, graph, source, do_expensive_check):
+    if not all(pylibcugraph.has_vertex(resource_handle, graph, cp_source, do_expensive_check)):
         raise ValueError(f"vertex {source} is not valid.")
 
     if compute_predecessors is False:

--- a/python/pylibcugraph/pylibcugraph/sssp.pyx
+++ b/python/pylibcugraph/pylibcugraph/sssp.pyx
@@ -17,7 +17,7 @@
 import cupy
 import numpy
 
-import pylibcugraph
+from pylibcugraph.has_vertex import has_vertex
 from pylibcugraph._cugraph_c.types cimport (
     bool_t,
 )
@@ -134,7 +134,7 @@ def sssp(ResourceHandle resource_handle,
     cp_source = cupy.asarray([source], dtype=vertex_type)
 
     # Check if sources are valid
-    if not all(pylibcugraph.has_vertex(resource_handle, graph, cp_source, do_expensive_check)):
+    if not all(has_vertex(resource_handle, graph, cp_source, do_expensive_check)):
         raise ValueError(f"vertex {source} is not valid.")
 
     if compute_predecessors is False:

--- a/python/pylibcugraph/pylibcugraph/sssp.pyx
+++ b/python/pylibcugraph/pylibcugraph/sssp.pyx
@@ -17,6 +17,7 @@
 import cupy
 import numpy
 
+import pylibcugraph
 from pylibcugraph._cugraph_c.types cimport (
     bool_t,
 )
@@ -126,6 +127,10 @@ def sssp(ResourceHandle resource_handle,
     >>> predecessors
     array([-1, -1,  1,  2], dtype=int32)
     """
+
+    # Check if sources are valid
+    if not pylibcugraph.has_vertex(resource_handle, graph, source, do_expensive_check):
+        raise ValueError(f"vertex {source} is not valid.")
 
     if compute_predecessors is False:
         raise ValueError("compute_predecessors must be True for the current "

--- a/python/pylibcugraph/pylibcugraph/utils.pyx
+++ b/python/pylibcugraph/pylibcugraph/utils.pyx
@@ -118,6 +118,8 @@ cdef get_numpy_type_from_c_type(cugraph_data_type_id_t c_type):
         return numpy.float64
     elif c_type == cugraph_data_type_id_t.SIZE_T:
         return numpy.int64
+    elif c_type == cugraph_data_type_id_t.BOOL:
+        return numpy.bool
     else:
         raise RuntimeError("Internal error: got invalid data type enum value "
                            f"from C: {c_type}")

--- a/python/pylibcugraph/pylibcugraph/utils.pyx
+++ b/python/pylibcugraph/pylibcugraph/utils.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
This PR leverages the CAPI to optimize the check for vertex existence which can lead to +100x speedup compared to the cudf based version as it can be noticed from the performance figure below

<img width="667" alt="Screenshot 2025-03-17 at 9 47 37 AM" src="https://github.com/user-attachments/assets/4a90cb59-c4cb-40d8-a6b5-9447b1a6cc42" />


closes #4956 