### PR TITLE
Update MST test

### DIFF
--- a/cpp/tests/c_api/legacy_mst_test.c
+++ b/cpp/tests/c_api/legacy_mst_test.c
@@ -195,8 +195,8 @@ int test_minimum_spanning_tree_no_weights()
   vertex_t h_src[] = {0, 1, 1, 2, 2, 2, 3, 4, 1, 3, 4, 0, 1, 3, 5, 5};
   vertex_t h_dst[] = {1, 3, 4, 0, 1, 3, 5, 5, 0, 1, 1, 2, 2, 2, 3, 4};
 
-  vertex_t h_result_src[]     = {0, 1, 2, 3, 4, 5, 0, 1, 1, 3};
-  vertex_t h_result_dst[]     = {1, 0, 0, 1, 1, 3, 2, 3, 4, 5};
+  vertex_t h_result_src[]     = {0, 1, 2, 3, 4, 5, 2, 3, 5, 3};
+  vertex_t h_result_dst[]     = {2, 3, 3, 2, 5, 3, 0, 1, 4, 5};
   weight_t h_result_wgt[]     = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
   size_t h_result_offsets[]   = {0, 10};
   size_t num_expected_edges   = 10;
@@ -221,7 +221,7 @@ int test_minimum_spanning_tree_no_weights()
 int main(int argc, char** argv)
 {
   int result = 0;
-  result |= RUN_TEST(test_minimum_spanning_tree);
+  //result |= RUN_TEST(test_minimum_spanning_tree);
   result |= RUN_TEST(test_minimum_spanning_tree_no_weights);
   return result;
 }

--- a/cpp/tests/c_api/legacy_mst_test.c
+++ b/cpp/tests/c_api/legacy_mst_test.c
@@ -221,7 +221,7 @@ int test_minimum_spanning_tree_no_weights()
 int main(int argc, char** argv)
 {
   int result = 0;
-  //result |= RUN_TEST(test_minimum_spanning_tree);
+  result |= RUN_TEST(test_minimum_spanning_tree);
   result |= RUN_TEST(test_minimum_spanning_tree_no_weights);
   return result;
 }


### PR DESCRIPTION
A change in the Raft API was merged to add support for graph with identical vertices. However, because of the new random weights being added to each edge weight to break-tie, it leads to a different but valid MST. The CAPI test hence has a different hardcoded MST result. This PR updates the test accordingly.