### PR TITLE
Adds `test_node2vec` to temporary non-xdist test list

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -76,7 +76,7 @@ rapids-logger "pytest cugraph (not mg, with xdist)"
   --numprocesses=8 \
   --dist=worksteal \
   -m "not mg" \
-  -k "not test_dataset and not test_bulk_sampler and not test_create_undirected_graph_from_asymmetric_adj_list and not test_uniform_neighbor_sample" \
+  -k "not test_dataset and not test_bulk_sampler and not test_create_undirected_graph_from_asymmetric_adj_list and not test_uniform_neighbor_sample and not test_node2vec" \
   --cov-config=../../.coveragerc \
   --cov=cugraph \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cugraph-coverage.xml" \
@@ -91,7 +91,7 @@ rapids-logger "pytest cugraph (not mg, without xdist)"
   --numprocesses=1 \
   --dist=worksteal \
   -m "not mg" \
-  -k "not test_dataset and (test_bulk_sampler or test_create_undirected_graph_from_asymmetric_adj_list or test_uniform_neighbor_sample)" \
+  -k "not test_dataset and (test_bulk_sampler or test_create_undirected_graph_from_asymmetric_adj_list or test_uniform_neighbor_sample or test_node2vec)" \
   --cov-config=../../.coveragerc \
   --cov=cugraph \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cugraph-coverage.xml" \


### PR DESCRIPTION
Adds `test_node2vec` to temporary non-xdist test list.
This is in response to the failed nightly test run [here](https://github.com/rapidsai/cugraph/actions/runs/15131078012/job/42532125240).