### PR TITLE
use 'rapids-init-pip' in wheel CI, other CI changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/build_cpp.sh
       sha: ${{ inputs.sha }}
       node_type: cpu32
   python-build:
@@ -43,6 +44,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/build_python.sh
       sha: ${{ inputs.sha }}
   upload-conda:
     needs: [cpp-build, python-build]
@@ -65,7 +67,7 @@ jobs:
       container_image: "rapidsai/ci-conda:cuda11.8.0-ubuntu22.04-py3.10"
       date: ${{ inputs.date }}
       node_type: "gpu-l4-latest-1"
-      run_script: "ci/build_docs.sh"
+      script: "ci/build_docs.sh"
       sha: ${{ inputs.sha }}
   wheel-build-libcugraph:
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -67,6 +67,7 @@ jobs:
           - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
+          - '!ci/release/update-version.sh'
           - '!docs/**'
           - '!img/**'
           - '!mg_utils/**'
@@ -78,12 +79,14 @@ jobs:
           - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
+          - '!ci/release/update-version.sh'
           - '!docs/**'
         test_python:
           - '**'
           - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
+          - '!ci/release/update-version.sh'
           - '!docs/**'
           - '!img/**'
           - '!notebooks/**'
@@ -101,6 +104,7 @@ jobs:
     with:
       build_type: pull-request
       node_type: cpu32
+      script: ci/build_cpp.sh
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit
@@ -108,6 +112,7 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
+      script: ci/test_cpp.sh
   conda-cpp-checks:
     needs: conda-cpp-build
     secrets: inherit
@@ -122,6 +127,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.06
     with:
       build_type: pull-request
+      script: ci/build_python.sh
   conda-python-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit
@@ -129,6 +135,7 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
       build_type: pull-request
+      script: ci/test_python.sh
   conda-notebook-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit
@@ -139,7 +146,7 @@ jobs:
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:cuda11.8.0-ubuntu22.04-py3.10"
-      run_script: "ci/test_notebooks.sh"
+      script: "ci/test_notebooks.sh"
   docs-build:
     needs: conda-python-build
     secrets: inherit
@@ -149,7 +156,7 @@ jobs:
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:cuda11.8.0-ubuntu22.04-py3.10"
-      run_script: "ci/build_docs.sh"
+      script: "ci/build_docs.sh"
   wheel-build-libcugraph:
     needs: checks
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,7 @@ jobs:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/test_cpp.sh
       sha: ${{ inputs.sha }}
   conda-python-tests:
     secrets: inherit
@@ -42,6 +43,7 @@ jobs:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/test_python.sh
       sha: ${{ inputs.sha }}
   wheel-tests-pylibcugraph:
     secrets: inherit

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -9,6 +9,7 @@ package_type=$3
 
 source rapids-configure-sccache
 source rapids-date-string
+source rapids-init-pip
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 

--- a/ci/build_wheel_cugraph.sh
+++ b/ci/build_wheel_cugraph.sh
@@ -3,23 +3,24 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 package_dir="python/cugraph"
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
 # Download the libcugraph and pylibcugraph wheels built in the previous step and make them
 # available for pip to find.
+#
+# Using env variable PIP_CONSTRAINT (initialized by 'rapids-init-pip') is necessary to ensure the constraints
+# are used when creating the isolated build environment.
 LIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
 PYLIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="pylibcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github python)
 
-cat >> ./constraints.txt <<EOF
+cat >> "${PIP_CONSTRAINT}" <<EOF
 libcugraph-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBCUGRAPH_WHEELHOUSE}"/libcugraph_*.whl)
 pylibcugraph-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${PYLIBCUGRAPH_WHEELHOUSE}"/pylibcugraph_*.whl)
 EOF
-
-# Using env variable PIP_CONSTRAINT is necessary to ensure the constraints
-# are used when creating the isolated build environment.
-export PIP_CONSTRAINT="${PWD}/constraints.txt"
 
 ./ci/build_wheel.sh cugraph ${package_dir} python
 ./ci/validate_wheel.sh ${package_dir} "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"

--- a/ci/build_wheel_libcugraph.sh
+++ b/ci/build_wheel_libcugraph.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 package_name="libcugraph"
 package_dir="python/libcugraph"
 

--- a/ci/build_wheel_pylibcugraph.sh
+++ b/ci/build_wheel_pylibcugraph.sh
@@ -3,21 +3,22 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 package_dir="python/pylibcugraph"
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
 # Download the libcugraph wheel built in the previous step and make it
 # available for pip to find.
+#
+# Using env variable PIP_CONSTRAINT (initialized by 'rapids-init-pip') is necessary to ensure the constraints
+# are used when creating the isolated build environment.
 LIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
 
-cat >> ./constraints.txt <<EOF
+cat >> "${PIP_CONSTRAINT}" <<EOF
 libcugraph-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBCUGRAPH_WHEELHOUSE}"/libcugraph_*.whl)
 EOF
-
-# Using env variable PIP_CONSTRAINT is necessary to ensure the constraints
-# are used when creating the isolated build environment.
-export PIP_CONSTRAINT="${PWD}/constraints.txt"
 
 ./ci/build_wheel.sh pylibcugraph ${package_dir} python
 ./ci/validate_wheel.sh ${package_dir} "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"

--- a/ci/test_wheel_cugraph.sh
+++ b/ci/test_wheel_cugraph.sh
@@ -3,8 +3,9 @@
 
 set -eoxu pipefail
 
+source rapids-init-pip
+
 # Download the packages built in the previous step
-mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 CUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="cugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github python)
 LIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)

--- a/ci/test_wheel_pylibcugraph.sh
+++ b/ci/test_wheel_pylibcugraph.sh
@@ -3,6 +3,8 @@
 
 set -eoxu pipefail
 
+source rapids-init-pip
+
 # Download the packages built in the previous step
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 LIBCUGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcugraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)


### PR DESCRIPTION
## Description

Proposes a batch of small, mostly-unrelated changes to building and packaging.

These are all part of RAPIDS-wide efforts to make it easier to reproduce CI locally and to use artifacts from one project's CI in another project's CI.

Contributes to https://github.com/rapidsai/build-planning/issues/178

* prevents triggering expensive CI jobs based on PRs modifying `ci/release/update-version.sh`

Contributes to https://github.com/rapidsai/shared-workflows/issues/356

* explicitly provides an input for `script` to workflows using it, instead of relying on a default value coming from the workflow file

Contributes to https://github.com/rapidsai/shared-workflows/issues/337

* switches from input `run_script` to `script` in uses of the `custom-job` workflow

Contributes to https://github.com/rapidsai/build-planning/issues/179

* adds a call to `rapids-init-pip` near the beginning of all CI scripts that use `pip`
* removes redefinitions of `PIP_CONSTRAINT` in scripts, in favor of using the one set up by `rapids-pip-init`

Contributes to https://github.com/rapidsai/gha-tools/issues/145

* confirmed that `rapids-configure-conda-channels` is not used in any builds scripts using `rattler-build`