### PR TITLE
Revert "ci: pre-filter 11.4 jobs before they are enabled in shared workflows (#4975)"

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -108,9 +108,6 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
-      # Filtering out 11.4 runs until 11.4 issues are resolved
-      # See https://github.com/rapidsai/build-planning/issues/164
-      matrix_filter: map(select(.CUDA_VER != "11.4.3"))
   conda-cpp-checks:
     needs: conda-cpp-build
     secrets: inherit
@@ -132,9 +129,6 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
       build_type: pull-request
-      # Filtering out 11.4 runs until 11.4 issues are resolved
-      # See https://github.com/rapidsai/build-planning/issues/164
-      matrix_filter: map(select(.CUDA_VER != "11.4.3"))
   conda-notebook-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit


### PR DESCRIPTION
Now that nightlies are passing, we should be able to test these jobs in PRs.