### PR TITLE
ci: pre-filter 11.4 jobs before they are enabled in shared workflows

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -111,6 +111,9 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
+      # Filtering out 11.4 runs until 11.4 issues are resolved
+      # See https://github.com/rapidsai/build-planning/issues/164
+      matrix_filter: map(select(.CUDA_VER != "11.4.3"))
   conda-cpp-checks:
     needs: conda-cpp-build
     secrets: inherit
@@ -132,6 +135,9 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
       build_type: pull-request
+      # Filtering out 11.4 runs until 11.4 issues are resolved
+      # See https://github.com/rapidsai/build-planning/issues/164
+      matrix_filter: map(select(.CUDA_VER != "11.4.3"))
   conda-notebook-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit


### PR DESCRIPTION
This PR adds a filter to skip CUDA 11.4 jobs on PRs as a precursor to enabling them in shared-workflows.
Once the 11.4 issues are fixed, this matrix filter should be removed so 11.4 gets tested on PRs.

xref: rapidsai/build-planning#164

