### PR TITLE
Remove largest property graph test to avoid OOM in CI

### DIFF
--- a/python/cugraph/cugraph/tests/data_store/test_property_graph.py
+++ b/python/cugraph/cugraph/tests/data_store/test_property_graph.py
@@ -2647,7 +2647,7 @@ def bench_add_edges_cyber(benchmark, N):
 
 
 # @pytest.mark.slow
-@pytest.mark.parametrize("n_rows", [10_000, 100_000, 1_000_000, 10_000_000])
+@pytest.mark.parametrize("n_rows", [10_000, 100_000, 1_000_000])
 @pytest.mark.parametrize("n_feats", [32, 64, 128])
 def bench_add_vector_features(benchmark, n_rows, n_feats):
     from cugraph.experimental import PropertyGraph


### PR DESCRIPTION
25.04 nightly tests are now failing in CI with an OOM in the property graph tests.  We are using smaller memory GPUs, so this PR will shrink the memory usage.