### PR TITLE
Compile optimizations - batch 2

### DIFF
--- a/cpp/include/cugraph/arithmetic_variant_types.hpp
+++ b/cpp/include/cugraph/arithmetic_variant_types.hpp
@@ -233,7 +233,7 @@ inline arithmetic_device_span_t make_arithmetic_device_span(arithmetic_device_uv
 {
   return variant_type_dispatch(v, [](auto& v) {
     using T = typename std::remove_reference<decltype(v)>::type::value_type;
-    return static_cast<arithmetic_device_span_t>(raft::device_span<T>(v.data(), v.size()));
+    return arithmetic_device_span_t(raft::device_span<T>(v.data(), v.size()));
   });
 }
 

--- a/cpp/include/cugraph/detail/shuffle_wrappers.hpp
+++ b/cpp/include/cugraph/detail/shuffle_wrappers.hpp
@@ -215,7 +215,7 @@ shuffle_int_vertex_value_pairs_to_local_gpu_by_vertex_partitioning(
  * the sparse 2D matrix using sources as major indices) or destinations (otherwise)
  * @param[in,out] edgelist_minors Vertex IDs for destinations (if we are internally storing edges
  * in the sparse 2D matrix using sources as major indices) or sources (otherwise)
- * @param[in,out] edgelist_properties Vector of edge properties, each element a device span of an
+ * @param[in,out] edgelist_properties Span of edge properties, each element a device span of an
  * edge property.
  * @param[in] groupby_and_count_local_partition_by_minor If set to true, groupby and count edges
  * based on (local partition ID, GPU ID) pairs (where GPU IDs are computed by applying the

--- a/cpp/include/cugraph/detail/shuffle_wrappers.hpp
+++ b/cpp/include/cugraph/detail/shuffle_wrappers.hpp
@@ -205,25 +205,18 @@ shuffle_int_vertex_value_pairs_to_local_gpu_by_vertex_partitioning(
 /**
  * @ingroup shuffle_wrappers_cpp
  * @brief Groupby and count edgelist using the key function which returns the target local partition
- * ID for an edge.
+ * ID for an edge.  The specified spans are reordered in place.
  *
  * @tparam vertex_t Type of vertex identifiers. Needs to be an integral type.
- * @tparam edge_t Type of edge identifiers. Needs to be an integral type.
- * @tparam weight_t Type of edge weights. Needs to be a floating point type.
- * @tparam edge_type_t Type of edge type identifiers. Needs to be an integral type.
- * @tparam edge_time_t Type of edge time. Needs to be an integral type.
  *
  * @param[in] handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator,
  * and handles to various CUDA libraries) to run graph algorithms.
- * @param[in,out] d_edgelist_majors Vertex IDs for sources (if we are internally storing edges in
+ * @param[in,out] edgelist_majors Vertex IDs for sources (if we are internally storing edges in
  * the sparse 2D matrix using sources as major indices) or destinations (otherwise)
- * @param[in,out] d_edgelist_minors Vertex IDs for destinations (if we are internally storing edges
+ * @param[in,out] edgelist_minors Vertex IDs for destinations (if we are internally storing edges
  * in the sparse 2D matrix using sources as major indices) or sources (otherwise)
- * @param[in,out] d_edgelist_weights Optional edge weights
- * @param[in,out] d_edgelist_ids Optional edge ids
- * @param[in,out] d_edgelist_types Optional edge types
- * @param[in,out] d_edgelist_start_times Optional edge start times
- * @param[in,out] d_edgelist_end_times Optional edge end times
+ * @param[in,out] edgelist_properties Vector of edge properties, each element a device span of an
+ * edge property.
  * @param[in] groupby_and_count_local_partition_by_minor If set to true, groupby and count edges
  * based on (local partition ID, GPU ID) pairs (where GPU IDs are computed by applying the
  * compute_gpu_id_from_vertex_t function to the minor vertex ID). If set to false, groupby and count
@@ -238,7 +231,7 @@ rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   raft::handle_t const& handle,
   raft::device_span<vertex_t> edgelist_majors,
   raft::device_span<vertex_t> edgelist_minors,
-  raft::host_span<cugraph::arithmetic_device_span_t> edgelist_properties,
+  raft::host_span<arithmetic_device_span_t> edgelist_properties,
   bool groupby_and_count_local_partition_by_minor = false);
 
 /**
@@ -277,4 +270,45 @@ rmm::device_uvector<value_t> collect_local_vertex_values_from_ext_vertex_value_p
   bool do_expensive_check);
 
 }  // namespace detail
+
+/**
+ * @ingroup shuffle_wrappers_cpp
+ * @brief Shuffle keys and their associated properties to the proper GPU based on a partitioning
+ * function.  Keys for this function are assumed to be an arithmetic type
+ *
+ * @tparam key_t type of key
+ * @tparam key_to_gpu_op_t Function to convert key to GPU id
+ *
+ * @param[in] handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator,
+ * and handles to various CUDA libraries) to run graph algorithms.
+ * @param [in] key Device vector of keys
+ * @param [in] properties Vector of device vectors of properties associated with each key
+ * @param [in] key_to_gpu_op function converting key to a GPU id
+ *
+ * @return tuple of device vector of keys and vector of device vector of properties associated with
+ * the key.
+ */
+template <typename key_t, typename key_to_gpu_op_t>
+std::tuple<rmm::device_uvector<key_t>, std::vector<arithmetic_device_uvector_t>>
+shuffle_keys_with_properties(raft::handle_t const& handle,
+                             rmm::device_uvector<key_t>&& keys,
+                             std::vector<arithmetic_device_uvector_t>&& properties,
+                             key_to_gpu_op_t key_to_gpu_op);
+
+/**
+ * @ingroup shuffle_wrappers_cpp
+ * @brief Shuffle properties to the proper GPU
+ * *
+ * @param[in] handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator,
+ * and handles to various CUDA libraries) to run graph algorithms.
+ * @param [in] gpu Device vector of gpu ids
+ * @param [in] properties Vector of device vectors of properties
+ *
+ * @return vector of device vector of properties shuffled to the proper GPU
+ */
+std::vector<arithmetic_device_uvector_t> shuffle_properties(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int>&& gpus,
+  std::vector<arithmetic_device_uvector_t>&& properties);
+
 }  // namespace cugraph

--- a/cpp/src/community/approx_weighted_matching_impl.cuh
+++ b/cpp/src/community/approx_weighted_matching_impl.cuh
@@ -142,8 +142,7 @@ std::tuple<rmm::device_uvector<vertex_t>, weight_t> approximate_weighted_matchin
     //
 
     if constexpr (multi_gpu) {
-      auto vertex_partition_range_lasts = current_graph_view.vertex_partition_range_lasts();
-
+      auto vertex_partition_range_lasts = graph_view.vertex_partition_range_lasts();
       rmm::device_uvector<vertex_t> d_vertex_partition_range_lasts(
         vertex_partition_range_lasts.size(), handle.get_stream());
 
@@ -152,26 +151,21 @@ std::tuple<rmm::device_uvector<vertex_t>, weight_t> approximate_weighted_matchin
                           vertex_partition_range_lasts.size(),
                           handle.get_stream());
 
-      auto& major_comm = handle.get_subcomm(cugraph::partition_manager::major_comm_name());
-      auto const major_comm_size = major_comm.get_size();
-      auto& minor_comm = handle.get_subcomm(cugraph::partition_manager::minor_comm_name());
-      auto const minor_comm_size = minor_comm.get_size();
+      std::vector<cugraph::arithmetic_device_uvector_t> vertex_properties{};
+      vertex_properties.push_back(std::move(candidates));
+      vertex_properties.push_back(std::move(offers_from_candidates));
 
-      auto key_func = cugraph::detail::compute_gpu_id_from_int_vertex_t<vertex_t>{
-        raft::device_span<vertex_t const>(d_vertex_partition_range_lasts.data(),
-                                          d_vertex_partition_range_lasts.size()),
-        major_comm_size,
-        minor_comm_size};
+      std::tie(targets, vertex_properties) = shuffle_keys_with_properties(
+        handle,
+        std::move(targets),
+        std::move(vertex_properties),
+        cugraph::detail::compute_gpu_id_from_int_vertex_t<vertex_t>{
+          raft::device_span<vertex_t const>{d_vertex_partition_range_lasts.data(),
+                                            d_vertex_partition_range_lasts.size()}});
 
-      std::forward_as_tuple(std::tie(candidates, offers_from_candidates, targets), std::ignore) =
-        cugraph::groupby_gpu_id_and_shuffle_values(
-          handle.get_comms(),
-          thrust::make_zip_iterator(thrust::make_tuple(
-            candidates.begin(), offers_from_candidates.begin(), targets.begin())),
-          thrust::make_zip_iterator(
-            thrust::make_tuple(candidates.end(), offers_from_candidates.end(), targets.end())),
-          [key_func] __device__(auto val) { return key_func(thrust::get<2>(val)); },
-          handle.get_stream());
+      candidates = std::move(std::get<rmm::device_uvector<vertex_t>>(vertex_properties[0]));
+      offers_from_candidates =
+        std::move(std::get<rmm::device_uvector<weight_t>>(vertex_properties[1]));
     }
 
     auto itr_to_tuples = thrust::make_zip_iterator(

--- a/cpp/src/sampling/random_walks_impl.cuh
+++ b/cpp/src/sampling/random_walks_impl.cuh
@@ -618,43 +618,56 @@ random_walk_impl(raft::handle_t const& handle,
       auto& minor_comm = handle.get_subcomm(cugraph::partition_manager::minor_comm_name());
       auto const minor_comm_size = minor_comm.get_size();
 
-      if (previous_vertices) {
-        std::forward_as_tuple(
-          std::tie(current_vertices, current_gpu, current_position, previous_vertices),
-          std::ignore) =
-          cugraph::groupby_gpu_id_and_shuffle_values(
-            handle.get_comms(),
-            thrust::make_zip_iterator(current_vertices.begin(),
-                                      current_gpu.begin(),
-                                      current_position.begin(),
-                                      previous_vertices->begin()),
-            thrust::make_zip_iterator(current_vertices.end(),
-                                      current_gpu.end(),
-                                      current_position.end(),
-                                      previous_vertices->end()),
-            [key_func =
-               cugraph::detail::compute_gpu_id_from_int_vertex_t<vertex_t>{
-                 {vertex_partition_range_lasts.begin(), vertex_partition_range_lasts.size()},
-                 major_comm_size,
-                 minor_comm_size}] __device__(auto val) { return key_func(thrust::get<0>(val)); },
-            handle.get_stream());
-      } else {
-        // Shuffle vertices to correct GPU to compute random indices
-        std::forward_as_tuple(std::tie(current_vertices, current_gpu, current_position),
-                              std::ignore) =
-          cugraph::groupby_gpu_id_and_shuffle_values(
-            handle.get_comms(),
-            thrust::make_zip_iterator(
-              current_vertices.begin(), current_gpu.begin(), current_position.begin()),
-            thrust::make_zip_iterator(
-              current_vertices.end(), current_gpu.end(), current_position.end()),
-            [key_func =
-               cugraph::detail::compute_gpu_id_from_int_vertex_t<vertex_t>{
-                 {vertex_partition_range_lasts.begin(), vertex_partition_range_lasts.size()},
-                 major_comm_size,
-                 minor_comm_size}] __device__(auto val) { return key_func(thrust::get<0>(val)); },
-            handle.get_stream());
-      }
+#if 0
+      sleep(handle.get_comms().get_rank());
+      std::cout << "level = " << level
+                << ", before shuffle rank = " << handle.get_comms().get_rank() << std::endl;
+
+      raft::print_device_vector(
+        "  current_vertices", current_vertices.data(), current_vertices.size(), std::cout);
+      raft::print_device_vector("  current_gpu", current_gpu.data(), current_gpu.size(), std::cout);
+      raft::print_device_vector(
+        "  current_position", current_position.data(), current_position.size(), std::cout);
+      if (previous_vertices)
+        raft::print_device_vector(
+          "  previous_vertices", previous_vertices->data(), previous_vertices->size(), std::cout);
+#endif
+
+      std::vector<cugraph::arithmetic_device_uvector_t> vertex_properties{};
+      vertex_properties.push_back(std::move(current_gpu));
+      vertex_properties.push_back(std::move(current_position));
+
+      if (previous_vertices) vertex_properties.push_back(std::move(*previous_vertices));
+
+      std::tie(current_vertices, vertex_properties) = cugraph::shuffle_keys_with_properties(
+        handle,
+        std::move(current_vertices),
+        std::move(vertex_properties),
+        cugraph::detail::compute_gpu_id_from_int_vertex_t<vertex_t>{
+          {vertex_partition_range_lasts.begin(), vertex_partition_range_lasts.size()},
+          major_comm_size,
+          minor_comm_size});
+
+      current_gpu      = std::move(std::get<rmm::device_uvector<int>>(vertex_properties[0]));
+      current_position = std::move(std::get<rmm::device_uvector<size_t>>(vertex_properties[1]));
+
+      if (previous_vertices)
+        *previous_vertices =
+          std::move(std::get<rmm::device_uvector<vertex_t>>(vertex_properties[2]));
+
+#if 0
+      sleep(handle.get_comms().get_rank());
+      std::cout << "after shuffle rank = " << handle.get_comms().get_rank() << std::endl;
+
+      raft::print_device_vector(
+        "  current_vertices", current_vertices.data(), current_vertices.size(), std::cout);
+      raft::print_device_vector("  current_gpu", current_gpu.data(), current_gpu.size(), std::cout);
+      raft::print_device_vector(
+        "  current_position", current_position.data(), current_position.size(), std::cout);
+      if (previous_vertices)
+        raft::print_device_vector(
+          "  previous_vertices", previous_vertices->data(), previous_vertices->size(), std::cout);
+#endif
     }
 
     //  Sort for nbr_intersection, must sort all together
@@ -838,69 +851,30 @@ random_walk_impl(raft::handle_t const& handle,
       current_gpu.shrink_to_fit(handle.get_stream());
 
       // Shuffle back to original GPU
-      if (previous_vertices) {
-        if (result_weights) {
-          auto current_iter = thrust::make_zip_iterator(current_vertices.begin(),
-                                                        new_weights->begin(),
-                                                        current_gpu.begin(),
-                                                        current_position.begin(),
-                                                        previous_vertices->begin());
 
-          std::forward_as_tuple(
-            std::tie(
-              current_vertices, *new_weights, current_gpu, current_position, *previous_vertices),
-            std::ignore) =
-            cugraph::groupby_gpu_id_and_shuffle_values(
-              handle.get_comms(),
-              current_iter,
-              current_iter + current_vertices.size(),
-              [] __device__(auto val) { return thrust::get<2>(val); },
-              handle.get_stream());
-        } else {
-          auto current_iter = thrust::make_zip_iterator(current_vertices.begin(),
-                                                        current_gpu.begin(),
-                                                        current_position.begin(),
-                                                        previous_vertices->begin());
+      std::vector<cugraph::arithmetic_device_uvector_t> vertex_properties{};
+      vertex_properties.push_back(std::move(current_vertices));
+      vertex_properties.push_back(std::move(current_position));
+      if (new_weights) vertex_properties.push_back(std::move(*new_weights));
+      if (previous_vertices) vertex_properties.push_back(std::move(*previous_vertices));
 
-          std::forward_as_tuple(
-            std::tie(current_vertices, current_gpu, current_position, *previous_vertices),
-            std::ignore) =
-            cugraph::groupby_gpu_id_and_shuffle_values(
-              handle.get_comms(),
-              current_iter,
-              current_iter + current_vertices.size(),
-              [] __device__(auto val) { return thrust::get<1>(val); },
-              handle.get_stream());
-        }
-      } else {
-        if (result_weights) {
-          auto current_iter = thrust::make_zip_iterator(current_vertices.begin(),
-                                                        new_weights->begin(),
-                                                        current_gpu.begin(),
-                                                        current_position.begin());
+      vertex_properties =
+        cugraph::shuffle_properties(handle, std::move(current_gpu), std::move(vertex_properties));
 
-          std::forward_as_tuple(
-            std::tie(current_vertices, *new_weights, current_gpu, current_position), std::ignore) =
-            cugraph::groupby_gpu_id_and_shuffle_values(
-              handle.get_comms(),
-              current_iter,
-              current_iter + current_vertices.size(),
-              [] __device__(auto val) { return thrust::get<2>(val); },
-              handle.get_stream());
-        } else {
-          auto current_iter = thrust::make_zip_iterator(
-            current_vertices.begin(), current_gpu.begin(), current_position.begin());
+      size_t pos{0};
+      current_vertices =
+        std::move(std::get<rmm::device_uvector<vertex_t>>(vertex_properties[pos++]));
 
-          std::forward_as_tuple(std::tie(current_vertices, current_gpu, current_position),
-                                std::ignore) =
-            cugraph::groupby_gpu_id_and_shuffle_values(
-              handle.get_comms(),
-              current_iter,
-              current_iter + current_vertices.size(),
-              [] __device__(auto val) { return thrust::get<1>(val); },
-              handle.get_stream());
-        }
-      }
+      current_gpu = rmm::device_uvector<int>{current_vertices.size(), handle.get_stream()};
+      detail::scalar_fill(
+        handle, current_gpu.data(), current_gpu.size(), handle.get_comms().get_rank());
+
+      current_position = std::move(std::get<rmm::device_uvector<size_t>>(vertex_properties[pos++]));
+      if (new_weights)
+        *new_weights = std::move(std::get<rmm::device_uvector<weight_t>>(vertex_properties[pos++]));
+      if (previous_vertices)
+        *previous_vertices =
+          std::move(std::get<rmm::device_uvector<vertex_t>>(vertex_properties[pos++]));
     }
 
     if (result_weights) {

--- a/cpp/src/utilities/shuffle_vertices_mg_v32_fp.cu
+++ b/cpp/src/utilities/shuffle_vertices_mg_v32_fp.cu
@@ -40,4 +40,36 @@ shuffle_ext_vertex_value_pairs(raft::handle_t const& handle,
                                rmm::device_uvector<int32_t>&& vertices,
                                rmm::device_uvector<double>&& values);
 
+template std::tuple<rmm::device_uvector<int32_t>, std::vector<arithmetic_device_uvector_t>>
+shuffle_keys_with_properties(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& keys,
+  std::vector<arithmetic_device_uvector_t>&& properties,
+  cugraph::detail::compute_gpu_id_from_int_vertex_t<int32_t> key_to_gpu_op);
+
+template std::tuple<rmm::device_uvector<int32_t>, std::vector<arithmetic_device_uvector_t>>
+shuffle_keys_with_properties(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& keys,
+  std::vector<arithmetic_device_uvector_t>&& properties,
+  cugraph::detail::compute_gpu_id_from_ext_vertex_t<int32_t> key_to_gpu_op);
+
+template std::tuple<rmm::device_uvector<int32_t>, std::vector<arithmetic_device_uvector_t>>
+shuffle_keys_with_properties(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int32_t>&& keys,
+  std::vector<arithmetic_device_uvector_t>&& properties,
+  cugraph::detail::compute_gpu_id_from_ext_edge_id_t<int32_t> key_to_gpu_op);
+
+std::vector<arithmetic_device_uvector_t> shuffle_properties(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int>&& gpus,
+  std::vector<arithmetic_device_uvector_t>&& properties)
+{
+  std::tie(std::ignore, properties) = shuffle_keys_with_properties(
+    handle, std::move(gpus), std::move(properties), [] __device__(auto& x) { return x; });
+
+  return std::move(properties);
+}
+
 }  // namespace cugraph

--- a/cpp/src/utilities/shuffle_vertices_mg_v64_fp.cu
+++ b/cpp/src/utilities/shuffle_vertices_mg_v64_fp.cu
@@ -40,4 +40,25 @@ shuffle_ext_vertex_value_pairs(raft::handle_t const& handle,
                                rmm::device_uvector<int64_t>&& vertices,
                                rmm::device_uvector<double>&& values);
 
+template std::tuple<rmm::device_uvector<int64_t>, std::vector<arithmetic_device_uvector_t>>
+shuffle_keys_with_properties(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t>&& keys,
+  std::vector<arithmetic_device_uvector_t>&& properties,
+  cugraph::detail::compute_gpu_id_from_int_vertex_t<int64_t> key_to_gpu_op);
+
+template std::tuple<rmm::device_uvector<int64_t>, std::vector<arithmetic_device_uvector_t>>
+shuffle_keys_with_properties(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t>&& keys,
+  std::vector<arithmetic_device_uvector_t>&& properties,
+  cugraph::detail::compute_gpu_id_from_ext_vertex_t<int64_t> key_to_gpu_op);
+
+template std::tuple<rmm::device_uvector<int64_t>, std::vector<arithmetic_device_uvector_t>>
+shuffle_keys_with_properties(
+  raft::handle_t const& handle,
+  rmm::device_uvector<int64_t>&& keys,
+  std::vector<arithmetic_device_uvector_t>&& properties,
+  cugraph::detail::compute_gpu_id_from_ext_edge_id_t<int64_t> key_to_gpu_op);
+
 }  // namespace cugraph

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -217,7 +217,7 @@ function(ConfigureTestMG CMAKE_TEST_NAME)
              ${MPIEXEC_NUMPROC_FLAG}
              ${GPU_COUNT}
              ${MPIEXEC_PREFLAGS}
-             ${CMAKE_TEST_NAME}
+             "${CUGRAPH_BINARY_DIR}/gtests/${CMAKE_TEST_NAME}"
              ${MPIEXEC_POSTFLAGS}
         GPUS ${GPU_COUNT}
         PERCENT 100


### PR DESCRIPTION
Second batch of updates to use the new variant structures.  This should reduce the compile time and compiler memory usage.

Another 1% savings from the baseline size of libcugraph.so.
