### PR TITLE
Update remove_multi_edges to support edge list in multiple chunks.

### DIFF
--- a/cpp/include/cugraph/detail/utility_wrappers.hpp
+++ b/cpp/include/cugraph/detail/utility_wrappers.hpp
@@ -36,7 +36,8 @@ namespace detail {
  * Fills a buffer with uniformly distributed random values between
  * the specified minimum and maximum values.
  *
- * @tparam      value_t      type of the value to operate on
+ * @tparam      value_t      type of the value to operate on (currently supports int32_t, int64_t,
+ * float and double)
  *
  * @param[in]   stream_view  stream view
  * @param[out]  d_value      device array to fill

--- a/cpp/include/cugraph/graph_functions.hpp
+++ b/cpp/include/cugraph/graph_functions.hpp
@@ -1261,7 +1261,7 @@ remove_self_loops(raft::handle_t const& handle,
  * edgelist_edge_types.has_value() | @p edgelist_edge_start_times.has_value() | @p
  * edgelist_edge_end_times.has_value()is true. If each edge has more than one property values, edge
  * property values are compared in the order of weight (if valid), edge ID (if valid), edge type (if
- * vlaid), edge start time (if valid) and edge end time (if valid). Setting this to true incurs
+ * valid), edge start time (if valid) and edge end time (if valid). Setting this to true incurs
  * performance overhead as this requires more comparisons.
  * @return Tuple of vectors storing edge sources, destinations, optional weights, optional edge ids,
  * optional edge types, optional edge start times and optional edge end times.

--- a/cpp/include/cugraph/graph_functions.hpp
+++ b/cpp/include/cugraph/graph_functions.hpp
@@ -1344,11 +1344,11 @@ template <typename vertex_t,
           typename edge_time_t>
 std::tuple<std::vector<rmm::device_uvector<vertex_t>>,
            std::vector<rmm::device_uvector<vertex_t>>,
-           std::vector<std::optional<rmm::device_uvector<weight_t>>>,
-           std::vector<std::optional<rmm::device_uvector<edge_t>>>,
-           std::vector<std::optional<rmm::device_uvector<edge_type_t>>>,
-           std::vector<std::optional<rmm::device_uvector<edge_time_t>>>,
-           std::vector<std::optional<rmm::device_uvector<edge_time_t>>>>
+           std::optional<std::vector<rmm::device_uvector<weight_t>>>,
+           std::optional<std::vector<rmm::device_uvector<edge_t>>>,
+           std::optional<std::vector<rmm::device_uvector<edge_type_t>>>,
+           std::optional<std::vector<rmm::device_uvector<edge_time_t>>>,
+           std::optional<std::vector<rmm::device_uvector<edge_time_t>>>>
 remove_multi_edges(
   raft::handle_t const& handle,
   std::vector<rmm::device_uvector<vertex_t>>&& edgelist_srcs,

--- a/cpp/include/cugraph/graph_functions.hpp
+++ b/cpp/include/cugraph/graph_functions.hpp
@@ -1240,6 +1240,8 @@ remove_self_loops(raft::handle_t const& handle,
  * In an MG context it is assumed that edges have been shuffled to the proper GPU,
  * in which case any multi-edges will be on the same GPU.
  *
+ * This version takes edges in a single chunk.
+ *
  * @tparam vertex_t    Type of vertex identifiers. Needs to be an integral type.
  * @tparam edge_t      Type of edge identifiers. Needs to be an integral type.
  * @tparam weight_t    Type of edge weight. Currently float and double are supported.
@@ -1263,8 +1265,9 @@ remove_self_loops(raft::handle_t const& handle,
  * property values are compared in the order of weight (if valid), edge ID (if valid), edge type (if
  * valid), edge start time (if valid) and edge end time (if valid). Setting this to true incurs
  * performance overhead as this requires more comparisons.
- * @return Tuple of vectors storing edge sources, destinations, optional weights, optional edge ids,
- * optional edge types, optional edge start times and optional edge end times.
+ * @return Tuple of rmm::device_uvector objects storing edge sources, destinations, optional
+ * weights, optional edge ids, optional edge types, optional edge start times and optional edge end
+ * times.
  */
 template <typename vertex_t,
           typename edge_t,
@@ -1287,5 +1290,74 @@ remove_multi_edges(raft::handle_t const& handle,
                    std::optional<rmm::device_uvector<edge_time_t>>&& edgelist_edge_start_times,
                    std::optional<rmm::device_uvector<edge_time_t>>&& edgelist_edge_edge_times,
                    bool keep_min_value_edge = false);
+
+/**
+ * @ingroup graph_functions_cpp
+ * @brief Remove all but one edge when a multi-edge exists.
+ *
+ * When a multi-edge exists, one of the edges will remain. If @p keep_min_value_edge is false, an
+ * arbitrary edge will be selected among the edges in the multi-edge. If @p keep_min_value_edge is
+ * true, the edge with the minimum value will be selected. The edge weights will be first compared
+ * (if @p edgelist_weights.has_value() is true); edge IDs will be compared next (if @p
+ * edgelist_edge_ids.has_value() is true); and edge types (if @p edgelist_edge_types.has_value() is
+ * true) will compared last.
+ *
+ * In an MG context it is assumed that edges have been shuffled to the proper GPU,
+ * in which case any multi-edges will be on the same GPU.
+ *
+ * This version takes edges in multiple chunks.
+ *
+ * @tparam vertex_t    Type of vertex identifiers. Needs to be an integral type.
+ * @tparam edge_t      Type of edge identifiers. Needs to be an integral type.
+ * @tparam weight_t    Type of edge weight. Currently float and double are supported.
+ * @tparam edge_type_t Type of edge type. Needs to be an integral type.
+ * @tparam edge_time_t Type of edge time.  Needs to be an integral type.
+ *
+ * @param handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator, and
+ * handles to various CUDA libraries) to run graph algorithms.
+ * @param edgelist_srcs  Vector of source vertex id lists (one vector element per edge chunk)
+ * @param edgelist_dsts  Vector of destination vertex id lists (one vector element per edge chunk)
+ * @param edgelist_weights  Optional vector of edge weight lists (one vector element per edge chunk)
+ * @param edgelist_edge_ids  Optional vector of edge id lists (one vector element per edge chunk)
+ * @param edgelist_edge_types  Optional vector of edge type lists (one vector element per edge
+ * chunk)
+ * @param edgelist_edge_start_times  Optional vector of edge start time lists (one vector element
+ * per edge chunk)
+ * @param edgelist_edge_end_times  Optional vector of edge end time lists (one vector element per
+ * edge chunk)
+ * @param keep_min_value_edge Flag indicating whether to keep an arbitrary edge (false) or the
+ * minimum value edge (true) among the edges in a multi-edge. Relevant only if @p
+ * edgelist_weights.has_value() | @p edgelist_edge_ids.has_value() | @p
+ * edgelist_edge_types.has_value() | @p edgelist_edge_start_times.has_value() | @p
+ * edgelist_edge_end_times.has_value()is true. If each edge has more than one property values, edge
+ * property values are compared in the order of weight (if valid), edge ID (if valid), edge type (if
+ * valid), edge start time (if valid) and edge end time (if valid). Setting this to true incurs
+ * performance overhead as this requires more comparisons.
+ * @return Tuple of std::vector objects holding rmm::device_uvector objects (# device_uvector objets
+ * per std::vector = # edge chunks) storing edge sources, destinations, optional weights, optional
+ * edge ids, optional edge types, optional edge start times and optional edge end times.
+ */
+template <typename vertex_t,
+          typename edge_t,
+          typename weight_t,
+          typename edge_type_t,
+          typename edge_time_t>
+std::tuple<std::vector<rmm::device_uvector<vertex_t>>,
+           std::vector<rmm::device_uvector<vertex_t>>,
+           std::vector<std::optional<rmm::device_uvector<weight_t>>>,
+           std::vector<std::optional<rmm::device_uvector<edge_t>>>,
+           std::vector<std::optional<rmm::device_uvector<edge_type_t>>>,
+           std::vector<std::optional<rmm::device_uvector<edge_time_t>>>,
+           std::vector<std::optional<rmm::device_uvector<edge_time_t>>>>
+remove_multi_edges(
+  raft::handle_t const& handle,
+  std::vector<rmm::device_uvector<vertex_t>>&& edgelist_srcs,
+  std::vector<rmm::device_uvector<vertex_t>>&& edgelist_dsts,
+  std::optional<std::vector<rmm::device_uvector<weight_t>>>&& edgelist_weights,
+  std::optional<std::vector<rmm::device_uvector<edge_t>>>&& edgelist_edge_ids,
+  std::optional<std::vector<rmm::device_uvector<edge_type_t>>>&& edgelist_edge_types,
+  std::optional<std::vector<rmm::device_uvector<edge_time_t>>>&& edgelist_edge_start_times,
+  std::optional<std::vector<rmm::device_uvector<edge_time_t>>>&& edgelist_edge_edge_times,
+  bool keep_min_value_edge = false);
 
 }  // namespace cugraph

--- a/cpp/include/cugraph/graph_functions.hpp
+++ b/cpp/include/cugraph/graph_functions.hpp
@@ -1258,8 +1258,11 @@ remove_self_loops(raft::handle_t const& handle,
  * @param keep_min_value_edge Flag indicating whether to keep an arbitrary edge (false) or the
  * minimum value edge (true) among the edges in a multi-edge. Relevant only if @p
  * edgelist_weights.has_value() | @p edgelist_edge_ids.has_value() | @p
- * edgelist_edge_types.has_value() is true. Setting this to true incurs performance overhead as this
- * requires more comparisons.
+ * edgelist_edge_types.has_value() | @p edgelist_edge_start_times.has_value() | @p
+ * edgelist_edge_end_times.has_value()is true. If each edge has more than one property values, edge
+ * property values are compared in the order of weight (if valid), edge ID (if valid), edge type (if
+ * vlaid), edge start time (if valid) and edge end time (if valid). Setting this to true incurs
+ * performance overhead as this requires more comparisons.
  * @return Tuple of vectors storing edge sources, destinations, optional weights, optional edge ids,
  * optional edge types, optional edge start times and optional edge end times.
  */

--- a/cpp/src/structure/detail/structure_utils.cuh
+++ b/cpp/src/structure/detail/structure_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/detail/structure_utils.cuh
+++ b/cpp/src/structure/detail/structure_utils.cuh
@@ -617,6 +617,8 @@ rmm::device_uvector<T> keep_flagged_elements(raft::handle_t const& handle,
 
   detail::copy_if_mask_set(
     handle, vector.begin(), vector.end(), keep_flags.begin(), result.begin());
+  vector.resize(0, handle.get_stream());
+  vector.shrink_to_fit(handle.get_stream());
 
   return result;
 }

--- a/cpp/src/structure/remove_multi_edges_impl.cuh
+++ b/cpp/src/structure/remove_multi_edges_impl.cuh
@@ -19,6 +19,7 @@
 
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/utilities/dataframe_buffer.hpp>
+#include <cugraph/utilities/device_functors.cuh>
 // FIXME: mem_frugal_partition should probably not be in shuffle_comm.hpp
 //        It's used here without any notion of shuffling
 #include <cugraph/utilities/shuffle_comm.cuh>
@@ -47,17 +48,35 @@ namespace cugraph {
 namespace detail {
 
 template <typename vertex_t>
-struct hash_src_dst_pair {
-  int32_t num_groups;
+struct hash_src_dst_pair_t {
+  using result_type = std::conditional_t<sizeof(vertex_t) == 8,
+                                         typename cuco::xxhash_64<vertex_t>::result_type,
+                                         typename cuco::xxhash_32<vertex_t>::result_type>;
 
-  int32_t __device__ operator()(thrust::tuple<vertex_t, vertex_t> t) const
+  __device__ result_type operator()(thrust::tuple<vertex_t, vertex_t> pair) const
   {
-    vertex_t pair[2];
-    pair[0] = thrust::get<0>(t);
-    pair[1] = thrust::get<1>(t);
-    cuco::murmurhash3_32<vertex_t*> hash_func{};
-    return hash_func.compute_hash(reinterpret_cast<cuda::std::byte*>(pair), 2 * sizeof(vertex_t)) %
-           num_groups;
+    vertex_t buf[2];
+    buf[0] = thrust::get<0>(pair);
+    buf[1] = thrust::get<1>(pair);
+    std::conditional_t<sizeof(vertex_t) == 8, cuco::xxhash_64<vertex_t>, cuco::xxhash_32<vertex_t>>
+      hash_func{};
+    return hash_func.compute_hash(reinterpret_cast<cuda::std::byte*>(buf), 2 * sizeof(vertex_t));
+  }
+};
+
+template <typename vertex_t>
+struct hash_and_mod_src_dst_pair_t {
+  int mod{};
+
+  __device__ int operator()(thrust::tuple<vertex_t, vertex_t> pair) const
+  {
+    vertex_t buf[2];
+    buf[0] = thrust::get<0>(pair);
+    buf[1] = thrust::get<1>(pair);
+    std::conditional_t<sizeof(vertex_t) == 8, cuco::xxhash_64<vertex_t>, cuco::xxhash_32<vertex_t>>
+      hash_func{};
+    return static_cast<int>(
+      hash_func.compute_hash(reinterpret_cast<cuda::std::byte*>(buf), 2 * sizeof(vertex_t)) % mod);
   }
 };
 
@@ -69,7 +88,7 @@ struct edge_value_compare_t {
   cuda::std::optional<raft::device_span<edge_time_t const>> edge_start_times;
   cuda::std::optional<raft::device_span<edge_time_t const>> edge_end_times;
 
-  __device__ bool operator()(edge_t l_idx, edge_t r_idx) const
+  __device__ bool operator()(size_t l_idx, size_t r_idx) const
   {
     if (weights) {
       auto l_weight = (*weights)[l_idx];
@@ -100,106 +119,226 @@ struct edge_value_compare_t {
   }
 };
 
-template <typename vertex_t>
-std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> group_multi_edges(
-  raft::handle_t const& handle,
-  rmm::device_uvector<vertex_t>&& edgelist_srcs,
-  rmm::device_uvector<vertex_t>&& edgelist_dsts,
-  size_t mem_frugal_threshold)
-{
-  auto pair_first = thrust::make_zip_iterator(edgelist_srcs.begin(), edgelist_dsts.begin());
-
-  if (edgelist_srcs.size() > mem_frugal_threshold) {
-    // FIXME: Tuning parameter to address high frequency multi-edges
-    //        Defaulting to 2 which makes the code easier.  If
-    //        num_groups > 2 we can evaluate whether to find a good
-    //        midpoint to do 2 sorts, or if we should do more than 2 sorts.
-    const size_t num_groups{2};
-
-    auto group_counts = groupby_and_count(pair_first,
-                                          pair_first + edgelist_srcs.size(),
-                                          hash_src_dst_pair<vertex_t>{},
-                                          num_groups,
-                                          mem_frugal_threshold,
-                                          handle.get_stream());
-
-    std::vector<size_t> h_group_counts(group_counts.size());
-    raft::update_host(
-      h_group_counts.data(), group_counts.data(), group_counts.size(), handle.get_stream());
-
-    thrust::sort(handle.get_thrust_policy(), pair_first, pair_first + h_group_counts[0]);
-    thrust::sort(handle.get_thrust_policy(),
-                 pair_first + h_group_counts[0],
-                 pair_first + edgelist_srcs.size());
-  } else {
-    thrust::sort(handle.get_thrust_policy(), pair_first, pair_first + edgelist_srcs.size());
-  }
-
-  return std::make_tuple(std::move(edgelist_srcs), std::move(edgelist_dsts));
-}
-
 template <typename vertex_t, typename edge_value_t>
 std::tuple<rmm::device_uvector<vertex_t>,
            rmm::device_uvector<vertex_t>,
-           rmm::device_uvector<edge_value_t>>
-group_multi_edges(raft::handle_t const& handle,
-                  rmm::device_uvector<vertex_t>&& edgelist_srcs,
-                  rmm::device_uvector<vertex_t>&& edgelist_dsts,
-                  rmm::device_uvector<edge_value_t>&& edgelist_values,
-                  size_t mem_frugal_threshold,
-                  bool keep_min_value_edge)
+           std::optional<rmm::device_uvector<edge_value_t>>,
+           std::vector<size_t>>
+group_edges(raft::handle_t const& handle,
+            rmm::device_uvector<vertex_t>&& edgelist_srcs,
+            rmm::device_uvector<vertex_t>&& edgelist_dsts,
+            std::optional<rmm::device_uvector<edge_value_t>>&& edgelist_values,
+            int num_groups)
+{
+  auto total_global_mem = handle.get_device_properties().totalGlobalMem;
+  auto constexpr mem_frugal_ratio =
+    0.25;  // if the expected temporary buffer size exceeds the mem_frugal_ratio of the
+           // total_global_mem, switch to the memory frugal approach
+  auto mem_frugal_threshold = static_cast<size_t>(
+    static_cast<double>(total_global_mem / (sizeof(vertex_t) * 2 +
+                                            (edgelist_values ? sizeof(edge_value_t) : size_t{0}))) *
+    mem_frugal_ratio);
+
+  auto pair_first = thrust::make_zip_iterator(edgelist_srcs.begin(), edgelist_dsts.begin());
+  std::vector<size_t> h_group_counts(num_groups);
+  if (edgelist_values) {
+    auto d_group_counts = groupby_and_count(pair_first,
+                                            pair_first + edgelist_srcs.size(),
+                                            edgelist_values->begin(),
+                                            hash_and_mod_src_dst_pair_t<vertex_t>{num_groups},
+                                            num_groups,
+                                            mem_frugal_threshold,
+                                            handle.get_stream());
+    raft::update_host(
+      h_group_counts.data(), d_group_counts.data(), d_group_counts.size(), handle.get_stream());
+  } else {
+    auto d_group_counts = groupby_and_count(pair_first,
+                                            pair_first + edgelist_srcs.size(),
+                                            hash_and_mod_src_dst_pair_t<vertex_t>{num_groups},
+                                            num_groups,
+                                            mem_frugal_threshold,
+                                            handle.get_stream());
+    raft::update_host(
+      h_group_counts.data(), d_group_counts.data(), d_group_counts.size(), handle.get_stream());
+  }
+  handle.sync_stream();
+
+  return std::make_tuple(std::move(edgelist_srcs),
+                         std::move(edgelist_dsts),
+                         std::move(edgelist_values),
+                         std::move(h_group_counts));
+}
+
+// returns a device_uvector of bool holding true for multi-edges and false for non-multi-edges
+template <typename vertex_t>
+std::vector<rmm::device_uvector<bool>> compute_multi_edge_flags(
+  raft::handle_t const& handle,
+  raft::host_span<raft::device_span<vertex_t const>> edgelist_srcs,
+  raft::host_span<raft::device_span<vertex_t const>> edgelist_dsts)
+{
+  using hash_result_type = typename hash_src_dst_pair_t<vertex_t>::result_type;
+
+  int num_chunks = static_cast<int>(edgelist_srcs.size());
+
+  size_t tot_edges{0};
+  for (int i = 0; i < num_chunks; ++i) {
+    tot_edges += edgelist_srcs[i].size();
+  }
+
+  rmm::device_uvector<hash_result_type> hashes(tot_edges, handle.get_stream());
+  {
+    size_t offset{0};
+    for (int i = 0; i < num_chunks; ++i) {
+      auto pair_first =
+        thrust::make_zip_iterator(edgelist_srcs[i].begin(), edgelist_dsts[i].begin());
+      thrust::transform(handle.get_thrust_policy(),
+                        pair_first,
+                        pair_first + edgelist_srcs[i].size(),
+                        hashes.begin() + offset,
+                        hash_src_dst_pair_t<vertex_t>{});
+      offset += edgelist_srcs[i].size();
+    }
+  }
+
+  rmm::device_uvector<hash_result_type> unique_possibly_multi_edge_hashes(0, handle.get_stream());
+  size_t num_possibly_multi_edges{0};
+  {
+    thrust::sort(handle.get_thrust_policy(), hashes.begin(), hashes.end());
+    rmm::device_uvector<bool> is_definitely_not_multi_edge_hashes(hashes.size(),
+                                                                  handle.get_stream());
+    thrust::tabulate(
+      handle.get_thrust_policy(),
+      is_definitely_not_multi_edge_hashes.begin(),
+      is_definitely_not_multi_edge_hashes.end(),
+      [hashes = raft::device_span<hash_result_type const>(hashes.data(), hashes.size())] __device__(
+        size_t i) {
+        if ((i != 0) && (hashes[i] == hashes[i - 1])) {  // compare with the previous element
+          return false;
+        }
+        if ((i != hashes.size() - 1) &&
+            (hashes[i] == hashes[i + 1])) {  // compare with the next element
+          return false;
+        }
+        return true;  // definitely unique (src, dst) pair
+      });
+
+    num_possibly_multi_edges = thrust::count(handle.get_thrust_policy(),
+                                             is_definitely_not_multi_edge_hashes.begin(),
+                                             is_definitely_not_multi_edge_hashes.end(),
+                                             false);
+    unique_possibly_multi_edge_hashes.resize(num_possibly_multi_edges, handle.get_stream());
+    thrust::copy_if(
+      handle.get_thrust_policy(),
+      hashes.begin(),
+      hashes.end(),
+      is_definitely_not_multi_edge_hashes.begin(),
+      unique_possibly_multi_edge_hashes.begin(),
+      [] __device__(bool definitely_not_multi_edge) { return !definitely_not_multi_edge; });
+
+    thrust::sort(handle.get_thrust_policy(),
+                 unique_possibly_multi_edge_hashes.begin(),
+                 unique_possibly_multi_edge_hashes.end());
+    unique_possibly_multi_edge_hashes.resize(
+      thrust::distance(unique_possibly_multi_edge_hashes.begin(),
+                       thrust::unique(handle.get_thrust_policy(),
+                                      unique_possibly_multi_edge_hashes.begin(),
+                                      unique_possibly_multi_edge_hashes.end())),
+      handle.get_stream());
+  }
+  hashes.resize(0, handle.get_stream());
+  hashes.shrink_to_fit(handle.get_stream());
+
+  rmm::device_uvector<vertex_t> unique_multi_edge_srcs(num_possibly_multi_edges,
+                                                       handle.get_stream());
+  rmm::device_uvector<vertex_t> unique_multi_edge_dsts(num_possibly_multi_edges,
+                                                       handle.get_stream());
+  {
+    auto output_pair_first =
+      thrust::make_zip_iterator(unique_multi_edge_srcs.begin(), unique_multi_edge_dsts.begin());
+    size_t offset = 0;
+    for (int i = 0; i < num_chunks; ++i) {
+      auto input_pair_first =
+        thrust::make_zip_iterator(edgelist_srcs[i].begin(), edgelist_dsts[i].begin());
+      auto output_pair_last = thrust::copy_if(
+        handle.get_thrust_policy(),
+        input_pair_first,
+        input_pair_first + edgelist_srcs[i].size(),
+        output_pair_first + offset,
+        [unique_possibly_multi_edge_hashes = raft::device_span<hash_result_type const>(
+           unique_possibly_multi_edge_hashes.data(), unique_possibly_multi_edge_hashes.size()),
+         hash_func =
+           hash_src_dst_pair_t<vertex_t>{}] __device__(thrust::tuple<vertex_t, vertex_t> pair) {
+          auto hash = hash_func(pair);
+          return thrust::binary_search(thrust::seq,
+                                       unique_possibly_multi_edge_hashes.begin(),
+                                       unique_possibly_multi_edge_hashes.end(),
+                                       hash);
+        });
+      offset += thrust::distance(output_pair_first + offset, output_pair_last);
+    }
+
+    thrust::sort(handle.get_thrust_policy(),
+                 output_pair_first,
+                 output_pair_first + unique_multi_edge_srcs.size());
+    unique_multi_edge_srcs.resize(
+      thrust::distance(output_pair_first,
+                       thrust::unique(handle.get_thrust_policy(),
+                                      output_pair_first,
+                                      output_pair_first + unique_multi_edge_srcs.size())),
+      handle.get_stream());
+    unique_multi_edge_dsts.resize(unique_multi_edge_srcs.size(), handle.get_stream());
+  }
+  unique_possibly_multi_edge_hashes.resize(0, handle.get_stream());
+  unique_possibly_multi_edge_hashes.shrink_to_fit(handle.get_stream());
+
+  std::vector<rmm::device_uvector<bool>> multi_edge_flags{};
+  multi_edge_flags.reserve(num_chunks);
+  for (int i = 0; i < num_chunks; ++i) {
+    multi_edge_flags.emplace_back(edgelist_srcs[i].size(), handle.get_stream());
+  }
+
+  auto unique_multi_edge_first =
+    thrust::make_zip_iterator(unique_multi_edge_srcs.begin(), unique_multi_edge_dsts.begin());
+  auto unique_multi_edge_last = unique_multi_edge_first + unique_multi_edge_srcs.size();
+  for (int i = 0; i < num_chunks; ++i) {
+    auto pair_first = thrust::make_zip_iterator(edgelist_srcs[i].begin(), edgelist_dsts[i].begin());
+    thrust::transform(handle.get_thrust_policy(),
+                      pair_first,
+                      pair_first + edgelist_srcs[i].size(),
+                      multi_edge_flags[i].begin(),
+                      [unique_multi_edge_first, unique_multi_edge_last] __device__(auto pair) {
+                        return thrust::binary_search(
+                          thrust::seq, unique_multi_edge_first, unique_multi_edge_last, pair);
+                      });
+  }
+
+  return multi_edge_flags;
+}
+
+template <typename vertex_t, typename edge_value_t>
+void sort_multi_edges(raft::handle_t const& handle,
+                      raft::device_span<vertex_t> edgelist_srcs,
+                      raft::device_span<vertex_t> edgelist_dsts,
+                      std::optional<raft::device_span<edge_value_t>> edgelist_values,
+                      bool keep_min_value_edge)
 {
   auto pair_first = thrust::make_zip_iterator(edgelist_srcs.begin(), edgelist_dsts.begin());
-  auto edge_first = thrust::make_zip_iterator(
-    edgelist_srcs.begin(), edgelist_dsts.begin(), edgelist_values.begin());
-
-  if (edgelist_srcs.size() > mem_frugal_threshold) {
-    // FIXME: Tuning parameter to address high frequency multi-edges
-    //        Defaulting to 2 which makes the code easier.  If
-    //        num_groups > 2 we can evaluate whether to find a good
-    //        midpoint to do 2 sorts, or if we should do more than 2 sorts.
-    const size_t num_groups{2};
-
-    auto group_counts = groupby_and_count(pair_first,
-                                          pair_first + edgelist_srcs.size(),
-                                          edgelist_values.begin(),
-                                          hash_src_dst_pair<vertex_t>{},
-                                          num_groups,
-                                          mem_frugal_threshold,
-                                          handle.get_stream());
-
-    std::vector<size_t> h_group_counts(group_counts.size());
-    raft::update_host(
-      h_group_counts.data(), group_counts.data(), group_counts.size(), handle.get_stream());
-
+  if (edgelist_values) {
     if (keep_min_value_edge) {
-      thrust::sort(handle.get_thrust_policy(), edge_first, edge_first + h_group_counts[0]);
-      thrust::sort(handle.get_thrust_policy(),
-                   edge_first + h_group_counts[0],
-                   edge_first + edgelist_srcs.size());
-    } else {
-      thrust::sort_by_key(handle.get_thrust_policy(),
-                          pair_first,
-                          pair_first + h_group_counts[0],
-                          edgelist_values.begin());
-      thrust::sort_by_key(handle.get_thrust_policy(),
-                          pair_first + h_group_counts[0],
-                          pair_first + edgelist_srcs.size(),
-                          edgelist_values.begin() + h_group_counts[0]);
-    }
-  } else {
-    if (keep_min_value_edge) {
+      auto edge_first = thrust::make_zip_iterator(
+        edgelist_srcs.begin(), edgelist_dsts.begin(), edgelist_values->begin());
       thrust::sort(handle.get_thrust_policy(), edge_first, edge_first + edgelist_srcs.size());
     } else {
       thrust::sort_by_key(handle.get_thrust_policy(),
                           pair_first,
                           pair_first + edgelist_srcs.size(),
-                          edgelist_values.begin());
+                          edgelist_values->begin());
     }
+  } else {
+    thrust::sort(handle.get_thrust_policy(), pair_first, pair_first + edgelist_srcs.size());
   }
 
-  return std::make_tuple(
-    std::move(edgelist_srcs), std::move(edgelist_dsts), std::move(edgelist_values));
+  return;
 }
 
 template <typename vertex_t,
@@ -207,83 +346,835 @@ template <typename vertex_t,
           typename weight_t,
           typename edge_type_t,
           typename edge_time_t>
-std::
-  tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>, rmm::device_uvector<edge_t>>
-  group_multi_edges(
-    raft::handle_t const& handle,
-    rmm::device_uvector<vertex_t>&& edgelist_srcs,
-    rmm::device_uvector<vertex_t>&& edgelist_dsts,
-    rmm::device_uvector<edge_t>&& edgelist_indices,
-    edge_value_compare_t<edge_t, weight_t, edge_type_t, edge_time_t> edge_value_compare,
-    size_t mem_frugal_threshold,
-    bool keep_min_value_edge)
+void sort_multi_edges(
+  raft::handle_t const& handle,
+  raft::device_span<vertex_t> edgelist_srcs,
+  raft::device_span<vertex_t> edgelist_dsts,
+  raft::device_span<size_t> edgelist_indices,
+  edge_value_compare_t<edge_t, weight_t, edge_type_t, edge_time_t> edge_value_compare,
+  bool keep_min_value_edge)
 {
   auto pair_first = thrust::make_zip_iterator(edgelist_srcs.begin(), edgelist_dsts.begin());
-  auto edge_first = thrust::make_zip_iterator(
-    edgelist_srcs.begin(), edgelist_dsts.begin(), edgelist_indices.begin());
-
-  auto edge_compare = [edge_value_compare] __device__(
-                        thrust::tuple<vertex_t, vertex_t, edge_t> lhs,
-                        thrust::tuple<vertex_t, vertex_t, edge_t> rhs) {
-    auto l_pair = thrust::make_tuple(thrust::get<0>(lhs), thrust::get<1>(lhs));
-    auto r_pair = thrust::make_tuple(thrust::get<0>(rhs), thrust::get<1>(rhs));
-    if (l_pair == r_pair) {
-      return edge_value_compare(thrust::get<2>(lhs), thrust::get<2>(rhs));
-    } else {
-      return l_pair < r_pair;
-    }
-  };
-
-  if (edgelist_srcs.size() > mem_frugal_threshold) {
-    // FIXME: Tuning parameter to address high frequency multi-edges
-    //        Defaulting to 2 which makes the code easier.  If
-    //        num_groups > 2 we can evaluate whether to find a good
-    //        midpoint to do 2 sorts, or if we should do more than 2 sorts.
-    const size_t num_groups{2};
-
-    auto group_counts = groupby_and_count(pair_first,
-                                          pair_first + edgelist_srcs.size(),
-                                          edgelist_indices.begin(),
-                                          hash_src_dst_pair<vertex_t>{},
-                                          num_groups,
-                                          mem_frugal_threshold,
-                                          handle.get_stream());
-
-    std::vector<size_t> h_group_counts(group_counts.size());
-    raft::update_host(
-      h_group_counts.data(), group_counts.data(), group_counts.size(), handle.get_stream());
-
-    if (keep_min_value_edge) {
-      thrust::sort(
-        handle.get_thrust_policy(), edge_first, edge_first + h_group_counts[0], edge_compare);
-      thrust::sort(handle.get_thrust_policy(),
-                   edge_first + h_group_counts[0],
-                   edge_first + edgelist_srcs.size(),
-                   edge_compare);
-    } else {
-      thrust::sort_by_key(handle.get_thrust_policy(),
-                          pair_first,
-                          pair_first + h_group_counts[0],
-                          edgelist_indices.begin());
-      thrust::sort_by_key(handle.get_thrust_policy(),
-                          pair_first + h_group_counts[0],
-                          pair_first + edgelist_srcs.size(),
-                          edgelist_indices.begin() + h_group_counts[0]);
-    }
+  if (keep_min_value_edge) {
+    auto edge_compare = [edge_value_compare] __device__(
+                          thrust::tuple<vertex_t, vertex_t, size_t> lhs,
+                          thrust::tuple<vertex_t, vertex_t, size_t> rhs) {
+      auto l_pair = thrust::make_tuple(thrust::get<0>(lhs), thrust::get<1>(lhs));
+      auto r_pair = thrust::make_tuple(thrust::get<0>(rhs), thrust::get<1>(rhs));
+      if (l_pair == r_pair) {
+        return edge_value_compare(thrust::get<2>(lhs), thrust::get<2>(rhs));
+      } else {
+        return l_pair < r_pair;
+      }
+    };
+    auto edge_first = thrust::make_zip_iterator(
+      edgelist_srcs.begin(), edgelist_dsts.begin(), edgelist_indices.begin());
+    thrust::sort(
+      handle.get_thrust_policy(), edge_first, edge_first + edgelist_srcs.size(), edge_compare);
   } else {
-    if (keep_min_value_edge) {
-      thrust::sort(
-        handle.get_thrust_policy(), edge_first, edge_first + edgelist_srcs.size(), edge_compare);
+    thrust::sort_by_key(handle.get_thrust_policy(),
+                        pair_first,
+                        pair_first + edgelist_srcs.size(),
+                        edgelist_indices.begin());
+  }
+
+  return;
+}
+
+template <typename vertex_t,
+          typename edge_t,
+          typename weight_t,
+          typename edge_type_t,
+          typename edge_time_t>
+std::tuple<std::vector<rmm::device_uvector<vertex_t>>,
+           std::vector<rmm::device_uvector<vertex_t>>,
+           std::optional<std::vector<rmm::device_uvector<weight_t>>>,
+           std::optional<std::vector<rmm::device_uvector<edge_t>>>,
+           std::optional<std::vector<rmm::device_uvector<edge_type_t>>>,
+           std::optional<std::vector<rmm::device_uvector<edge_time_t>>>,
+           std::optional<std::vector<rmm::device_uvector<edge_time_t>>>>
+remove_multi_edges_impl(
+  raft::handle_t const& handle,
+  std::vector<rmm::device_uvector<vertex_t>>&& edgelist_srcs,
+  std::vector<rmm::device_uvector<vertex_t>>&& edgelist_dsts,
+  std::optional<std::vector<rmm::device_uvector<weight_t>>>&& edgelist_weights,
+  std::optional<std::vector<rmm::device_uvector<edge_t>>>&& edgelist_edge_ids,
+  std::optional<std::vector<rmm::device_uvector<edge_type_t>>>&& edgelist_edge_types,
+  std::optional<std::vector<rmm::device_uvector<edge_time_t>>>&& edgelist_edge_start_times,
+  std::optional<std::vector<rmm::device_uvector<edge_time_t>>>&& edgelist_edge_end_times,
+  bool keep_min_value_edge)
+{
+  int edge_property_count = 0;
+  if (edgelist_weights) { ++edge_property_count; }
+  if (edgelist_edge_ids) { ++edge_property_count; }
+  if (edgelist_edge_types) { ++edge_property_count; }
+  if (edgelist_edge_start_times) { ++edge_property_count; }
+  if (edgelist_edge_end_times) { ++edge_property_count; }
+
+  // 1. group edges (to cut peak memory usage)
+
+  CUGRAPH_EXPECTS(edgelist_srcs.size() <= std::numeric_limits<int>::max(),
+                  "Invalid input argument: edgelist_srcs.size() must be less than or equal to "
+                  "std::numeric_limits<int>::max().");
+  int num_chunks = edgelist_srcs.size();
+  int num_groups = std::max(edgelist_srcs.size(), size_t{2});  // to cut peak memory usage
+
+  std::vector<std::vector<size_t>> group_counts(num_chunks);
+  std::optional<std::vector<rmm::device_uvector<size_t>>> edgelist_indices{std::nullopt};
+  if (edge_property_count > 1) {
+    edgelist_indices = std::vector<rmm::device_uvector<size_t>>{};
+    for (int i = 0; i < num_chunks; ++i) {
+      edgelist_indices->emplace_back(edgelist_srcs[i].size(), handle.get_stream());
+    }
+  }
+  for (int i = 0; i < num_chunks; ++i) {
+    if (edge_property_count == 0) {
+      std::tie(edgelist_srcs[i], edgelist_dsts[i], std::ignore, group_counts[i]) =
+        detail::group_edges<vertex_t, size_t /* dummy */>(handle,
+                                                          std::move(edgelist_srcs[i]),
+                                                          std::move(edgelist_dsts[i]),
+                                                          std::nullopt,
+                                                          num_groups);
+    } else if (edge_property_count == 1) {
+      if (edgelist_weights) {
+        std::optional<rmm::device_uvector<weight_t>> tmp{std::nullopt};
+        std::tie(edgelist_srcs[i], edgelist_dsts[i], tmp, group_counts[i]) =
+          detail::group_edges<vertex_t, weight_t>(
+            handle,
+            std::move(edgelist_srcs[i]),
+            std::move(edgelist_dsts[i]),
+            std::make_optional(std::move((*edgelist_weights)[i])),
+            num_groups);
+        (*edgelist_weights)[i] = std::move(*tmp);
+      } else if (edgelist_edge_ids) {
+        std::optional<rmm::device_uvector<edge_t>> tmp{std::nullopt};
+        std::tie(edgelist_srcs[i], edgelist_dsts[i], tmp, group_counts[i]) =
+          detail::group_edges<vertex_t, edge_t>(
+            handle,
+            std::move(edgelist_srcs[i]),
+            std::move(edgelist_dsts[i]),
+            std::make_optional(std::move((*edgelist_edge_ids)[i])),
+            num_groups);
+        (*edgelist_edge_ids)[i] = std::move(*tmp);
+      } else if (edgelist_edge_types) {
+        std::optional<rmm::device_uvector<edge_type_t>> tmp{std::nullopt};
+        std::tie(edgelist_srcs[i], edgelist_dsts[i], tmp, group_counts[i]) =
+          detail::group_edges<vertex_t, edge_type_t>(
+            handle,
+            std::move(edgelist_srcs[i]),
+            std::move(edgelist_dsts[i]),
+            std::make_optional(std::move((*edgelist_edge_types)[i])),
+            num_groups);
+        (*edgelist_edge_types)[i] = std::move(*tmp);
+      } else if (edgelist_edge_start_times) {
+        std::optional<rmm::device_uvector<edge_time_t>> tmp{std::nullopt};
+        std::tie(edgelist_srcs[i], edgelist_dsts[i], tmp, group_counts[i]) =
+          detail::group_edges<vertex_t, edge_time_t>(
+            handle,
+            std::move(edgelist_srcs[i]),
+            std::move(edgelist_dsts[i]),
+            std::make_optional(std::move((*edgelist_edge_start_times)[i])),
+            num_groups);
+        (*edgelist_edge_start_times)[i] = std::move(*tmp);
+      } else {
+        assert(edgelist_edge_end_times);
+        std::optional<rmm::device_uvector<edge_time_t>> tmp{std::nullopt};
+        std::tie(edgelist_srcs[i], edgelist_dsts[i], tmp, group_counts[i]) =
+          detail::group_edges<vertex_t, edge_time_t>(
+            handle,
+            std::move(edgelist_srcs[i]),
+            std::move(edgelist_dsts[i]),
+            std::make_optional(std::move((*edgelist_edge_end_times)[i])),
+            num_groups);
+        (*edgelist_edge_end_times)[i] = std::move(*tmp);
+      }
     } else {
-      thrust::sort_by_key(handle.get_thrust_policy(),
-                          pair_first,
-                          pair_first + edgelist_srcs.size(),
-                          edgelist_indices.begin());
+      detail::sequence_fill(handle.get_stream(),
+                            (*edgelist_indices)[i].data(),
+                            (*edgelist_indices)[i].size(),
+                            size_t{0});
+      std::optional<rmm::device_uvector<size_t>> tmp{std::nullopt};
+      std::tie(edgelist_srcs[i], edgelist_dsts[i], tmp, group_counts[i]) =
+        detail::group_edges<vertex_t, size_t>(handle,
+                                              std::move(edgelist_srcs[i]),
+                                              std::move(edgelist_dsts[i]),
+                                              std::make_optional(std::move((*edgelist_indices)[i])),
+                                              num_groups);
+      (*edgelist_indices)[i] = std::move(*tmp);
     }
   }
 
-  return std::make_tuple(
-    std::move(edgelist_srcs), std::move(edgelist_dsts), std::move(edgelist_indices));
+  // 2. for each group, partition non-multi-edges and multi-edges
+
+  std::vector<std::vector<size_t>> group_disps(num_chunks);
+  std::vector<std::vector<size_t>> non_multi_edge_counts(num_chunks);
+  for (int i = 0; i < num_chunks; ++i) {
+    group_disps[i] = std::vector<size_t>(num_groups);
+    std::exclusive_scan(
+      group_counts[i].begin(), group_counts[i].end(), group_disps[i].begin(), size_t{0});
+    non_multi_edge_counts[i] = std::vector<size_t>(num_groups, 0);
+  }
+
+  for (int i = 0; i < num_groups; ++i) {
+    std::vector<raft::device_span<vertex_t const>> group_edgelist_srcs(num_chunks);
+    std::vector<raft::device_span<vertex_t const>> group_edgelist_dsts(num_chunks);
+    for (int j = 0; j < num_chunks; ++j) {
+      group_edgelist_srcs[j] = raft::device_span<vertex_t const>(
+        edgelist_srcs[j].data() + group_disps[j][i], group_counts[j][i]);
+      group_edgelist_dsts[j] = raft::device_span<vertex_t const>(
+        edgelist_dsts[j].data() + group_disps[j][i], group_counts[j][i]);
+    }
+    auto multi_edge_flags =
+      detail::compute_multi_edge_flags(handle,
+                                       raft::host_span<raft::device_span<vertex_t const>>(
+                                         group_edgelist_srcs.data(), group_edgelist_srcs.size()),
+                                       raft::host_span<raft::device_span<vertex_t const>>(
+                                         group_edgelist_dsts.data(), group_edgelist_dsts.size()));
+
+    for (int j = 0; j < num_chunks; ++j) {
+      auto pair_first =
+        thrust::make_zip_iterator(edgelist_srcs[j].begin(), edgelist_dsts[j].begin()) +
+        group_disps[j][i];
+      non_multi_edge_counts[j][i] = static_cast<size_t>(
+        thrust::distance(pair_first,
+                         thrust::stable_partition(
+                           handle.get_thrust_policy(),
+                           pair_first,
+                           pair_first + group_counts[j][i],
+                           multi_edge_flags[j].begin(),
+                           [] __device__(auto multi_edge_flag) { return !multi_edge_flag; })));
+      if (edge_property_count == 0) {
+        /* nothing to do */
+      } else if (edge_property_count == 1) {
+        if (edgelist_weights) {
+          thrust::stable_partition(
+            handle.get_thrust_policy(),
+            (*edgelist_weights)[j].begin() + group_disps[j][i],
+            (*edgelist_weights)[j].begin() + (group_disps[j][i] + group_counts[j][i]),
+            multi_edge_flags[j].begin(),
+            [] __device__(auto multi_edge_flag) { return !multi_edge_flag; });
+        } else if (edgelist_edge_ids) {
+          thrust::stable_partition(
+            handle.get_thrust_policy(),
+            (*edgelist_edge_ids)[j].begin() + group_disps[j][i],
+            (*edgelist_edge_ids)[j].begin() + (group_disps[j][i] + group_counts[j][i]),
+            multi_edge_flags[j].begin(),
+            [] __device__(auto multi_edge_flag) { return !multi_edge_flag; });
+        } else if (edgelist_edge_types) {
+          thrust::stable_partition(
+            handle.get_thrust_policy(),
+            (*edgelist_edge_types)[j].begin() + group_disps[j][i],
+            (*edgelist_edge_types)[j].begin() + (group_disps[j][i] + group_counts[j][i]),
+            multi_edge_flags[j].begin(),
+            [] __device__(auto multi_edge_flag) { return !multi_edge_flag; });
+        } else if (edgelist_edge_start_times) {
+          thrust::stable_partition(
+            handle.get_thrust_policy(),
+            (*edgelist_edge_start_times)[j].begin() + group_disps[j][i],
+            (*edgelist_edge_start_times)[j].begin() + (group_disps[j][i] + group_counts[j][i]),
+            multi_edge_flags[j].begin(),
+            [] __device__(auto multi_edge_flag) { return !multi_edge_flag; });
+        } else {
+          assert(edgelist_edge_end_times);
+          thrust::stable_partition(
+            handle.get_thrust_policy(),
+            (*edgelist_edge_end_times)[j].begin() + group_disps[j][i],
+            (*edgelist_edge_end_times)[j].begin() + (group_disps[j][i] + group_counts[j][i]),
+            multi_edge_flags[j].begin(),
+            [] __device__(auto multi_edge_flag) { return !multi_edge_flag; });
+        }
+      } else {
+        thrust::stable_partition(
+          handle.get_thrust_policy(),
+          (*edgelist_indices)[j].begin() + group_disps[j][i],
+          (*edgelist_indices)[j].begin() + (group_disps[j][i] + group_counts[j][i]),
+          multi_edge_flags[j].begin(),
+          [] __device__(auto multi_edge_flag) { return !multi_edge_flag; });
+      }
+    }
+  }
+
+  if (num_chunks > 1) {
+    std::vector<std::vector<size_t>> group_valid_counts(num_chunks);
+    for (int i = 0; i < num_chunks; ++i) {
+      group_valid_counts[i] = std::vector<size_t>(num_groups, 0);
+    }
+
+    for (int i = 0; i < num_groups; ++i) {
+      // 3. for each group, aggregate multi-edges from every chunk to a single multi-edge list
+
+      std::vector<size_t> multi_edge_counts(num_chunks);
+      for (int j = 0; j < num_chunks; ++j) {
+        multi_edge_counts[j] = group_counts[j][i] - non_multi_edge_counts[j][i];
+      }
+      std::vector<size_t> multi_edge_disps(num_chunks);
+      std::exclusive_scan(
+        multi_edge_counts.begin(), multi_edge_counts.end(), multi_edge_disps.begin(), size_t{0});
+      auto tot_multi_edge_count = multi_edge_disps.back() + multi_edge_counts.back();
+
+      rmm::device_uvector<vertex_t> multi_edge_srcs(tot_multi_edge_count, handle.get_stream());
+      rmm::device_uvector<vertex_t> multi_edge_dsts(tot_multi_edge_count, handle.get_stream());
+      auto multi_edge_weights = edgelist_weights ? std::make_optional(rmm::device_uvector<weight_t>(
+                                                     tot_multi_edge_count, handle.get_stream()))
+                                                 : std::nullopt;
+      auto multi_edge_edge_ids = edgelist_edge_ids ? std::make_optional(rmm::device_uvector<edge_t>(
+                                                       tot_multi_edge_count, handle.get_stream()))
+                                                   : std::nullopt;
+      auto multi_edge_edge_types       = edgelist_edge_types
+                                           ? std::make_optional(rmm::device_uvector<edge_type_t>(
+                                         tot_multi_edge_count, handle.get_stream()))
+                                           : std::nullopt;
+      auto multi_edge_edge_start_times = edgelist_edge_start_times
+                                           ? std::make_optional(rmm::device_uvector<edge_time_t>(
+                                               tot_multi_edge_count, handle.get_stream()))
+                                           : std::nullopt;
+      auto multi_edge_edge_end_times   = edgelist_edge_end_times
+                                           ? std::make_optional(rmm::device_uvector<edge_time_t>(
+                                             tot_multi_edge_count, handle.get_stream()))
+                                           : std::nullopt;
+
+      for (int j = 0; j < num_chunks; ++j) {
+        auto input_start_offset  = group_disps[j][i] + non_multi_edge_counts[j][i];
+        auto input_end_offset    = group_disps[j][i] + group_counts[j][i];
+        auto output_start_offset = multi_edge_disps[j];
+        thrust::copy(handle.get_thrust_policy(),
+                     edgelist_srcs[j].begin() + input_start_offset,
+                     edgelist_srcs[j].begin() + input_end_offset,
+                     multi_edge_srcs.begin() + output_start_offset);
+        thrust::copy(handle.get_thrust_policy(),
+                     edgelist_dsts[j].begin() + input_start_offset,
+                     edgelist_dsts[j].begin() + input_end_offset,
+                     multi_edge_dsts.begin() + output_start_offset);
+        if (edgelist_weights) {
+          if (edge_property_count == 1) {
+            thrust::copy(handle.get_thrust_policy(),
+                         (*edgelist_weights)[j].begin() + input_start_offset,
+                         (*edgelist_weights)[j].begin() + input_end_offset,
+                         multi_edge_weights->begin() + output_start_offset);
+          } else {
+            assert(edge_property_count > 1);
+            thrust::gather(handle.get_thrust_policy(),
+                           (*edgelist_indices)[j].begin() + input_start_offset,
+                           (*edgelist_indices)[j].begin() + input_end_offset,
+                           (*edgelist_weights)[j].begin(),
+                           multi_edge_weights->begin() + output_start_offset);
+          }
+        }
+        if (edgelist_edge_ids) {
+          if (edge_property_count == 1) {
+            thrust::copy(handle.get_thrust_policy(),
+                         (*edgelist_edge_ids)[j].begin() + input_start_offset,
+                         (*edgelist_edge_ids)[j].begin() + input_end_offset,
+                         multi_edge_edge_ids->begin() + output_start_offset);
+          } else {
+            assert(edge_property_count > 1);
+            thrust::gather(handle.get_thrust_policy(),
+                           (*edgelist_indices)[j].begin() + input_start_offset,
+                           (*edgelist_indices)[j].begin() + input_end_offset,
+                           (*edgelist_edge_ids)[j].begin(),
+                           multi_edge_edge_ids->begin() + output_start_offset);
+          }
+        }
+        if (edgelist_edge_types) {
+          if (edge_property_count == 1) {
+            thrust::copy(handle.get_thrust_policy(),
+                         (*edgelist_edge_types)[j].begin() + input_start_offset,
+                         (*edgelist_edge_types)[j].begin() + input_end_offset,
+                         multi_edge_edge_types->begin() + output_start_offset);
+          } else {
+            assert(edge_property_count > 1);
+            thrust::gather(handle.get_thrust_policy(),
+                           (*edgelist_indices)[j].begin() + input_start_offset,
+                           (*edgelist_indices)[j].begin() + input_end_offset,
+                           (*edgelist_edge_types)[j].begin(),
+                           multi_edge_edge_types->begin() + output_start_offset);
+          }
+        }
+        if (edgelist_edge_start_times) {
+          if (edge_property_count == 1) {
+            thrust::copy(handle.get_thrust_policy(),
+                         (*edgelist_edge_start_times)[j].begin() + input_start_offset,
+                         (*edgelist_edge_start_times)[j].begin() + input_end_offset,
+                         multi_edge_edge_start_times->begin() + output_start_offset);
+          } else {
+            assert(edge_property_count > 1);
+            thrust::gather(handle.get_thrust_policy(),
+                           (*edgelist_indices)[j].begin() + input_start_offset,
+                           (*edgelist_indices)[j].begin() + input_end_offset,
+                           (*edgelist_edge_start_times)[j].begin(),
+                           multi_edge_edge_start_times->begin() + output_start_offset);
+          }
+        }
+        if (edgelist_edge_end_times) {
+          if (edge_property_count == 1) {
+            thrust::copy(handle.get_thrust_policy(),
+                         (*edgelist_edge_end_times)[j].begin() + input_start_offset,
+                         (*edgelist_edge_end_times)[j].begin() + input_end_offset,
+                         multi_edge_edge_end_times->begin() + output_start_offset);
+          } else {
+            assert(edge_property_count > 1);
+            thrust::gather(handle.get_thrust_policy(),
+                           (*edgelist_indices)[j].begin() + input_start_offset,
+                           (*edgelist_indices)[j].begin() + input_end_offset,
+                           (*edgelist_edge_end_times)[j].begin(),
+                           multi_edge_edge_end_times->begin() + output_start_offset);
+          }
+        }
+      }
+      auto multi_edge_indices =
+        rmm::device_uvector<size_t>(tot_multi_edge_count, handle.get_stream());
+      thrust::sequence(handle.get_thrust_policy(),
+                       multi_edge_indices.begin(),
+                       multi_edge_indices.end(),
+                       size_t{0});
+
+      // 4. for each group, sort the aggregate multi-edge list
+
+      detail::sort_multi_edges<vertex_t, edge_t>(
+        handle,
+        raft::device_span<vertex_t>(multi_edge_srcs.data(), multi_edge_srcs.size()),
+        raft::device_span<vertex_t>(multi_edge_dsts.data(), multi_edge_dsts.size()),
+        raft::device_span<size_t>(multi_edge_indices.data(), multi_edge_indices.size()),
+        detail::edge_value_compare_t<edge_t, weight_t, edge_type_t, edge_time_t>{
+          multi_edge_weights ? cuda::std::make_optional(raft::device_span<weight_t const>(
+                                 multi_edge_weights->data(), multi_edge_weights->size()))
+                             : cuda::std::nullopt,
+          multi_edge_edge_ids ? cuda::std::make_optional(raft::device_span<edge_t const>(
+                                  multi_edge_edge_ids->data(), multi_edge_edge_ids->size()))
+                              : cuda::std::nullopt,
+          multi_edge_edge_types ? cuda::std::make_optional(raft::device_span<edge_type_t const>(
+                                    multi_edge_edge_types->data(), multi_edge_edge_types->size()))
+                                : cuda::std::nullopt,
+          multi_edge_edge_start_times
+            ? cuda::std::make_optional(raft::device_span<edge_time_t const>(
+                multi_edge_edge_start_times->data(), multi_edge_edge_start_times->size()))
+            : cuda::std::nullopt,
+          multi_edge_edge_end_times
+            ? cuda::std::make_optional(raft::device_span<edge_time_t const>(
+                multi_edge_edge_end_times->data(), multi_edge_edge_end_times->size()))
+            : cuda::std::nullopt},
+        keep_min_value_edge);
+
+      // 5. for each group, remove multi-edges (keep just one edge per multi-edge)
+
+      auto pair_first = thrust::make_zip_iterator(multi_edge_srcs.begin(), multi_edge_dsts.begin());
+      auto [keep_count, keep_flags] =
+        detail::mark_entries(handle,
+                             multi_edge_srcs.size(),
+                             detail::is_first_in_run_t<decltype(pair_first)>{pair_first});
+      multi_edge_srcs = detail::keep_flagged_elements(
+        handle,
+        std::move(multi_edge_srcs),
+        raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+        keep_count);
+      multi_edge_dsts = detail::keep_flagged_elements(
+        handle,
+        std::move(multi_edge_dsts),
+        raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+        keep_count);
+      multi_edge_indices = detail::keep_flagged_elements(
+        handle,
+        std::move(multi_edge_indices),
+        raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+        keep_count);
+
+      // 6. copy multi-edges back to the original edgelists
+
+      // 6-1. sort & find chunk boundaries
+
+      thrust::sort_by_key(
+        handle.get_thrust_policy(),
+        multi_edge_indices.begin(),
+        multi_edge_indices.end(),
+        thrust::make_zip_iterator(multi_edge_srcs.begin(), multi_edge_dsts.begin()));
+
+      std::vector<size_t> h_lasts(num_chunks);
+      std::inclusive_scan(multi_edge_counts.begin(), multi_edge_counts.end(), h_lasts.begin());
+      rmm::device_uvector<size_t> d_lasts(num_chunks, handle.get_stream());
+      raft::update_device(d_lasts.data(), h_lasts.data(), num_chunks, handle.get_stream());
+      rmm::device_uvector<size_t> d_keep_count_offsets(num_chunks + 1, handle.get_stream());
+      thrust::lower_bound(handle.get_thrust_policy(),
+                          multi_edge_indices.begin(),
+                          multi_edge_indices.end(),
+                          d_lasts.begin(),
+                          d_lasts.end(),
+                          d_keep_count_offsets.begin() + 1);
+      std::vector<size_t> h_keep_count_offsets(num_chunks + 1);
+      raft::update_host(h_keep_count_offsets.data(),
+                        d_keep_count_offsets.data(),
+                        num_chunks + 1,
+                        handle.get_stream());
+      handle.sync_stream();
+
+      // 6-2. copy
+
+      for (int j = 0; j < num_chunks; ++j) {
+        thrust::copy(handle.get_thrust_policy(),
+                     multi_edge_srcs.begin() + h_keep_count_offsets[j],
+                     multi_edge_srcs.begin() + h_keep_count_offsets[j + 1],
+                     edgelist_srcs[j].begin() + group_disps[j][i] + non_multi_edge_counts[j][i]);
+        thrust::copy(handle.get_thrust_policy(),
+                     multi_edge_dsts.begin() + h_keep_count_offsets[j],
+                     multi_edge_dsts.begin() + h_keep_count_offsets[j + 1],
+                     edgelist_dsts[j].begin() + group_disps[j][i] + non_multi_edge_counts[j][i]);
+        if (multi_edge_weights) {
+          thrust::gather(
+            handle.get_thrust_policy(),
+            multi_edge_indices.begin() + h_keep_count_offsets[j],
+            multi_edge_indices.begin() + h_keep_count_offsets[j + 1],
+            multi_edge_weights->begin(),
+            (*edgelist_weights)[j].begin() + group_disps[j][i] + non_multi_edge_counts[j][i]);
+        }
+        if (multi_edge_edge_ids) {
+          thrust::gather(
+            handle.get_thrust_policy(),
+            multi_edge_indices.begin() + h_keep_count_offsets[j],
+            multi_edge_indices.begin() + h_keep_count_offsets[j + 1],
+            multi_edge_edge_ids->begin(),
+            (*edgelist_edge_ids)[j].begin() + group_disps[j][i] + non_multi_edge_counts[j][i]);
+        }
+        if (multi_edge_edge_types) {
+          thrust::gather(
+            handle.get_thrust_policy(),
+            multi_edge_indices.begin() + h_keep_count_offsets[j],
+            multi_edge_indices.begin() + h_keep_count_offsets[j + 1],
+            multi_edge_edge_types->begin(),
+            (*edgelist_edge_types)[j].begin() + group_disps[j][i] + non_multi_edge_counts[j][i]);
+        }
+        if (multi_edge_edge_start_times) {
+          thrust::gather(handle.get_thrust_policy(),
+                         multi_edge_indices.begin() + h_keep_count_offsets[j],
+                         multi_edge_indices.begin() + h_keep_count_offsets[j + 1],
+                         multi_edge_edge_start_times->begin(),
+                         (*edgelist_edge_start_times)[j].begin() + group_disps[j][i] +
+                           non_multi_edge_counts[j][i]);
+        }
+        if (multi_edge_edge_end_times) {
+          thrust::gather(handle.get_thrust_policy(),
+                         multi_edge_indices.begin() + h_keep_count_offsets[j],
+                         multi_edge_indices.begin() + h_keep_count_offsets[j + 1],
+                         multi_edge_edge_end_times->begin(),
+                         (*edgelist_edge_end_times)[j].begin() + group_disps[j][i] +
+                           non_multi_edge_counts[j][i]);
+        }
+        group_valid_counts[j][i] =
+          non_multi_edge_counts[j][i] + (h_keep_count_offsets[j + 1] - h_keep_count_offsets[j]);
+      }
+    }
+    edgelist_indices = std::nullopt;
+
+    // 7. For each chunk, remove invalid edges
+
+    for (int i = 0; i < num_chunks; ++i) {
+      std::vector<size_t> h_lasts(num_chunks);
+      std::inclusive_scan(group_counts[i].begin(), group_counts[i].end(), h_lasts.begin());
+      rmm::device_uvector<size_t> d_lasts(num_chunks, handle.get_stream());
+      raft::update_device(d_lasts.data(), h_lasts.data(), num_chunks, handle.get_stream());
+      rmm::device_uvector<size_t> d_group_valid_counts(num_chunks, handle.get_stream());
+      raft::update_device(
+        d_group_valid_counts.data(), group_valid_counts[i].data(), num_chunks, handle.get_stream());
+
+      auto [keep_count, keep_flags] = detail::mark_entries(
+        handle,
+        edgelist_srcs[i].size(),
+        [lasts              = raft::device_span<size_t const>(d_lasts.data(), d_lasts.size()),
+         group_valid_counts = raft::device_span<size_t const>(
+           d_group_valid_counts.data(), d_group_valid_counts.size())] __device__(auto i) {
+          auto group_idx = thrust::distance(
+            lasts.begin(), thrust::upper_bound(thrust::seq, lasts.begin(), lasts.end(), i));
+          auto intra_group_idx = i - (group_idx == 0 ? 0 : lasts[group_idx - 1]);
+          return intra_group_idx < group_valid_counts[group_idx];
+        });
+
+      edgelist_srcs[i] = detail::keep_flagged_elements(
+        handle,
+        std::move(edgelist_srcs[i]),
+        raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+        keep_count);
+      edgelist_dsts[i] = detail::keep_flagged_elements(
+        handle,
+        std::move(edgelist_dsts[i]),
+        raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+        keep_count);
+      if (edgelist_weights) {
+        (*edgelist_weights)[i] = detail::keep_flagged_elements(
+          handle,
+          std::move((*edgelist_weights)[i]),
+          raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+          keep_count);
+      }
+      if (edgelist_edge_ids) {
+        (*edgelist_edge_ids)[i] = detail::keep_flagged_elements(
+          handle,
+          std::move((*edgelist_edge_ids)[i]),
+          raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+          keep_count);
+      }
+      if (edgelist_edge_types) {
+        (*edgelist_edge_types)[i] = detail::keep_flagged_elements(
+          handle,
+          std::move((*edgelist_edge_types)[i]),
+          raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+          keep_count);
+      }
+      if (edgelist_edge_start_times) {
+        (*edgelist_edge_start_times)[i] = detail::keep_flagged_elements(
+          handle,
+          std::move((*edgelist_edge_start_times)[i]),
+          raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+          keep_count);
+      }
+      if (edgelist_edge_end_times) {
+        (*edgelist_edge_end_times)[i] = detail::keep_flagged_elements(
+          handle,
+          std::move((*edgelist_edge_end_times)[i]),
+          raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+          keep_count);
+      }
+    }
+  } else {  // num_chunks == 1
+    // 3. for each group, sort edges
+
+    for (int i = 0; i < num_groups; ++i) {
+      if (edge_property_count == 0) {
+        detail::sort_multi_edges<vertex_t, size_t /* dummy */>(
+          handle,
+          raft::device_span<vertex_t>(
+            edgelist_srcs[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+            group_counts[0][i] - non_multi_edge_counts[0][i]),
+          raft::device_span<vertex_t>(
+            edgelist_dsts[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+            group_counts[0][i] - non_multi_edge_counts[0][i]),
+          std::nullopt,
+          keep_min_value_edge);
+      } else if (edge_property_count == 1) {
+        if (edgelist_weights) {
+          detail::sort_multi_edges<vertex_t, weight_t>(
+            handle,
+            raft::device_span<vertex_t>(
+              edgelist_srcs[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+              group_counts[0][i] - non_multi_edge_counts[0][i]),
+            raft::device_span<vertex_t>(
+              edgelist_dsts[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+              group_counts[0][i] - non_multi_edge_counts[0][i]),
+            std::make_optional(raft::device_span<weight_t>(
+              (*edgelist_weights)[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+              group_counts[0][i] - non_multi_edge_counts[0][i])),
+            keep_min_value_edge);
+        } else if (edgelist_edge_ids) {
+          detail::sort_multi_edges<vertex_t, edge_t>(
+            handle,
+            raft::device_span<vertex_t>(
+              edgelist_srcs[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+              group_counts[0][i] - non_multi_edge_counts[0][i]),
+            raft::device_span<vertex_t>(
+              edgelist_dsts[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+              group_counts[0][i] - non_multi_edge_counts[0][i]),
+            std::make_optional(raft::device_span<edge_t>(
+              (*edgelist_edge_ids)[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+              group_counts[0][i] - non_multi_edge_counts[0][i])),
+            keep_min_value_edge);
+        } else if (edgelist_edge_types) {
+          detail::sort_multi_edges<vertex_t, edge_type_t>(
+            handle,
+            raft::device_span<vertex_t>(
+              edgelist_srcs[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+              group_counts[0][i] - non_multi_edge_counts[0][i]),
+            raft::device_span<vertex_t>(
+              edgelist_dsts[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+              group_counts[0][i] - non_multi_edge_counts[0][i]),
+            std::make_optional(raft::device_span<edge_type_t>(
+              (*edgelist_edge_types)[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+              group_counts[0][i] - non_multi_edge_counts[0][i])),
+            keep_min_value_edge);
+        } else if (edgelist_edge_start_times) {
+          detail::sort_multi_edges<vertex_t, edge_time_t>(
+            handle,
+            raft::device_span<vertex_t>(
+              edgelist_srcs[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+              group_counts[0][i] - non_multi_edge_counts[0][i]),
+            raft::device_span<vertex_t>(
+              edgelist_dsts[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+              group_counts[0][i] - non_multi_edge_counts[0][i]),
+            std::make_optional(
+              raft::device_span<edge_time_t>((*edgelist_edge_start_times)[0].data() +
+                                               group_disps[0][i] + non_multi_edge_counts[0][i],
+                                             group_counts[0][i] - non_multi_edge_counts[0][i])),
+            keep_min_value_edge);
+        } else {
+          assert(edgelist_edge_end_times);
+          detail::sort_multi_edges<vertex_t, edge_time_t>(
+            handle,
+            raft::device_span<vertex_t>(
+              edgelist_srcs[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+              group_counts[0][i] - non_multi_edge_counts[0][i]),
+            raft::device_span<vertex_t>(
+              edgelist_dsts[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+              group_counts[0][i] - non_multi_edge_counts[0][i]),
+            std::make_optional(
+              raft::device_span<edge_time_t>((*edgelist_edge_end_times)[0].data() +
+                                               group_disps[0][i] + non_multi_edge_counts[0][i],
+                                             group_counts[0][i] - non_multi_edge_counts[0][i])),
+            keep_min_value_edge);
+        }
+      } else {
+        detail::sort_multi_edges<vertex_t, edge_t>(
+          handle,
+          raft::device_span<vertex_t>(
+            edgelist_srcs[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+            group_counts[0][i] - non_multi_edge_counts[0][i]),
+          raft::device_span<vertex_t>(
+            edgelist_dsts[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+            group_counts[0][i] - non_multi_edge_counts[0][i]),
+          raft::device_span<size_t>(
+            (*edgelist_indices)[0].data() + group_disps[0][i] + non_multi_edge_counts[0][i],
+            group_counts[0][i] - non_multi_edge_counts[0][i]),
+          detail::edge_value_compare_t<edge_t, weight_t, edge_type_t, edge_time_t>{
+            edgelist_weights ? cuda::std::make_optional(raft::device_span<weight_t const>(
+                                 (*edgelist_weights)[0].data(), (*edgelist_weights)[0].size()))
+                             : cuda::std::nullopt,
+            edgelist_edge_ids ? cuda::std::make_optional(raft::device_span<edge_t const>(
+                                  (*edgelist_edge_ids)[0].data(), (*edgelist_edge_ids)[0].size()))
+                              : cuda::std::nullopt,
+            edgelist_edge_types
+              ? cuda::std::make_optional(raft::device_span<edge_type_t const>(
+                  (*edgelist_edge_types)[0].data(), (*edgelist_edge_types)[0].size()))
+              : cuda::std::nullopt,
+            edgelist_edge_start_times
+              ? cuda::std::make_optional(raft::device_span<edge_time_t const>(
+                  (*edgelist_edge_start_times)[0].data(), (*edgelist_edge_start_times)[0].size()))
+              : cuda::std::nullopt,
+            edgelist_edge_end_times
+              ? cuda::std::make_optional(raft::device_span<edge_time_t const>(
+                  (*edgelist_edge_end_times)[0].data(), (*edgelist_edge_end_times)[0].size()))
+              : cuda::std::nullopt},
+          keep_min_value_edge);
+      }
+    }
+
+    // 4. remove multi-edges (keep just one edge per multi-edge)
+
+    auto pair_first = thrust::make_zip_iterator(edgelist_srcs[0].begin(), edgelist_dsts[0].begin());
+    auto [keep_count, keep_flags] = detail::mark_entries(
+      handle, edgelist_srcs[0].size(), detail::is_first_in_run_t<decltype(pair_first)>{pair_first});
+
+    if (keep_count < edgelist_srcs[0].size()) {
+      edgelist_srcs[0] = detail::keep_flagged_elements(
+        handle,
+        std::move(edgelist_srcs[0]),
+        raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+        keep_count);
+      edgelist_dsts[0] = detail::keep_flagged_elements(
+        handle,
+        std::move(edgelist_dsts[0]),
+        raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+        keep_count);
+
+      if (edge_property_count == 0) {
+        /* nothing to do */
+      } else if (edge_property_count == 1) {
+        if (edgelist_weights) {
+          (*edgelist_weights)[0] = detail::keep_flagged_elements(
+            handle,
+            std::move((*edgelist_weights)[0]),
+            raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+            keep_count);
+        }
+
+        if (edgelist_edge_ids) {
+          (*edgelist_edge_ids)[0] = detail::keep_flagged_elements(
+            handle,
+            std::move((*edgelist_edge_ids)[0]),
+            raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+            keep_count);
+        }
+
+        if (edgelist_edge_types) {
+          (*edgelist_edge_types)[0] = detail::keep_flagged_elements(
+            handle,
+            std::move((*edgelist_edge_types)[0]),
+            raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+            keep_count);
+        }
+
+        if (edgelist_edge_start_times) {
+          (*edgelist_edge_start_times)[0] = detail::keep_flagged_elements(
+            handle,
+            std::move((*edgelist_edge_start_times)[0]),
+            raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+            keep_count);
+        }
+
+        if (edgelist_edge_end_times) {
+          (*edgelist_edge_end_times)[0] = detail::keep_flagged_elements(
+            handle,
+            std::move((*edgelist_edge_end_times)[0]),
+            raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+            keep_count);
+        }
+      } else {
+        assert(edgelist_indices);
+        (*edgelist_indices)[0] = detail::keep_flagged_elements(
+          handle,
+          std::move((*edgelist_indices)[0]),
+          raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
+          keep_count);
+        if (edgelist_weights) {
+          auto tmp = rmm::device_uvector<weight_t>(keep_count, handle.get_stream());
+          thrust::gather(handle.get_thrust_policy(),
+                         (*edgelist_indices)[0].begin(),
+                         (*edgelist_indices)[0].end(),
+                         (*edgelist_weights)[0].begin(),
+                         tmp.begin());
+          (*edgelist_weights)[0] = std::move(tmp);
+        }
+        if (edgelist_edge_ids) {
+          auto tmp = rmm::device_uvector<edge_t>(keep_count, handle.get_stream());
+          thrust::gather(handle.get_thrust_policy(),
+                         (*edgelist_indices)[0].begin(),
+                         (*edgelist_indices)[0].end(),
+                         (*edgelist_edge_ids)[0].begin(),
+                         tmp.begin());
+          (*edgelist_edge_ids)[0] = std::move(tmp);
+        }
+        if (edgelist_edge_types) {
+          auto tmp = rmm::device_uvector<edge_type_t>(keep_count, handle.get_stream());
+          thrust::gather(handle.get_thrust_policy(),
+                         (*edgelist_indices)[0].begin(),
+                         (*edgelist_indices)[0].end(),
+                         (*edgelist_edge_types)[0].begin(),
+                         tmp.begin());
+          (*edgelist_edge_types)[0] = std::move(tmp);
+        }
+        if (edgelist_edge_start_times) {
+          auto tmp = rmm::device_uvector<edge_time_t>(keep_count, handle.get_stream());
+          thrust::gather(handle.get_thrust_policy(),
+                         (*edgelist_indices)[0].begin(),
+                         (*edgelist_indices)[0].end(),
+                         (*edgelist_edge_start_times)[0].begin(),
+                         tmp.begin());
+          (*edgelist_edge_start_times)[0] = std::move(tmp);
+        }
+        if (edgelist_edge_end_times) {
+          auto tmp = rmm::device_uvector<edge_time_t>(keep_count, handle.get_stream());
+          thrust::gather(handle.get_thrust_policy(),
+                         (*edgelist_indices)[0].begin(),
+                         (*edgelist_indices)[0].end(),
+                         (*edgelist_edge_end_times)[0].begin(),
+                         tmp.begin());
+          (*edgelist_edge_end_times)[0] = std::move(tmp);
+        }
+      }
+    }
+  }
+
+  return std::make_tuple(std::move(edgelist_srcs),
+                         std::move(edgelist_dsts),
+                         std::move(edgelist_weights),
+                         std::move(edgelist_edge_ids),
+                         std::move(edgelist_edge_types),
+                         std::move(edgelist_edge_start_times),
+                         std::move(edgelist_edge_end_times));
 }
 
 }  // namespace detail
@@ -310,228 +1201,177 @@ remove_multi_edges(raft::handle_t const& handle,
                    std::optional<rmm::device_uvector<edge_time_t>>&& edgelist_edge_end_times,
                    bool keep_min_value_edge)
 {
-  auto total_global_mem   = handle.get_device_properties().totalGlobalMem;
+  CUGRAPH_EXPECTS(
+    edgelist_dsts.size() == edgelist_srcs.size(),
+    "Invalid input argument: edgelist_srcs and edgelist_dsts must have the same size.");
+  CUGRAPH_EXPECTS(!edgelist_weights || edgelist_weights->size() == edgelist_srcs.size(),
+                  "Invalid input argument: edgelist_weights (if valid) and edgelist_srcs must have "
+                  "the same size.");
+  CUGRAPH_EXPECTS(!edgelist_edge_ids || edgelist_edge_ids->size() == edgelist_srcs.size(),
+                  "Invalid input argument: edgelist_edge_ids (if valid) and edgelist_srcs must "
+                  "have the same size.");
+  CUGRAPH_EXPECTS(!edgelist_edge_types || edgelist_edge_types->size() == edgelist_srcs.size(),
+                  "Invalid input argument: edgelist_edge_types (if valid) and edgelist_srcs must "
+                  "have the same size.");
+  CUGRAPH_EXPECTS(
+    !edgelist_edge_start_times || edgelist_edge_start_times->size() == edgelist_srcs.size(),
+    "Invalid input argument: edgelist_edge_start_times (if valid) and edgelist_srcs must have the "
+    "same size.");
+  CUGRAPH_EXPECTS(
+    !edgelist_edge_end_times || edgelist_edge_end_times->size() == edgelist_srcs.size(),
+    "Invalid input argument: edgelist_edge_end_times (if valid) and edgelist_srcs must have the "
+    "same size.");
+
   int edge_property_count = 0;
-  size_t element_size     = sizeof(vertex_t) * 2;
+  if (edgelist_weights) { ++edge_property_count; }
+  if (edgelist_edge_ids) { ++edge_property_count; }
+  if (edgelist_edge_types) { ++edge_property_count; }
+  if (edgelist_edge_start_times) { ++edge_property_count; }
+  if (edgelist_edge_end_times) { ++edge_property_count; }
 
+  std::vector<rmm::device_uvector<vertex_t>> edgelist_src_chunks{};
+  edgelist_src_chunks.push_back(std::move(edgelist_srcs));
+  std::vector<rmm::device_uvector<vertex_t>> edgelist_dst_chunks{};
+  edgelist_dst_chunks.push_back(std::move(edgelist_dsts));
+  std::optional<std::vector<rmm::device_uvector<weight_t>>> edgelist_weight_chunks{std::nullopt};
   if (edgelist_weights) {
-    ++edge_property_count;
-    element_size += sizeof(weight_t);
+    edgelist_weight_chunks = std::vector<rmm::device_uvector<weight_t>>{};
+    edgelist_weight_chunks->push_back(std::move(*edgelist_weights));
   }
-
+  std::optional<std::vector<rmm::device_uvector<edge_t>>> edgelist_edge_id_chunks{std::nullopt};
   if (edgelist_edge_ids) {
-    ++edge_property_count;
-    element_size += sizeof(edge_t);
+    edgelist_edge_id_chunks = std::vector<rmm::device_uvector<edge_t>>{};
+    edgelist_edge_id_chunks->push_back(std::move(*edgelist_edge_ids));
   }
+  std::optional<std::vector<rmm::device_uvector<edge_type_t>>> edgelist_edge_type_chunks{
+    std::nullopt};
   if (edgelist_edge_types) {
-    ++edge_property_count;
-    element_size += sizeof(edge_type_t);
+    edgelist_edge_type_chunks = std::vector<rmm::device_uvector<edge_type_t>>{};
+    edgelist_edge_type_chunks->push_back(std::move(*edgelist_edge_types));
   }
+  std::optional<std::vector<rmm::device_uvector<edge_time_t>>> edgelist_edge_start_time_chunks{
+    std::nullopt};
   if (edgelist_edge_start_times) {
-    ++edge_property_count;
-    element_size += sizeof(edge_time_t);
+    edgelist_edge_start_time_chunks = std::vector<rmm::device_uvector<edge_time_t>>{};
+    edgelist_edge_start_time_chunks->push_back(std::move(*edgelist_edge_start_times));
   }
+  std::optional<std::vector<rmm::device_uvector<edge_time_t>>> edgelist_edge_end_time_chunks{
+    std::nullopt};
   if (edgelist_edge_end_times) {
-    ++edge_property_count;
-    element_size += sizeof(edge_time_t);
+    edgelist_edge_end_time_chunks = std::vector<rmm::device_uvector<edge_time_t>>{};
+    edgelist_edge_end_time_chunks->push_back(std::move(*edgelist_edge_end_times));
   }
 
-  if (edge_property_count > 1) { element_size = sizeof(vertex_t) * 2 + sizeof(size_t); }
+  std::tie(edgelist_src_chunks,
+           edgelist_dst_chunks,
+           edgelist_weight_chunks,
+           edgelist_edge_id_chunks,
+           edgelist_edge_type_chunks,
+           edgelist_edge_start_time_chunks,
+           edgelist_edge_end_time_chunks) =
+    detail::remove_multi_edges_impl(handle,
+                                    std::move(edgelist_src_chunks),
+                                    std::move(edgelist_dst_chunks),
+                                    std::move(edgelist_weight_chunks),
+                                    std::move(edgelist_edge_id_chunks),
+                                    std::move(edgelist_edge_type_chunks),
+                                    std::move(edgelist_edge_start_time_chunks),
+                                    std::move(edgelist_edge_end_time_chunks),
+                                    keep_min_value_edge);
 
-  auto constexpr mem_frugal_ratio =
-    0.25;  // if the expected temporary buffer size exceeds the mem_frugal_ratio of the
-           // total_global_mem, switch to the memory frugal approach
-  auto mem_frugal_threshold =
-    static_cast<size_t>(static_cast<double>(total_global_mem / element_size) * mem_frugal_ratio);
+  return std::make_tuple(
+    std::move(edgelist_src_chunks[0]),
+    std::move(edgelist_dst_chunks[0]),
+    edgelist_weight_chunks ? std::make_optional(std::move((*edgelist_weight_chunks)[0]))
+                           : std::nullopt,
+    edgelist_edge_id_chunks ? std::make_optional(std::move((*edgelist_edge_id_chunks)[0]))
+                            : std::nullopt,
+    edgelist_edge_type_chunks ? std::make_optional(std::move((*edgelist_edge_type_chunks)[0]))
+                              : std::nullopt,
+    edgelist_edge_start_time_chunks
+      ? std::make_optional(std::move((*edgelist_edge_start_time_chunks)[0]))
+      : std::nullopt,
+    edgelist_edge_end_time_chunks
+      ? std::make_optional(std::move((*edgelist_edge_end_time_chunks)[0]))
+      : std::nullopt);
+}
 
-  if (edge_property_count == 0) {
-    std::tie(edgelist_srcs, edgelist_dsts) = detail::group_multi_edges(
-      handle, std::move(edgelist_srcs), std::move(edgelist_dsts), mem_frugal_threshold);
-  } else if (edge_property_count == 1) {
-    if (edgelist_weights) {
-      std::tie(edgelist_srcs, edgelist_dsts, edgelist_weights) =
-        detail::group_multi_edges<vertex_t, weight_t>(handle,
-                                                      std::move(edgelist_srcs),
-                                                      std::move(edgelist_dsts),
-                                                      std::move(*edgelist_weights),
-                                                      mem_frugal_threshold,
-                                                      keep_min_value_edge);
-    } else if (edgelist_edge_ids) {
-      std::tie(edgelist_srcs, edgelist_dsts, edgelist_edge_ids) =
-        detail::group_multi_edges<vertex_t, edge_t>(handle,
-                                                    std::move(edgelist_srcs),
-                                                    std::move(edgelist_dsts),
-                                                    std::move(*edgelist_edge_ids),
-                                                    mem_frugal_threshold,
-                                                    keep_min_value_edge);
-    } else if (edgelist_edge_types) {
-      std::tie(edgelist_srcs, edgelist_dsts, edgelist_edge_types) =
-        detail::group_multi_edges<vertex_t, edge_type_t>(handle,
-                                                         std::move(edgelist_srcs),
-                                                         std::move(edgelist_dsts),
-                                                         std::move(*edgelist_edge_types),
-                                                         mem_frugal_threshold,
-                                                         keep_min_value_edge);
-    } else if (edgelist_edge_start_times) {
-      std::tie(edgelist_srcs, edgelist_dsts, edgelist_edge_start_times) =
-        detail::group_multi_edges<vertex_t, edge_time_t>(handle,
-                                                         std::move(edgelist_srcs),
-                                                         std::move(edgelist_dsts),
-                                                         std::move(*edgelist_edge_start_times),
-                                                         mem_frugal_threshold,
-                                                         keep_min_value_edge);
-    } else if (edgelist_edge_end_times) {
-      std::tie(edgelist_srcs, edgelist_dsts, edgelist_edge_end_times) =
-        detail::group_multi_edges<vertex_t, edge_time_t>(handle,
-                                                         std::move(edgelist_srcs),
-                                                         std::move(edgelist_dsts),
-                                                         std::move(*edgelist_edge_end_times),
-                                                         mem_frugal_threshold,
-                                                         keep_min_value_edge);
-    }
-  } else {
-    rmm::device_uvector<edge_t> property_position(edgelist_srcs.size(), handle.get_stream());
-    detail::sequence_fill(
-      handle.get_stream(), property_position.data(), property_position.size(), edge_t{0});
-
-    std::tie(edgelist_srcs, edgelist_dsts, property_position) =
-      detail::group_multi_edges<vertex_t, edge_t, weight_t, edge_type_t, edge_time_t>(
-        handle,
-        std::move(edgelist_srcs),
-        std::move(edgelist_dsts),
-        std::move(property_position),
-        detail::edge_value_compare_t<edge_t, weight_t, edge_type_t, edge_time_t>{
-          edgelist_weights ? cuda::std::make_optional(raft::device_span<weight_t const>(
-                               (*edgelist_weights).data(), (*edgelist_weights).size()))
-                           : cuda::std::nullopt,
-          edgelist_edge_ids ? cuda::std::make_optional(raft::device_span<edge_t const>(
-                                (*edgelist_edge_ids).data(), (*edgelist_edge_ids).size()))
-                            : cuda::std::nullopt,
-          edgelist_edge_types ? cuda::std::make_optional(raft::device_span<edge_type_t const>(
-                                  (*edgelist_edge_types).data(), (*edgelist_edge_types).size()))
-                              : cuda::std::nullopt,
-          edgelist_edge_start_times
-            ? cuda::std::make_optional(raft::device_span<edge_time_t const>(
-                (*edgelist_edge_start_times).data(), (*edgelist_edge_start_times).size()))
-            : cuda::std::nullopt,
-          edgelist_edge_end_times
-            ? cuda::std::make_optional(raft::device_span<edge_time_t const>(
-                (*edgelist_edge_end_times).data(), (*edgelist_edge_end_times).size()))
-            : cuda::std::nullopt},
-        mem_frugal_threshold,
-        keep_min_value_edge);
-
-    if (edgelist_weights) {
-      rmm::device_uvector<weight_t> tmp(property_position.size(), handle.get_stream());
-
-      thrust::gather(handle.get_thrust_policy(),
-                     property_position.begin(),
-                     property_position.end(),
-                     edgelist_weights->begin(),
-                     tmp.begin());
-
-      edgelist_weights = std::move(tmp);
-    }
-
-    if (edgelist_edge_ids) {
-      rmm::device_uvector<edge_t> tmp(property_position.size(), handle.get_stream());
-
-      thrust::gather(handle.get_thrust_policy(),
-                     property_position.begin(),
-                     property_position.end(),
-                     edgelist_edge_ids->begin(),
-                     tmp.begin());
-
-      edgelist_edge_ids = std::move(tmp);
-    }
-
-    if (edgelist_edge_types) {
-      rmm::device_uvector<edge_type_t> tmp(property_position.size(), handle.get_stream());
-
-      thrust::gather(handle.get_thrust_policy(),
-                     property_position.begin(),
-                     property_position.end(),
-                     edgelist_edge_types->begin(),
-                     tmp.begin());
-
-      edgelist_edge_types = std::move(tmp);
-    }
-
-    if (edgelist_edge_start_times) {
-      rmm::device_uvector<edge_time_t> tmp(property_position.size(), handle.get_stream());
-
-      thrust::gather(handle.get_thrust_policy(),
-                     property_position.begin(),
-                     property_position.end(),
-                     edgelist_edge_start_times->begin(),
-                     tmp.begin());
-
-      edgelist_edge_start_times = std::move(tmp);
-    }
-
-    if (edgelist_edge_end_times) {
-      rmm::device_uvector<edge_time_t> tmp(property_position.size(), handle.get_stream());
-
-      thrust::gather(handle.get_thrust_policy(),
-                     property_position.begin(),
-                     property_position.end(),
-                     edgelist_edge_end_times->begin(),
-                     tmp.begin());
-
-      edgelist_edge_end_times = std::move(tmp);
-    }
+template <typename vertex_t,
+          typename edge_t,
+          typename weight_t,
+          typename edge_type_t,
+          typename edge_time_t>
+std::tuple<std::vector<rmm::device_uvector<vertex_t>>,
+           std::vector<rmm::device_uvector<vertex_t>>,
+           std::optional<std::vector<rmm::device_uvector<weight_t>>>,
+           std::optional<std::vector<rmm::device_uvector<edge_t>>>,
+           std::optional<std::vector<rmm::device_uvector<edge_type_t>>>,
+           std::optional<std::vector<rmm::device_uvector<edge_time_t>>>,
+           std::optional<std::vector<rmm::device_uvector<edge_time_t>>>>
+remove_multi_edges(
+  raft::handle_t const& handle,
+  std::vector<rmm::device_uvector<vertex_t>>&& edgelist_srcs,
+  std::vector<rmm::device_uvector<vertex_t>>&& edgelist_dsts,
+  std::optional<std::vector<rmm::device_uvector<weight_t>>>&& edgelist_weights,
+  std::optional<std::vector<rmm::device_uvector<edge_t>>>&& edgelist_edge_ids,
+  std::optional<std::vector<rmm::device_uvector<edge_type_t>>>&& edgelist_edge_types,
+  std::optional<std::vector<rmm::device_uvector<edge_time_t>>>&& edgelist_edge_start_times,
+  std::optional<std::vector<rmm::device_uvector<edge_time_t>>>&& edgelist_edge_end_times,
+  bool keep_min_value_edge)
+{
+  CUGRAPH_EXPECTS(
+    edgelist_dsts.size() == edgelist_srcs.size(),
+    "Invalid input argument: edgelist_dsts and edgelist_srcs must have the same size.");
+  CUGRAPH_EXPECTS(!edgelist_weights || edgelist_weights->size() == edgelist_srcs.size(),
+                  "Invalid input argument: edgelist_weights (if valid) and edgelist_edge_ids must "
+                  "have the same size.");
+  CUGRAPH_EXPECTS(!edgelist_edge_ids || edgelist_edge_ids->size() == edgelist_srcs.size(),
+                  "Invalid input argument: edgelist_edge_ids (if valid) and edgelist_srcs must "
+                  "have the same size.");
+  CUGRAPH_EXPECTS(!edgelist_edge_types || edgelist_edge_types->size() == edgelist_srcs.size(),
+                  "Invalid input argument: edgelist_edge_types (if valid) and edgelist_srcs must "
+                  "have the same size.");
+  CUGRAPH_EXPECTS(
+    !edgelist_edge_start_times || edgelist_edge_start_times->size() == edgelist_srcs.size(),
+    "Invalid input argument: edgelist_edge_start_times (if valid) and edgelist_srcs must have the "
+    "same size.");
+  CUGRAPH_EXPECTS(
+    !edgelist_edge_end_times || edgelist_edge_end_times->size() == edgelist_srcs.size(),
+    "Invalid input argument: edgelist_edge_end_times (if valid) and edgelist_srcs must have the "
+    "same size.");
+  for (size_t i = 0; i < edgelist_srcs.size(); ++i) {
+    CUGRAPH_EXPECTS(
+      edgelist_dsts[i].size() == edgelist_srcs[i].size(),
+      "Invalid input argument: edgelist_dsts[i] and edgelist_srcs[i] must have the same size.");
+    CUGRAPH_EXPECTS(!edgelist_weights || (*edgelist_weights)[i].size() == edgelist_srcs[i].size(),
+                    "Invalid input argument: edgelist_weights[i] (if valid) and edgelist_srcs[i] "
+                    "must have the same size.");
+    CUGRAPH_EXPECTS(!edgelist_edge_ids || (*edgelist_edge_ids)[i].size() == edgelist_srcs[i].size(),
+                    "Invalid input argument: edgelist_edge_ids[i] (if valid) and edgelist_srcs[i] "
+                    "must have the same size.");
+    CUGRAPH_EXPECTS(
+      !edgelist_edge_types || (*edgelist_edge_types)[i].size() == edgelist_srcs[i].size(),
+      "Invalid input argument: edgelist_edge_types[i] (if valid) and edgelist_srcs[i] must have "
+      "the same size.");
+    CUGRAPH_EXPECTS(!edgelist_edge_start_times ||
+                      (*edgelist_edge_start_times)[i].size() == edgelist_srcs[i].size(),
+                    "Invalid input argument: edgelist_edge_start_times[i] (if valid) and "
+                    "edgelist_srcs[i] must have the same size.");
+    CUGRAPH_EXPECTS(
+      !edgelist_edge_end_times || (*edgelist_edge_end_times)[i].size() == edgelist_srcs[i].size(),
+      "Invalid input argument: edgelist_edge_end_times[i] (if valid) and edgelist_srcs[i] must "
+      "have the same size.");
   }
 
-  auto [keep_count, keep_flags] = detail::mark_entries(
-    handle,
-    edgelist_srcs.size(),
-    [d_edgelist_srcs = edgelist_srcs.data(),
-     d_edgelist_dsts = edgelist_dsts.data()] __device__(auto idx) {
-      return !((idx > 0) && (d_edgelist_srcs[idx - 1] == d_edgelist_srcs[idx]) &&
-               (d_edgelist_dsts[idx - 1] == d_edgelist_dsts[idx]));
-    });
-
-  if (keep_count < edgelist_srcs.size()) {
-    edgelist_srcs = detail::keep_flagged_elements(
-      handle,
-      std::move(edgelist_srcs),
-      raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
-      keep_count);
-    edgelist_dsts = detail::keep_flagged_elements(
-      handle,
-      std::move(edgelist_dsts),
-      raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
-      keep_count);
-
-    if (edgelist_weights)
-      edgelist_weights = detail::keep_flagged_elements(
-        handle,
-        std::move(*edgelist_weights),
-        raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
-        keep_count);
-
-    if (edgelist_edge_ids)
-      edgelist_edge_ids = detail::keep_flagged_elements(
-        handle,
-        std::move(*edgelist_edge_ids),
-        raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
-        keep_count);
-
-    if (edgelist_edge_types)
-      edgelist_edge_types = detail::keep_flagged_elements(
-        handle,
-        std::move(*edgelist_edge_types),
-        raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
-        keep_count);
-  }
-
-  return std::make_tuple(std::move(edgelist_srcs),
-                         std::move(edgelist_dsts),
-                         std::move(edgelist_weights),
-                         std::move(edgelist_edge_ids),
-                         std::move(edgelist_edge_types),
-                         std::move(edgelist_edge_start_times),
-                         std::move(edgelist_edge_end_times));
+  return detail::remove_multi_edges_impl(handle,
+                                         std::move(edgelist_srcs),
+                                         std::move(edgelist_dsts),
+                                         std::move(edgelist_weights),
+                                         std::move(edgelist_edge_ids),
+                                         std::move(edgelist_edge_types),
+                                         std::move(edgelist_edge_start_times),
+                                         std::move(edgelist_edge_end_times),
+                                         keep_min_value_edge);
 }
 
 }  // namespace cugraph

--- a/cpp/src/structure/remove_multi_edges_sg_v32_e32.cu
+++ b/cpp/src/structure/remove_multi_edges_sg_v32_e32.cu
@@ -85,4 +85,76 @@ remove_multi_edges(raft::handle_t const& handle,
                    std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
                    bool keep_min_value_edge);
 
+template std::tuple<std::vector<rmm::device_uvector<int32_t>>,
+                    std::vector<rmm::device_uvector<int32_t>>,
+                    std::optional<std::vector<rmm::device_uvector<float>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>>
+remove_multi_edges(
+  raft::handle_t const& handle,
+  std::vector<rmm::device_uvector<int32_t>>&& edgelist_srcs,
+  std::vector<rmm::device_uvector<int32_t>>&& edgelist_dsts,
+  std::optional<std::vector<rmm::device_uvector<float>>>&& edgelist_weights,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_ids,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_start_times,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
+  bool keep_min_value_edge);
+
+template std::tuple<std::vector<rmm::device_uvector<int32_t>>,
+                    std::vector<rmm::device_uvector<int32_t>>,
+                    std::optional<std::vector<rmm::device_uvector<double>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>>
+remove_multi_edges(
+  raft::handle_t const& handle,
+  std::vector<rmm::device_uvector<int32_t>>&& edgelist_srcs,
+  std::vector<rmm::device_uvector<int32_t>>&& edgelist_dsts,
+  std::optional<std::vector<rmm::device_uvector<double>>>&& edgelist_weights,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_ids,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_start_times,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
+  bool keep_min_value_edge);
+
+template std::tuple<std::vector<rmm::device_uvector<int32_t>>,
+                    std::vector<rmm::device_uvector<int32_t>>,
+                    std::optional<std::vector<rmm::device_uvector<float>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int64_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int64_t>>>>
+remove_multi_edges(
+  raft::handle_t const& handle,
+  std::vector<rmm::device_uvector<int32_t>>&& edgelist_srcs,
+  std::vector<rmm::device_uvector<int32_t>>&& edgelist_dsts,
+  std::optional<std::vector<rmm::device_uvector<float>>>&& edgelist_weights,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_ids,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
+  std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_start_times,
+  std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
+  bool keep_min_value_edge);
+
+template std::tuple<std::vector<rmm::device_uvector<int32_t>>,
+                    std::vector<rmm::device_uvector<int32_t>>,
+                    std::optional<std::vector<rmm::device_uvector<double>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int64_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int64_t>>>>
+remove_multi_edges(
+  raft::handle_t const& handle,
+  std::vector<rmm::device_uvector<int32_t>>&& edgelist_srcs,
+  std::vector<rmm::device_uvector<int32_t>>&& edgelist_dsts,
+  std::optional<std::vector<rmm::device_uvector<double>>>&& edgelist_weights,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_ids,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
+  std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_start_times,
+  std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
+  bool keep_min_value_edge);
+
 }  // namespace cugraph

--- a/cpp/src/structure/remove_multi_edges_sg_v64_e64.cu
+++ b/cpp/src/structure/remove_multi_edges_sg_v64_e64.cu
@@ -85,4 +85,76 @@ remove_multi_edges(raft::handle_t const& handle,
                    std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
                    bool keep_min_value_edge);
 
+template std::tuple<std::vector<rmm::device_uvector<int64_t>>,
+                    std::vector<rmm::device_uvector<int64_t>>,
+                    std::optional<std::vector<rmm::device_uvector<float>>>,
+                    std::optional<std::vector<rmm::device_uvector<int64_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>>
+remove_multi_edges(
+  raft::handle_t const& handle,
+  std::vector<rmm::device_uvector<int64_t>>&& edgelist_srcs,
+  std::vector<rmm::device_uvector<int64_t>>&& edgelist_dsts,
+  std::optional<std::vector<rmm::device_uvector<float>>>&& edgelist_weights,
+  std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_ids,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_start_times,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
+  bool keep_min_value_edge);
+
+template std::tuple<std::vector<rmm::device_uvector<int64_t>>,
+                    std::vector<rmm::device_uvector<int64_t>>,
+                    std::optional<std::vector<rmm::device_uvector<double>>>,
+                    std::optional<std::vector<rmm::device_uvector<int64_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>>
+remove_multi_edges(
+  raft::handle_t const& handle,
+  std::vector<rmm::device_uvector<int64_t>>&& edgelist_srcs,
+  std::vector<rmm::device_uvector<int64_t>>&& edgelist_dsts,
+  std::optional<std::vector<rmm::device_uvector<double>>>&& edgelist_weights,
+  std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_ids,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_start_times,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
+  bool keep_min_value_edge);
+
+template std::tuple<std::vector<rmm::device_uvector<int64_t>>,
+                    std::vector<rmm::device_uvector<int64_t>>,
+                    std::optional<std::vector<rmm::device_uvector<float>>>,
+                    std::optional<std::vector<rmm::device_uvector<int64_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int64_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int64_t>>>>
+remove_multi_edges(
+  raft::handle_t const& handle,
+  std::vector<rmm::device_uvector<int64_t>>&& edgelist_srcs,
+  std::vector<rmm::device_uvector<int64_t>>&& edgelist_dsts,
+  std::optional<std::vector<rmm::device_uvector<float>>>&& edgelist_weights,
+  std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_ids,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
+  std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_start_times,
+  std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
+  bool keep_min_value_edge);
+
+template std::tuple<std::vector<rmm::device_uvector<int64_t>>,
+                    std::vector<rmm::device_uvector<int64_t>>,
+                    std::optional<std::vector<rmm::device_uvector<double>>>,
+                    std::optional<std::vector<rmm::device_uvector<int64_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int32_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int64_t>>>,
+                    std::optional<std::vector<rmm::device_uvector<int64_t>>>>
+remove_multi_edges(
+  raft::handle_t const& handle,
+  std::vector<rmm::device_uvector<int64_t>>&& edgelist_srcs,
+  std::vector<rmm::device_uvector<int64_t>>&& edgelist_dsts,
+  std::optional<std::vector<rmm::device_uvector<double>>>&& edgelist_weights,
+  std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_ids,
+  std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
+  std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_start_times,
+  std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
+  bool keep_min_value_edge);
+
 }  // namespace cugraph

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -374,6 +374,10 @@ ConfigureTest(GENERATE_BIPARTITE_RMAT_TEST generators/generate_bipartite_rmat_te
     GPUS 1 PERCENT 100)
 
 ###################################################################################################
+# - Remove multi-edges tests ----------------------------------------------------------------------
+ConfigureTest(REMOVE_MULTI_EDGES_TEST structure/remove_multi_edges_test.cpp)
+
+###################################################################################################
 # - Symmetrize tests ------------------------------------------------------------------------------
 ConfigureTest(SYMMETRIZE_TEST structure/symmetrize_test.cpp)
 

--- a/cpp/tests/structure/remove_multi_edges_test.cpp
+++ b/cpp/tests/structure/remove_multi_edges_test.cpp
@@ -1,0 +1,637 @@
+/*
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governin_from_mtxg permissions and
+ * limitations under the License.
+ */
+
+#include "utilities/base_fixture.hpp"
+#include "utilities/conversion_utilities.hpp"
+
+#include <cugraph/detail/utility_wrappers.hpp>
+#include <cugraph/graph.hpp>
+#include <cugraph/graph_functions.hpp>
+#include <cugraph/utilities/high_res_timer.hpp>
+
+#include <raft/core/handle.hpp>
+#include <raft/util/cudart_utils.hpp>
+
+#include <rmm/device_uvector.hpp>
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+typedef struct RemoveMultiEdges_Usecase_t {
+  int num_chunks{1};
+  bool keep_min_value_edge{false};
+  bool check_correctness{true};
+} RemoveMultiEdges_Usecase;
+
+template <typename value_t>
+rmm::device_uvector<value_t> aggregate_buffers(raft::handle_t const handle,
+                                               std::vector<rmm::device_uvector<value_t>>&& chunks)
+{
+  size_t tot_edge_count{0};
+  for (size_t i = 0; i < chunks.size(); ++i) {
+    tot_edge_count += chunks[i].size();
+  }
+
+  rmm::device_uvector<value_t> values(tot_edge_count, handle.get_stream());
+  size_t offset{0};
+  for (size_t i = 0; i < chunks.size(); ++i) {
+    raft::copy_async(
+      values.data() + offset, chunks[i].data(), chunks[i].size(), handle.get_stream());
+    offset += chunks[i].size();
+  }
+  return values;
+}
+
+template <typename vertex_t, typename edge_t, typename weight_t, typename edge_type_t>
+std::tuple<rmm::device_uvector<vertex_t>,
+           rmm::device_uvector<vertex_t>,
+           rmm::device_uvector<weight_t>,
+           rmm::device_uvector<edge_t>,
+           rmm::device_uvector<edge_type_t>>
+aggregate_buffers(raft::handle_t const handle,
+                  std::vector<rmm::device_uvector<vertex_t>>&& src_chunks,
+                  std::vector<rmm::device_uvector<vertex_t>>&& dst_chunks,
+                  std::vector<rmm::device_uvector<weight_t>>&& weight_chunks,
+                  std::vector<rmm::device_uvector<edge_t>>&& edge_id_chunks,
+                  std::vector<rmm::device_uvector<edge_type_t>>&& edge_type_chunks)
+{
+  size_t tot_edge_count{0};
+  for (size_t i = 0; i < src_chunks.size(); ++i) {
+    tot_edge_count += src_chunks[i].size();
+  }
+  rmm::device_uvector<vertex_t> srcs(tot_edge_count, handle.get_stream());
+  rmm::device_uvector<vertex_t> dsts(tot_edge_count, handle.get_stream());
+  rmm::device_uvector<weight_t> weights(tot_edge_count, handle.get_stream());
+  rmm::device_uvector<edge_t> edge_ids(tot_edge_count, handle.get_stream());
+  rmm::device_uvector<edge_type_t> edge_types(tot_edge_count, handle.get_stream());
+
+  size_t offset{0};
+  for (size_t i = 0; i < src_chunks.size(); ++i) {
+    raft::copy_async(
+      srcs.data() + offset, src_chunks[i].data(), src_chunks[i].size(), handle.get_stream());
+    raft::copy_async(
+      dsts.data() + offset, dst_chunks[i].data(), dst_chunks[i].size(), handle.get_stream());
+    raft::copy_async(weights.data() + offset,
+                     weight_chunks[i].data(),
+                     weight_chunks[i].size(),
+                     handle.get_stream());
+    raft::copy_async(edge_ids.data() + offset,
+                     edge_id_chunks[i].data(),
+                     edge_id_chunks[i].size(),
+                     handle.get_stream());
+    raft::copy_async(edge_types.data() + offset,
+                     edge_type_chunks[i].data(),
+                     edge_type_chunks[i].size(),
+                     handle.get_stream());
+    offset += src_chunks[i].size();
+  }
+  src_chunks.clear();
+  dst_chunks.clear();
+  weight_chunks.clear();
+  edge_id_chunks.clear();
+  edge_type_chunks.clear();
+
+  return std::make_tuple(std::move(srcs),
+                         std::move(dsts),
+                         std::move(weights),
+                         std::move(edge_ids),
+                         std::move(edge_types));
+}
+
+template <typename vertex_t, typename edge_t, typename weight_t, typename edge_type_t>
+std::tuple<std::vector<rmm::device_uvector<vertex_t>>,
+           std::vector<rmm::device_uvector<vertex_t>>,
+           std::vector<rmm::device_uvector<weight_t>>,
+           std::vector<rmm::device_uvector<edge_t>>,
+           std::vector<rmm::device_uvector<edge_type_t>>>
+split_buffer(raft::handle_t const handle,
+             raft::device_span<vertex_t const> srcs,
+             raft::device_span<vertex_t const> dsts,
+             raft::device_span<weight_t const> weights,
+             raft::device_span<edge_t const> edge_ids,
+             raft::device_span<edge_type_t const> edge_types,
+             size_t num_chunks)
+{
+  std::vector<rmm::device_uvector<vertex_t>> src_chunks{};
+  std::vector<rmm::device_uvector<vertex_t>> dst_chunks{};
+  std::vector<rmm::device_uvector<weight_t>> weight_chunks{};
+  std::vector<rmm::device_uvector<edge_t>> edge_id_chunks{};
+  std::vector<rmm::device_uvector<edge_type_t>> edge_type_chunks{};
+
+  src_chunks.reserve(num_chunks);
+  dst_chunks.reserve(num_chunks);
+  weight_chunks.reserve(num_chunks);
+  edge_id_chunks.reserve(num_chunks);
+  edge_type_chunks.reserve(num_chunks);
+
+  for (size_t i = 0; i < num_chunks; ++i) {
+    src_chunks.emplace_back(0, handle.get_stream());
+    dst_chunks.emplace_back(0, handle.get_stream());
+    weight_chunks.emplace_back(0, handle.get_stream());
+    edge_id_chunks.emplace_back(0, handle.get_stream());
+    edge_type_chunks.emplace_back(0, handle.get_stream());
+  }
+
+  size_t chunk_size = (srcs.size() + (num_chunks - 1)) / num_chunks;
+  for (size_t i = 0; i < num_chunks; ++i) {
+    auto start_offset = chunk_size * i;
+    auto end_offset   = std::min(chunk_size * (i + 1), srcs.size());
+    src_chunks[i].resize(end_offset - start_offset, handle.get_stream());
+    raft::copy_async(src_chunks[i].data(),
+                     srcs.data() + start_offset,
+                     end_offset - start_offset,
+                     handle.get_stream());
+    dst_chunks[i].resize(end_offset - start_offset, handle.get_stream());
+    raft::copy_async(dst_chunks[i].data(),
+                     dsts.data() + start_offset,
+                     end_offset - start_offset,
+                     handle.get_stream());
+    weight_chunks[i].resize(end_offset - start_offset, handle.get_stream());
+    raft::copy_async(weight_chunks[i].data(),
+                     weights.data() + start_offset,
+                     end_offset - start_offset,
+                     handle.get_stream());
+    edge_id_chunks[i].resize(end_offset - start_offset, handle.get_stream());
+    raft::copy_async(edge_id_chunks[i].data(),
+                     edge_ids.data() + start_offset,
+                     end_offset - start_offset,
+                     handle.get_stream());
+    edge_type_chunks[i].resize(end_offset - start_offset, handle.get_stream());
+    raft::copy_async(edge_type_chunks[i].data(),
+                     edge_types.data() + start_offset,
+                     end_offset - start_offset,
+                     handle.get_stream());
+  }
+
+  return std::make_tuple(std::move(src_chunks),
+                         std::move(dst_chunks),
+                         std::move(weight_chunks),
+                         std::move(edge_id_chunks),
+                         std::move(edge_type_chunks));
+}
+
+template <typename input_usecase_t>
+class Tests_RemoveMultiEdges
+  : public ::testing::TestWithParam<std::tuple<RemoveMultiEdges_Usecase, input_usecase_t>> {
+ public:
+  Tests_RemoveMultiEdges() {}
+
+  static void SetUpTestCase() {}
+  static void TearDownTestCase() {}
+
+  virtual void SetUp() {}
+  virtual void TearDown() {}
+
+  template <typename vertex_t, typename edge_t>
+  void run_current_test(RemoveMultiEdges_Usecase const& remove_multi_edges_usecase,
+                        input_usecase_t const& input_usecase)
+  {
+    using weight_t    = float;
+    using edge_type_t = int32_t;
+    using edge_time_t = int32_t;
+
+    bool constexpr store_transposed = false;
+    bool constexpr multi_gpu        = false;
+    bool constexpr test_weighted    = true;
+    bool constexpr shuffle          = false;  // irrelevant if multi_gpu = false
+
+    raft::handle_t handle{};
+    HighResTimer hr_timer{};
+    raft::random::RngState rng_state(0);
+
+    if (cugraph::test::g_perf) {
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      hr_timer.start("Construct edge list");
+    }
+
+    std::vector<rmm::device_uvector<vertex_t>> src_chunks{};
+    std::vector<rmm::device_uvector<vertex_t>> dst_chunks{};
+    std::vector<rmm::device_uvector<weight_t>> weight_chunks{};
+    std::vector<rmm::device_uvector<edge_t>> edge_id_chunks{};
+    std::vector<rmm::device_uvector<edge_type_t>> edge_type_chunks{};
+
+    {
+      std::optional<std::vector<rmm::device_uvector<weight_t>>> tmp_weight_chunks{};
+      std::tie(src_chunks, dst_chunks, tmp_weight_chunks, std::ignore, std::ignore) =
+        input_usecase.template construct_edgelist<vertex_t, weight_t>(
+          handle, test_weighted, store_transposed, multi_gpu);
+      weight_chunks = std::move(*tmp_weight_chunks);
+    }
+
+    edge_id_chunks.reserve(src_chunks.size());
+    edge_type_chunks.reserve(src_chunks.size());
+    for (size_t i = 0; i < src_chunks.size(); ++i) {
+      edge_id_chunks.emplace_back(src_chunks[i].size(), handle.get_stream());
+      edge_type_chunks.emplace_back(src_chunks[i].size(), handle.get_stream());
+    }
+    for (size_t i = 0; i < src_chunks.size(); ++i) {
+      edge_id_chunks[i].resize(src_chunks[i].size(), handle.get_stream());
+      edge_type_chunks[i].resize(src_chunks[i].size(), handle.get_stream());
+      cugraph::detail::uniform_random_fill(handle.get_stream(),
+                                           edge_id_chunks[i].data(),
+                                           edge_id_chunks[i].size(),
+                                           edge_t{0},
+                                           std::numeric_limits<edge_t>::max(),
+                                           rng_state);
+      cugraph::detail::uniform_random_fill(handle.get_stream(),
+                                           edge_type_chunks[i].data(),
+                                           edge_type_chunks[i].size(),
+                                           edge_type_t{0},
+                                           std::numeric_limits<edge_type_t>::max(),
+                                           rng_state);
+    }
+
+    if (cugraph::test::g_perf) {
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      hr_timer.stop();
+      hr_timer.display_and_clear(std::cout);
+    }
+
+    auto [org_srcs, org_dsts, org_weights, org_edge_ids, org_edge_types] =
+      aggregate_buffers(handle,
+                        std::move(src_chunks),
+                        std::move(dst_chunks),
+                        std::move(weight_chunks),
+                        std::move(edge_id_chunks),
+                        std::move(edge_type_chunks));
+
+    rmm::device_uvector<vertex_t> result_srcs(0, handle.get_stream());
+    rmm::device_uvector<vertex_t> result_dsts(0, handle.get_stream());
+    rmm::device_uvector<weight_t> result_weights(0, handle.get_stream());
+    rmm::device_uvector<edge_t> result_edge_ids(0, handle.get_stream());
+    rmm::device_uvector<edge_type_t> result_edge_types(0, handle.get_stream());
+
+    std::tie(src_chunks, dst_chunks, weight_chunks, edge_id_chunks, edge_type_chunks) =
+      split_buffer(
+        handle,
+        raft::device_span<vertex_t const>(org_srcs.data(), org_srcs.size()),
+        raft::device_span<vertex_t const>(org_dsts.data(), org_dsts.size()),
+        raft::device_span<weight_t const>(org_weights.data(), org_weights.size()),
+        raft::device_span<edge_t const>(org_edge_ids.data(), org_edge_ids.size()),
+        raft::device_span<edge_type_t const>(org_edge_types.data(), org_edge_types.size()),
+        remove_multi_edges_usecase.num_chunks);
+
+    if (cugraph::test::g_perf) {
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      hr_timer.start("Remove multi-edges (just src, dst)");
+    }
+
+    if (src_chunks.size() == 1) {
+      std::tie(
+        result_srcs, result_dsts, std::ignore, std::ignore, std::ignore, std::ignore, std::ignore) =
+        cugraph::remove_multi_edges<vertex_t, edge_t, weight_t, edge_type_t, edge_time_t>(
+          handle,
+          std::move(src_chunks[0]),
+          std::move(dst_chunks[0]),
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          remove_multi_edges_usecase.keep_min_value_edge);
+    } else {
+      auto [result_src_chunks,
+            result_dst_chunks,
+            result_weight_chunks /* dummy */,
+            result_edge_id_chunks /* dummy */,
+            result_edge_type_chunks /* dummy */,
+            result_edge_start_time_chunks /* dummy */,
+            result_edge_end_time_chunks /* dummy */] =
+        cugraph::remove_multi_edges<vertex_t, edge_t, weight_t, edge_type_t, edge_time_t>(
+          handle,
+          std::move(src_chunks),
+          std::move(dst_chunks),
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          remove_multi_edges_usecase.keep_min_value_edge);
+      result_srcs = aggregate_buffers(handle, std::move(result_src_chunks));
+      result_dsts = aggregate_buffers(handle, std::move(result_dst_chunks));
+    }
+
+    if (cugraph::test::g_perf) {
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      hr_timer.stop();
+      hr_timer.display_and_clear(std::cout);
+    }
+
+    if (remove_multi_edges_usecase.check_correctness) {
+      auto h_org_srcs = cugraph::test::to_host(handle, org_srcs);
+      auto h_org_dsts = cugraph::test::to_host(handle, org_dsts);
+      std::vector<std::tuple<vertex_t, vertex_t>> h_org_edges(h_org_srcs.size());
+      for (size_t i = 0; i < h_org_srcs.size(); ++i) {
+        h_org_edges[i] = std::make_tuple(h_org_srcs[i], h_org_dsts[i]);
+      }
+      std::sort(h_org_edges.begin(), h_org_edges.end());
+      h_org_edges.resize(
+        std::distance(h_org_edges.begin(), std::unique(h_org_edges.begin(), h_org_edges.end())));
+
+      auto h_result_srcs = cugraph::test::to_host(handle, result_srcs);
+      auto h_result_dsts = cugraph::test::to_host(handle, result_dsts);
+      std::vector<std::tuple<vertex_t, vertex_t>> h_result_edges(h_result_srcs.size());
+      for (size_t i = 0; i < h_result_srcs.size(); ++i) {
+        h_result_edges[i] = std::make_tuple(h_result_srcs[i], h_result_dsts[i]);
+      }
+      std::sort(h_result_edges.begin(), h_result_edges.end());
+
+      ASSERT_EQ(h_org_edges.size(), h_result_edges.size());
+      ASSERT_TRUE(std::equal(h_org_edges.begin(), h_org_edges.end(), h_result_edges.begin()));
+    }
+
+    std::tie(src_chunks, dst_chunks, weight_chunks, edge_id_chunks, edge_type_chunks) =
+      split_buffer(
+        handle,
+        raft::device_span<vertex_t const>(org_srcs.data(), org_srcs.size()),
+        raft::device_span<vertex_t const>(org_dsts.data(), org_dsts.size()),
+        raft::device_span<weight_t const>(org_weights.data(), org_weights.size()),
+        raft::device_span<edge_t const>(org_edge_ids.data(), org_edge_ids.size()),
+        raft::device_span<edge_type_t const>(org_edge_types.data(), org_edge_types.size()),
+        remove_multi_edges_usecase.num_chunks);
+
+    if (cugraph::test::g_perf) {
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      hr_timer.start("Remove multi-edges (src, dst, weight)");
+    }
+
+    if (src_chunks.size() == 1) {
+      std::optional<rmm::device_uvector<weight_t>> tmp_weights{};
+      std::tie(
+        result_srcs, result_dsts, tmp_weights, std::ignore, std::ignore, std::ignore, std::ignore) =
+        cugraph::remove_multi_edges<vertex_t, edge_t, weight_t, edge_type_t, edge_time_t>(
+          handle,
+          std::move(src_chunks[0]),
+          std::move(dst_chunks[0]),
+          std::move(weight_chunks[0]),
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          remove_multi_edges_usecase.keep_min_value_edge);
+      result_weights = std::move(*tmp_weights);
+    } else {
+      auto [result_src_chunks,
+            result_dst_chunks,
+            result_weight_chunks,
+            result_edge_id_chunks /* dummy */,
+            result_edge_type_chunks /* dummy */,
+            result_edge_start_time_chunks /* dummy */,
+            result_edge_end_time_chunks /* dummy */] =
+        cugraph::remove_multi_edges<vertex_t, edge_t, weight_t, edge_type_t, edge_time_t>(
+          handle,
+          std::move(src_chunks),
+          std::move(dst_chunks),
+          std::move(weight_chunks),
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          remove_multi_edges_usecase.keep_min_value_edge);
+      result_srcs    = aggregate_buffers(handle, std::move(result_src_chunks));
+      result_dsts    = aggregate_buffers(handle, std::move(result_dst_chunks));
+      result_weights = aggregate_buffers(handle, std::move(*result_weight_chunks));
+    }
+
+    if (cugraph::test::g_perf) {
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      hr_timer.stop();
+      hr_timer.display_and_clear(std::cout);
+    }
+
+    if (remove_multi_edges_usecase.check_correctness) {
+      auto h_org_srcs    = cugraph::test::to_host(handle, org_srcs);
+      auto h_org_dsts    = cugraph::test::to_host(handle, org_dsts);
+      auto h_org_weights = cugraph::test::to_host(handle, org_weights);
+      std::vector<std::tuple<vertex_t, vertex_t, weight_t>> h_org_edges(h_org_srcs.size());
+      for (size_t i = 0; i < h_org_srcs.size(); ++i) {
+        h_org_edges[i] = std::make_tuple(h_org_srcs[i], h_org_dsts[i], h_org_weights[i]);
+      }
+      std::sort(h_org_edges.begin(), h_org_edges.end());
+      h_org_edges.resize(
+        std::distance(h_org_edges.begin(), std::unique(h_org_edges.begin(), h_org_edges.end())));
+
+      auto h_result_srcs    = cugraph::test::to_host(handle, result_srcs);
+      auto h_result_dsts    = cugraph::test::to_host(handle, result_dsts);
+      auto h_result_weights = cugraph::test::to_host(handle, result_weights);
+      std::vector<std::tuple<vertex_t, vertex_t, weight_t>> h_result_edges(h_result_srcs.size());
+      for (size_t i = 0; i < h_result_srcs.size(); ++i) {
+        h_result_edges[i] =
+          std::make_tuple(h_result_srcs[i], h_result_dsts[i], h_result_weights[i]);
+      }
+      std::sort(h_result_edges.begin(), h_result_edges.end());
+
+      ASSERT_EQ(h_org_edges.size(), h_result_edges.size());
+      if (remove_multi_edges_usecase.keep_min_value_edge) {
+        ASSERT_TRUE(std::equal(h_org_edges.begin(), h_org_edges.end(), h_result_edges.begin()));
+      } else {
+        ASSERT_TRUE(std::equal(
+          h_org_edges.begin(), h_org_edges.end(), h_result_edges.begin(), [](auto lhs, auto rhs) {
+            return std::get<0>(lhs) == std::get<0>(rhs) && std::get<1>(lhs) == std::get<1>(rhs);
+          }));
+      }
+    }
+
+    std::tie(src_chunks, dst_chunks, weight_chunks, edge_id_chunks, edge_type_chunks) =
+      split_buffer(
+        handle,
+        raft::device_span<vertex_t const>(org_srcs.data(), org_srcs.size()),
+        raft::device_span<vertex_t const>(org_dsts.data(), org_dsts.size()),
+        raft::device_span<weight_t const>(org_weights.data(), org_weights.size()),
+        raft::device_span<edge_t const>(org_edge_ids.data(), org_edge_ids.size()),
+        raft::device_span<edge_type_t const>(org_edge_types.data(), org_edge_types.size()),
+        remove_multi_edges_usecase.num_chunks);
+
+    if (cugraph::test::g_perf) {
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      hr_timer.start("Remove multi-edges (src, dst, weight, edge_id, edge_type)");
+    }
+
+    if (src_chunks.size() == 1) {
+      std::optional<rmm::device_uvector<weight_t>> tmp_weights{};
+      std::optional<rmm::device_uvector<edge_t>> tmp_edge_ids{};
+      std::optional<rmm::device_uvector<edge_type_t>> tmp_edge_types{};
+      std::tie(result_srcs,
+               result_dsts,
+               tmp_weights,
+               tmp_edge_ids,
+               tmp_edge_types,
+               std::ignore,
+               std::ignore) =
+        cugraph::remove_multi_edges<vertex_t, edge_t, weight_t, edge_type_t, edge_time_t>(
+          handle,
+          std::move(src_chunks[0]),
+          std::move(dst_chunks[0]),
+          std::move(weight_chunks[0]),
+          std::move(edge_id_chunks[0]),
+          std::move(edge_type_chunks[0]),
+          std::nullopt,
+          std::nullopt,
+          remove_multi_edges_usecase.keep_min_value_edge);
+      result_weights    = std::move(*tmp_weights);
+      result_edge_ids   = std::move(*tmp_edge_ids);
+      result_edge_types = std::move(*tmp_edge_types);
+    } else {
+      auto [result_src_chunks,
+            result_dst_chunks,
+            result_weight_chunks,
+            result_edge_id_chunks,
+            result_edge_type_chunks,
+            result_edge_start_time_chunks /* dummy */,
+            result_edge_end_time_chunks /* dummy */] =
+        cugraph::remove_multi_edges<vertex_t, edge_t, weight_t, edge_type_t, edge_time_t>(
+          handle,
+          std::move(src_chunks),
+          std::move(dst_chunks),
+          std::move(weight_chunks),
+          std::move(edge_id_chunks),
+          std::move(edge_type_chunks),
+          std::nullopt,
+          std::nullopt,
+          remove_multi_edges_usecase.keep_min_value_edge);
+      result_srcs       = aggregate_buffers(handle, std::move(result_src_chunks));
+      result_dsts       = aggregate_buffers(handle, std::move(result_dst_chunks));
+      result_weights    = aggregate_buffers(handle, std::move(*result_weight_chunks));
+      result_edge_ids   = aggregate_buffers(handle, std::move(*result_edge_id_chunks));
+      result_edge_types = aggregate_buffers(handle, std::move(*result_edge_type_chunks));
+    }
+
+    if (cugraph::test::g_perf) {
+      RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
+      hr_timer.stop();
+      hr_timer.display_and_clear(std::cout);
+    }
+
+    if (remove_multi_edges_usecase.check_correctness) {
+      auto h_org_srcs       = cugraph::test::to_host(handle, org_srcs);
+      auto h_org_dsts       = cugraph::test::to_host(handle, org_dsts);
+      auto h_org_weights    = cugraph::test::to_host(handle, org_weights);
+      auto h_org_edge_ids   = cugraph::test::to_host(handle, org_edge_ids);
+      auto h_org_edge_types = cugraph::test::to_host(handle, org_edge_types);
+      std::vector<std::tuple<vertex_t, vertex_t, weight_t, edge_t, edge_type_t>> h_org_edges(
+        h_org_srcs.size());
+      for (size_t i = 0; i < h_org_srcs.size(); ++i) {
+        h_org_edges[i] = std::make_tuple(
+          h_org_srcs[i], h_org_dsts[i], h_org_weights[i], h_org_edge_ids[i], h_org_edge_types[i]);
+      }
+      std::sort(h_org_edges.begin(), h_org_edges.end());
+      h_org_edges.resize(
+        std::distance(h_org_edges.begin(), std::unique(h_org_edges.begin(), h_org_edges.end())));
+
+      auto h_result_srcs       = cugraph::test::to_host(handle, result_srcs);
+      auto h_result_dsts       = cugraph::test::to_host(handle, result_dsts);
+      auto h_result_weights    = cugraph::test::to_host(handle, result_weights);
+      auto h_result_edge_ids   = cugraph::test::to_host(handle, result_edge_ids);
+      auto h_result_edge_types = cugraph::test::to_host(handle, result_edge_types);
+      std::vector<std::tuple<vertex_t, vertex_t, weight_t, edge_t, edge_type_t>> h_result_edges(
+        h_result_srcs.size());
+      for (size_t i = 0; i < h_result_srcs.size(); ++i) {
+        h_result_edges[i] = std::make_tuple(h_result_srcs[i],
+                                            h_result_dsts[i],
+                                            h_result_weights[i],
+                                            h_result_edge_ids[i],
+                                            h_result_edge_types[i]);
+      }
+      std::sort(h_result_edges.begin(), h_result_edges.end());
+
+      ASSERT_EQ(h_org_edges.size(), h_result_edges.size());
+      if (remove_multi_edges_usecase.keep_min_value_edge) {
+        ASSERT_TRUE(std::equal(h_org_edges.begin(), h_org_edges.end(), h_result_edges.begin()));
+      } else {
+        ASSERT_TRUE(std::equal(
+          h_org_edges.begin(), h_org_edges.end(), h_result_edges.begin(), [](auto lhs, auto rhs) {
+            return std::get<0>(lhs) == std::get<0>(rhs) && std::get<1>(lhs) == std::get<1>(rhs);
+          }));
+      }
+    }
+  }
+};
+
+using Tests_RemoveMultiEdges_File = Tests_RemoveMultiEdges<cugraph::test::File_Usecase>;
+using Tests_RemoveMultiEdges_Rmat = Tests_RemoveMultiEdges<cugraph::test::Rmat_Usecase>;
+
+TEST_P(Tests_RemoveMultiEdges_File, CheckInt32Int32)
+{
+  auto param = GetParam();
+  run_current_test<int32_t, int32_t>(std::get<0>(param), std::get<1>(param));
+}
+
+TEST_P(Tests_RemoveMultiEdges_Rmat, CheckInt32Int32)
+{
+  auto param = GetParam();
+  run_current_test<int32_t, int32_t>(std::get<0>(param), std::get<1>(param));
+}
+
+TEST_P(Tests_RemoveMultiEdges_Rmat, CheckInt64Int64)
+{
+  auto param = GetParam();
+  run_current_test<int64_t, int64_t>(std::get<0>(param), std::get<1>(param));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  file_test,
+  Tests_RemoveMultiEdges_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(RemoveMultiEdges_Usecase{1, false},
+                      RemoveMultiEdges_Usecase{1, true},
+                      RemoveMultiEdges_Usecase{4, false},
+                      RemoveMultiEdges_Usecase{4, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_large_test,
+  Tests_RemoveMultiEdges_File,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(RemoveMultiEdges_Usecase{1, false},
+                      RemoveMultiEdges_Usecase{1, true},
+                      RemoveMultiEdges_Usecase{4, false},
+                      RemoveMultiEdges_Usecase{4, true}),
+    ::testing::Values(cugraph::test::File_Usecase("test/datasets/web-Google.mtx"),
+                      cugraph::test::File_Usecase("test/datasets/webbase-1M.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  rmat_small_test,
+  Tests_RemoveMultiEdges_Rmat,
+  ::testing::Combine(
+    // enable correctness checks
+    ::testing::Values(RemoveMultiEdges_Usecase{1, false},
+                      RemoveMultiEdges_Usecase{1, true},
+                      RemoveMultiEdges_Usecase{4, false},
+                      RemoveMultiEdges_Usecase{4, true}),
+    ::testing::Values(cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false))));
+
+INSTANTIATE_TEST_SUITE_P(
+  rmat_benchmark_test, /* note that scale & edge factor can be overridden in benchmarking (with
+                          --gtest_filter to select only the rmat_benchmark_test with a specific
+                          vertex & edge type combination) by command line arguments and do not
+                          include more than one Rmat_Usecase that differ only in scale or edge
+                          factor (to avoid running same benchmarks more than once) */
+  Tests_RemoveMultiEdges_Rmat,
+  ::testing::Combine(
+    // disable correctness checks for large graphs
+    ::testing::Values(RemoveMultiEdges_Usecase{1, false, false},
+                      RemoveMultiEdges_Usecase{1, true, false},
+                      RemoveMultiEdges_Usecase{4, false, false},
+                      RemoveMultiEdges_Usecase{4, true, false}),
+    ::testing::Values(cugraph::test::Rmat_Usecase(20, 32, 0.57, 0.19, 0.19, 0, false, false))));
+
+CUGRAPH_TEST_PROGRAM_MAIN()

--- a/cpp/tests/structure/remove_multi_edges_test.cpp
+++ b/cpp/tests/structure/remove_multi_edges_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
We can create a graph from an edge list in a single chunk or multiple chunks (e.g. reading from multiple files, and this has advantage in peak memory requirement).

To support the latter case, this PR updates the `remove_multi_edges` function to take an edge list in multiple chunks.

Tests were previously missing and this PR adds tests as well.