### PR TITLE
Added  #include <cuda/std/cmath> for correct cuda::std::log reference

### DIFF
--- a/cpp/src/prims/detail/sample_and_compute_local_nbr_indices.cuh
+++ b/cpp/src/prims/detail/sample_and_compute_local_nbr_indices.cuh
@@ -37,6 +37,7 @@
 #include <cub/cub.cuh>
 #include <cuda/atomic>
 #include <cuda/functional>
+#include <cuda/std/cmath>
 #include <cuda/std/iterator>
 #include <cuda/std/optional>
 #include <thrust/adjacent_difference.h>

--- a/cpp/src/traversal/od_shortest_distances_impl.cuh
+++ b/cpp/src/traversal/od_shortest_distances_impl.cuh
@@ -130,6 +130,7 @@ struct e_op_t {
   detail::kv_cuco_store_find_device_view_t<detail::kv_cuco_store_view_t<key_t, weight_t const*>>
     key_to_dist_map{};
   tag_t num_origins{};
+  weight_t invalid_distance{};
 
   __device__ thrust::tuple<tag_t, weight_t> operator()(thrust::tuple<vertex_t, tag_t> tagged_src,
                                                        vertex_t dst,
@@ -655,7 +656,8 @@ rmm::device_uvector<weight_t> od_shortest_distances(
 
       auto e_op = e_op_t<vertex_t, od_idx_t, key_t, weight_t>{
         detail::kv_cuco_store_find_device_view_t(key_to_dist_map.view()),
-        static_cast<od_idx_t>(origins.size())};
+        static_cast<od_idx_t>(origins.size()), 
+        invalid_distance};
       detail::transform_reduce_if_v_frontier_call_e_op_t<
         thrust::tuple<vertex_t, od_idx_t>,
         weight_t,

--- a/cpp/src/traversal/od_shortest_distances_impl.cuh
+++ b/cpp/src/traversal/od_shortest_distances_impl.cuh
@@ -656,7 +656,7 @@ rmm::device_uvector<weight_t> od_shortest_distances(
 
       auto e_op = e_op_t<vertex_t, od_idx_t, key_t, weight_t>{
         detail::kv_cuco_store_find_device_view_t(key_to_dist_map.view()),
-        static_cast<od_idx_t>(origins.size()), 
+        static_cast<od_idx_t>(origins.size()),
         invalid_distance};
       detail::transform_reduce_if_v_frontier_call_e_op_t<
         thrust::tuple<vertex_t, od_idx_t>,


### PR DESCRIPTION
1. Added  #include <cuda/std/cmath> for correct cuda::std::log reference in sample_and_compute_local_nbr_indices.cuh
Without proper include, the following error would be raised during building libcugraph in my environment:

```
cpp/src/prims/detail/sample_and_compute_local_nbr_indices.cuh([[1994|2006|2260|2272]]):
error: namespace "cuda::std" has no member "log"
	return cuda::std::min(-cuda::std::log(r) / b, std::numeric_limits<bias_t>::max());
```
2. Update od_shortest_distances_impl.cuh, fix missing required parameter: invalid_distance in struct e_op_t
Without proper include, the following error would be raised during building libcugraph in my environment:

```
cpp/src/traversal/od_shortest_distances_impl.cuh(143):
	Build log is lost, but the line 143 would complain on missing variable invalid_distance.
```


> Apologies for missing the labels earlier, and now I'm not able to edit them myself. Could someone with the appropriate permissions kindly add the 'bug' and 'non-breaking' labels? Thanks for your help!