### PR TITLE
Download build artifacts from GitHub for CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,8 +79,8 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/build_wheel_libcugraph.sh
       node_type: cpu32
+      package-name: libcugraph
       package-type: cpp
-      wheel-name: libcugraph
   wheel-publish-libcugraph:
     needs: wheel-build-libcugraph
     secrets: inherit
@@ -102,8 +102,8 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel_pylibcugraph.sh
+      package-name: pylibcugraph
       package-type: python
-      wheel-name: pylibcugraph
   wheel-publish-pylibcugraph:
     needs: wheel-build-pylibcugraph
     secrets: inherit
@@ -125,8 +125,8 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel_cugraph.sh
+      package-name: cugraph
       package-type: python
-      wheel-name: cugraph
   wheel-publish-cugraph:
     needs: wheel-build-cugraph
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -159,8 +159,8 @@ jobs:
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
       build_type: pull-request
       script: ci/build_wheel_libcugraph.sh
+      package-name: libcugraph
       package-type: cpp
-      wheel-name: libcugraph
   wheel-build-pylibcugraph:
     needs: wheel-build-libcugraph
     secrets: inherit
@@ -168,8 +168,8 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel_pylibcugraph.sh
+      package-name: pylibcugraph
       package-type: python
-      wheel-name: pylibcugraph
   wheel-tests-pylibcugraph:
     needs: [wheel-build-pylibcugraph, changed-files]
     secrets: inherit
@@ -185,8 +185,8 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel_cugraph.sh
+      package-name: cugraph
       package-type: python
-      wheel-name: cugraph
   wheel-tests-cugraph:
     needs: [wheel-build-cugraph, changed-files]
     secrets: inherit

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -10,8 +10,8 @@ else
 fi
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -11,7 +11,7 @@ export CMAKE_GENERATOR=Ninja
 
 rapids-print-env
 
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
 
 rapids-generate-version > ./VERSION
 

--- a/ci/build_wheel_cugraph.sh
+++ b/ci/build_wheel_cugraph.sh
@@ -9,8 +9,8 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
 # Download the libcugraph and pylibcugraph wheels built in the previous step and make them
 # available for pip to find.
-LIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 cpp /tmp/libcugraph_dist)
-PYLIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="pylibcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python /tmp/pylibcugraph_dist)
+LIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
+PYLIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="pylibcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github python)
 
 cat >> ./constraints.txt <<EOF
 libcugraph-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBCUGRAPH_WHEELHOUSE}"/libcugraph_*.whl)

--- a/ci/build_wheel_pylibcugraph.sh
+++ b/ci/build_wheel_pylibcugraph.sh
@@ -9,7 +9,7 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
 # Download the libcugraph wheel built in the previous step and make it
 # available for pip to find.
-LIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 cpp /tmp/libcugraph_dist)
+LIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
 
 cat >> ./constraints.txt <<EOF
 libcugraph-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBCUGRAPH_WHEELHOUSE}"/libcugraph_*.whl)

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 . /opt/conda/etc/profile.d/conda.sh
 
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
 
 rapids-logger "Generate C++ testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -6,8 +6,8 @@ set -Eeuo pipefail
 . /opt/conda/etc/profile.d/conda.sh
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 
 rapids-logger "Generate notebook testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -9,8 +9,8 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 . /opt/conda/etc/profile.d/conda.sh
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_wheel_cugraph.sh
+++ b/ci/test_wheel_cugraph.sh
@@ -6,14 +6,14 @@ set -eoxu pipefail
 # Download the packages built in the previous step
 mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
-RAPIDS_PY_WHEEL_NAME="cugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python ./dist
-RAPIDS_PY_WHEEL_NAME="libcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 cpp ./local-libcugraph-dep
-RAPIDS_PY_WHEEL_NAME="pylibcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python ./local-pylibcugraph-dep
+CUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="cugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github python)
+LIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
+PYLIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="pylibcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github python)
 
 # echo to expand wildcard before adding `[extra]` requires for pip
 rapids-pip-retry install \
-    "$(echo ./dist/cugraph*.whl)[test]" \
-    ./local-pylibcugraph-dep/pylibcugraph*.whl \
-    ./local-libcugraph-dep/libcugraph*.whl
+    "$(echo "${CUGRAPH_WHEELHOUSE}"/cugraph*.whl)[test]" \
+    "${PYLIBCUGRAPH_WHEELHOUSE}/pylibcugraph*.whl" \
+    "${LIBCUGRAPH_WHEELHOUSE}/libcugraph*.whl"
 
 ./ci/test_wheel.sh cugraph

--- a/ci/test_wheel_pylibcugraph.sh
+++ b/ci/test_wheel_pylibcugraph.sh
@@ -4,14 +4,13 @@
 set -eoxu pipefail
 
 # Download the packages built in the previous step
-mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
-RAPIDS_PY_WHEEL_NAME="libcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 cpp ./local-libcugraph-dep
-RAPIDS_PY_WHEEL_NAME="pylibcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python ./dist
+LIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
+PYLIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="pylibcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github python)
 
 # echo to expand wildcard before adding `[extra]` requires for pip
 rapids-pip-retry install \
-    "$(echo ./dist/pylibcugraph*.whl)[test]" \
-    ./local-libcugraph-dep/libcugraph*.whl
+    "$(echo "${PYLIBCUGRAPH_WHEELHOUSE}"/pylibcugraph*.whl)[test]" \
+    "${LIBCUGRAPH_WHEELHOUSE}/libcugraph*.whl"
 
 ./ci/test_wheel.sh pylibcugraph


### PR DESCRIPTION
This work is towards moving build artifacts from `downloads.rapids.ai` to Github Artifact Store (see https://github.com/rapidsai/ops/issues/2982)

Updates conda and wheel artifact download source from S3 to GitHub across CI scripts, wherever applicable. 

Uses dynamic temporary paths for wheel downloads returned by `rapids-download-wheels-from-github` instead of using fixed directories, to streamline wheel downloads in the same way as conda downloads.

Also updates CI workflows to follow `package-name` convention between wheel build and wheel publish jobs. 