### PR TITLE
Resolve inconsistencies in algorithms that do not support self-loops & multi-edges.

### DIFF
--- a/cpp/include/cugraph/algorithms.hpp
+++ b/cpp/include/cugraph/algorithms.hpp
@@ -436,7 +436,6 @@ enum class cugraph_cc_t {
  * @ingroup components_cpp
  * @brief      Compute connected components.
  *
- * The weak version (for undirected graphs, only) was imported from cuML.
  * This implementation comes from [1] and solves component labeling problem in
  * parallel on CSR-indexes based upon the vertex degree and adjacency graph.
  *
@@ -1782,8 +1781,8 @@ enum class k_core_degree_type_t { IN = 0, OUT = 1, INOUT = 2 };
 .* @ingroup core_cpp
  * @brief   Compute core numbers of individual vertices from K-Core decomposition.
  *
- * The input graph should not have self-loops nor multi-edges. Currently, only undirected graphs are
- * supported.
+ * This algorithms does not support multi-graphs. Self-loops are excluded in computing core
+nuumbers.
  *
  * @tparam vertex_t Type of vertex identifiers. Needs to be an integral type.
  * @tparam edge_t Type of edge identifiers. Needs to be an integral type.
@@ -1814,7 +1813,8 @@ void core_number(raft::handle_t const& handle,
 .* @ingroup core_cpp
  * @brief   Extract K-Core of a graph
  *
- * @throws     cugraph::logic_error when an error occurs.
+ * This function internally calls core_number (if @p core_numbers.has_value() is false). core_number
+does not support multi-graphs. Self-loops are excluded in computing core nuumbers.
  *
  * @tparam vertex_t Type of vertex identifiers. Needs to be an integral type.
  * @tparam edge_t Type of edge identifiers. Needs to be an integral type.
@@ -1851,6 +1851,9 @@ k_core(raft::handle_t const& handle,
  * Compute triangle counts for the entire set of vertices (if @p vertices is std::nullopt) or the
  * given vertices (@p vertices.has_value() is true).
  *
+ * This algorithms does not support multi-graphs. Self-loops are excluded in computing triangle
+ * counts.
+ *
  * @tparam vertex_t Type of vertex identifiers. Needs to be an integral type.
  * @tparam edge_t Type of edge identifiers. Needs to be an integral type.
  * @tparam multi_gpu Flag indicating whether template instantiation should target single-GPU (false)
@@ -1877,6 +1880,9 @@ void triangle_count(raft::handle_t const& handle,
  *
  * Compute edge triangle counts for the entire set of edges.
  *
+ * This algorithms does not support multi-graphs. Self-loops are excluded in computing edge triangle
+counts (they will have a triangle count of 0).
+ *
  * @tparam vertex_t Type of vertex identifiers. Needs to be an integral type.
  * @tparam edge_t Type of edge identifiers. Needs to be an integral type.
  * @tparam multi_gpu Flag indicating whether template instantiation should target single-GPU (false)
@@ -1899,6 +1905,8 @@ edge_property_t<edge_t, edge_t> edge_triangle_count(
  * @brief Compute K-Truss.
  *
  * Extract the K-Truss subgraph of a graph
+ *
+ * This algorithms does not support multi-graphs. Self-loops are excluded in computing K-Truss.
  *
  * @tparam vertex_t Type of vertex identifiers. Needs to be an integral type.
  * @tparam edge_t Type of edge identifiers. Needs to be an integral type.

--- a/cpp/include/cugraph/algorithms.hpp
+++ b/cpp/include/cugraph/algorithms.hpp
@@ -1814,7 +1814,8 @@ void core_number(raft::handle_t const& handle,
  * @brief   Extract K-Core of a graph
  *
  * This function internally calls core_number (if @p core_numbers.has_value() is false). core_number
-does not support multi-graphs. Self-loops are excluded in computing core nuumbers.
+does not support multi-graphs. Self-loops are excluded in computing core nuumbers. Note that the
+extracted K-Core can still include self-loops.
  *
  * @tparam vertex_t Type of vertex identifiers. Needs to be an integral type.
  * @tparam edge_t Type of edge identifiers. Needs to be an integral type.

--- a/cpp/src/community/edge_triangle_count_impl.cuh
+++ b/cpp/src/community/edge_triangle_count_impl.cuh
@@ -18,6 +18,7 @@
 
 #include "detail/graph_partition_utils.cuh"
 #include "prims/edge_bucket.cuh"
+#include "prims/fill_edge_property.cuh"
 #include "prims/per_v_pair_dst_nbr_intersection.cuh"
 #include "prims/transform_e.cuh"
 
@@ -130,11 +131,37 @@ edge_property_t<edge_t, edge_t> edge_triangle_count_impl(
   bool do_expensive_check)
 {
   using weight_t = float;
+
+  CUGRAPH_EXPECTS(
+    !graph_view.is_multigraph(),
+    "Invalid input argument: edge triangle count currently does not support multi-graphs.");
+
+  // Exclude self-loops
+
+  std::optional<cugraph::edge_property_t<edge_t, bool>> self_loop_edge_mask{std::nullopt};
+  auto cur_graph_view = graph_view;
+  if (cur_graph_view.count_self_loops(handle) > edge_t{0}) {
+    self_loop_edge_mask = cugraph::edge_property_t<edge_t, bool>(handle, cur_graph_view);
+    if (cur_graph_view.has_edge_mask()) { cur_graph_view.clear_edge_mask(); }
+    cugraph::fill_edge_property(handle, cur_graph_view, self_loop_edge_mask->mutable_view(), false);
+
+    transform_e(handle,
+                graph_view,
+                edge_src_dummy_property_t{}.view(),
+                edge_dst_dummy_property_t{}.view(),
+                edge_dummy_property_t{}.view(),
+                cuda::proclaim_return_type<bool>(
+                  [] __device__(auto src, auto dst, auto, auto, auto) { return src != dst; }),
+                self_loop_edge_mask->mutable_view());
+
+    cur_graph_view.attach_edge_mask(self_loop_edge_mask->view());
+  }
+
   rmm::device_uvector<vertex_t> edgelist_srcs(0, handle.get_stream());
   rmm::device_uvector<vertex_t> edgelist_dsts(0, handle.get_stream());
   std::tie(edgelist_srcs, edgelist_dsts, std::ignore, std::ignore, std::ignore) =
     decompress_to_edgelist<vertex_t, edge_t, weight_t, int32_t>(
-      handle, graph_view, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
+      handle, cur_graph_view, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
 
   auto edge_first = thrust::make_zip_iterator(edgelist_srcs.begin(), edgelist_dsts.begin());
 
@@ -162,7 +189,7 @@ edge_property_t<edge_t, edge_t> edge_triangle_count_impl(
     // Perform 'nbr_intersection' in chunks to reduce peak memory.
     auto [intersection_offsets, intersection_indices] =
       per_v_pair_dst_nbr_intersection(handle,
-                                      graph_view,
+                                      cur_graph_view,
                                       edge_first + prev_chunk_size,
                                       edge_first + prev_chunk_size + chunk_size,
                                       do_expensive_check);
@@ -272,7 +299,7 @@ edge_property_t<edge_t, edge_t> edge_triangle_count_impl(
           std::nullopt,
           std::nullopt,
           std::nullopt,
-          graph_view.vertex_partition_range_lasts());
+          cur_graph_view.vertex_partition_range_lasts());
 
       thrust::for_each(
         handle.get_thrust_policy(),
@@ -335,16 +362,19 @@ edge_property_t<edge_t, edge_t> edge_triangle_count_impl(
     prev_chunk_size += chunk_size;
   }
 
-  cugraph::edge_property_t<edge_t, edge_t> counts(handle, graph_view);
+  cugraph::edge_property_t<edge_t, edge_t> counts(handle, cur_graph_view);
+  {
+    auto unmasked_graph_view = cur_graph_view;
+    if (unmasked_graph_view.has_edge_mask()) { unmasked_graph_view.clear_edge_mask(); }
+    cugraph::fill_edge_property(handle, unmasked_graph_view, counts.mutable_view(), edge_t{0});
+  }
 
   cugraph::edge_bucket_t<vertex_t, void, true, multi_gpu, true> valid_edges(handle);
   valid_edges.insert(edgelist_srcs.begin(), edgelist_srcs.end(), edgelist_dsts.begin());
 
-  auto cur_graph_view = graph_view;
-
   cugraph::transform_e(
     handle,
-    graph_view,
+    cur_graph_view,
     valid_edges,
     cugraph::edge_src_dummy_property_t{}.view(),
     cugraph::edge_dst_dummy_property_t{}.view(),

--- a/cpp/src/cores/core_number_impl.cuh
+++ b/cpp/src/cores/core_number_impl.cuh
@@ -15,8 +15,10 @@
  */
 #pragma once
 
+#include "prims/fill_edge_property.cuh"
 #include "prims/fill_edge_src_dst_property.cuh"
 #include "prims/reduce_v.cuh"
+#include "prims/transform_e.cuh"
 #include "prims/transform_reduce_if_v_frontier_outgoing_e_by_dst.cuh"
 #include "prims/update_v_frontier.cuh"
 #include "prims/vertex_frontier.cuh"
@@ -86,15 +88,31 @@ void core_number(raft::handle_t const& handle,
                   "Invalid input argument: degree_type should be IN, OUT, or INOUT.");
   CUGRAPH_EXPECTS(k_first <= k_last, "Invalid input argument: k_first <= k_last.");
 
-  if (do_expensive_check) {
-    CUGRAPH_EXPECTS(graph_view.count_self_loops(handle) == 0,
-                    "Invalid input argument: graph_view has self-loops.");
+  // Exclude self-loops
+
+  std::optional<cugraph::edge_property_t<edge_t, bool>> self_loop_edge_mask{std::nullopt};
+  auto cur_graph_view = graph_view;
+  if (cur_graph_view.count_self_loops(handle) > edge_t{0}) {
+    self_loop_edge_mask = cugraph::edge_property_t<edge_t, bool>(handle, cur_graph_view);
+    if (cur_graph_view.has_edge_mask()) { cur_graph_view.clear_edge_mask(); }
+    cugraph::fill_edge_property(handle, cur_graph_view, self_loop_edge_mask->mutable_view(), false);
+
+    transform_e(handle,
+                graph_view,
+                edge_src_dummy_property_t{}.view(),
+                edge_dst_dummy_property_t{}.view(),
+                edge_dummy_property_t{}.view(),
+                cuda::proclaim_return_type<bool>(
+                  [] __device__(auto src, auto dst, auto, auto, auto) { return src != dst; }),
+                self_loop_edge_mask->mutable_view());
+
+    cur_graph_view.attach_edge_mask(self_loop_edge_mask->view());
   }
 
   // initialize core_numbers to degrees (upper-bound)
 
-  if (graph_view.is_symmetric()) {  // in-degree == out-degree
-    auto out_degrees = graph_view.compute_out_degrees(handle);
+  if (cur_graph_view.is_symmetric()) {  // in-degree == out-degree
+    auto out_degrees = cur_graph_view.compute_out_degrees(handle);
     if ((degree_type == k_core_degree_type_t::IN) || (degree_type == k_core_degree_type_t::OUT)) {
       thrust::copy(
         handle.get_thrust_policy(), out_degrees.begin(), out_degrees.end(), core_numbers);
@@ -108,15 +126,15 @@ void core_number(raft::handle_t const& handle,
     }
   } else {
     if (degree_type == k_core_degree_type_t::IN) {
-      auto in_degrees = graph_view.compute_in_degrees(handle);
+      auto in_degrees = cur_graph_view.compute_in_degrees(handle);
       thrust::copy(handle.get_thrust_policy(), in_degrees.begin(), in_degrees.end(), core_numbers);
     } else if (degree_type == k_core_degree_type_t::OUT) {
-      auto out_degrees = graph_view.compute_out_degrees(handle);
+      auto out_degrees = cur_graph_view.compute_out_degrees(handle);
       thrust::copy(
         handle.get_thrust_policy(), out_degrees.begin(), out_degrees.end(), core_numbers);
     } else {
-      auto in_degrees  = graph_view.compute_in_degrees(handle);
-      auto out_degrees = graph_view.compute_out_degrees(handle);
+      auto in_degrees  = cur_graph_view.compute_in_degrees(handle);
+      auto out_degrees = cur_graph_view.compute_out_degrees(handle);
       auto degree_pair_first =
         thrust::make_zip_iterator(thrust::make_tuple(in_degrees.begin(), out_degrees.begin()));
       thrust::transform(handle.get_thrust_policy(),
@@ -130,17 +148,17 @@ void core_number(raft::handle_t const& handle,
   // remove 0 degree vertices (as they already belong to 0-core and they don't affect core numbers)
   // and clip core numbers of the "less than k_first degree" vertices to 0
 
-  rmm::device_uvector<vertex_t> remaining_vertices(graph_view.local_vertex_partition_range_size(),
-                                                   handle.get_stream());
+  rmm::device_uvector<vertex_t> remaining_vertices(
+    cur_graph_view.local_vertex_partition_range_size(), handle.get_stream());
   remaining_vertices.resize(
     cuda::std::distance(
       remaining_vertices.begin(),
       thrust::copy_if(
         handle.get_thrust_policy(),
-        thrust::make_counting_iterator(graph_view.local_vertex_partition_range_first()),
-        thrust::make_counting_iterator(graph_view.local_vertex_partition_range_last()),
+        thrust::make_counting_iterator(cur_graph_view.local_vertex_partition_range_first()),
+        thrust::make_counting_iterator(cur_graph_view.local_vertex_partition_range_last()),
         remaining_vertices.begin(),
-        [core_numbers, v_first = graph_view.local_vertex_partition_range_first()] __device__(
+        [core_numbers, v_first = cur_graph_view.local_vertex_partition_range_first()] __device__(
           auto v) { return core_numbers[v - v_first] > edge_t{0}; })),
     handle.get_stream());
 
@@ -149,8 +167,9 @@ void core_number(raft::handle_t const& handle,
       handle.get_thrust_policy(),
       remaining_vertices.begin(),
       remaining_vertices.end(),
-      [k_first, core_numbers, v_first = graph_view.local_vertex_partition_range_first()] __device__(
-        auto v) {
+      [k_first,
+       core_numbers,
+       v_first = cur_graph_view.local_vertex_partition_range_first()] __device__(auto v) {
         if (core_numbers[v - v_first] < k_first) { core_numbers[v - v_first] = edge_t{0}; }
       });
   }
@@ -163,24 +182,23 @@ void core_number(raft::handle_t const& handle,
 
   vertex_frontier_t<vertex_t, void, multi_gpu, true> vertex_frontier(handle, num_buckets);
 
-  edge_dst_property_t<edge_t, bool> edge_dst_valids(handle, graph_view);
-  fill_edge_dst_property(handle, graph_view, edge_dst_valids.mutable_view(), true);
-  if (!graph_view.is_symmetric() &&
+  edge_dst_property_t<edge_t, bool> edge_dst_valids(handle, cur_graph_view);
+  fill_edge_dst_property(handle, cur_graph_view, edge_dst_valids.mutable_view(), true);
+  if (!cur_graph_view.is_symmetric() &&
       degree_type != k_core_degree_type_t::INOUT) {  // 0 core number vertex may have non-zero
                                                      // in|out-degrees (so still can be accessed)
     rmm::device_uvector<vertex_t> zero_degree_vertices(
-      graph_view.local_vertex_partition_range_size() - remaining_vertices.size(),
+      cur_graph_view.local_vertex_partition_range_size() - remaining_vertices.size(),
       handle.get_stream());
     thrust::copy_if(
       handle.get_thrust_policy(),
-      thrust::make_counting_iterator(graph_view.local_vertex_partition_range_first()),
-      thrust::make_counting_iterator(graph_view.local_vertex_partition_range_last()),
+      thrust::make_counting_iterator(cur_graph_view.local_vertex_partition_range_first()),
+      thrust::make_counting_iterator(cur_graph_view.local_vertex_partition_range_last()),
       zero_degree_vertices.begin(),
-      [core_numbers, v_first = graph_view.local_vertex_partition_range_first()] __device__(auto v) {
-        return core_numbers[v - v_first] == edge_t{0};
-      });
+      [core_numbers, v_first = cur_graph_view.local_vertex_partition_range_first()] __device__(
+        auto v) { return core_numbers[v - v_first] == edge_t{0}; });
     fill_edge_dst_property(handle,
-                           graph_view,
+                           cur_graph_view,
                            zero_degree_vertices.begin(),
                            zero_degree_vertices.end(),
                            edge_dst_valids.mutable_view(),
@@ -190,7 +208,7 @@ void core_number(raft::handle_t const& handle,
   }
 
   auto k = std::max(k_first, size_t{2});  // degree 0|1 vertices belong to 0|1-core
-  if (graph_view.is_symmetric() && (degree_type == k_core_degree_type_t::INOUT) &&
+  if (cur_graph_view.is_symmetric() && (degree_type == k_core_degree_type_t::INOUT) &&
       ((k % 2) == 1)) {  // core numbers are always even numbers if symmetric and INOUT
     ++k;
   }
@@ -213,19 +231,19 @@ void core_number(raft::handle_t const& handle,
       handle.get_thrust_policy(),
       remaining_vertices.begin(),
       remaining_vertices.end(),
-      [core_numbers, k, v_first = graph_view.local_vertex_partition_range_first()] __device__(
+      [core_numbers, k, v_first = cur_graph_view.local_vertex_partition_range_first()] __device__(
         auto v) { return core_numbers[v - v_first] >= k; });
     vertex_frontier.bucket(bucket_idx_cur).insert(less_than_k_first, remaining_vertices.end());
     remaining_vertices.resize(cuda::std::distance(remaining_vertices.begin(), less_than_k_first),
                               handle.get_stream());
 
-    auto delta = (graph_view.is_symmetric() && (degree_type == k_core_degree_type_t::INOUT))
+    auto delta = (cur_graph_view.is_symmetric() && (degree_type == k_core_degree_type_t::INOUT))
                    ? edge_t{2}
                    : edge_t{1};
     if (vertex_frontier.bucket(bucket_idx_cur).aggregate_size() > 0) {
       do {
         fill_edge_dst_property(handle,
-                               graph_view,
+                               cur_graph_view,
                                vertex_frontier.bucket(bucket_idx_cur).begin(),
                                vertex_frontier.bucket(bucket_idx_cur).end(),
                                edge_dst_valids.mutable_view(),
@@ -236,13 +254,13 @@ void core_number(raft::handle_t const& handle,
         // the number of distinct core numbers in [k_first, std::min(max_degree, k_last)] is large).
         // There are two potential solutions: 1) extract a sub-graph and work on the sub-graph & 2)
         // mask-out/delete edges.
-        if (graph_view.is_symmetric() ||
+        if (cur_graph_view.is_symmetric() ||
             ((degree_type == k_core_degree_type_t::IN) ||
              (degree_type == k_core_degree_type_t::INOUT))) {  // decrement in-degrees
           auto [new_frontier_vertex_buffer, delta_buffer] =
             cugraph::transform_reduce_if_v_frontier_outgoing_e_by_dst(
               handle,
-              graph_view,
+              cur_graph_view,
               vertex_frontier.bucket(bucket_idx_cur),
               edge_src_dummy_property_t{}.view(),
               edge_dst_valids.view(),
@@ -257,7 +275,7 @@ void core_number(raft::handle_t const& handle,
 
           update_v_frontier(
             handle,
-            graph_view,
+            cur_graph_view,
             std::move(new_frontier_vertex_buffer),
             std::move(delta_buffer),
             vertex_frontier,
@@ -268,9 +286,9 @@ void core_number(raft::handle_t const& handle,
              k,
              delta,
              v_first =
-               graph_view.local_vertex_partition_range_first()] __device__(auto v,
-                                                                           auto v_val,
-                                                                           auto pushed_val) {
+               cur_graph_view.local_vertex_partition_range_first()] __device__(auto v,
+                                                                               auto v_val,
+                                                                               auto pushed_val) {
               auto new_core_number = v_val >= pushed_val ? v_val - pushed_val : edge_t{0};
               new_core_number      = new_core_number < (k - delta) ? (k - delta) : new_core_number;
               new_core_number      = new_core_number < k_first ? edge_t{0} : new_core_number;
@@ -279,7 +297,7 @@ void core_number(raft::handle_t const& handle,
             });
         }
 
-        if (!graph_view.is_symmetric() &&
+        if (!cur_graph_view.is_symmetric() &&
             ((degree_type == k_core_degree_type_t::OUT) ||
              (degree_type == k_core_degree_type_t::INOUT))) {  // decrement out-degrees
           // FIXME: we can create a transposed copy of the input graph (note that currently,
@@ -296,7 +314,7 @@ void core_number(raft::handle_t const& handle,
               vertex_frontier.bucket(bucket_idx_next).end(),
               [core_numbers,
                k,
-               v_first = graph_view.local_vertex_partition_range_first()] __device__(auto v) {
+               v_first = cur_graph_view.local_vertex_partition_range_first()] __device__(auto v) {
                 return core_numbers[v - v_first] >= k;
               }))));
         vertex_frontier.bucket(bucket_idx_next).shrink_to_fit();
@@ -318,15 +336,18 @@ void core_number(raft::handle_t const& handle,
             handle.get_thrust_policy(),
             remaining_vertices.begin(),
             remaining_vertices.end(),
-            [core_numbers, k, v_first = graph_view.local_vertex_partition_range_first()] __device__(
-              auto v) { return core_numbers[v - v_first] < k; })),
+            [core_numbers,
+             k,
+             v_first = cur_graph_view.local_vertex_partition_range_first()] __device__(auto v) {
+              return core_numbers[v - v_first] < k;
+            })),
         handle.get_stream());
       k += delta;
     } else {
       auto remaining_vertex_core_number_first = thrust::make_transform_iterator(
         remaining_vertices.begin(),
         v_to_core_number_t<vertex_t, edge_t>{core_numbers,
-                                             graph_view.local_vertex_partition_range_first()});
+                                             cur_graph_view.local_vertex_partition_range_first()});
       auto min_core_number =
         thrust::reduce(handle.get_thrust_policy(),
                        remaining_vertex_core_number_first,

--- a/cpp/tests/community/edge_triangle_count_test.cpp
+++ b/cpp/tests/community/edge_triangle_count_test.cpp
@@ -66,8 +66,10 @@ class Tests_EdgeTriangleCount
 
     for (int i = 0; i < h_srcs.size(); ++i) {  // edge centric implementation
       // for each edge, find the intersection
-      auto src          = h_srcs[i];
-      auto dst          = h_dsts[i];
+      auto src = h_srcs[i];
+      auto dst = h_dsts[i];
+      if (src == dst) continue;  // exclude self-loops
+
       auto it_src_start = std::lower_bound(h_srcs.begin(), h_srcs.end(), src);
       auto src_start    = std::distance(h_srcs.begin(), it_src_start);
 
@@ -87,12 +89,10 @@ class Tests_EdgeTriangleCount
                             std::inserter(nbr_intersection, nbr_intersection.end()));
       // Find the supporting edges
       for (auto v : nbr_intersection) {
+        if ((v == src) || (v == dst)) continue;  // exclude self-loops
         auto it_edge  = std::lower_bound(h_dsts.begin() + src_start, h_dsts.begin() + src_end, v);
         auto idx_edge = std::distance(h_dsts.begin(), it_edge);
         edge_triangle_counts[idx_edge] += 1;
-
-        it_edge  = std::lower_bound(h_dsts.begin() + dst_start, h_dsts.begin() + dst_end, v);
-        idx_edge = std::distance(h_dsts.begin(), it_edge);
       }
     }
 

--- a/cpp/tests/community/edge_triangle_count_test.cpp
+++ b/cpp/tests/community/edge_triangle_count_test.cpp
@@ -57,20 +57,6 @@ class Tests_EdgeTriangleCount
   virtual void SetUp() {}
   virtual void TearDown() {}
 
-  // FIXME: There is an utility equivalent functor not
-  // supporting host vectors.
-  template <typename type_t>
-  struct host_nearly_equal {
-    const type_t threshold_ratio;
-    const type_t threshold_magnitude;
-
-    bool operator()(type_t lhs, type_t rhs) const
-    {
-      return std::abs(lhs - rhs) <
-             std::max(std::max(lhs, rhs) * threshold_ratio, threshold_magnitude);
-    }
-  };
-
   template <typename vertex_t, typename edge_t>
   std::vector<edge_t> edge_triangle_count_reference(std::vector<vertex_t> h_srcs,
                                                     std::vector<vertex_t> h_dsts)
@@ -133,7 +119,7 @@ class Tests_EdgeTriangleCount
 
     auto [graph, edge_weight, d_renumber_map_labels] =
       cugraph::test::construct_graph<vertex_t, edge_t, weight_t, false, false>(
-        handle, input_usecase, false, renumber, true, true);
+        handle, input_usecase, false, renumber, false, true);
 
     if (cugraph::test::g_perf) {
       RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement

--- a/cpp/tests/community/k_truss_test.cpp
+++ b/cpp/tests/community/k_truss_test.cpp
@@ -181,7 +181,7 @@ class Tests_KTruss : public ::testing::TestWithParam<std::tuple<KTruss_Usecase, 
     // them especially for rmat generated graphs.
     auto [graph, edge_weight, d_renumber_map_labels] =
       cugraph::test::construct_graph<vertex_t, edge_t, weight_t, false, false>(
-        handle, input_usecase, k_truss_usecase.test_weighted_, renumber, true, true);
+        handle, input_usecase, k_truss_usecase.test_weighted_, renumber, false, true);
 
     if (cugraph::test::g_perf) {
       RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement

--- a/cpp/tests/community/k_truss_test.cpp
+++ b/cpp/tests/community/k_truss_test.cpp
@@ -73,94 +73,86 @@ class Tests_KTruss : public ::testing::TestWithParam<std::tuple<KTruss_Usecase, 
   template <typename vertex_t, typename edge_t, typename weight_t>
   std::tuple<std::vector<vertex_t>, std::vector<vertex_t>, std::optional<std::vector<weight_t>>>
   k_truss_reference(std::vector<vertex_t> h_offsets,
-                    std::vector<vertex_t> h_indices,
+                    std::vector<vertex_t> h_indices,  // this assumes that h_indices are sorted in
+                                                      // [h_offsets[i], h_offsets[i + 1])
                     std::optional<std::vector<weight_t>> h_values,
                     edge_t k)
   {
-    std::vector<vertex_t> vertices(h_offsets.size() - 1);
-    std::iota(vertices.begin(), vertices.end(), 0);
+    auto constexpr invalid_vertex_id = cugraph::invalid_vertex_id_v<vertex_t>;
 
     auto n_dropped = 1;
-
     while (n_dropped > 0) {
       n_dropped = 0;
-      std::set<vertex_t> seen;
+      std::vector<vertex_t> seen{};
       // Go over all the vertices.
-      for (auto u = vertices.begin(); u != vertices.end(); ++u) {
-        std::set<vertex_t> nbrs_u;
+      for (vertex_t u = 0; u < static_cast<vertex_t>(h_offsets.size() - 1); ++u) {
+        std::vector<vertex_t> nbrs_u{};
         // Find all neighbors of u from the offsets and indices array
-        auto idx_start = (h_offsets.begin() + (*u));
-        auto idx_end   = idx_start + 1;
-
-        for (edge_t i = *idx_start; i < *idx_end; ++i) {
-          nbrs_u.insert(*(h_indices.begin() + i));
+        for (auto i = h_offsets[u]; i < h_offsets[u + 1]; ++i) {
+          auto nbr = h_indices[i];
+          if ((nbr != invalid_vertex_id) && (nbr != u)) { nbrs_u.push_back(nbr); }
         }
 
-        seen.insert(*u);
-        std::set<vertex_t> new_nbrs;
-        std::set_difference(nbrs_u.begin(),
-                            nbrs_u.end(),
-                            seen.begin(),
-                            seen.end(),
-                            std::inserter(new_nbrs, new_nbrs.end()));
+        seen.push_back(u);
+        std::vector<vertex_t> new_nbrs(nbrs_u.size());
+        new_nbrs.resize(std::distance(
+          new_nbrs.begin(),
+          std::set_difference(
+            nbrs_u.begin(), nbrs_u.end(), seen.begin(), seen.end(), new_nbrs.begin())));
 
         // Finding the neighbors of v
-        for (auto v = new_nbrs.begin(); v != new_nbrs.end(); ++v) {
-          std::set<vertex_t> nbrs_v;
+        for (size_t i = 0; i < new_nbrs.size(); ++i) {
+          auto v = new_nbrs[i];
+          std::vector<vertex_t> nbrs_v{};
           // Find all neighbors of v from the offsets and indices array
-          idx_start = (h_offsets.begin() + (*v));
-          idx_end   = idx_start + 1;
-          for (edge_t i = *idx_start; i < *idx_end; ++i) {
-            nbrs_v.insert(*(h_indices.begin() + i));
+          for (auto i = h_offsets[v]; i < h_offsets[v + 1]; ++i) {
+            auto nbr = h_indices[i];
+            if ((nbr != invalid_vertex_id) && (nbr != v)) { nbrs_v.push_back(nbr); }
           }
 
-          std::set<vertex_t> nbr_intersection_u_v;
+          std::vector<vertex_t> nbr_intersection_u_v(std::min(nbrs_u.size(), nbrs_v.size()));
           // Find the intersection of nbr_u and nbr_v
-          std::set_intersection(nbrs_u.begin(),
-                                nbrs_u.end(),
-                                nbrs_v.begin(),
-                                nbrs_v.end(),
-                                std::inserter(nbr_intersection_u_v, nbr_intersection_u_v.end()));
+          nbr_intersection_u_v.resize(
+            std::distance(nbr_intersection_u_v.begin(),
+                          std::set_intersection(nbrs_u.begin(),
+                                                nbrs_u.end(),
+                                                nbrs_v.begin(),
+                                                nbrs_v.end(),
+                                                nbr_intersection_u_v.begin())));
 
           if (nbr_intersection_u_v.size() < (k - 2)) {
-            auto del_v = std::find(
-              h_indices.begin() + h_offsets[*u], h_indices.begin() + h_offsets[*u + 1], *v);
-
-            if (h_values) {
-              (*h_values).erase((*h_values).begin() + std::distance(h_indices.begin(), del_v));
-            }
-
-            std::transform(std::begin(h_offsets) + (*u) + 1,
-                           std::end(h_offsets),
-                           std::begin(h_offsets) + (*u) + 1,
-                           [](int x) { return x - 1; });
-            h_indices.erase(del_v);
+            auto del_v =
+              std::find(h_indices.begin() + h_offsets[u], h_indices.begin() + h_offsets[u + 1], v);
+            *del_v = invalid_vertex_id;
 
             // Delete edge in both directions
-            auto del_u = std::find(
-              h_indices.begin() + h_offsets[*v], h_indices.begin() + h_offsets[*v + 1], *u);
+            auto del_u =
+              std::find(h_indices.begin() + h_offsets[v], h_indices.begin() + h_offsets[v + 1], u);
+            *del_u = invalid_vertex_id;
 
-            if (h_values) {
-              (*h_values).erase((*h_values).begin() + std::distance(h_indices.begin(), del_u));
-            }
-            std::transform(std::begin(h_offsets) + (*v) + 1,
-                           std::end(h_offsets),
-                           std::begin(h_offsets) + (*v) + 1,
-                           [](int x) { return x - 1; });
-            h_indices.erase(del_u);
             n_dropped += 1;
           }
         }
       }
     }
 
-    std::vector<vertex_t> h_srcs(h_indices.size());
+    std::vector<vertex_t> h_k_truss_srcs{};
+    std::vector<vertex_t> h_k_truss_dsts{};
+    auto h_k_truss_values = h_values ? std::make_optional(std::vector<weight_t>{}) : std::nullopt;
 
-    for (auto i = 0; i < h_offsets.size() - 1; ++i) {
-      std::fill(h_srcs.begin() + h_offsets[i], h_srcs.begin() + h_offsets[i + 1], i);
+    for (vertex_t u = 0; u < static_cast<vertex_t>(h_offsets.size() - 1); ++u) {
+      for (auto i = h_offsets[u]; i < h_offsets[u + 1]; ++i) {
+        auto v = h_indices[i];
+        if ((v != invalid_vertex_id) && (v != u)) {
+          h_k_truss_srcs.push_back(u);
+          h_k_truss_dsts.push_back(v);
+          if (h_k_truss_values) { h_k_truss_values->push_back((*h_values)[i]); }
+        }
+      }
     }
 
-    return std::make_tuple(std::move(h_srcs), std::move(h_indices), std::move(h_values));
+    return std::make_tuple(
+      std::move(h_k_truss_srcs), std::move(h_k_truss_dsts), std::move(h_k_truss_values));
   }
 
   template <typename vertex_t, typename edge_t, typename weight_t>
@@ -177,8 +169,6 @@ class Tests_KTruss : public ::testing::TestWithParam<std::tuple<KTruss_Usecase, 
       hr_timer.start("SG Construct graph");
     }
 
-    // NX k_truss is not implemented for graph with self loop and multi edges therefore dropped
-    // them especially for rmat generated graphs.
     auto [graph, edge_weight, d_renumber_map_labels] =
       cugraph::test::construct_graph<vertex_t, edge_t, weight_t, false, false>(
         handle, input_usecase, k_truss_usecase.test_weighted_, renumber, false, true);
@@ -211,7 +201,6 @@ class Tests_KTruss : public ::testing::TestWithParam<std::tuple<KTruss_Usecase, 
     }
 
     if (k_truss_usecase.check_correctness_) {
-      std::optional<cugraph::graph_t<vertex_t, edge_t, false, false>> modified_graph{std::nullopt};
       auto [h_offsets, h_indices, h_values] = cugraph::test::graph_to_host_csr(
         handle,
         graph_view,

--- a/cpp/tests/cores/core_number_test.cpp
+++ b/cpp/tests/cores/core_number_test.cpp
@@ -236,7 +236,7 @@ class Tests_CoreNumber
     std::optional<rmm::device_uvector<vertex_t>> d_renumber_map_labels{std::nullopt};
     std::tie(graph, std::ignore, d_renumber_map_labels) =
       cugraph::test::construct_graph<vertex_t, edge_t, weight_t, false, false>(
-        handle, input_usecase, false, renumber, true, true);
+        handle, input_usecase, false, renumber, false, true);
 
     if (cugraph::test::g_perf) {
       RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement

--- a/cpp/tests/cores/k_core_test.cpp
+++ b/cpp/tests/cores/k_core_test.cpp
@@ -72,7 +72,7 @@ class Tests_KCore : public ::testing::TestWithParam<std::tuple<KCore_Usecase, in
 
     auto [graph, edge_weights, d_renumber_map_labels] =
       cugraph::test::construct_graph<vertex_t, edge_t, weight_t, false, false>(
-        handle, input_usecase, false, renumber, true, true);
+        handle, input_usecase, false, renumber, false, true);
 
     if (cugraph::test::g_perf) {
       RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement

--- a/cpp/tests/cores/mg_core_number_test.cpp
+++ b/cpp/tests/cores/mg_core_number_test.cpp
@@ -84,7 +84,7 @@ class Tests_MGCoreNumber
     std::optional<rmm::device_uvector<vertex_t>> mg_renumber_map{std::nullopt};
     std::tie(mg_graph, std::ignore, mg_renumber_map) =
       cugraph::test::construct_graph<vertex_t, edge_t, weight_t, false, true>(
-        *handle_, input_usecase, false, true, true, true);
+        *handle_, input_usecase, false, true, false, true);
 
     if (cugraph::test::g_perf) {
       RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement

--- a/cpp/tests/cores/mg_k_core_test.cpp
+++ b/cpp/tests/cores/mg_k_core_test.cpp
@@ -75,7 +75,7 @@ class Tests_MGKCore : public ::testing::TestWithParam<std::tuple<KCore_Usecase, 
 
     auto [mg_graph, mg_edge_weights, mg_renumber_map] =
       cugraph::test::construct_graph<vertex_t, edge_t, weight_t, false, true>(
-        *handle_, input_usecase, false, renumber, true, true);
+        *handle_, input_usecase, false, renumber, false, true);
 
     if (cugraph::test::g_perf) {
       RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement


### PR DESCRIPTION
Core number, K-Core, K-Truss, Triangle Count, and Edge Triangle Count do not support graphs with self-loops and multi-edges.

But they have been inconsistent in handling graphs with self-loops and multi-edges.

Core number throws an exception if the input graph has a self-loop but other algorithms ignores (by edge masking) self-loops in computing.

Most algorithms throws an exception if the input graph is a multi-graph but edge triangle count does not check for this.

In C++ tests, some tests include graphs with self-loops but some tests don't (drop_self_loops is set to true in graph generation).

We can simply check whether the input graph is a multi graph or not by just calling is_multigraph() (even though this does not necessarily mean the input graph actually has multi-edges) and this PR updates cugraph to consistently throw an exception if graph_view.is_multigraph() returns true.

Regarding self-loops, we mask out self-loops if count_self_loops() returns a non-zero value.

In C++ tests, we consistently set drop_self_loops to false; so we can test input graphs with self-loops.