### PR TITLE
Fix pylibcudf dependency

### DIFF
--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -45,7 +45,7 @@ dependencies:
 - pre-commit
 - pydantic
 - pydata-sphinx-theme
-- pylibcudf==25.6.*,>=0.0.0a0
+- pylibcudf==25.8.*,>=0.0.0a0
 - pylibraft==25.8.*,>=0.0.0a0
 - pytest
 - pytest-benchmark

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -45,7 +45,7 @@ dependencies:
 - pre-commit
 - pydantic
 - pydata-sphinx-theme
-- pylibcudf==25.6.*,>=0.0.0a0
+- pylibcudf==25.8.*,>=0.0.0a0
 - pylibraft==25.8.*,>=0.0.0a0
 - pytest
 - pytest-benchmark

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -50,7 +50,7 @@ dependencies:
 - pre-commit
 - pydantic
 - pydata-sphinx-theme
-- pylibcudf==25.6.*,>=0.0.0a0
+- pylibcudf==25.8.*,>=0.0.0a0
 - pylibraft==25.8.*,>=0.0.0a0
 - pytest
 - pytest-benchmark

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -50,7 +50,7 @@ dependencies:
 - pre-commit
 - pydantic
 - pydata-sphinx-theme
-- pylibcudf==25.6.*,>=0.0.0a0
+- pylibcudf==25.8.*,>=0.0.0a0
 - pylibraft==25.8.*,>=0.0.0a0
 - pytest
 - pytest-benchmark

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -760,7 +760,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - &pylibcudf_unsuffixed pylibcudf==25.6.*,>=0.0.0a0
+          - &pylibcudf_unsuffixed pylibcudf==25.8.*,>=0.0.0a0
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
@@ -773,12 +773,12 @@ dependencies:
               cuda: "12.*"
               cuda_suffixed: "true"
             packages:
-              - pylibcudf-cu12==25.6.*,>=0.0.0a0
+              - pylibcudf-cu12==25.8.*,>=0.0.0a0
           - matrix:
               cuda: "11.*"
               cuda_suffixed: "true"
             packages:
-              - pylibcudf-cu11==25.6.*,>=0.0.0a0
+              - pylibcudf-cu11==25.8.*,>=0.0.0a0
           - {matrix: null, packages: [*pylibcudf_unsuffixed]}
 
   depends_on_cudf:

--- a/python/cugraph/pyproject.toml
+++ b/python/cugraph/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "libcugraph==25.8.*,>=0.0.0a0",
     "numba>=0.59.1,<0.62.0a0",
     "numpy>=1.23,<3.0a0",
-    "pylibcudf==25.6.*,>=0.0.0a0",
+    "pylibcudf==25.8.*,>=0.0.0a0",
     "pylibcugraph==25.8.*,>=0.0.0a0",
     "pylibraft==25.8.*,>=0.0.0a0",
     "raft-dask==25.8.*,>=0.0.0a0",


### PR DESCRIPTION
The 25.6 dependency probably stuck in through a forward merge.