### PR TITLE
Add missing thrust headers & Pass dtype objects to cuDF as_column

### DIFF
--- a/cpp/include/cugraph/utilities/misc_utils.cuh
+++ b/cpp/include/cugraph/utilities/misc_utils.cuh
@@ -28,6 +28,7 @@
 #include <thrust/gather.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
+#include <thrust/scan.h>
 
 #include <optional>
 #include <tuple>

--- a/cpp/src/detail/utility_wrappers_impl.cuh
+++ b/cpp/src/detail/utility_wrappers_impl.cuh
@@ -27,6 +27,7 @@
 #include <cuda/functional>
 #include <thrust/count.h>
 #include <thrust/distance.h>
+#include <thrust/equal.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/reduce.h>

--- a/cpp/tests/centrality/betweenness_centrality_validate.cu
+++ b/cpp/tests/centrality/betweenness_centrality_validate.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 #include "betweenness_centrality_validate.hpp"
 #include "utilities/check_utilities.hpp"
-
 
 #include <thrust/equal.h>
 #include <thrust/sort.h>

--- a/cpp/tests/centrality/betweenness_centrality_validate.cu
+++ b/cpp/tests/centrality/betweenness_centrality_validate.cu
@@ -17,6 +17,8 @@
 #include "betweenness_centrality_validate.hpp"
 #include "utilities/check_utilities.hpp"
 
+
+#include <thrust/equal.h>
 #include <thrust/sort.h>
 
 #include <gtest/gtest.h>

--- a/cpp/tests/community/egonet_validate.cu
+++ b/cpp/tests/community/egonet_validate.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 
 #include <thrust/binary_search.h>
 #include <thrust/count.h>
+#include <thrust/equal.h>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/sort.h>

--- a/cpp/tests/prims/mg_per_v_pair_transform_dst_nbr_intersection.cu
+++ b/cpp/tests/prims/mg_per_v_pair_transform_dst_nbr_intersection.cu
@@ -40,6 +40,7 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <thrust/equal.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/tuple.h>
 

--- a/cpp/tests/prims/mg_per_v_pair_transform_dst_nbr_weighted_intersection.cu
+++ b/cpp/tests/prims/mg_per_v_pair_transform_dst_nbr_weighted_intersection.cu
@@ -41,6 +41,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <thrust/equal.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/tuple.h>
 

--- a/cpp/tests/prims/mg_transform_reduce_dst_nbr_intersection_of_e_endpoints_by_v.cu
+++ b/cpp/tests/prims/mg_transform_reduce_dst_nbr_intersection_of_e_endpoints_by_v.cu
@@ -40,6 +40,7 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <thrust/equal.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/tuple.h>
 

--- a/cpp/tests/utilities/csv_file_utilities.cu
+++ b/cpp/tests/utilities/csv_file_utilities.cu
@@ -25,6 +25,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/distance.h>
+#include <thrust/equal.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/remove.h>
 

--- a/cpp/tests/utilities/thrust_wrapper.cu
+++ b/cpp/tests/utilities/thrust_wrapper.cu
@@ -23,6 +23,7 @@
 
 #include <thrust/copy.h>
 #include <thrust/distance.h>
+#include <thrust/equal.h>
 #include <thrust/extrema.h>
 #include <thrust/gather.h>
 #include <thrust/iterator/zip_iterator.h>

--- a/python/cugraph/cugraph/structure/hypergraph.py
+++ b/python/cugraph/cugraph/structure/hypergraph.py
@@ -630,7 +630,9 @@ def _str_scalar_to_category(size, val):
         mask=None,
         offset=0,
         null_count=0,
-        children=(cudf.core.column.as_column(0, length=size, dtype=np.int32),),
+        children=(
+            cudf.core.column.as_column(0, length=size, dtype=np.dtype(np.int32)),
+        ),
     )
 
 


