### PR TITLE
[BUGFIX] Fixed quoting in wheel paths in cugraph and pylibcugraph tests

### DIFF
--- a/ci/test_wheel_cugraph.sh
+++ b/ci/test_wheel_cugraph.sh
@@ -13,7 +13,7 @@ PYLIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="pylibcugraph_${RAPIDS_PY_CUDA_SU
 # echo to expand wildcard before adding `[extra]` requires for pip
 rapids-pip-retry install \
     "$(echo "${CUGRAPH_WHEELHOUSE}"/cugraph*.whl)[test]" \
-    "${PYLIBCUGRAPH_WHEELHOUSE}/pylibcugraph*.whl" \
-    "${LIBCUGRAPH_WHEELHOUSE}/libcugraph*.whl"
+    "${PYLIBCUGRAPH_WHEELHOUSE}"/pylibcugraph*.whl \
+    "${LIBCUGRAPH_WHEELHOUSE}"/libcugraph*.whl
 
 ./ci/test_wheel.sh cugraph

--- a/ci/test_wheel_pylibcugraph.sh
+++ b/ci/test_wheel_pylibcugraph.sh
@@ -11,6 +11,6 @@ PYLIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="pylibcugraph_${RAPIDS_PY_CUDA_SU
 # echo to expand wildcard before adding `[extra]` requires for pip
 rapids-pip-retry install \
     "$(echo "${PYLIBCUGRAPH_WHEELHOUSE}"/pylibcugraph*.whl)[test]" \
-    "${LIBCUGRAPH_WHEELHOUSE}/libcugraph*.whl"
+    "${LIBCUGRAPH_WHEELHOUSE}"/libcugraph*.whl
 
 ./ci/test_wheel.sh pylibcugraph


### PR DESCRIPTION
Fixes the `libcugraph*.whl is not a valid wheel filename.` bug in the wheel test steps of `pylibcugraph` and `cugraph`on Github CI