### PR TITLE
Update method retrieving the edgelist

### DIFF
--- a/python/cugraph/cugraph/structure/graph_classes.py
+++ b/python/cugraph/cugraph/structure/graph_classes.py
@@ -72,9 +72,9 @@ class Graph:
                     # with different weight column names than the one provided
                     # by the user.
                     weights = m_graph.weight_column
-                    elist = elist.rename(
-                        columns={'weight': weights}
-                    ).reset_index(drop=True)
+                    elist = elist.rename(columns={"weight": weights}).reset_index(
+                        drop=True
+                    )
                 else:
                     weights = None
                 self.from_cudf_edgelist(

--- a/python/cugraph/cugraph/structure/graph_classes.py
+++ b/python/cugraph/cugraph/structure/graph_classes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -68,7 +68,13 @@ class Graph:
             if isinstance(m_graph, MultiGraph):
                 elist = m_graph.view_edge_list()
                 if m_graph.is_weighted():
+                    # 'view_edge_list' retrieves the edgelist possibly
+                    # with different weight column names than the one provided
+                    # by the user.
                     weights = m_graph.weight_column
+                    elist = elist.rename(
+                        columns={'weight': weights}
+                    ).reset_index(drop=True)
                 else:
                     weights = None
                 self.from_cudf_edgelist(

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
@@ -463,14 +463,14 @@ class simpleDistributedGraphImpl:
                 # FIXME: Use the renumbered vertices instead and then un-renumber.
                 # This operation can be expensive.
                 is_string_dtype = True
-                edgelist_df = self.decompress_to_edgelist()
+                edgelist_df = self.edgelist.edgelist_df
                 srcCol = self.renumber_map.renumbered_src_col_name
                 dstCol = self.renumber_map.renumbered_dst_col_name
 
             if isinstance(srcCol, list):
                 srcCol = self.renumber_map.renumbered_src_col_name
                 dstCol = self.renumber_map.renumbered_dst_col_name
-                edgelist_df = self.decompress_to_edgelist()
+                edgelist_df = self.edgelist.edgelist_df
                 # unrenumber before extracting the upper triangular part
                 if len(self.source_columns) == 1:
                     edgelist_df = self.renumber_map.unrenumber(edgelist_df, srcCol)

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
@@ -463,14 +463,14 @@ class simpleDistributedGraphImpl:
                 # FIXME: Use the renumbered vertices instead and then un-renumber.
                 # This operation can be expensive.
                 is_string_dtype = True
-                edgelist_df = self.edgelist.edgelist_df
+                edgelist_df = self.decompress_to_edgelist()
                 srcCol = self.renumber_map.renumbered_src_col_name
                 dstCol = self.renumber_map.renumbered_dst_col_name
 
             if isinstance(srcCol, list):
                 srcCol = self.renumber_map.renumbered_src_col_name
                 dstCol = self.renumber_map.renumbered_dst_col_name
-                edgelist_df = self.edgelist.edgelist_df
+                edgelist_df = self.decompress_to_edgelist()
                 # unrenumber before extracting the upper triangular part
                 if len(self.source_columns) == 1:
                     edgelist_df = self.renumber_map.unrenumber(edgelist_df, srcCol)

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -476,7 +476,6 @@ class simpleGraphImpl:
         else:
             use_initial_input_df = False
             return_unrenumbered_edgelist = False
-        
 
         if self.properties.directed:
             # If the graph is directed, no need for the renumbered edgelist
@@ -484,15 +483,16 @@ class simpleGraphImpl:
             return_unrenumbered_edgelist = True
 
         if use_initial_input_df and self.properties.directed:
-            edgelist_df = self.input_df # Original input.
+            edgelist_df = self.input_df  # Original input.
         else:
             edgelist_df = self.decompress_to_edgelist(
-                return_unrenumbered_edgelist=return_unrenumbered_edgelist)
+                return_unrenumbered_edgelist=return_unrenumbered_edgelist
+            )
 
             if self.properties.renumbered:
                 edgelist_df = edgelist_df.rename(
-                        columns=self.renumber_map.internal_to_external_col_names
-                    )
+                    columns=self.renumber_map.internal_to_external_col_names
+                )
 
             if srcCol is None and dstCol is None:
                 srcCol = simpleGraphImpl.srcCol
