### PR TITLE
Fix update-version script

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -59,6 +59,8 @@ DEPENDENCIES=(
   dask-cudf
   libcudf
   libcugraph
+  libcugraph_etl
+  libcugraph-tests
   libraft
   librmm
   pylibcugraph


### PR DESCRIPTION
Add two new dependencies to `update-version.sh`

Skipping CI because this script is not tested in CI