### PR DESCRIPTION
Note by @jakirkham this includes C++ and Python fixes needed for CI. Details below:

<hr>

From @alliepiper :

Discovered in CCCL CI.

```
/usr/bin/sccache /home/coder/.conda/envs/rapids/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/home/coder/.conda/envs/rapids/bin/x86_64-conda-linux-gnu-c++ -DCUDA_API_PER_THREAD_DEFAULT_STREAM -DCUTLASS_NAMESPACE=raft_cutlass -DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE -DRAFT_COMPILED -DRAFT_LOG_ACTIVE_LEVEL=RAPIDS_LOGGER_LOG_LEVEL_INFO -DRAFT_SYSTEM_LITTLE_ENDIAN=1 -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_DISABLE_ABI_NAMESPACE -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -DTHRUST_IGNORE_ABI_NAMESPACE_ERROR -Dcugraph_EXPORTS -I/home/coder/cugraph/cpp/../thirdparty -I/home/coder/cugraph/cpp/src -I/home/coder/cugraph/cpp/include -I/home/coder/cugraph/cpp/build/conda/cuda-12.8/release/_deps/cccl-src/lib/cmake/thrust/../../../thrust -I/home/coder/cugraph/cpp/build/conda/cuda-12.8/release/_deps/cccl-src/lib/cmake/libcudacxx/../../../libcudacxx/include -I/home/coder/cugraph/cpp/build/conda/cuda-12.8/release/_deps/cccl-src/lib/cmake/cub/../../../cub -I/home/coder/cugraph/cpp/build/conda/cuda-12.8/release/_deps/cuco-src/include -isystem /home/coder/rmm/include -isystem /home/coder/rmm/build/conda/cuda-12.8/release/include -isystem /home/coder/.conda/envs/rapids/targets/x86_64-linux/include -isystem /home/coder/.conda/envs/rapids/include -isystem /home/coder/raft/cpp/include -isystem /home/coder/raft/cpp/build/conda/cuda-12.8/release/include -isystem /home/coder/raft/cpp/build/conda/cuda-12.8/release/_deps/nvidiacutlass-src/include -isystem /home/coder/raft/cpp/build/conda/cuda-12.8/release/_deps/nvidiacutlass-build/include -t=1 -O3 -DNDEBUG -std=c++17 "--generate-code=arch=compute_70,code=[sm_70]" -Xcompiler=-fPIC --expt-extended-lambda --expt-relaxed-constexpr -Werror=cross-execution-space-call -Wno-deprecated-declarations -DRAFT_HIDE_DEPRECATION_WARNINGS -Xptxas=--disable-warnings -Xcompiler=-Wall,-Wno-error=sign-compare,-Wno-error=unused-but-set-variable -Xfatbin=-compress-all -MD -MT CMakeFiles/cugraph.dir/src/detail/utility_wrappers_64.cu.o -MF CMakeFiles/cugraph.dir/src/detail/utility_wrappers_64.cu.o.d -x cu -c /home/coder/cugraph/cpp/src/detail/utility_wrappers_64.cu -o CMakeFiles/cugraph.dir/src/detail/utility_wrappers_64.cu.o
nvcc warning : Support for offline compilation for architectures prior to '<compute/sm/lto>_75' will be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning).
/home/coder/cugraph/cpp/src/detail/utility_wrappers_impl.cuh(191): error: namespace "thrust" has no member "equal"
    return thrust::equal(handle.get_thrust_policy(), span1.begin(), span1.end(), span2.begin());
```

Cugraph CI was failing on this PR with several other missing thrust headers, adding those as I discover them.

<hr>

From @mroeschke :


With https://github.com/rapidsai/cudf/pull/18331, cuDF now requires values passed to `dtype` in `as_column` to be supported data type objects recognized by cuDF (cuDF's custom types or `np.dtype`).

I only found this usage which was passing `np.int32` instead of `np.dtype(np.int32)` which should fix the failures on the Python build