### PR TITLE
Utility functions to create an edge_src|dst_property view objects.

### DIFF
--- a/cpp/include/cugraph/edge_src_dst_property.hpp
+++ b/cpp/include/cugraph/edge_src_dst_property.hpp
@@ -294,9 +294,9 @@ class edge_major_property_t {
 
   void clear()
   {
-    edge_partition_keys_                    = std::nullopt;
-    edge_partition_key_chunk_start_offsets_ = std::nullopt;
-    key_chunk_size_                         = std::nullopt;
+    edge_partition_keys_.reset();
+    edge_partition_key_chunk_start_offsets_.reset();
+    key_chunk_size_.reset();
 
     buffers_.clear();
     buffers_.shrink_to_fit();
@@ -424,9 +424,9 @@ class edge_minor_property_t {
 
   void clear()
   {
-    keys_                    = std::nullopt;
-    key_chunk_start_offsets_ = std::nullopt;
-    key_chunk_size_          = std::nullopt;
+    keys_.reset();
+    key_chunk_start_offsets_.reset();
+    key_chunk_size_.reset();
 
     rmm::cuda_stream_view stream{};
     if constexpr (std::is_arithmetic_v<T>) {

--- a/cpp/src/community/approx_weighted_matching_impl.cuh
+++ b/cpp/src/community/approx_weighted_matching_impl.cuh
@@ -45,9 +45,7 @@ std::tuple<rmm::device_uvector<vertex_t>, weight_t> approximate_weighted_matchin
                   "Invalid input arguments: input graph for approximate_weighted_matching must "
                   "need to be symmetric");
 
-  using graph_view_t = cugraph::graph_view_t<vertex_t, edge_t, false, multi_gpu>;
-
-  graph_view_t current_graph_view(graph_view);
+  auto current_graph_view = graph_view;
   if (current_graph_view.has_edge_mask()) { current_graph_view.clear_edge_mask(); }
 
   cugraph::edge_property_t<edge_t, bool> edge_masks_even(handle, current_graph_view);
@@ -100,7 +98,7 @@ std::tuple<rmm::device_uvector<vertex_t>, weight_t> approximate_weighted_matchin
   cugraph::edge_src_property_t<vertex_t, bool> src_match_flags(handle);
   cugraph::edge_dst_property_t<vertex_t, bool> dst_match_flags(handle);
 
-  if constexpr (graph_view_t::is_multi_gpu) {
+  if constexpr (multi_gpu) {
     src_key_cache = cugraph::edge_src_property_t<vertex_t, vertex_t>(handle, current_graph_view);
 
     update_edge_src_property(
@@ -129,11 +127,9 @@ std::tuple<rmm::device_uvector<vertex_t>, weight_t> approximate_weighted_matchin
         cugraph::edge_src_dummy_property_t{}.view(),
         cugraph::edge_dst_dummy_property_t{}.view(),
         edge_weight_view,
-        graph_view_t::is_multi_gpu
-          ? src_key_cache.view()
-          : detail::edge_endpoint_property_view_t<vertex_t, vertex_t const*>(
-              std::vector<vertex_t const*>{local_vertices.begin()},
-              std::vector<vertex_t>{vertex_t{0}}),
+        multi_gpu ? src_key_cache.view()
+                  : make_edge_src_property_view<vertex_t, vertex_t>(
+                      current_graph_view, local_vertices.begin(), local_vertices.size()),
         [] __device__(auto, auto dst, cuda::std::nullopt_t, cuda::std::nullopt_t, auto wt) {
           return thrust::make_tuple(wt, dst);
         },
@@ -145,7 +141,7 @@ std::tuple<rmm::device_uvector<vertex_t>, weight_t> approximate_weighted_matchin
     // For each target, find the best offer
     //
 
-    if constexpr (graph_view_t::is_multi_gpu) {
+    if constexpr (multi_gpu) {
       auto vertex_partition_range_lasts = current_graph_view.vertex_partition_range_lasts();
 
       rmm::device_uvector<vertex_t> d_vertex_partition_range_lasts(
@@ -225,7 +221,7 @@ std::tuple<rmm::device_uvector<vertex_t>, weight_t> approximate_weighted_matchin
 
     rmm::device_uvector<vertex_t> candidates_of_candidates(0, handle.get_stream());
 
-    if (graph_view_t::is_multi_gpu) {
+    if constexpr (multi_gpu) {
       auto& comm       = handle.get_comms();
       auto& major_comm = handle.get_subcomm(cugraph::partition_manager::major_comm_name());
       auto const major_comm_size = major_comm.get_size();
@@ -302,7 +298,7 @@ std::tuple<rmm::device_uvector<vertex_t>, weight_t> approximate_weighted_matchin
 
     if (current_graph_view.compute_number_of_edges(handle) == 0) { break; }
 
-    if constexpr (graph_view_t::is_multi_gpu) {
+    if constexpr (multi_gpu) {
       cugraph::update_edge_src_property(
         handle, current_graph_view, is_vertex_matched.begin(), src_match_flags.mutable_view());
       cugraph::update_edge_dst_property(
@@ -310,7 +306,7 @@ std::tuple<rmm::device_uvector<vertex_t>, weight_t> approximate_weighted_matchin
     }
 
     if (loop_counter % 2 == 0) {
-      if constexpr (graph_view_t::is_multi_gpu) {
+      if constexpr (multi_gpu) {
         cugraph::transform_e(
           handle,
           current_graph_view,
@@ -326,14 +322,17 @@ std::tuple<rmm::device_uvector<vertex_t>, weight_t> approximate_weighted_matchin
         cugraph::transform_e(
           handle,
           current_graph_view,
-          detail::edge_endpoint_property_view_t<vertex_t, bool const*>(
-            std::vector<bool const*>{is_vertex_matched.begin()},
-            std::vector<vertex_t>{vertex_t{0}}),
-          detail::edge_endpoint_property_view_t<vertex_t, bool const*>(is_vertex_matched.begin(),
-                                                                       vertex_t{0}),
+          cugraph::edge_src_dummy_property_t{}.view(),
+          cugraph::edge_dst_dummy_property_t{}.view(),
           cugraph::edge_dummy_property_t{}.view(),
-          [] __device__(
-            auto src, auto dst, auto is_src_matched, auto is_dst_matched, cuda::std::nullopt_t) {
+          [is_vertex_matched = raft::device_span<bool const>(
+             is_vertex_matched.data(), is_vertex_matched.size())] __device__(auto src,
+                                                                             auto dst,
+                                                                             cuda::std::nullopt_t,
+                                                                             cuda::std::nullopt_t,
+                                                                             cuda::std::nullopt_t) {
+            auto is_src_matched = is_vertex_matched[src];
+            auto is_dst_matched = is_vertex_matched[dst];
             return !((is_src_matched == true) || (is_dst_matched == true));
           },
           edge_masks_odd.mutable_view());
@@ -344,7 +343,7 @@ std::tuple<rmm::device_uvector<vertex_t>, weight_t> approximate_weighted_matchin
         handle, current_graph_view, edge_masks_even.mutable_view(), bool{false});
       current_graph_view.attach_edge_mask(edge_masks_odd.view());
     } else {
-      if constexpr (graph_view_t::is_multi_gpu) {
+      if constexpr (multi_gpu) {
         cugraph::transform_e(
           handle,
           current_graph_view,
@@ -360,14 +359,17 @@ std::tuple<rmm::device_uvector<vertex_t>, weight_t> approximate_weighted_matchin
         cugraph::transform_e(
           handle,
           current_graph_view,
-          detail::edge_endpoint_property_view_t<vertex_t, bool const*>(
-            std::vector<bool const*>{is_vertex_matched.begin()},
-            std::vector<vertex_t>{vertex_t{0}}),
-          detail::edge_endpoint_property_view_t<vertex_t, bool const*>(is_vertex_matched.begin(),
-                                                                       vertex_t{0}),
+          cugraph::edge_src_dummy_property_t{}.view(),
+          cugraph::edge_dst_dummy_property_t{}.view(),
           cugraph::edge_dummy_property_t{}.view(),
-          [] __device__(
-            auto src, auto dst, auto is_src_matched, auto is_dst_matched, cuda::std::nullopt_t) {
+          [is_vertex_matched = raft::device_span<bool const>(
+             is_vertex_matched.data(), is_vertex_matched.size())] __device__(auto src,
+                                                                             auto dst,
+                                                                             cuda::std::nullopt_t,
+                                                                             cuda::std::nullopt_t,
+                                                                             cuda::std::nullopt_t) {
+            auto is_src_matched = is_vertex_matched[src];
+            auto is_dst_matched = is_vertex_matched[dst];
             return !((is_src_matched == true) || (is_dst_matched == true));
           },
           edge_masks_even.mutable_view());
@@ -385,13 +387,14 @@ std::tuple<rmm::device_uvector<vertex_t>, weight_t> approximate_weighted_matchin
   weight_t sum_matched_edge_weights = thrust::reduce(
     handle.get_thrust_policy(), offers_from_partners.begin(), offers_from_partners.end());
 
-  if constexpr (graph_view_t::is_multi_gpu) {
+  if constexpr (multi_gpu) {
     sum_matched_edge_weights = host_scalar_allreduce(
       handle.get_comms(), sum_matched_edge_weights, raft::comms::op_t::SUM, handle.get_stream());
   }
 
   return std::make_tuple(std::move(partners), sum_matched_edge_weights / 2.0);
 }
+
 }  // namespace detail
 
 template <typename vertex_t, typename edge_t, typename weight_t, bool multi_gpu>

--- a/cpp/src/community/detail/maximal_independent_moves.cuh
+++ b/cpp/src/community/detail/maximal_independent_moves.cuh
@@ -179,12 +179,11 @@ rmm::device_uvector<vertex_t> maximal_independent_moves(
       handle,
       graph_view,
       multi_gpu ? src_rank_cache.view()
-                : detail::edge_endpoint_property_view_t<vertex_t, vertex_t const*>(
-                    std::vector<vertex_t const*>{temporary_ranks.data()},
-                    std::vector<vertex_t>{vertex_t{0}}),
+                : make_edge_src_property_view<vertex_t, vertex_t>(
+                    graph_view, temporary_ranks.begin(), temporary_ranks.size()),
       multi_gpu ? dst_rank_cache.view()
-                : detail::edge_endpoint_property_view_t<vertex_t, vertex_t const*>(
-                    temporary_ranks.data(), vertex_t{0}),
+                : make_edge_dst_property_view<vertex_t, vertex_t>(
+                    graph_view, temporary_ranks.begin(), temporary_ranks.size()),
       edge_dummy_property_t{}.view(),
       [] __device__(auto src, auto dst, auto src_rank, auto dst_rank, auto wt) { return dst_rank; },
       std::numeric_limits<vertex_t>::lowest(),
@@ -201,12 +200,11 @@ rmm::device_uvector<vertex_t> maximal_independent_moves(
       handle,
       graph_view,
       multi_gpu ? src_rank_cache.view()
-                : detail::edge_endpoint_property_view_t<vertex_t, vertex_t const*>(
-                    std::vector<vertex_t const*>{temporary_ranks.data()},
-                    std::vector<vertex_t>{vertex_t{0}}),
+                : make_edge_src_property_view<vertex_t, vertex_t>(
+                    graph_view, temporary_ranks.begin(), temporary_ranks.size()),
       multi_gpu ? dst_rank_cache.view()
-                : detail::edge_endpoint_property_view_t<vertex_t, vertex_t const*>(
-                    temporary_ranks.data(), vertex_t{0}),
+                : make_edge_dst_property_view<vertex_t, vertex_t>(
+                    graph_view, temporary_ranks.begin(), temporary_ranks.size()),
       edge_dummy_property_t{}.view(),
       [] __device__(auto src, auto dst, auto src_rank, auto dst_rank, auto wt) { return src_rank; },
       std::numeric_limits<vertex_t>::lowest(),

--- a/cpp/src/components/mis_impl.cuh
+++ b/cpp/src/components/mis_impl.cuh
@@ -189,12 +189,11 @@ rmm::device_uvector<vertex_t> maximal_independent_set(
       handle,
       graph_view,
       multi_gpu ? src_rank_cache.view()
-                : detail::edge_endpoint_property_view_t<vertex_t, vertex_t const*>(
-                    std::vector<vertex_t const*>{temporary_ranks.data()},
-                    std::vector<vertex_t>{vertex_t{0}}),
+                : make_edge_src_property_view<vertex_t, vertex_t>(
+                    graph_view, temporary_ranks.begin(), temporary_ranks.size()),
       multi_gpu ? dst_rank_cache.view()
-                : detail::edge_endpoint_property_view_t<vertex_t, vertex_t const*>(
-                    temporary_ranks.data(), vertex_t{0}),
+                : make_edge_dst_property_view<vertex_t, vertex_t>(
+                    graph_view, temporary_ranks.begin(), temporary_ranks.size()),
       edge_dummy_property_t{}.view(),
       [] __device__(auto src, auto dst, auto src_rank, auto dst_rank, auto wt) { return dst_rank; },
       std::numeric_limits<vertex_t>::lowest(),
@@ -211,12 +210,11 @@ rmm::device_uvector<vertex_t> maximal_independent_set(
       handle,
       graph_view,
       multi_gpu ? src_rank_cache.view()
-                : detail::edge_endpoint_property_view_t<vertex_t, vertex_t const*>(
-                    std::vector<vertex_t const*>{temporary_ranks.data()},
-                    std::vector<vertex_t>{vertex_t{0}}),
+                : make_edge_src_property_view<vertex_t, vertex_t>(
+                    graph_view, temporary_ranks.begin(), temporary_ranks.size()),
       multi_gpu ? dst_rank_cache.view()
-                : detail::edge_endpoint_property_view_t<vertex_t, vertex_t const*>(
-                    temporary_ranks.data(), vertex_t{0}),
+                : make_edge_dst_property_view<vertex_t, vertex_t>(
+                    graph_view, temporary_ranks.begin(), temporary_ranks.size()),
       edge_dummy_property_t{}.view(),
       [] __device__(auto src, auto dst, auto src_rank, auto dst_rank, auto wt) { return src_rank; },
       std::numeric_limits<vertex_t>::lowest(),

--- a/cpp/src/components/vertex_coloring_impl.cuh
+++ b/cpp/src/components/vertex_coloring_impl.cuh
@@ -112,13 +112,14 @@ rmm::device_uvector<vertex_t> vertex_coloring(
       cugraph::transform_e(
         handle,
         current_graph_view,
-        graph_view_t::is_multi_gpu ? src_mis_flags.view()
-                                   : detail::edge_endpoint_property_view_t<vertex_t, flag_t const*>(
-                                       std::vector<flag_t const*>{is_vertex_in_mis.begin()},
-                                       std::vector<vertex_t>{vertex_t{0}}),
-        graph_view_t::is_multi_gpu ? dst_mis_flags.view()
-                                   : detail::edge_endpoint_property_view_t<vertex_t, flag_t const*>(
-                                       is_vertex_in_mis.begin(), vertex_t{0}),
+        graph_view_t::is_multi_gpu
+          ? src_mis_flags.view()
+          : make_edge_src_property_view<vertex_t, flag_t>(
+              current_graph_view, is_vertex_in_mis.begin(), is_vertex_in_mis.size()),
+        graph_view_t::is_multi_gpu
+          ? dst_mis_flags.view()
+          : make_edge_dst_property_view<vertex_t, flag_t>(
+              current_graph_view, is_vertex_in_mis.begin(), is_vertex_in_mis.size()),
         cugraph::edge_dummy_property_t{}.view(),
         [color_id] __device__(
           auto src, auto dst, auto is_src_in_mis, auto is_dst_in_mis, cuda::std::nullopt_t) {
@@ -134,13 +135,14 @@ rmm::device_uvector<vertex_t> vertex_coloring(
       cugraph::transform_e(
         handle,
         current_graph_view,
-        graph_view_t::is_multi_gpu ? src_mis_flags.view()
-                                   : detail::edge_endpoint_property_view_t<vertex_t, flag_t const*>(
-                                       std::vector<flag_t const*>{is_vertex_in_mis.begin()},
-                                       std::vector<vertex_t>{vertex_t{0}}),
-        graph_view_t::is_multi_gpu ? dst_mis_flags.view()
-                                   : detail::edge_endpoint_property_view_t<vertex_t, flag_t const*>(
-                                       is_vertex_in_mis.begin(), vertex_t{0}),
+        graph_view_t::is_multi_gpu
+          ? src_mis_flags.view()
+          : make_edge_src_property_view<vertex_t, flag_t>(
+              current_graph_view, is_vertex_in_mis.begin(), is_vertex_in_mis.size()),
+        graph_view_t::is_multi_gpu
+          ? dst_mis_flags.view()
+          : make_edge_dst_property_view<vertex_t, flag_t>(
+              current_graph_view, is_vertex_in_mis.begin(), is_vertex_in_mis.size()),
         cugraph::edge_dummy_property_t{}.view(),
         [color_id] __device__(
           auto src, auto dst, auto is_src_in_mis, auto is_dst_in_mis, cuda::std::nullopt_t) {

--- a/cpp/src/components/weakly_connected_components_impl.cuh
+++ b/cpp/src/components/weakly_connected_components_impl.cuh
@@ -738,8 +738,10 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
                 ? detail::edge_partition_endpoint_property_device_view_t<vertex_t, vertex_t*>(
                     edge_dst_components.mutable_view())
                 : detail::edge_partition_endpoint_property_device_view_t<vertex_t, vertex_t*>(
-                    detail::edge_endpoint_property_view_t<vertex_t, vertex_t*>(level_components,
-                                                                               vertex_t{0})),
+                    make_edge_dst_property_mutable_view<vertex_t, vertex_t>(
+                      level_graph_view,
+                      level_components,
+                      static_cast<size_t>(level_graph_view.local_vertex_partition_range_size()))),
               level_graph_view.local_edge_partition_dst_range_first(),
               get_dataframe_buffer_begin(edge_buffer),
               num_edge_inserts.data()});

--- a/cpp/src/traversal/sssp_impl.cuh
+++ b/cpp/src/traversal/sssp_impl.cuh
@@ -210,8 +210,8 @@ void sssp(raft::handle_t const& handle,
         vertex_frontier.bucket(bucket_idx_cur_near),
         GraphViewType::is_multi_gpu
           ? edge_src_distances.view()
-          : detail::edge_endpoint_property_view_t<vertex_t, weight_t const*>(
-              std::vector<weight_t const*>{distances}, std::vector<vertex_t>{vertex_t{0}}),
+          : make_edge_src_property_view<vertex_t, weight_t>(
+              push_graph_view, distances, push_graph_view.local_vertex_partition_range_size()),
         edge_dst_dummy_property_t{}.view(),
         edge_weight_view,
         e_op_t<vertex_t, weight_t>{},


### PR DESCRIPTION
In SG, the vertex range of edge source/destination property values coincide with the local vertex partition size; so, creating owning data structures for both vertex property values & edge source|destination property values waste memory.

Users can directly call detail::edge_endpoint_property_view_t constructor functions to avoid this (this was considered as tricks for advanced users). To make this easier, this PR adds non-detail space utility functions.