### PR TITLE
Pass dtype objects to cuDF as_column

### DIFF
--- a/python/cugraph/cugraph/structure/hypergraph.py
+++ b/python/cugraph/cugraph/structure/hypergraph.py
@@ -630,7 +630,9 @@ def _str_scalar_to_category(size, val):
         mask=None,
         offset=0,
         null_count=0,
-        children=(cudf.core.column.as_column(0, length=size, dtype=np.int32),),
+        children=(
+            cudf.core.column.as_column(0, length=size, dtype=np.dtype(np.int32)),
+        ),
     )
 
 


### PR DESCRIPTION
With https://github.com/rapidsai/cudf/pull/18331, cuDF now requires values passed to `dtype` in `as_column` to be supported data type objects recognized by cuDF (cuDF's custom types or `np.dtype`).

I only found this usage which was passing `np.int32` instead of `np.dtype(np.int32)` which should fix the failures on the Python build