### PR TITLE
Fix compiler dependency on ARM

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -358,7 +358,7 @@ dependencies:
               arch: aarch64
               cuda: "11.8"
             packages:
-              - gcc_linux-64=11.*
+              - gcc_linux-aarch64=11.*
               - nvcc_linux-aarch64=11.8
           - matrix:
               arch: x86_64


### PR DESCRIPTION
I noticed that `dependencies.yaml` had a dependency on an `x86_64` compiler on `aarch64`. This was a typo, not an attempt at cross-compilation.
