### PR TITLE
Re-enable cugraph service test

### DIFF
--- a/python/cugraph-service/tests/test_e2e.py
+++ b/python/cugraph-service/tests/test_e2e.py
@@ -461,23 +461,31 @@ def test_uniform_neighbor_sampling(client_with_edgelist_csv_loaded):
     )
 
 
-@pytest.mark.skip(reason="FIXME: this fails in CI")
 def test_renumber_vertices_by_type(client_with_property_csvs_loaded):
     client, _ = client_with_property_csvs_loaded
     re = client.renumber_vertices_by_type(prev_id_column="old_vid")
     assert re.start == [0, 5]
     assert re.stop == [4, 8]
     print(client.get_graph_vertex_data(property_keys=["old_vid"]))
-    assert client.get_graph_vertex_data(property_keys=["old_vid"])[:, -1].tolist() == [
-        11,
+    sorted_old_vid = client.get_graph_vertex_data(
+        property_keys=["old_vid"])[:, -1].tolist()
+    sorted_old_vid.sort()
+
+    # Ensure that the original vertices are all represented in the
+    # vertex data property_keys "old_vid"
+
+    # TODO: add a more detailed test to the PG test suite for verifying
+    # contiguity within the vertex types
+    assert sorted_old_vid == [
         4,
-        21,
+        11,
         16,
+        21,
         86,
-        89021,
         32431,
-        89216,
         78634,
+        89021,
+        89216,
     ]
 
 

--- a/python/cugraph-service/tests/test_e2e.py
+++ b/python/cugraph-service/tests/test_e2e.py
@@ -461,6 +461,7 @@ def test_uniform_neighbor_sampling(client_with_edgelist_csv_loaded):
     )
 
 
+@pytest.mark.skip(reason="FIXME: this fails in CI")
 def test_renumber_vertices_by_type(client_with_property_csvs_loaded):
     client, _ = client_with_property_csvs_loaded
     re = client.renumber_vertices_by_type(prev_id_column="old_vid")

--- a/python/cugraph-service/tests/test_e2e.py
+++ b/python/cugraph-service/tests/test_e2e.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/cugraph-service/tests/test_e2e.py
+++ b/python/cugraph-service/tests/test_e2e.py
@@ -461,7 +461,6 @@ def test_uniform_neighbor_sampling(client_with_edgelist_csv_loaded):
     )
 
 
-@pytest.mark.skip(reason="FIXME: this fails in CI")
 def test_renumber_vertices_by_type(client_with_property_csvs_loaded):
     client, _ = client_with_property_csvs_loaded
     re = client.renumber_vertices_by_type(prev_id_column="old_vid")


### PR DESCRIPTION
This PR temporarily re-enable a cuGraph service test after fixing an assumption made in the test. In fact, a breaking cuDF change alters the result order when `joining` two dataframes with the argument `how=outer`. It also add a TODO prompting the design of another pG test verifying contiguity within the vertex types with respect to the breaking cuDF change