### PR TITLE
Fix failing test with new cccl

### DIFF
--- a/cpp/tests/sampling/sampling_heterogeneous_post_processing_test.cpp
+++ b/cpp/tests/sampling/sampling_heterogeneous_post_processing_test.cpp
@@ -497,6 +497,9 @@ class Tests_SamplingHeterogeneousPostProcessing
 
         // Check the invariants in vertex renumber_map
 
+        // FIXME:  Adding this in https://github.com/rapidsai/cugraph/pull/5046 to
+        //         work around a test failure.  Need to investigate the root cause
+        //         of the failure rather than mask it.
         handle.sync_stream();
 
         ASSERT_TRUE(check_vertex_renumber_map_invariants<vertex_t>(

--- a/cpp/tests/sampling/sampling_heterogeneous_post_processing_test.cpp
+++ b/cpp/tests/sampling/sampling_heterogeneous_post_processing_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -496,6 +496,8 @@ class Tests_SamplingHeterogeneousPostProcessing
              "edgelist.";
 
         // Check the invariants in vertex renumber_map
+
+        handle.sync_stream();
 
         ASSERT_TRUE(check_vertex_renumber_map_invariants<vertex_t>(
           handle,


### PR DESCRIPTION
Newest CCCL is causing a test to fail.

This fix adds a sync stream call which seems to address the issue.