### PR TITLE
Remove pure=False from client.compute calls

### DIFF
--- a/python/cugraph/cugraph/dask/common/part_utils.py
+++ b/python/cugraph/cugraph/dask/common/part_utils.py
@@ -123,7 +123,7 @@ def persist_dask_df_equal_parts_per_worker(
     persisted_keys_d = {}
     for w, ddf_k in zip(workers, ddf_keys_ls):
         persisted_keys_d[w] = client.compute(
-            ddf_k, workers=w, allow_other_workers=False, pure=False
+            ddf_k, workers=w, allow_other_workers=False,
         )
 
     persisted_keys_ls = [

--- a/python/cugraph/cugraph/dask/common/part_utils.py
+++ b/python/cugraph/cugraph/dask/common/part_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -123,7 +123,9 @@ def persist_dask_df_equal_parts_per_worker(
     persisted_keys_d = {}
     for w, ddf_k in zip(workers, ddf_keys_ls):
         persisted_keys_d[w] = client.compute(
-            ddf_k, workers=w, allow_other_workers=False,
+            ddf_k,
+            workers=w,
+            allow_other_workers=False,
         )
 
     persisted_keys_ls = [

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -391,7 +391,9 @@ class simpleDistributedGraphImpl:
         del persisted_keys_d
         self._plc_graph = {
             w: _client.compute(
-                delayed_task, workers=w, allow_other_workers=False,
+                delayed_task,
+                workers=w,
+                allow_other_workers=False,
             )
             for w, delayed_task in delayed_tasks_d.items()
         }

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
@@ -391,7 +391,7 @@ class simpleDistributedGraphImpl:
         del persisted_keys_d
         self._plc_graph = {
             w: _client.compute(
-                delayed_task, workers=w, allow_other_workers=False, pure=False
+                delayed_task, workers=w, allow_other_workers=False,
             )
             for w, delayed_task in delayed_tasks_d.items()
         }


### PR DESCRIPTION
Removes the invalid keyword argument `pure=False` from `Client.compute` calls. Hoping to fix https://github.com/rapidsai/cugraph/actions/runs/15036791514/job/42294643137?pr=5075#step:9:13232