### PR TITLE
Correct C API test for uniform neighborhood sampling

### DIFF
--- a/cpp/tests/c_api/uniform_neighbor_sample_test.c
+++ b/cpp/tests/c_api/uniform_neighbor_sample_test.c
@@ -762,6 +762,8 @@ int test_uniform_neighbor_sample_with_labels(const cugraph_resource_handle_t* ha
 
   cugraph_graph_free(graph);
   cugraph_error_free(ret_error);
+
+  return test_ret_value;
 }
 
 int test_uniform_neighbor_sample_clean(const cugraph_resource_handle_t* handle)


### PR DESCRIPTION
All C API tests should return a result, one of the tests was not.

Closes #5130 