@@ -518,7 +518,8 @@ class simpleGraphImpl:
             if not self.properties.directed:
 
                 edgelist_df = self.decompress_to_edgelist(
-                    return_unrenumbered_edgelist=return_unrenumbered_edgelist)
+                    return_unrenumbered_edgelist=return_unrenumbered_edgelist
+                )
 
                 # Need to leverage the renumbered edgelist to extract the upper
                 # triangular matrix for multi-column or string vertices
@@ -529,7 +530,7 @@ class simpleGraphImpl:
 
                 # unrenumber the edgelist
                 edgelist_df = self.renumber_map.unrenumber(
-                edgelist_df, simpleGraphImpl.srcCol
+                    edgelist_df, simpleGraphImpl.srcCol
                 )
                 edgelist_df = self.renumber_map.unrenumber(
                     edgelist_df, simpleGraphImpl.dstCol
@@ -562,7 +563,6 @@ class simpleGraphImpl:
         ).reset_index(drop=True)
 
         return edgelist_df
-
 
     def delete_edge_list(self):
         """

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -491,7 +491,7 @@ class simpleGraphImpl:
                 ]
 
         elif not use_initial_input_df and self.properties.renumbered:
-            # Do not unrenumber the vertices if the initial input df was used
+            # Do not unrenumber the vertices if the initial input df was used.
             if not self.properties.directed:
                 edgelist_df = edgelist_df[
                     edgelist_df[simpleGraphImpl.srcCol]

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -322,7 +322,7 @@ class simpleGraphImpl:
         self,
         source="src",
         destination="dst",
-        weight="weights",
+        weight="weight",
     ):
         """
         Returns the graph edge list as a Pandas DataFrame.

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -831,7 +831,7 @@ class simpleGraphImpl:
         ----------
         return_unrenumbered_edgelist : bool (default=True)
             Flag determining whether to return the original input edgelist
-            if 'True' or the renumbered one of 'False' and the edgelist was
+            if 'True' or the renumbered one if 'False' and the edgelist was
             renumbered.
 
         Returns
@@ -947,7 +947,8 @@ class simpleGraphImpl:
         """
         # TODO: Move to Outer graphs?
         if directed_edges and self.edgelist is not None:
-            return len(self.decompress_to_edgelist())
+            return len(self.decompress_to_edgelist(
+                return_unrenumbered_edgelist=False))
         if self.properties.edge_count is None:
             if self.edgelist is not None:
                 edgelist_df = self.decompress_to_edgelist()

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -947,8 +947,7 @@ class simpleGraphImpl:
         """
         # TODO: Move to Outer graphs?
         if directed_edges and self.edgelist is not None:
-            return len(self.decompress_to_edgelist(
-                return_unrenumbered_edgelist=False))
+            return len(self.decompress_to_edgelist(return_unrenumbered_edgelist=False))
         if self.properties.edge_count is None:
             if self.edgelist is not None:
                 edgelist_df = self.decompress_to_edgelist()

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -468,7 +468,7 @@ class simpleGraphImpl:
             use_initial_input_df = False
 
         if use_initial_input_df and self.properties.directed:
-            edgelist_df = self.input_df # Original input.
+            edgelist_df = self.input_df  # Original input.
         else:
             edgelist_df = self.decompress_to_edgelist()
             if srcCol is None and dstCol is None:
@@ -526,7 +526,6 @@ class simpleGraphImpl:
         ).reset_index(drop=True)
 
         return edgelist_df
