### PR TITLE
[HOTFIX] Adds deprecation warnings for BulkSampler, bulk sampling API, and DGL extensions.

### DIFF
--- a/python/cugraph/cugraph/gnn/data_loading/bulk_sampler.py
+++ b/python/cugraph/cugraph/gnn/data_loading/bulk_sampler.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -89,6 +89,11 @@ class BulkSampler:
 
         self.__logger = logging.getLogger(__name__)
         self.__logger.setLevel(log_level or logging.WARNING)
+
+        warnings.warn(
+            "The BulkSampler class and bulk sampling API are "
+            "deprecated and will be removed in a future release."
+        )
 
         max_batches_per_partition = seeds_per_call // batch_size
         if batches_per_partition > max_batches_per_partition:

--- a/python/cugraph/cugraph/gnn/dgl_extensions/__init__.py
+++ b/python/cugraph/cugraph/gnn/dgl_extensions/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,3 +10,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import warnings
+
+
+warnings.warn(
+    "The legacy cuGraph-DGL API is deprecated and will be removed in "
+    "a future release. cuGraph-DGL is no longer under active development. "
+    "We strongly recommend migrating to cuGraph-PyG."
+)


### PR DESCRIPTION
Adds deprecation warnings for BulkSampler, bulk sampling API, and DGL extensions.
This is needed for 25.04 to maintain the standard number of releases for a deprecation before removing the features.
