### PR TITLE
Revert hacks around compile issue with host device deduction

### DIFF
--- a/cpp/include/cugraph/edge_property.hpp
+++ b/cpp/include/cugraph/edge_property.hpp
@@ -52,9 +52,6 @@ class edge_property_view_t {
   {
   }
 
-  // nvcc 12.5 sometimes deduces this as a host device function, just defining it fixes that
-  ~edge_property_view_t() {}
-
   std::vector<ValueIterator> const& value_firsts() const { return edge_partition_value_firsts_; }
 
   std::vector<edge_t> const& edge_counts() const { return edge_partition_edge_counts_; }

--- a/cpp/include/cugraph/edge_property.hpp
+++ b/cpp/include/cugraph/edge_property.hpp
@@ -54,10 +54,6 @@ class edge_property_view_t {
 
   // nvcc 12.5 sometimes deduces this as a host device function, just defining it fixes that
   ~edge_property_view_t() {}
-  edge_property_view_t(const edge_property_view_t&)            = default;
-  edge_property_view_t(edge_property_view_t&&)                 = default;
-  edge_property_view_t& operator=(const edge_property_view_t&) = default;
-  edge_property_view_t& operator=(edge_property_view_t&&)      = default;
 
   std::vector<ValueIterator> const& value_firsts() const { return edge_partition_value_firsts_; }
 
@@ -116,13 +112,6 @@ class edge_property_t {
     : buffers_(std::move(buffers)), edge_counts_(std::move(edge_counts))
   {
   }
-
-  // nvcc 12.5 sometimes deduces this as a host device function, just defining it fixes that
-  ~edge_property_t() {}
-  edge_property_t(const edge_property_t&)            = delete;
-  edge_property_t& operator=(const edge_property_t&) = delete;
-  edge_property_t(edge_property_t&&)                 = default;
-  edge_property_t& operator=(edge_property_t&&)      = default;
 
   void clear(raft::handle_t const& handle)
   {


### PR DESCRIPTION
We found the issue to be in some unclear compile issues within libcu++ `not_fn`, so we can revert all those hacks


Revert "Silence compiler warnings about host device destructor (#4960)"
Revert "[CTK 12.5]: Avoid another compiler issue with host device detection (#4971)"