### PR TITLE
Fix ForceAtlas2 incorrect loop conditions

### DIFF
--- a/cpp/src/layout/legacy/exact_repulsion.cuh
+++ b/cpp/src/layout/legacy/exact_repulsion.cuh
@@ -30,11 +30,10 @@ __global__ static void repulsion_kernel(const float* restrict x_pos,
                                         const float scaling_ratio,
                                         const vertex_t n)
 {
-  int j = (blockIdx.x * blockDim.x) + threadIdx.x;  // for every item in row
   int i = (blockIdx.y * blockDim.y) + threadIdx.y;  // for every row
   for (; i < n; i += gridDim.y * blockDim.y) {
-    for (; j < n; j += gridDim.x * blockDim.x) {
-      if (j >= i) return;
+    int j = (blockIdx.x * blockDim.x) + threadIdx.x;  // for every item in row
+    for (; j < i; j += gridDim.x * blockDim.x) {
       float x_dist   = x_pos[i] - x_pos[j];
       float y_dist   = y_pos[i] - y_pos[j];
       float distance = x_dist * x_dist + y_dist * y_dist;

--- a/cpp/src/layout/legacy/fa2_kernels.cuh
+++ b/cpp/src/layout/legacy/fa2_kernels.cuh
@@ -47,7 +47,7 @@ __global__ static void attraction_kernel(const vertex_t* restrict row,
     dst = col[i];
 
     // We only need the lower triangular part
-    if (dst <= src) return;
+    if (dst <= src) continue;
 
     if (v) { weight = v[i]; }
     weight = pow(weight, edge_weight_influence);


### PR DESCRIPTION
As noted in #5029, it appears that ForceAtlas2 kernels will sometimes return without computing all forces.

Any of the two following conditions will result in an incorrect computation:
- graphs with more than 8k vertices, if `barnes_hut_optimize` is false (repulsion kernel)
- graphs with more than 16M edges (attraction kernel)