-
 
     def delete_edge_list(self):
         """

--- a/python/cugraph/cugraph/tests/structure/test_convert_matrix.py
+++ b/python/cugraph/cugraph/tests/structure/test_convert_matrix.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -67,14 +67,14 @@ def test_to_from_pandas(graph_file):
     # Compare pandas edgelist
     exp_pdf = nx.to_pandas_edgelist(new_nxG)
     res_pdf = cugraph.to_pandas_edgelist(new_cuG)
-
+    
     exp_pdf = exp_pdf.rename(
-        columns={"source": "src", "target": "dst", "weight": "weights"}
+        columns={"source": "src", "target": "dst"}
     )
 
     exp_pdf = exp_pdf.sort_values(by=["src", "dst"]).reset_index(drop=True)
     res_pdf = res_pdf.sort_values(by=["src", "dst"]).reset_index(drop=True)
-    res_pdf = res_pdf[["src", "dst", "weights"]]
+    res_pdf = res_pdf[["src", "dst", "weight"]]
 
     assert exp_pdf.equals(res_pdf)
 
@@ -119,12 +119,12 @@ def test_from_to_numpy(graph_file):
     res_pdf = cugraph.to_pandas_edgelist(new_cuG)
 
     exp_pdf = exp_pdf.rename(
-        columns={"source": "src", "target": "dst", "weight": "weights"}
+        columns={"source": "src", "target": "dst"}
     )
 
     exp_pdf = exp_pdf.sort_values(by=["src", "dst"]).reset_index(drop=True)
     res_pdf = res_pdf.sort_values(by=["src", "dst"]).reset_index(drop=True)
-    res_pdf = res_pdf[["src", "dst", "weights"]]
+    res_pdf = res_pdf[["src", "dst", "weight"]]
 
     assert exp_pdf.equals(res_pdf)
 
@@ -139,12 +139,12 @@ def test_from_to_numpy(graph_file):
     res_pdf = cugraph.to_pandas_edgelist(new_cuG)
 
     exp_pdf = exp_pdf.rename(
-        columns={"source": "src", "target": "dst", "weight": "weights"}
+        columns={"source": "src", "target": "dst"}
     )
 
     exp_pdf = exp_pdf.sort_values(by=["src", "dst"]).reset_index(drop=True)
     res_pdf = res_pdf.sort_values(by=["src", "dst"]).reset_index(drop=True)
-    res_pdf = res_pdf[["src", "dst", "weights"]]
+    res_pdf = res_pdf[["src", "dst", "weight"]]
 
     assert exp_pdf.equals(res_pdf)
 

--- a/python/cugraph/cugraph/tests/structure/test_convert_matrix.py
+++ b/python/cugraph/cugraph/tests/structure/test_convert_matrix.py
@@ -67,10 +67,8 @@ def test_to_from_pandas(graph_file):
     # Compare pandas edgelist
     exp_pdf = nx.to_pandas_edgelist(new_nxG)
     res_pdf = cugraph.to_pandas_edgelist(new_cuG)
-    
-    exp_pdf = exp_pdf.rename(
-        columns={"source": "src", "target": "dst"}
-    )
+
+    exp_pdf = exp_pdf.rename(columns={"source": "src", "target": "dst"})
 
     exp_pdf = exp_pdf.sort_values(by=["src", "dst"]).reset_index(drop=True)
     res_pdf = res_pdf.sort_values(by=["src", "dst"]).reset_index(drop=True)
@@ -118,9 +116,7 @@ def test_from_to_numpy(graph_file):
     exp_pdf = nx.to_pandas_edgelist(new_nxG)
     res_pdf = cugraph.to_pandas_edgelist(new_cuG)
 
-    exp_pdf = exp_pdf.rename(
-        columns={"source": "src", "target": "dst"}
-    )
+    exp_pdf = exp_pdf.rename(columns={"source": "src", "target": "dst"})
 
     exp_pdf = exp_pdf.sort_values(by=["src", "dst"]).reset_index(drop=True)
     res_pdf = res_pdf.sort_values(by=["src", "dst"]).reset_index(drop=True)
@@ -138,9 +134,7 @@ def test_from_to_numpy(graph_file):
     exp_pdf = nx.to_pandas_edgelist(new_nxG)
     res_pdf = cugraph.to_pandas_edgelist(new_cuG)
 
-    exp_pdf = exp_pdf.rename(
-        columns={"source": "src", "target": "dst"}
-    )
+    exp_pdf = exp_pdf.rename(columns={"source": "src", "target": "dst"})
 
     exp_pdf = exp_pdf.sort_values(by=["src", "dst"]).reset_index(drop=True)
     res_pdf = res_pdf.sort_values(by=["src", "dst"]).reset_index(drop=True)

--- a/python/cugraph/cugraph/tests/structure/test_graph.py
+++ b/python/cugraph/cugraph/tests/structure/test_graph.py
@@ -459,7 +459,7 @@ def test_view_edge_list_for_nxGraph(directed):
     G = nx.florentine_families_graph()
     df = nx.to_pandas_edgelist(G)
     cG = cugraph.Graph(directed=directed)
-    cG.from_pandas_edgelist(df, source='source', destination='target')
+    cG.from_pandas_edgelist(df, source="source", destination="target")
 
     assert df.shape == cG.view_edge_list().shape
 
@@ -621,26 +621,25 @@ def test_number_of_vertices(graph_file):
 def test_number_of_edges():
 
     # cycle edges
-    cycle_edges = [
-        (0, 1, 1.0),
-        (1, 2, 1.0),
-        (2, 3, 1.0),
-        (3, 0, 1.0)
-    ]
+    cycle_edges = [(0, 1, 1.0), (1, 2, 1.0), (2, 3, 1.0), (3, 0, 1.0)]
 
     # Create pandas DataFrame
-    df = pd.DataFrame(cycle_edges, columns=['source', 'destination', 'weight'])
-        
+    df = pd.DataFrame(cycle_edges, columns=["source", "destination", "weight"])
+
     # Convert to cuDF
     cudf_edges = cudf.DataFrame.from_pandas(df)
-        
+
     # Create directed graph
     G_directed = cugraph.Graph(directed=True)
-    G_directed.from_cudf_edgelist(cudf_edges, source='source', destination='destination', edge_attr='weight')
-        
+    G_directed.from_cudf_edgelist(
+        cudf_edges, source="source", destination="destination", edge_attr="weight"
+    )
+
     # Create undirected graph
     G_undirected = cugraph.Graph(directed=False)
-    G_undirected.from_cudf_edgelist(cudf_edges, source='source', destination='destination', edge_attr='weight')
+    G_undirected.from_cudf_edgelist(
+        cudf_edges, source="source", destination="destination", edge_attr="weight"
+    )
 
     assert G_directed.number_of_edges() == G_undirected.number_of_edges()
 

--- a/python/cugraph/cugraph/tests/structure/test_graph.py
+++ b/python/cugraph/cugraph/tests/structure/test_graph.py
@@ -250,8 +250,7 @@ def test_add_adj_list_to_edge_list(graph_file):
     G = cugraph.Graph(directed=True)
     G.from_cudf_adjlist(offsets, indices, None)
 
-    edgelist = G.view_edge_list().sort_values(
-        by=["src", "dst"]).reset_index(drop=True)
+    edgelist = G.view_edge_list().sort_values(by=["src", "dst"]).reset_index(drop=True)
     sources_cu = edgelist["src"]
     destinations_cu = edgelist["dst"]
     compare_series(sources_cu, sources_exp)
@@ -301,7 +300,9 @@ def test_view_edge_list_from_adj_list(graph_file):
     indices = cudf.Series(Mcsr.indices)
     G = cugraph.Graph(directed=True)
     G.from_cudf_adjlist(offsets, indices, None)
-    edgelist_df = G.view_edge_list().sort_values(by=["src", "dst"]).reset_index(drop=True)
+    edgelist_df = (
+        G.view_edge_list().sort_values(by=["src", "dst"]).reset_index(drop=True)
+    )
     Mcoo = Mcsr.tocoo()
     src1 = Mcoo.row
     dst1 = Mcoo.col

--- a/python/cugraph/cugraph/tests/structure/test_graph.py
+++ b/python/cugraph/cugraph/tests/structure/test_graph.py
@@ -250,7 +250,8 @@ def test_add_adj_list_to_edge_list(graph_file):
     G = cugraph.Graph(directed=True)
     G.from_cudf_adjlist(offsets, indices, None)
 
-    edgelist = G.view_edge_list()
+    edgelist = G.view_edge_list().sort_values(
+        by=["src", "dst"]).reset_index(drop=True)
     sources_cu = edgelist["src"]
     destinations_cu = edgelist["dst"]
     compare_series(sources_cu, sources_exp)
@@ -300,7 +301,7 @@ def test_view_edge_list_from_adj_list(graph_file):
     indices = cudf.Series(Mcsr.indices)
     G = cugraph.Graph(directed=True)
     G.from_cudf_adjlist(offsets, indices, None)
-    edgelist_df = G.view_edge_list()
+    edgelist_df = G.view_edge_list().sort_values(by=["src", "dst"]).reset_index(drop=True)
     Mcoo = Mcsr.tocoo()
     src1 = Mcoo.row
     dst1 = Mcoo.col
@@ -1101,6 +1102,7 @@ def test_graph_creation_edges_multi_col_vertices(graph_file, directed):
     G.from_cudf_edgelist(input_df, source=srcCol, destination=dstCol, edge_attr=wgtCol)
 
     input_df = input_df.loc[:, columns]
+
     edge_list_view = G.view_edge_list().loc[:, columns]
     edges = G.edges().loc[:, vertexCol]
 

--- a/python/cugraph/cugraph/tests/structure/test_graph_mg.py
+++ b/python/cugraph/cugraph/tests/structure/test_graph_mg.py
@@ -378,7 +378,7 @@ def test_graph_creation_edge_properties(dask_client, graph_file, edge_props):
 def test_graph_creation_properties(dask_client, graph_file, directed, renumber):
     srcCol = "src"
     dstCol = "dst"
-    wgtCol = "wgt"
+    wgtCol = "weight"
     df = cudf.read_csv(
         graph_file,
         delimiter=" ",

--- a/python/cugraph/cugraph/tests/structure/test_multigraph.py
+++ b/python/cugraph/cugraph/tests/structure/test_multigraph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -63,6 +63,7 @@ def test_multigraph(graph_file):
 @pytest.mark.parametrize("graph_file", DEFAULT_DATASETS)
 def test_Graph_from_MultiGraph(graph_file):
     # FIXME: Migrate to new test fixtures for Graph setup once available
+    # Test undirected Multigraph
     GM = graph_file.get_graph(create_using=cugraph.MultiGraph())
     dataset_path = graph_file.get_path()
     nxM = utils.read_csv_for_nx(dataset_path, read_weights_in_sp=True)
@@ -76,7 +77,9 @@ def test_Graph_from_MultiGraph(graph_file):
 
     G = cugraph.Graph(GM)
     Gnx = nx.Graph(GnxM)
-    assert Gnx.number_of_edges() == G.number_of_edges(directed_edges=True)
+    assert Gnx.number_of_edges() == G.number_of_edges(directed_edges=False)
+
+    # Test directed Multigraph
     GdM = graph_file.get_graph(create_using=cugraph.MultiGraph(directed=True))
     GnxdM = nx.from_pandas_edgelist(
         nxM,
@@ -87,7 +90,7 @@ def test_Graph_from_MultiGraph(graph_file):
     )
     Gd = cugraph.Graph(GdM, directed=True)
     Gnxd = nx.DiGraph(GnxdM)
-    assert Gnxd.number_of_edges() == Gd.number_of_edges()
+    assert Gnxd.number_of_edges() == Gd.number_of_edges(directed_edges=True)
 
 
 @pytest.mark.sg


### PR DESCRIPTION
A breaking change was introduced few releases ago that modifies the way an undirected graph is created. In fact, the method symmetrizing the edgelist was there used to be a cudf/dask_cudf based method that symmetrizes the edgelist however, this operation is now supported internally during the graph creation through our C/C++ API with the flag `symmetrize` and the edgelist is exposed through [decompress_to_edgelist ](https://github.com/rapidsai/cugraph/pull/4750).

This PR leverages the method `decompress_to_edgelist` to extract the symmetric edges which is then leverage by the method `view_edge_list` and `number_of_edges`

closes #5003 
closes #4976 