### PR TITLE
[CTK 12.5]: Avoid another compiler issue with host device detection

### DIFF
--- a/cpp/include/cugraph/edge_property.hpp
+++ b/cpp/include/cugraph/edge_property.hpp
@@ -54,6 +54,10 @@ class edge_property_view_t {
 
   // nvcc 12.5 sometimes deduces this as a host device function, just defining it fixes that
   ~edge_property_view_t() {}
+  edge_property_view_t(const edge_property_view_t&)            = default;
+  edge_property_view_t(edge_property_view_t&&)                 = default;
+  edge_property_view_t& operator=(const edge_property_view_t&) = default;
+  edge_property_view_t& operator=(edge_property_view_t&&)      = default;
 
   std::vector<ValueIterator> const& value_firsts() const { return edge_partition_value_firsts_; }
 
@@ -115,6 +119,10 @@ class edge_property_t {
 
   // nvcc 12.5 sometimes deduces this as a host device function, just defining it fixes that
   ~edge_property_t() {}
+  edge_property_t(const edge_property_t&)            = default;
+  edge_property_t(edge_property_t&&)                 = default;
+  edge_property_t& operator=(const edge_property_t&) = default;
+  edge_property_t& operator=(edge_property_t&&)      = default;
 
   void clear(raft::handle_t const& handle)
   {

--- a/cpp/include/cugraph/edge_property.hpp
+++ b/cpp/include/cugraph/edge_property.hpp
@@ -119,9 +119,9 @@ class edge_property_t {
 
   // nvcc 12.5 sometimes deduces this as a host device function, just defining it fixes that
   ~edge_property_t() {}
-  edge_property_t(const edge_property_t&)            = default;
+  edge_property_t(const edge_property_t&)            = delete;
+  edge_property_t& operator=(const edge_property_t&) = delete;
   edge_property_t(edge_property_t&&)                 = default;
-  edge_property_t& operator=(const edge_property_t&) = default;
   edge_property_t& operator=(edge_property_t&&)      = default;
 
   void clear(raft::handle_t const& handle)

--- a/cpp/include/cugraph/edge_property.hpp
+++ b/cpp/include/cugraph/edge_property.hpp
@@ -113,6 +113,9 @@ class edge_property_t {
   {
   }
 
+  // nvcc 12.5 sometimes deduces this as a host device function, just defining it fixes that
+  ~edge_property_t() {}
+
   void clear(raft::handle_t const& handle)
   {
     buffers_.clear();


### PR DESCRIPTION
NVCC seems to also incorrectly deduce this in 12.5