### PR TITLE
Revert "temporarily increase the timeout for nightly test failures" (#4957)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,9 +56,6 @@ jobs:
         uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:
           repo: cugraph
-          # TODO: remove this once upstream issues in RAFT are resolved on 11.4.
-          # The limit was temporarily increased to unblock work.
-          max_days_without_success: 30
   changed-files:
     secrets: inherit
     needs: telemetry-setup


### PR DESCRIPTION
This PR adds the nightly CI check back and removes the temporarily increase length as nightlies were blocked due to failing changes in RAFT that are now resolved as of https://github.com/rapidsai/raft/actions/runs/13913530930