### PR TITLE
fix(rattler): add librmm to host to fix overlinking errors

### DIFF
--- a/conda/recipes/libcugraph/recipe.yaml
+++ b/conda/recipes/libcugraph/recipe.yaml
@@ -107,6 +107,7 @@ outputs:
         - ${{ stdlib("c") }}
       host:
         - cuda-version =${{ cuda_version }}
+        - librmm =${{ minor_version }}
         - rapids-logger =0.1
         - if: cuda_major == "11"
           then:
@@ -183,6 +184,7 @@ outputs:
       host:
         - cuda-version =${{ cuda_version }}
         - libcudf =${{ minor_version }}
+        - librmm =${{ minor_version }}
         - if: cuda_major == "11"
           then: cudatoolkit
           else: cuda-cudart-dev


### PR DESCRIPTION
## Description

We need `librmm` for _building_ `libcudf` and `librmm` is available in the cache build stage.  However the overlinking checks happen on a per-output basis and now that `librmm` isn't header-only, `rattler` is detecting a missing link.
This adds the `librmm` entry to the `host` section of the appropriate outputs.

xref rapidsai/build-planning#175
