### PR TITLE
Avoid private cuDF Python APIs

### DIFF
--- a/python/cugraph/cugraph/structure/hypergraph.py
+++ b/python/cugraph/cugraph/structure/hypergraph.py
@@ -351,7 +351,7 @@ def _create_entity_nodes(
                 NODETYPE: key
                 if not categorical_metadata
                 else cudf.CategoricalIndex.from_codes(
-                    codes=[0] * len(events), categories=[key], ordered=False
+                    codes=[0] * len(col), categories=[key], ordered=False
                 ),
             }
         )
@@ -391,7 +391,7 @@ def _create_hyper_nodes(
         "event"
         if not categorical_metadata
         else cudf.CategoricalIndex.from_codes(
-            codes=[0] * len(events), categories=["event"], ordered=False
+            codes=[0] * len(nodes), categories=["event"], ordered=False
         )
     )
     nodes[NODEID] = nodes[EVENTID]


### PR DESCRIPTION
From the discussion in https://github.com/rapidsai/cugraph/pull/5023, cugraph appears to be using some private cuDF Python APIs (from `cudf.core`). It appears their usage can be wholly replaced with public APIs which will prevent breakage as cuDF should be at liberty to modify private functionality.

This PR will require https://github.com/rapidsai/cudf/pull/18485 to be merged first.