### PR TITLE
Fix build error with gcc 14.

### DIFF
--- a/cpp/src/prims/detail/per_v_transform_reduce_e.cuh
+++ b/cpp/src/prims/detail/per_v_transform_reduce_e.cuh
@@ -3093,7 +3093,7 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
                 graph_view.local_edge_partition_view(partition_idx));
             auto const& segment_offsets =
               graph_view.local_edge_partition_segment_offsets(partition_idx);
-            // check segment_offfsets->size() >= 2 to silence a compiler warning with GCC 14 (if
+            // check segment_offsets->size() >= 2 to silence a compiler warning with GCC 14 (if
             // segment_offsets.has_value() is true, segment_offsets->size() should always be larger
             // than 2, so this check shouldn't be necessary otherwise).
             buffer_size =

--- a/cpp/src/prims/vertex_frontier.cuh
+++ b/cpp/src/prims/vertex_frontier.cuh
@@ -318,7 +318,15 @@ class key_bucket_t {
   {
   }
 
-  ~key_bucket_t() = default;
+  ~key_bucket_t()
+  {
+    // to silence a compiler warning with GCC 14 (otherwise, the default destructor will be
+    // sufficient)
+    if (vertices_.index() == 1) {
+      std::get<1>(vertices_).resize(0, std::get<1>(vertices_).stream());
+      std::get<1>(vertices_).shrink_to_fit(std::get<1>(vertices_).stream());
+    }
+  }
 
   key_bucket_t& operator=(key_bucket_t const& other) = delete;
 
@@ -327,8 +335,8 @@ class key_bucket_t {
   {
     if (this != &other) {
       this->handle_ptr_ = other.handle_ptr_;
-      // to silence a compiler warning with GCC 14 (this->vertices_ = std::move(other.vertices_)
-      // should be sufficient, otherwise)
+      // to silence a compiler warning with GCC 14 (otherwise, the default destructor will be
+      // sufficient)
       if (other.vertices_.index() == 0) {
         this->vertices_ = std::move(std::get<0>(other.vertices_));
       } else {

--- a/cpp/src/prims/vertex_frontier.cuh
+++ b/cpp/src/prims/vertex_frontier.cuh
@@ -327,8 +327,14 @@ class key_bucket_t {
   {
     if (this != &other) {
       this->handle_ptr_ = other.handle_ptr_;
-      this->vertices_   = std::move(other.vertices_);
-      this->tags_       = std::move(other.tags_);
+      // to silence a compiler warning with GCC 14 (this->vertices_ = std::move(other.vertices_)
+      // should be sufficient, otherwise)
+      if (other.vertices_.index() == 0) {
+        this->vertices_ = std::move(std::get<0>(other.vertices_));
+      } else {
+        this->vertices_ = std::move(std::get<1>(other.vertices_));
+      }
+      this->tags_ = std::move(other.tags_);
     }
     return *this;
   }

--- a/cpp/src/sampling/detail/shuffle_and_organize_output_impl.cuh
+++ b/cpp/src/sampling/detail/shuffle_and_organize_output_impl.cuh
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include "prims/update_edge_src_dst_property.cuh"  // ??
-#include "prims/vertex_frontier.cuh"
 #include "structure/detail/structure_utils.cuh"
 
 #include <cugraph/detail/shuffle_wrappers.hpp>

--- a/cpp/tests/centrality/betweenness_centrality_reference.hpp
+++ b/cpp/tests/centrality/betweenness_centrality_reference.hpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <limits>
 #include <optional>
 #include <queue>


### PR DESCRIPTION
This fixes build errors occurred in https://github.com/rapidsai/cugraph/pull/5124 + add workarounds to silence (spurious) compiler warnings.