### PR TITLE
Optionally create a graph object in a large memory buffer

### DIFF
--- a/cpp/include/cugraph/detail/shuffle_wrappers.hpp
+++ b/cpp/include/cugraph/detail/shuffle_wrappers.hpp
@@ -55,8 +55,10 @@ namespace detail {
  * @param[in] edge_types Optional vector of vertex pair edge type values.
  * @param[in] edge_start_times Optional vector of vertex pair edge start time values.
  * @param[in] edge_end_times Optional vector of vertex pair edge end time values.
- * @param[in] large_buffer_type Dictates the large buffer type to use in storing the shuffled vertex
- * value pairs (if the value is std::nullopt, the default RMM per-device memory resource is used).
+ * @param[in] large_buffer_type Flag indicating the large buffer type to use when we need to create
+ * a large device-accessible vector object (if the value is std::nullopt, the default RMM per-device
+ * memory resource is used). The shuffled vertex pairs and values will also be stored in the buffer
+ * type dictated by this parameter.
  *
  * @return Tuple of vectors storing shuffled major vertices, minor vertices and optional weights,
  * edge ids and edge types
@@ -110,8 +112,10 @@ shuffle_ext_vertex_pairs_with_values_to_local_gpu_by_edge_partitioning(
  * @param[in] edge_end_times Optional vector of vertex pair edge end time values.
  * @param[in] vertex_partition_range_lasts Vector of each GPU's vertex partition range's last
  * (exclusive) vertex ID.
- * @param[in] large_buffer_type Dictates the large buffer type to use in storing the shuffled vertex
- * pairs (if the value is std::nullopt, the default RMM per-device memory resource is used).
+ * @param[in] large_buffer_type Flag indicating the large buffer type to use when we need to create
+ * a large device-accessible vector object (if the value is std::nullopt, the default RMM per-device
+ * memory resource is used). The shuffled vertex pairs and values will also be stored in the buffer
+ * type dictated by this parameter.
  *
  * @return Tuple of vectors storing shuffled major vertices, minor vertices and optional weights,
  * edge ids and edge types and rx counts
@@ -176,8 +180,10 @@ rmm::device_uvector<vertex_t> permute_range(raft::handle_t const& handle,
  * @param[in] vertices Vertices to shuffle.
  * @param[in] vertex_partition_range_lasts Vector of each GPU's vertex partition range's last
  * (exclusive) vertex ID.
- * @param[in] large_buffer_type Dictates the large buffer type to use in storing the shuffled
- * vertices (if the value is std::nullopt, the default RMM per-device memory resource is used).
+ * @param[in] large_buffer_type Flag indicating the large buffer type to use when we need to create
+ * a large device-accessible vector object (if the value is std::nullopt, the default RMM per-device
+ * memory resource is used). The shuffled vertices will also be stored in the buffer type dictated
+ * by this parameter.
  *
  * @return Vector of shuffled vertices.
  */
@@ -199,8 +205,10 @@ rmm::device_uvector<vertex_t> shuffle_int_vertices_to_local_gpu_by_vertex_partit
  * @param[in] vertices Vertex IDs to shuffle
  * @param[in] values Vertex Values to shuffle
  * @param[in] vertex_partition_range_lasts From graph view, vector of last vertex id for each gpu
- * @param[in] large_buffer_type Dictates the large buffer type to use in storing the shuffled vertex
- * value pairs (if the value is std::nullopt, the default RMM per-device memory resource is used).
+ * @param[in] large_buffer_type Flag indicating the large buffer type to use when we need to create
+ * a large device-accessible vector object (if the value is std::nullopt, the default RMM per-device
+ * memory resource is used). The shuffled vertex value pairs will also be stored in the buffer type
+ * dictated by this parameter.
  *
  * @return tuple containing device vector of shuffled vertices and device vector of corresponding
  *         values
@@ -233,6 +241,9 @@ shuffle_int_vertex_value_pairs_to_local_gpu_by_vertex_partitioning(
  * based on (local partition ID, GPU ID) pairs (where GPU IDs are computed by applying the
  * compute_gpu_id_from_vertex_t function to the minor vertex ID). If set to false, groupby and count
  * edges by just local partition ID.
+ * @param[in] large_buffer_type Flag indicating the large buffer type to use when we need to create
+ * a large device-accessible vector object (if the value is std::nullopt, the default RMM per-device
+ * memory resource is used).
  *
  * @return A vector containing the number of edges in each local partition (if
  * groupby_and_count_local_partition is false) or in each segment with the same (local partition ID,
@@ -244,7 +255,8 @@ rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
   raft::device_span<vertex_t> edgelist_majors,
   raft::device_span<vertex_t> edgelist_minors,
   raft::host_span<arithmetic_device_span_t> edgelist_properties,
-  bool groupby_and_count_local_partition_by_minor = false);
+  bool groupby_and_count_local_partition_by_minor      = false,
+  std::optional<large_buffer_type_t> large_buffer_type = std::nullopt);
 
 /**
  * @ingroup shuffle_wrappers_cpp
@@ -296,8 +308,13 @@ rmm::device_uvector<value_t> collect_local_vertex_values_from_ext_vertex_value_p
  * @param [in] key Device vector of keys
  * @param [in] properties Vector of device vectors of properties associated with each key
  * @param [in] key_to_gpu_op function converting key to a GPU id
- * @param[in] large_buffer_type Dictates the large buffer type to use in storing the shuffled key
- * value pairs (if the value is std::nullopt, the default RMM per-device memory resource is used).
+ * @param[in] large_buffer_type Flag indicating the large buffer type to use in storing the shuffled
+ * key value pairs (if the value is std::nullopt, the default RMM per-device memory resource is
+ * used).
+ * @param[in] large_buffer_type Flag indicating the large buffer type to use when we need to create
+ * a large device-accessible vector object (if the value is std::nullopt, the default RMM per-device
+ * memory resource is used). The shuffled keys and property values will also be stored in the buffer
+ * type dictated by this parameter.
  *
  * @return tuple of device vector of keys and vector of device vector of properties associated with
  * the key.
@@ -318,9 +335,10 @@ shuffle_keys_with_properties(raft::handle_t const& handle,
  * and handles to various CUDA libraries) to run graph algorithms.
  * @param [in] gpu Device vector of gpu ids
  * @param [in] properties Vector of device vectors of properties
- * @param[in] large_buffer_type Dictates the large buffer type to use in storing the shuffled
- * property values (if the value is std::nullopt, the default RMM per-device memory resource is
- * used).
+ * @param[in] large_buffer_type Flag indicating the large buffer type to use when we need to create
+ * a large device-accessible vector object (if the value is std::nullopt, the default RMM per-device
+ * memory resource is used). The shuffled property values will also be stored in the buffer type
+ * dictated by this parameter.
  *
  * @return vector of device vector of properties shuffled to the proper GPU
  */

--- a/cpp/include/cugraph/graph_functions.hpp
+++ b/cpp/include/cugraph/graph_functions.hpp
@@ -18,6 +18,7 @@
 #include <cugraph/edge_property.hpp>
 #include <cugraph/graph.hpp>
 #include <cugraph/graph_view.hpp>
+#include <cugraph/large_buffer_manager.hpp>
 
 #include <raft/core/device_span.hpp>
 #include <raft/core/handle.hpp>
@@ -93,6 +94,13 @@ struct renumber_meta_t<vertex_t, edge_t, multi_gpu, std::enable_if_t<!multi_gpu>
  * @param store_transposed Should be true if renumbered edges will be used to create a graph with
  * store_transposed = true. Should be false if the edges will be used to create a graph with
  * store_transposed = false.
+ * @param large_vertex_buffer_type Flag indicating the large buffer type to use when we need to
+ * create a per-vertex device-accessible vector object (if the value is std::nullopt, the default
+ * RMM per-device memory resource is used). The returned renumber map (storing vertex IDs before
+ * renumbering) will also be stored in the buffer type dictated by this parameter.
+ * @param large_edge_buffer_type Flag indicating the large buffer type to use when we need to create
+ * a per-edge device-accessible vector object (if the value is std::nullopt, the default RMM
+ * per-device memory resource is used).
  * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
  * @return std::tuple<rmm::device_uvector<vertex_t>, renumber_meta_t<vertex_t, edge_t, multi_gpu>>
  * Tuple of labels (vertex IDs before renumbering) for the entire set of vertices (assigned to this
@@ -114,7 +122,9 @@ renumber_edgelist(
   std::vector<edge_t> const& edgelist_edge_counts,
   std::optional<std::vector<std::vector<edge_t>>> const& edgelist_intra_partition_segment_offsets,
   bool store_transposed,
-  bool do_expensive_check = false);
+  std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt,
+  std::optional<large_buffer_type_t> large_edge_buffer_type   = std::nullopt,
+  bool do_expensive_check                                     = false);
 
 /**
  * @ingroup graph_functions_cpp
@@ -136,6 +146,13 @@ renumber_edgelist(
  * @param store_transposed Should be true if renumbered edges will be used to create a graph with
  * store_transposed = true. Should be false if the edges will be used to create a graph with
  * store_transposed = false.
+ * @param large_vertex_buffer_type Flag indicating the large buffer type to use when we need to
+ * create a per-vertex device-accessible vector object (if the value is std::nullopt, the default
+ * RMM per-device memory resource is used). The returned renumber map (storing vertex IDs before
+ * renumbering) will also be stored in the buffer type dictated by this parameter.
+ * @param large_edge_buffer_type Flag indicating the large buffer type to use when we need to create
+ * a per-edge device-accessible vector object (if the value is std::nullopt, the default RMM
+ * per-device memory resource is used).
  * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
  * @return std::tuple<rmm::device_uvector<vertex_t>, renumber_meta_t<vertex_t, edge_t, multi_gpu>>
  * Tuple of labels (vertex IDs before renumbering) for the entire set of vertices and meta-data
@@ -153,7 +170,9 @@ renumber_edgelist(raft::handle_t const& handle,
                   vertex_t* edgelist_dsts /* [INOUT] */,
                   edge_t num_edgelist_edges,
                   bool store_transposed,
-                  bool do_expensive_check = false);
+                  std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt,
+                  std::optional<large_buffer_type_t> large_edge_buffer_type   = std::nullopt,
+                  bool do_expensive_check                                     = false);
 
 /**
  * @ingroup graph_functions_cpp
@@ -727,6 +746,14 @@ extract_induced_subgraphs(
  * and) edge list.
  * @param renumber Flag indicating whether to renumber vertices or not (must be true if @p multi_gpu
  * is true).
+ * @param large_vertex_buffer_type Flag indicating the large buffer type to use when we need to
+ * create a per-vertex device-accessible vector object (if the value is std::nullopt, the default
+ * RMM per-device memory resource is used). The per-vertex vectors in the created graph will also be
+ * stored in the buffer type dictated by this parameter.
+ * @param large_edge_buffer_type Flag indicating the large buffer type to use when we need to create
+ * a per-edge device-accessible vector object (if the value is std::nullopt, the default RMM
+ * per-device memory resource is used). The per-edge vectors in the created graph will also be
+ * stored in the buffer type dictated by this parameter.
  * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
  * @return Tuple of the generated graph and optional edge_property_t objects storing the provided
  * edge properties and a renumber map (if @p renumber is true).
@@ -742,16 +769,19 @@ std::tuple<graph_t<vertex_t, edge_t, store_transposed, multi_gpu>,
            std::optional<edge_property_t<edge_t, edge_t>>,
            std::optional<edge_property_t<edge_t, edge_type_t>>,
            std::optional<rmm::device_uvector<vertex_t>>>
-create_graph_from_edgelist(raft::handle_t const& handle,
-                           std::optional<rmm::device_uvector<vertex_t>>&& vertices,
-                           rmm::device_uvector<vertex_t>&& edgelist_srcs,
-                           rmm::device_uvector<vertex_t>&& edgelist_dsts,
-                           std::optional<rmm::device_uvector<weight_t>>&& edgelist_weights,
-                           std::optional<rmm::device_uvector<edge_t>>&& edgelist_edge_ids,
-                           std::optional<rmm::device_uvector<edge_type_t>>&& edgelist_edge_types,
-                           graph_properties_t graph_properties,
-                           bool renumber,
-                           bool do_expensive_check = false);
+create_graph_from_edgelist(
+  raft::handle_t const& handle,
+  std::optional<rmm::device_uvector<vertex_t>>&& vertices,
+  rmm::device_uvector<vertex_t>&& edgelist_srcs,
+  rmm::device_uvector<vertex_t>&& edgelist_dsts,
+  std::optional<rmm::device_uvector<weight_t>>&& edgelist_weights,
+  std::optional<rmm::device_uvector<edge_t>>&& edgelist_edge_ids,
+  std::optional<rmm::device_uvector<edge_type_t>>&& edgelist_edge_types,
+  graph_properties_t graph_properties,
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt,
+  std::optional<large_buffer_type_t> large_edge_buffer_type   = std::nullopt,
+  bool do_expensive_check                                     = false);
 
 /**
  * @ingroup graph_functions_cpp
@@ -788,6 +818,14 @@ create_graph_from_edgelist(raft::handle_t const& handle,
  * and) edge list.
  * @param renumber Flag indicating whether to renumber vertices or not (must be true if @p multi_gpu
  * is true).
+ * @param large_vertex_buffer_type Flag indicating the large buffer type to use when we need to
+ * create a per-vertex device-accessible vector object (if the value is std::nullopt, the default
+ * RMM per-device memory resource is used). The per-vertex vectors in the created graph will also be
+ * stored in the buffer type dictated by this parameter.
+ * @param large_edge_buffer_type Flag indicating the large buffer type to use when we need to create
+ * a per-edge device-accessible vector object (if the value is std::nullopt, the default RMM
+ * per-device memory resource is used). The per-edge vectors in the created graph will also be
+ * stored in the buffer type dictated by this parameter.
  * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
  * @return Tuple of the generated graph and optional edge_property_t objects storing the provided
  * edge properties and a renumber map (if @p renumber is true).
@@ -818,7 +856,9 @@ create_graph_from_edgelist(
   std::optional<rmm::device_uvector<edge_time_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
-  bool do_expensive_check = false);
+  std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt,
+  std::optional<large_buffer_type_t> large_edge_buffer_type   = std::nullopt,
+  bool do_expensive_check                                     = false);
 
 /**
  * @ingroup graph_functions_cpp
@@ -854,6 +894,14 @@ create_graph_from_edgelist(
  * and) edge list.
  * @param renumber Flag indicating whether to renumber vertices or not (must be true if @p multi_gpu
  * is true).
+ * @param large_vertex_buffer_type Flag indicating the large buffer type to use when we need to
+ * create a per-vertex device-accessible vector object (if the value is std::nullopt, the default
+ * RMM per-device memory resource is used). The per-vertex vectors in the created graph will also be
+ * stored in the buffer type dictated by this parameter.
+ * @param large_edge_buffer_type Flag indicating the large buffer type to use when we need to create
+ * a per-edge device-accessible vector object (if the value is std::nullopt, the default RMM
+ * per-device memory resource is used). The per-edge vectors in the created graph will also be
+ * stored in the buffer type dictated by this parameter.
  * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
  * @return Tuple of the generated graph and optional edge_property_t objects storing the provided
  * edge properties and a renumber map (if @p renumber is true).
@@ -879,7 +927,9 @@ create_graph_from_edgelist(
   std::optional<std::vector<rmm::device_uvector<edge_type_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
-  bool do_expensive_check = false);
+  std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt,
+  std::optional<large_buffer_type_t> large_edge_buffer_type   = std::nullopt,
+  bool do_expensive_check                                     = false);
 
 /**
  * @ingroup graph_functions_cpp
@@ -917,7 +967,14 @@ create_graph_from_edgelist(
  * @param graph_properties Properties of the graph represented by the input (optional vertex list
  * and) edge list.
  * @param renumber Flag indicating whether to renumber vertices or not (must be true if @p multi_gpu
- * is true).
+ * @param large_vertex_buffer_type Flag indicating the large buffer type to use when we need to
+ * create a per-vertex device-accessible vector object (if the value is std::nullopt, the default
+ * RMM per-device memory resource is used). The per-vertex vectors in the created graph will also be
+ * stored in the buffer type dictated by this parameter.
+ * @param large_edge_buffer_type Flag indicating the large buffer type to use when we need to create
+ * a per-edge device-accessible vector object (if the value is std::nullopt, the default RMM
+ * per-device memory resource is used). The per-edge vectors in the created graph will also be
+ * stored in the buffer type dictated by this parameter.
  * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
  * @return Tuple of the generated graph and optional edge_property_t objects storing the provided
  * edge properties and a renumber map (if @p renumber is true).
@@ -948,7 +1005,9 @@ create_graph_from_edgelist(
   std::optional<std::vector<rmm::device_uvector<edge_time_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
-  bool do_expensive_check = false);
+  std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt,
+  std::optional<large_buffer_type_t> large_edge_buffer_type   = std::nullopt,
+  bool do_expensive_check                                     = false);
 
 /**
  * @ingroup graph_functions_cpp
@@ -1168,6 +1227,10 @@ rmm::device_uvector<vertex_t> select_random_vertices(
  * @param edgelist_edge_types  Optional list of edge types
  * @param edgelist_edge_start_times  Optional list of edge start times
  * @param edgelist_edge_end_times  Optional list of edge end times
+ * @param large_buffer_type Flag indicating the large buffer type to use when we need to create a
+ * large device-accessible vector object (if the value is std::nullopt, the default RMM per-device
+ * memory resource is used). The returned edge list will also be stored in the buffer type dictated
+ * by this parameter.
  * @return Tuple of vectors storing edge sources, destinations, optional weights, optional edge ids,
  * optional edge types, optional edge start times and optional edge end times.
  */
@@ -1190,7 +1253,8 @@ remove_self_loops(raft::handle_t const& handle,
                   std::optional<rmm::device_uvector<edge_t>>&& edgelist_edge_ids,
                   std::optional<rmm::device_uvector<edge_type_t>>&& edgelist_edge_types,
                   std::optional<rmm::device_uvector<edge_time_t>>&& edgelist_edge_start_times,
-                  std::optional<rmm::device_uvector<edge_time_t>>&& edgelist_edge_end_times);
+                  std::optional<rmm::device_uvector<edge_time_t>>&& edgelist_edge_end_times,
+                  std::optional<large_buffer_type_t> large_buffer_type = std::nullopt);
 
 /**
  * @ingroup graph_functions_cpp
@@ -1231,6 +1295,10 @@ remove_self_loops(raft::handle_t const& handle,
  * property values are compared in the order of weight (if valid), edge ID (if valid), edge type (if
  * valid), edge start time (if valid) and edge end time (if valid). Setting this to true incurs
  * performance overhead as this requires more comparisons.
+ * @param large_buffer_type Flag indicating the large buffer type to use when we need to create a
+ * large device-accessible vector object (if the value is std::nullopt, the default RMM per-device
+ * memory resource is used). The returned edge list will also be stored in the buffer type dictated
+ * by this parameter.
  * @return Tuple of rmm::device_uvector objects storing edge sources, destinations, optional
  * weights, optional edge ids, optional edge types, optional edge start times and optional edge end
  * times.
@@ -1255,7 +1323,8 @@ remove_multi_edges(raft::handle_t const& handle,
                    std::optional<rmm::device_uvector<edge_type_t>>&& edgelist_edge_types,
                    std::optional<rmm::device_uvector<edge_time_t>>&& edgelist_edge_start_times,
                    std::optional<rmm::device_uvector<edge_time_t>>&& edgelist_edge_edge_times,
-                   bool keep_min_value_edge = false);
+                   bool keep_min_value_edge                             = false,
+                   std::optional<large_buffer_type_t> large_buffer_type = std::nullopt);
 
 /**
  * @ingroup graph_functions_cpp
@@ -1299,6 +1368,10 @@ remove_multi_edges(raft::handle_t const& handle,
  * property values are compared in the order of weight (if valid), edge ID (if valid), edge type (if
  * valid), edge start time (if valid) and edge end time (if valid). Setting this to true incurs
  * performance overhead as this requires more comparisons.
+ * @param large_buffer_type Flag indicating the large buffer type to use when we need to create a
+ * large device-accessible vector object (if the value is std::nullopt, the default RMM per-device
+ * memory resource is used). The returned edge list will also be stored in the buffer type dictated
+ * by this parameter.
  * @return Tuple of std::vector objects holding rmm::device_uvector objects (# device_uvector objets
  * per std::vector = # edge chunks) storing edge sources, destinations, optional weights, optional
  * edge ids, optional edge types, optional edge start times and optional edge end times.
@@ -1324,6 +1397,7 @@ remove_multi_edges(
   std::optional<std::vector<rmm::device_uvector<edge_type_t>>>&& edgelist_edge_types,
   std::optional<std::vector<rmm::device_uvector<edge_time_t>>>&& edgelist_edge_start_times,
   std::optional<std::vector<rmm::device_uvector<edge_time_t>>>&& edgelist_edge_edge_times,
-  bool keep_min_value_edge = false);
+  bool keep_min_value_edge                             = false,
+  std::optional<large_buffer_type_t> large_buffer_type = std::nullopt);
 
 }  // namespace cugraph

--- a/cpp/include/cugraph/graph_generators.hpp
+++ b/cpp/include/cugraph/graph_generators.hpp
@@ -68,8 +68,10 @@ namespace cugraph {
  * @param scramble_vertex_ids Flag controlling whether to scramble vertex ID bits (if set to `true`)
  * or not (if set to `false`); scrambling vertex ID bits breaks correlation between vertex ID values
  * and vertex degrees.
- * @param large_buffer_type Dictates the large buffer type to use in generating and storing the edge
- * list (if the value is std::nullopt, the default RMM per-device memory resource is used).
+ * @param large_buffer_type Flag indicating the large buffer type to use when we need to create a
+ * large device-accessible vector object (if the value is std::nullopt, the default RMM per-device
+ * memory resource is used). The generated R-mat edgelist will also be stored in the buffer type
+ * dictated by this parameter.
  * @return std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> A tuple of
  * rmm::device_uvector objects for edge source vertex IDs and edge destination vertex IDs.
  */
@@ -161,8 +163,10 @@ enum class generator_distribution_t { POWER_LAW = 0, UNIFORM };
  * @param scramble_vertex_ids Flag controlling whether to scramble vertex ID bits (if set to `true`)
  * or not (if set to `false`); scrambling vertex ID bits breaks correlation between vertex ID values
  * and vertex degrees.
- * @param large_buffer_type Dictates the large buffer type to use in generating and storing the edge
- * list (if the value is std::nullopt, the default RMM per-device memory resource is used).
+ * @param large_buffer_type Flag indicating the large buffer type to use when we need to create a
+ *large device-accessible vector object (if the value is std::nullopt, the default RMM per-device
+ *memory resource is used). The generated R-mat edgelist will also be stored in the buffer type
+ *dictated by this parameter.
  * @return A vector of std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> of
  *size @p n_edgelists, each vector element being a tuple of rmm::device_uvector objects for edge
  *source vertex IDs and edge destination vertex IDs.
@@ -360,8 +364,10 @@ generate_erdos_renyi_graph_edgelist_gnm(raft::handle_t const& handle,
  * @param d_weight_v Optional vector of edge weights
  * @param check_diagonal Flag indicating whether to check for diagonal edges or not. If set to true,
  * symmetrize only the edges with source != destination (to avoid duplicating every self-loops).
- * @param large_buffer_type Dictates the large buffer type to use in storing the symmetrized edge
- * list.
+ * @param large_buffer_type Flag indicating the large buffer type to use when we need to create a
+ * large device-accessible vector object (if the value is std::nullopt, the default RMM per-device
+ * memory resource is used). The symmetrized edgelist will also be stored in the buffer type
+ * dictated by this parameter.
  * @return std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> A tuple of
  * rmm::device_uvector objects for edge source vertex IDs and edge destination vertex IDs.
  */
@@ -397,31 +403,6 @@ template <typename vertex_t>
 rmm::device_uvector<vertex_t> scramble_vertex_ids(raft::handle_t const& handle,
                                                   rmm::device_uvector<vertex_t>&& vertices,
                                                   size_t lgN);
-
-/**
- * @ingroup graph_generators_cpp
- * @brief scramble vertex ids in a graph
- *
- * Given an edge list for a graph, scramble the input vertex IDs.
- *
- * The scramble code here follows the algorithm in the Graph 500 reference
- * implementation version 3.0.0.
- *
- * @tparam vertex_t Type of vertex identifiers. Needs to be an integral type.
- * @param handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator, and
- * handles to various CUDA libraries) to run graph algorithms.
- * @param d_src_v Vector of input source vertices
- * @param d_dst_v Vector of input destination vertices
- * @param lgN The input & output (scrambled) vertex IDs are assumed to be in [0, 2^lgN).
- * @return Tuple of two rmm::device_uvector objects storing scrambled source & destination vertex
- * IDs, respectively.
- */
-template <typename vertex_t>
-std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> scramble_vertex_ids(
-  raft::handle_t const& handle,
-  rmm::device_uvector<vertex_t>&& srcs,
-  rmm::device_uvector<vertex_t>&& dsts,
-  size_t lgN);
 
 /**
  * @ingroup graph_generators_cpp

--- a/cpp/include/cugraph/mtmg/graph.hpp
+++ b/cpp/include/cugraph/mtmg/graph.hpp
@@ -132,6 +132,8 @@ void create_graph_from_edgelist(
       : std::nullopt,
     graph_properties,
     renumber,
+    std::nullopt,
+    std::nullopt,
     do_expensive_check);
 
   graph.set(handle, std::move(local_graph));

--- a/cpp/include/cugraph/utilities/dataframe_buffer.hpp
+++ b/cpp/include/cugraph/utilities/dataframe_buffer.hpp
@@ -70,7 +70,9 @@ auto get_dataframe_buffer_cend_tuple_impl(std::index_sequence<Is...>, TupleType&
 
 }  // namespace detail
 
-template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+template <
+  typename T,
+  typename std::enable_if_t<std::is_same_v<T, std::byte> || std::is_arithmetic_v<T>>* = nullptr>
 auto allocate_dataframe_buffer(
   size_t buffer_size,
   rmm::cuda_stream_view stream_view,
@@ -145,7 +147,8 @@ void reserve_dataframe_buffer(BufferType& buffer,
                               rmm::cuda_stream_view stream_view)
 {
   static_assert(is_std_tuple_of_arithmetic_vectors<std::remove_cv_t<BufferType>>::value ||
-                is_arithmetic_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value);
+                is_arithmetic_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value ||
+                is_byte_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value);
   if constexpr (is_std_tuple_of_arithmetic_vectors<std::remove_cv_t<BufferType>>::value) {
     std::apply([new_buffer_capacity, stream_view](
                  auto&&... args) { (args.reserve(new_buffer_capacity, stream_view), ...); },
@@ -161,7 +164,8 @@ void resize_dataframe_buffer(BufferType& buffer,
                              rmm::cuda_stream_view stream_view)
 {
   static_assert(is_std_tuple_of_arithmetic_vectors<std::remove_cv_t<BufferType>>::value ||
-                is_arithmetic_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value);
+                is_arithmetic_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value ||
+                is_byte_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value);
   if constexpr (is_std_tuple_of_arithmetic_vectors<std::remove_cv_t<BufferType>>::value) {
     std::apply([new_buffer_size,
                 stream_view](auto&&... args) { (args.resize(new_buffer_size, stream_view), ...); },
@@ -175,7 +179,8 @@ template <typename BufferType>
 void shrink_to_fit_dataframe_buffer(BufferType& buffer, rmm::cuda_stream_view stream_view)
 {
   static_assert(is_std_tuple_of_arithmetic_vectors<std::remove_cv_t<BufferType>>::value ||
-                is_arithmetic_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value);
+                is_arithmetic_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value ||
+                is_byte_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value);
   if constexpr (is_std_tuple_of_arithmetic_vectors<std::remove_cv_t<BufferType>>::value) {
     std::apply([stream_view](auto&&... args) { (args.shrink_to_fit(stream_view), ...); }, buffer);
   } else {
@@ -187,7 +192,8 @@ template <typename BufferType>
 size_t size_dataframe_buffer(BufferType& buffer)
 {
   static_assert(is_std_tuple_of_arithmetic_vectors<std::remove_cv_t<BufferType>>::value ||
-                is_arithmetic_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value);
+                is_arithmetic_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value ||
+                is_byte_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value);
   if constexpr (is_std_tuple_of_arithmetic_vectors<std::remove_cv_t<BufferType>>::value) {
     return std::get<0>(buffer).size();
   } else {
@@ -195,9 +201,11 @@ size_t size_dataframe_buffer(BufferType& buffer)
   }
 }
 
-template <typename BufferType,
-          typename std::enable_if_t<is_arithmetic_vector<std::remove_cv_t<BufferType>,
-                                                         rmm::device_uvector>::value>* = nullptr>
+template <
+  typename BufferType,
+  typename std::enable_if_t<
+    is_byte_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value ||
+    is_arithmetic_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value>* = nullptr>
 auto get_dataframe_buffer_begin(BufferType& buffer)
 {
   return buffer.begin();
@@ -212,9 +220,11 @@ auto get_dataframe_buffer_begin(BufferType& buffer)
     std::make_index_sequence<std::tuple_size<BufferType>::value>(), buffer);
 }
 
-template <typename BufferType,
-          typename std::enable_if_t<is_arithmetic_vector<std::remove_cv_t<BufferType>,
-                                                         rmm::device_uvector>::value>* = nullptr>
+template <
+  typename BufferType,
+  typename std::enable_if_t<
+    is_byte_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value ||
+    is_arithmetic_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value>* = nullptr>
 auto get_dataframe_buffer_cbegin(BufferType& buffer)
 {
   return buffer.cbegin();
@@ -229,9 +239,11 @@ auto get_dataframe_buffer_cbegin(BufferType& buffer)
     std::make_index_sequence<std::tuple_size<BufferType>::value>(), buffer);
 }
 
-template <typename BufferType,
-          typename std::enable_if_t<is_arithmetic_vector<std::remove_cv_t<BufferType>,
-                                                         rmm::device_uvector>::value>* = nullptr>
+template <
+  typename BufferType,
+  typename std::enable_if_t<
+    is_byte_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value ||
+    is_arithmetic_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value>* = nullptr>
 auto get_dataframe_buffer_end(BufferType& buffer)
 {
   return buffer.end();
@@ -246,9 +258,11 @@ auto get_dataframe_buffer_end(BufferType& buffer)
     std::make_index_sequence<std::tuple_size<BufferType>::value>(), buffer);
 }
 
-template <typename BufferType,
-          typename std::enable_if_t<is_arithmetic_vector<std::remove_cv_t<BufferType>,
-                                                         rmm::device_uvector>::value>* = nullptr>
+template <
+  typename BufferType,
+  typename std::enable_if_t<
+    is_byte_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value ||
+    is_arithmetic_vector<std::remove_cv_t<BufferType>, rmm::device_uvector>::value>* = nullptr>
 auto get_dataframe_buffer_cend(BufferType& buffer)
 {
   return buffer.cend();

--- a/cpp/include/cugraph/utilities/thrust_tuple_utils.hpp
+++ b/cpp/include/cugraph/utilities/thrust_tuple_utils.hpp
@@ -209,6 +209,13 @@ template <typename... Ts>
 struct is_std_tuple<std::tuple<Ts...>> : std::true_type {};
 
 template <typename T, template <typename> typename Vector>
+struct is_byte_vector : std::false_type {};
+
+template <template <typename> typename Vector, typename T>
+struct is_byte_vector<Vector<T>, Vector>
+  : std::integral_constant<bool, std::is_same_v<T, std::byte>> {};
+
+template <typename T, template <typename> typename Vector>
 struct is_arithmetic_vector : std::false_type {};
 
 template <template <typename> typename Vector, typename T>

--- a/cpp/src/c_api/capi_helper.cu
+++ b/cpp/src/c_api/capi_helper.cu
@@ -44,7 +44,7 @@ shuffle_vertex_ids_and_offsets(raft::handle_t const& handle,
                thrust::make_zip_iterator(ids.end(), vertices.end()));
 
   auto return_offsets = cugraph::detail::compute_sparse_offsets<size_t>(
-    ids.begin(), ids.end(), size_t{0}, size_t{offsets.size() - 1}, true, handle.get_stream());
+    handle, ids.begin(), ids.end(), size_t{0}, size_t{offsets.size() - 1}, true);
 
   return std::make_tuple(std::move(vertices), std::move(return_offsets));
 }

--- a/cpp/src/c_api/graph_mg.cpp
+++ b/cpp/src/c_api/graph_mg.cpp
@@ -283,6 +283,8 @@ struct create_graph_functor : public cugraph::c_api::abstract_functor {
         std::move(edgelist_edge_end_times),
         cugraph::graph_properties_t{properties_->is_symmetric, properties_->is_multigraph},
         renumber_,
+        std::nullopt,
+        std::nullopt,
         do_expensive_check_);
 
       if (renumber_) {

--- a/cpp/src/c_api/graph_sg.cpp
+++ b/cpp/src/c_api/graph_sg.cpp
@@ -272,6 +272,8 @@ struct create_graph_functor : public cugraph::c_api::abstract_functor {
         std::move(dummy_end_times),
         cugraph::graph_properties_t{properties_->is_symmetric, properties_->is_multigraph},
         renumber_,
+        std::nullopt,
+        std::nullopt,
         do_expensive_check_);
 
       if (renumber_) {
@@ -511,6 +513,8 @@ struct create_graph_csr_functor : public cugraph::c_api::abstract_functor {
         std::move(edgelist_edge_end_times),
         cugraph::graph_properties_t{properties_->is_symmetric, properties_->is_multigraph},
         renumber_,
+        std::nullopt,
+        std::nullopt,
         do_expensive_check_);
 
       if (renumber_) {

--- a/cpp/src/community/detail/refine_impl.cuh
+++ b/cpp/src/community/detail/refine_impl.cuh
@@ -675,8 +675,7 @@ refine_clustering(
         std::nullopt,
         std::nullopt,
         cugraph::graph_properties_t{false, false},
-        true,
-        false);
+        true /* renumber */);
 
     auto decision_graph_view = decision_graph.view();
 

--- a/cpp/src/detail/collect_comm_wrapper.cuh
+++ b/cpp/src/detail/collect_comm_wrapper.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/detail/collect_comm_wrapper.cuh
+++ b/cpp/src/detail/collect_comm_wrapper.cuh
@@ -17,7 +17,6 @@
 #pragma once
 
 #include "c_api/capi_helper.hpp"
-#include "structure/detail/structure_utils.cuh"
 #include "utilities/collect_comm.cuh"
 
 #include <cugraph/detail/shuffle_wrappers.hpp>

--- a/cpp/src/detail/collect_comm_wrapper_mg_v32_e32.cu
+++ b/cpp/src/detail/collect_comm_wrapper_mg_v32_e32.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/detail/collect_comm_wrapper_mg_v32_e32.cu
+++ b/cpp/src/detail/collect_comm_wrapper_mg_v32_e32.cu
@@ -14,16 +14,7 @@
  * limitations under the License.
  */
 
-#include "c_api/capi_helper.hpp"
 #include "detail/collect_comm_wrapper.cuh"
-#include "structure/detail/structure_utils.cuh"
-#include "utilities/collect_comm.cuh"
-
-#include <cugraph/detail/shuffle_wrappers.hpp>
-#include <cugraph/utilities/misc_utils.cuh>
-
-#include <thrust/iterator/zip_iterator.h>
-#include <thrust/sort.h>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/detail/collect_comm_wrapper_mg_v64_e64.cu
+++ b/cpp/src/detail/collect_comm_wrapper_mg_v64_e64.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/detail/collect_comm_wrapper_mg_v64_e64.cu
+++ b/cpp/src/detail/collect_comm_wrapper_mg_v64_e64.cu
@@ -14,16 +14,7 @@
  * limitations under the License.
  */
 
-#include "c_api/capi_helper.hpp"
 #include "detail/collect_comm_wrapper.cuh"
-#include "structure/detail/structure_utils.cuh"
-#include "utilities/collect_comm.cuh"
-
-#include <cugraph/detail/shuffle_wrappers.hpp>
-#include <cugraph/utilities/misc_utils.cuh>
-
-#include <thrust/iterator/zip_iterator.h>
-#include <thrust/sort.h>
 
 namespace cugraph {
 namespace detail {

--- a/cpp/src/detail/groupby_and_count_mg_v32_e32.cu
+++ b/cpp/src/detail/groupby_and_count_mg_v32_e32.cu
@@ -40,7 +40,8 @@ template rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partiti
   raft::device_span<int32_t> edgelist_majors,
   raft::device_span<int32_t> edgelist_minors,
   raft::host_span<cugraph::arithmetic_device_span_t> edgelist_properties,
-  bool groupby_and_counts_local_partition);
+  bool groupby_and_counts_local_partition,
+  std::optional<large_buffer_type_t> large_buffer_type);
 
 }  // namespace detail
 }  // namespace cugraph

--- a/cpp/src/detail/groupby_and_count_mg_v64_e64.cu
+++ b/cpp/src/detail/groupby_and_count_mg_v64_e64.cu
@@ -40,7 +40,8 @@ template rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partiti
   raft::device_span<int64_t> edgelist_majors,
   raft::device_span<int64_t> edgelist_minors,
   raft::host_span<cugraph::arithmetic_device_span_t> edgelist_properties,
-  bool groupby_and_counts_local_partition);
+  bool groupby_and_counts_local_partition,
+  std::optional<large_buffer_type_t> large_buffer_type);
 
 }  // namespace detail
 }  // namespace cugraph

--- a/cpp/src/generators/generator_tools.cuh
+++ b/cpp/src/generators/generator_tools.cuh
@@ -78,26 +78,6 @@ rmm::device_uvector<vertex_t> scramble_vertex_ids(raft::handle_t const& handle,
   return std::move(vertices);
 }
 
-template <typename vertex_t>
-std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> scramble_vertex_ids(
-  raft::handle_t const& handle,
-  rmm::device_uvector<vertex_t>&& srcs,
-  rmm::device_uvector<vertex_t>&& dsts,
-  size_t lgN)
-{
-  auto pair_first = thrust::make_zip_iterator(thrust::make_tuple(srcs.begin(), dsts.begin()));
-  thrust::transform(handle.get_thrust_policy(),
-                    pair_first,
-                    pair_first + srcs.size(),
-                    pair_first,
-                    [lgN] __device__(auto pair) {
-                      return thrust::make_tuple(detail::scramble(thrust::get<0>(pair), lgN),
-                                                detail::scramble(thrust::get<1>(pair), lgN));
-                    });
-
-  return std::make_tuple(std::move(srcs), std::move(dsts));
-}
-
 template <typename vertex_t, typename weight_t>
 std::tuple<rmm::device_uvector<vertex_t>,
            rmm::device_uvector<vertex_t>,

--- a/cpp/src/generators/generator_tools_sg_v32_e32.cu
+++ b/cpp/src/generators/generator_tools_sg_v32_e32.cu
@@ -43,12 +43,6 @@ template rmm::device_uvector<int32_t> scramble_vertex_ids(raft::handle_t const& 
                                                           rmm::device_uvector<int32_t>&& vertices,
                                                           size_t lgN);
 
-template std::tuple<rmm::device_uvector<int32_t>, rmm::device_uvector<int32_t>> scramble_vertex_ids(
-  raft::handle_t const& handle,
-  rmm::device_uvector<int32_t>&& srcs,
-  rmm::device_uvector<int32_t>&& dsts,
-  size_t lgN);
-
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
                     std::optional<rmm::device_uvector<float>>>

--- a/cpp/src/generators/generator_tools_sg_v64_e64.cu
+++ b/cpp/src/generators/generator_tools_sg_v64_e64.cu
@@ -43,12 +43,6 @@ template rmm::device_uvector<int64_t> scramble_vertex_ids(raft::handle_t const& 
                                                           rmm::device_uvector<int64_t>&& vertices,
                                                           size_t lgN);
 
-template std::tuple<rmm::device_uvector<int64_t>, rmm::device_uvector<int64_t>> scramble_vertex_ids(
-  raft::handle_t const& handle,
-  rmm::device_uvector<int64_t>&& srcs,
-  rmm::device_uvector<int64_t>&& dsts,
-  size_t lgN);
-
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
                     std::optional<rmm::device_uvector<float>>>

--- a/cpp/src/prims/detail/sample_and_compute_local_nbr_indices.cuh
+++ b/cpp/src/prims/detail/sample_and_compute_local_nbr_indices.cuh
@@ -2558,28 +2558,15 @@ compute_aggregate_local_frontier_biases(raft::handle_t const& handle,
 
   // 3. exclude 0 bias neighbors & update offsets
 
-  rmm::device_uvector<edge_t> aggregate_local_frontier_nz_bias_indices(
-    aggregate_local_frontier_biases.size(), handle.get_stream());
-  thrust::tabulate(handle.get_thrust_policy(),
-                   aggregate_local_frontier_nz_bias_indices.begin(),
-                   aggregate_local_frontier_nz_bias_indices.end(),
-                   [offsets = raft::device_span<size_t const>(
-                      aggregate_local_frontier_local_degree_offsets.data(),
-                      aggregate_local_frontier_local_degree_offsets.size())] __device__(size_t i) {
-                     auto it =
-                       thrust::upper_bound(thrust::seq, offsets.begin() + 1, offsets.end(), i);
-                     auto idx = cuda::std::distance(offsets.begin() + 1, it);
-                     return static_cast<edge_t>(i - offsets[idx]);
-                   });
-
-  rmm::device_uvector<size_t> aggregate_local_frontier_local_degrees(local_frontier_offsets.back(),
-                                                                     handle.get_stream());
-  thrust::adjacent_difference(handle.get_thrust_policy(),
-                              aggregate_local_frontier_local_degree_offsets.begin() + 1,
-                              aggregate_local_frontier_local_degree_offsets.end(),
-                              aggregate_local_frontier_local_degrees.begin());
-
+  rmm::device_uvector<size_t> aggregate_local_frontier_local_degrees(
+    local_frontier_offsets.back(),
+    handle.get_stream());  // excluding 0 bias neighbors
   {
+    thrust::adjacent_difference(handle.get_thrust_policy(),
+                                aggregate_local_frontier_local_degree_offsets.begin() + 1,
+                                aggregate_local_frontier_local_degree_offsets.end(),
+                                aggregate_local_frontier_local_degrees.begin());
+
     auto pair_first = thrust::make_zip_iterator(aggregate_local_frontier_biases.begin(),
                                                 thrust::make_counting_iterator(size_t{0}));
     thrust::for_each(handle.get_thrust_policy(),
@@ -2603,26 +2590,41 @@ compute_aggregate_local_frontier_biases(raft::handle_t const& handle,
                      });
   }
 
+  auto num_nz_bias_nbrs = thrust::reduce(handle.get_thrust_policy(),
+                                         aggregate_local_frontier_local_degrees.begin(),
+                                         aggregate_local_frontier_local_degrees.end());
+
+  rmm::device_uvector<edge_t> aggregate_local_frontier_nz_bias_indices(num_nz_bias_nbrs,
+                                                                       handle.get_stream());
+  {
+    auto nz_biases  = rmm::device_uvector<bias_t>(num_nz_bias_nbrs, handle.get_stream());
+    auto pair_first = thrust::make_zip_iterator(
+      aggregate_local_frontier_biases.begin(),
+      thrust::make_transform_iterator(
+        thrust::make_counting_iterator(size_t{0}),
+        cuda::proclaim_return_type<edge_t>(
+          [offsets = raft::device_span<size_t const>(
+             aggregate_local_frontier_local_degree_offsets.data(),
+             aggregate_local_frontier_local_degree_offsets.size())] __device__(size_t i) {
+            auto idx = cuda::std::distance(
+              offsets.begin() + 1,
+              thrust::upper_bound(thrust::seq, offsets.begin() + 1, offsets.end(), i));
+            return static_cast<edge_t>(i - offsets[idx]);
+          })));
+    thrust::copy_if(handle.get_thrust_policy(),
+                    pair_first,
+                    pair_first + aggregate_local_frontier_biases.size(),
+                    aggregate_local_frontier_biases.begin(),
+                    thrust::make_zip_iterator(nz_biases.begin(),
+                                              aggregate_local_frontier_nz_bias_indices.begin()),
+                    cuda::proclaim_return_type<bool>([] __device__(bias_t b) { return b != 0.0; }));
+    aggregate_local_frontier_biases = std::move(nz_biases);
+  }
+
   thrust::inclusive_scan(handle.get_thrust_policy(),
                          aggregate_local_frontier_local_degrees.begin(),
                          aggregate_local_frontier_local_degrees.end(),
                          aggregate_local_frontier_local_degree_offsets.begin() + 1);
-
-  {
-    auto pair_first = thrust::make_zip_iterator(aggregate_local_frontier_biases.begin(),
-                                                aggregate_local_frontier_nz_bias_indices.begin());
-    auto pair_last =
-      thrust::remove_if(handle.get_thrust_policy(),
-                        pair_first,
-                        pair_first + aggregate_local_frontier_biases.size(),
-                        [] __device__(auto pair) { return thrust::get<0>(pair) == 0.0; });
-    aggregate_local_frontier_biases.resize(cuda::std::distance(pair_first, pair_last),
-                                           handle.get_stream());
-    aggregate_local_frontier_nz_bias_indices.resize(cuda::std::distance(pair_first, pair_last),
-                                                    handle.get_stream());
-    aggregate_local_frontier_biases.shrink_to_fit(handle.get_stream());
-    aggregate_local_frontier_nz_bias_indices.shrink_to_fit(handle.get_stream());
-  }
 
   return std::make_tuple(std::move(aggregate_local_frontier_biases),
                          std::move(aggregate_local_frontier_nz_bias_indices),

--- a/cpp/src/sampling/detail/gather_one_hop_edgelist_impl.cuh
+++ b/cpp/src/sampling/detail/gather_one_hop_edgelist_impl.cuh
@@ -19,7 +19,6 @@
 #include "prims/extract_transform_v_frontier_outgoing_e.cuh"
 #include "prims/update_edge_src_dst_property.cuh"
 #include "prims/vertex_frontier.cuh"
-#include "structure/detail/structure_utils.cuh"
 
 #include <cugraph/edge_src_dst_property.hpp>
 #include <cugraph/graph.hpp>

--- a/cpp/src/sampling/detail/sample_edges.cuh
+++ b/cpp/src/sampling/detail/sample_edges.cuh
@@ -18,7 +18,6 @@
 
 #include "prims/per_v_random_select_transform_outgoing_e.cuh"
 #include "prims/vertex_frontier.cuh"
-#include "structure/detail/structure_utils.cuh"
 
 #include <cugraph/edge_src_dst_property.hpp>
 #include <cugraph/graph.hpp>

--- a/cpp/src/structure/coarsen_graph_impl.cuh
+++ b/cpp/src/structure/coarsen_graph_impl.cuh
@@ -570,7 +570,9 @@ coarsen_graph(raft::handle_t const& handle,
       std::nullopt,
       std::nullopt,
       graph_properties_t{graph_view.is_symmetric(), false},
-      true,
+      true /* renumber */,
+      std::nullopt,
+      std::nullopt,
       do_expensive_check);
 
   return std::make_tuple(std::move(coarsened_graph),
@@ -723,6 +725,8 @@ coarsen_graph(raft::handle_t const& handle,
       std::nullopt,
       graph_properties_t{graph_view.is_symmetric(), false},
       renumber,
+      std::nullopt,
+      std::nullopt,
       do_expensive_check);
 
   return std::make_tuple(

--- a/cpp/src/structure/create_graph_from_edgelist_impl.cuh
+++ b/cpp/src/structure/create_graph_from_edgelist_impl.cuh
@@ -330,7 +330,8 @@ split_edge_chunk_compressed_elements_to_local_edge_partitions(
   std::vector<std::vector<edge_t>> const& edge_partition_intra_partition_segment_offset_vectors,
   std::vector<std::vector<edge_t>> const&
     edge_partition_intra_segment_copy_output_displacement_vectors,
-  size_t element_size)
+  size_t element_size,
+  std::optional<large_buffer_type_t> large_buffer_type)
 {
   auto num_chunks          = edgelist_compressed_elements.size();
   auto num_edge_partitions = edge_partition_edge_counts.size();
@@ -342,8 +343,11 @@ split_edge_chunk_compressed_elements_to_local_edge_partitions(
   std::vector<rmm::device_uvector<std::byte>> edge_partition_compressed_elements{};
   edge_partition_compressed_elements.reserve(num_edge_partitions);
   for (size_t i = 0; i < num_edge_partitions; ++i) {
-    edge_partition_compressed_elements.push_back(rmm::device_uvector<std::byte>(
-      edge_partition_edge_counts[i] * element_size, handle.get_stream()));
+    auto num_bytes = edge_partition_edge_counts[i] * element_size;
+    edge_partition_compressed_elements.push_back(
+      large_buffer_type
+        ? large_buffer_manager::allocate_memory_buffer<std::byte>(num_bytes, handle.get_stream())
+        : rmm::device_uvector<std::byte>(num_bytes, handle.get_stream()));
   }
 
   for (size_t i = 0; i < num_edge_partitions; ++i) {
@@ -376,7 +380,8 @@ std::vector<rmm::device_uvector<T>> split_edge_chunk_elements_to_local_edge_part
   std::vector<edge_t> const& edge_partition_edge_counts,
   std::vector<std::vector<edge_t>> const& edge_partition_intra_partition_segment_offset_vectors,
   std::vector<std::vector<edge_t>> const&
-    edge_partition_intra_segment_copy_output_displacement_vectors)
+    edge_partition_intra_segment_copy_output_displacement_vectors,
+  std::optional<large_buffer_type_t> large_buffer_type)
 {
   static_assert(std::is_arithmetic_v<T>);  // otherwise, unimplemented.
   auto num_chunks          = edgelist_elements.size();
@@ -390,7 +395,10 @@ std::vector<rmm::device_uvector<T>> split_edge_chunk_elements_to_local_edge_part
   edge_partition_elements.reserve(num_edge_partitions);
   for (size_t i = 0; i < num_edge_partitions; ++i) {
     edge_partition_elements.push_back(
-      rmm::device_uvector<T>(edge_partition_edge_counts[i], handle.get_stream()));
+      large_buffer_type
+        ? large_buffer_manager::allocate_memory_buffer<T>(edge_partition_edge_counts[i],
+                                                          handle.get_stream())
+        : rmm::device_uvector<T>(edge_partition_edge_counts[i], handle.get_stream()));
   }
 
   for (size_t i = 0; i < num_edge_partitions; ++i) {
@@ -465,8 +473,14 @@ create_graph_from_partitioned_edgelist(
     edge_partition_edgelist_edge_end_times,
   std::vector<std::vector<edge_t>> const& edgelist_intra_partition_segment_offset_vectors,
   graph_properties_t graph_properties,
-  bool renumber)
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type)
 {
+  CUGRAPH_EXPECTS((!large_vertex_buffer_type && !large_edge_buffer_type) ||
+                    cugraph::large_buffer_manager::memory_buffer_initialized(),
+                  "Invalid input argument: large memory buffer is not initialized.");
+
   auto& major_comm           = handle.get_subcomm(cugraph::partition_manager::major_comm_name());
   auto const major_comm_size = major_comm.get_size();
   auto& minor_comm           = handle.get_subcomm(cugraph::partition_manager::minor_comm_name());
@@ -492,7 +506,9 @@ create_graph_from_partitioned_edgelist(
     dst_ptrs,
     edgelist_edge_counts,
     edgelist_intra_partition_segment_offset_vectors,
-    store_transposed);
+    store_transposed,
+    large_vertex_buffer_type,
+    large_edge_buffer_type);
 
   auto num_segments_per_vertex_partition =
     static_cast<size_t>(meta.edge_partition_segment_offsets.size() / minor_comm_size);
@@ -500,6 +516,7 @@ create_graph_from_partitioned_edgelist(
     num_segments_per_vertex_partition > (detail::num_sparse_segments_per_vertex_partition + 2);
 
   // 2. sort and compress edge list (COO) to CSR (or CSC) or CSR + DCSR (CSC + DCSC) hybrid
+
   int edge_property_count = 0;
   size_t element_size     = sizeof(vertex_t) * 2;
 
@@ -527,13 +544,16 @@ create_graph_from_partitioned_edgelist(
 
   if (edge_property_count > 1) { element_size = sizeof(vertex_t) * 2 + sizeof(size_t); }
 
-  auto total_global_mem = handle.get_device_properties().totalGlobalMem;
-  auto constexpr mem_frugal_ratio =
-    0.5;  // if the aggregate edge data size exceeds the mem_frugal_ratio of the total_global_mem
-          // (in an approximate sense), switch to the memory frugal approach
-  auto mem_frugal_threshold =
-    static_cast<size_t>(static_cast<double>(total_global_mem / element_size) * mem_frugal_ratio) /
-    static_cast<size_t>(minor_comm_size);
+  auto mem_frugal_threshold = std::numeric_limits<size_t>::max();
+  if (!large_edge_buffer_type) {
+    auto total_global_mem = handle.get_device_properties().totalGlobalMem;
+    auto constexpr mem_frugal_ratio =
+      0.5;  // if the aggregate edge data size exceeds the mem_frugal_ratio of the total_global_mem
+            // (in an approximate sense), switch to the memory frugal approach
+    mem_frugal_threshold =
+      static_cast<size_t>(static_cast<double>(total_global_mem / element_size) * mem_frugal_ratio) /
+      static_cast<size_t>(minor_comm_size);
+  }
 
   std::vector<rmm::device_uvector<edge_t>> edge_partition_offsets;
   std::vector<rmm::device_uvector<vertex_t>> edge_partition_indices;
@@ -597,6 +617,7 @@ create_graph_from_partitioned_edgelist(
     if (edge_property_count == 0) {
       std::tie(offsets, indices, dcs_nzd_vertices) =
         detail::sort_and_compress_edgelist<vertex_t, edge_t, store_transposed>(
+          handle,
           std::move(edge_partition_edgelist_srcs[i]),
           std::move(edge_partition_edgelist_dsts[i]),
           major_range_first,
@@ -605,11 +626,13 @@ create_graph_from_partitioned_edgelist(
           minor_range_first,
           minor_range_last,
           mem_frugal_threshold,
-          handle.get_stream());
+          large_vertex_buffer_type,
+          large_edge_buffer_type);
     } else if (edge_property_count == 1) {
       if (edge_partition_edgelist_weights) {
         std::tie(offsets, indices, weights, dcs_nzd_vertices) =
           detail::sort_and_compress_edgelist<vertex_t, edge_t, weight_t, store_transposed>(
+            handle,
             std::move(edge_partition_edgelist_srcs[i]),
             std::move(edge_partition_edgelist_dsts[i]),
             std::move((*edge_partition_edgelist_weights)[i]),
@@ -619,10 +642,12 @@ create_graph_from_partitioned_edgelist(
             minor_range_first,
             minor_range_last,
             mem_frugal_threshold,
-            handle.get_stream());
+            large_vertex_buffer_type,
+            large_edge_buffer_type);
       } else if (edge_partition_edgelist_edge_ids) {
         std::tie(offsets, indices, edge_ids, dcs_nzd_vertices) =
           detail::sort_and_compress_edgelist<vertex_t, edge_t, edge_t, store_transposed>(
+            handle,
             std::move(edge_partition_edgelist_srcs[i]),
             std::move(edge_partition_edgelist_dsts[i]),
             std::move((*edge_partition_edgelist_edge_ids)[i]),
@@ -632,10 +657,12 @@ create_graph_from_partitioned_edgelist(
             minor_range_first,
             minor_range_last,
             mem_frugal_threshold,
-            handle.get_stream());
+            large_vertex_buffer_type,
+            large_edge_buffer_type);
       } else if (edge_partition_edgelist_edge_types) {
         std::tie(offsets, indices, edge_types, dcs_nzd_vertices) =
           detail::sort_and_compress_edgelist<vertex_t, edge_t, edge_type_t, store_transposed>(
+            handle,
             std::move(edge_partition_edgelist_srcs[i]),
             std::move(edge_partition_edgelist_dsts[i]),
             std::move((*edge_partition_edgelist_edge_types)[i]),
@@ -645,10 +672,12 @@ create_graph_from_partitioned_edgelist(
             minor_range_first,
             minor_range_last,
             mem_frugal_threshold,
-            handle.get_stream());
+            large_vertex_buffer_type,
+            large_edge_buffer_type);
       } else if (edge_partition_edgelist_edge_start_times) {
         std::tie(offsets, indices, edge_start_times, dcs_nzd_vertices) =
           detail::sort_and_compress_edgelist<vertex_t, edge_t, edge_time_t, store_transposed>(
+            handle,
             std::move(edge_partition_edgelist_srcs[i]),
             std::move(edge_partition_edgelist_dsts[i]),
             std::move((*edge_partition_edgelist_edge_start_times)[i]),
@@ -658,10 +687,12 @@ create_graph_from_partitioned_edgelist(
             minor_range_first,
             minor_range_last,
             mem_frugal_threshold,
-            handle.get_stream());
+            large_vertex_buffer_type,
+            large_edge_buffer_type);
       } else if (edge_partition_edgelist_edge_end_times) {
         std::tie(offsets, indices, edge_end_times, dcs_nzd_vertices) =
           detail::sort_and_compress_edgelist<vertex_t, edge_t, edge_time_t, store_transposed>(
+            handle,
             std::move(edge_partition_edgelist_srcs[i]),
             std::move(edge_partition_edgelist_dsts[i]),
             std::move((*edge_partition_edgelist_edge_end_times)[i]),
@@ -671,71 +702,92 @@ create_graph_from_partitioned_edgelist(
             minor_range_first,
             minor_range_last,
             mem_frugal_threshold,
-            handle.get_stream());
+            large_vertex_buffer_type,
+            large_edge_buffer_type);
       }
     } else {
-      rmm::device_uvector<edge_t> property_position(edge_partition_edgelist_srcs[i].size(),
-                                                    handle.get_stream());
+      auto property_positions = large_edge_buffer_type
+                                  ? large_buffer_manager::allocate_memory_buffer<edge_t>(
+                                      edge_partition_edgelist_srcs[i].size(), handle.get_stream())
+                                  : rmm::device_uvector<edge_t>(
+                                      edge_partition_edgelist_srcs[i].size(), handle.get_stream());
       detail::sequence_fill(
-        handle.get_stream(), property_position.data(), property_position.size(), edge_t{0});
+        handle.get_stream(), property_positions.data(), property_positions.size(), edge_t{0});
 
-      std::tie(offsets, indices, property_position, dcs_nzd_vertices) =
+      std::tie(offsets, indices, property_positions, dcs_nzd_vertices) =
         detail::sort_and_compress_edgelist<vertex_t, edge_t, edge_t, store_transposed>(
+          handle,
           std::move(edge_partition_edgelist_srcs[i]),
           std::move(edge_partition_edgelist_dsts[i]),
-          std::move(property_position),
+          std::move(property_positions),
           major_range_first,
           major_hypersparse_first,
           major_range_last,
           minor_range_first,
           minor_range_last,
           mem_frugal_threshold,
-          handle.get_stream());
+          large_vertex_buffer_type,
+          large_edge_buffer_type);
 
       if (edge_partition_edgelist_weights) {
-        weights = rmm::device_uvector<weight_t>(property_position.size(), handle.get_stream());
+        weights = large_edge_buffer_type
+                    ? large_buffer_manager::allocate_memory_buffer<weight_t>(
+                        property_positions.size(), handle.get_stream())
+                    : rmm::device_uvector<weight_t>(property_positions.size(), handle.get_stream());
         thrust::gather(handle.get_thrust_policy(),
-                       property_position.begin(),
-                       property_position.end(),
+                       property_positions.begin(),
+                       property_positions.end(),
                        (*edge_partition_edgelist_weights)[i].begin(),
                        weights->begin());
       }
 
       if (edge_partition_edgelist_edge_ids) {
-        edge_ids = rmm::device_uvector<edge_t>(property_position.size(), handle.get_stream());
+        edge_ids = large_edge_buffer_type
+                     ? large_buffer_manager::allocate_memory_buffer<edge_t>(
+                         property_positions.size(), handle.get_stream())
+                     : rmm::device_uvector<edge_t>(property_positions.size(), handle.get_stream());
         thrust::gather(handle.get_thrust_policy(),
-                       property_position.begin(),
-                       property_position.end(),
+                       property_positions.begin(),
+                       property_positions.end(),
                        (*edge_partition_edgelist_edge_ids)[i].begin(),
                        edge_ids->begin());
       }
 
       if (edge_partition_edgelist_edge_types) {
         edge_types =
-          rmm::device_uvector<edge_type_t>(property_position.size(), handle.get_stream());
+          large_edge_buffer_type
+            ? large_buffer_manager::allocate_memory_buffer<edge_type_t>(property_positions.size(),
+                                                                        handle.get_stream())
+            : rmm::device_uvector<edge_type_t>(property_positions.size(), handle.get_stream());
         thrust::gather(handle.get_thrust_policy(),
-                       property_position.begin(),
-                       property_position.end(),
+                       property_positions.begin(),
+                       property_positions.end(),
                        (*edge_partition_edgelist_edge_types)[i].begin(),
                        edge_types->begin());
       }
 
       if (edge_partition_edgelist_edge_start_times) {
         edge_start_times =
-          rmm::device_uvector<edge_time_t>(property_position.size(), handle.get_stream());
+          large_edge_buffer_type
+            ? large_buffer_manager::allocate_memory_buffer<edge_time_t>(property_positions.size(),
+                                                                        handle.get_stream())
+            : rmm::device_uvector<edge_time_t>(property_positions.size(), handle.get_stream());
         thrust::gather(handle.get_thrust_policy(),
-                       property_position.begin(),
-                       property_position.end(),
+                       property_positions.begin(),
+                       property_positions.end(),
                        (*edge_partition_edgelist_edge_start_times)[i].begin(),
                        edge_start_times->begin());
       }
 
       if (edge_partition_edgelist_edge_end_times) {
         edge_end_times =
-          rmm::device_uvector<edge_time_t>(property_position.size(), handle.get_stream());
+          large_edge_buffer_type
+            ? large_buffer_manager::allocate_memory_buffer<edge_time_t>(property_positions.size(),
+                                                                        handle.get_stream())
+            : rmm::device_uvector<edge_time_t>(property_positions.size(), handle.get_stream());
         thrust::gather(handle.get_thrust_policy(),
-                       property_position.begin(),
-                       property_position.end(),
+                       property_positions.begin(),
+                       property_positions.end(),
                        (*edge_partition_edgelist_edge_end_times)[i].begin(),
                        edge_end_times->begin());
       }
@@ -743,20 +795,19 @@ create_graph_from_partitioned_edgelist(
 
     edge_partition_offsets.push_back(std::move(offsets));
     edge_partition_indices.push_back(std::move(indices));
+
     if (edge_partition_weights) { (*edge_partition_weights).push_back(std::move(*weights)); }
     if (edge_partition_edge_ids) { (*edge_partition_edge_ids).push_back(std::move(*edge_ids)); }
-    if (edge_partition_edge_types) {
-      (*edge_partition_edge_types).push_back(std::move(*edge_types));
-    }
+    if (edge_partition_edge_types) { edge_partition_edge_types->push_back(std::move(*edge_types)); }
     if (edge_partition_edge_start_times) {
-      (*edge_partition_edge_start_times).push_back(std::move(*edge_start_times));
+      edge_partition_edge_start_times->push_back(std::move(*edge_start_times));
     }
     if (edge_partition_edge_end_times) {
-      (*edge_partition_edge_end_times).push_back(std::move(*edge_end_times));
+      edge_partition_edge_end_times->push_back(std::move(*edge_end_times));
     }
 
     if (edge_partition_dcs_nzd_vertices) {
-      (*edge_partition_dcs_nzd_vertices).push_back(std::move(*dcs_nzd_vertices));
+      edge_partition_dcs_nzd_vertices->push_back(std::move(*dcs_nzd_vertices));
     }
   }
 
@@ -812,59 +863,80 @@ create_graph_from_partitioned_edgelist(
           (*edge_partition_edge_end_times)[i].begin());
       }
     } else {
-      rmm::device_uvector<edge_t> property_position(edge_partition_indices[i].size(),
-                                                    handle.get_stream());
+      auto property_positions =
+        large_edge_buffer_type
+          ? large_buffer_manager::allocate_memory_buffer<edge_t>(edge_partition_indices[i].size(),
+                                                                 handle.get_stream())
+          : rmm::device_uvector<edge_t>(edge_partition_indices[i].size(), handle.get_stream());
       detail::sequence_fill(
-        handle.get_stream(), property_position.data(), property_position.size(), edge_t{0});
+        handle.get_stream(), property_positions.data(), property_positions.size(), edge_t{0});
 
       detail::sort_adjacency_list(handle,
                                   raft::device_span<edge_t const>(edge_partition_offsets[i].data(),
                                                                   edge_partition_offsets[i].size()),
                                   edge_partition_indices[i].begin(),
                                   edge_partition_indices[i].end(),
-                                  property_position.begin());
+                                  property_positions.begin());
 
       if (edge_partition_edgelist_weights) {
-        rmm::device_uvector<weight_t> tmp(property_position.size(), handle.get_stream());
+        auto tmp = large_edge_buffer_type ? large_buffer_manager::allocate_memory_buffer<weight_t>(
+                                              property_positions.size(), handle.get_stream())
+                                          : rmm::device_uvector<weight_t>(property_positions.size(),
+                                                                          handle.get_stream());
         thrust::gather(handle.get_thrust_policy(),
-                       property_position.begin(),
-                       property_position.end(),
+                       property_positions.begin(),
+                       property_positions.end(),
                        (*edge_partition_edgelist_weights)[i].begin(),
                        tmp.begin());
         (*edge_partition_edgelist_weights)[i] = std::move(tmp);
       }
       if (edge_partition_edgelist_edge_ids) {
-        rmm::device_uvector<edge_t> tmp(property_position.size(), handle.get_stream());
+        auto tmp = large_edge_buffer_type
+                     ? large_buffer_manager::allocate_memory_buffer<edge_t>(
+                         property_positions.size(), handle.get_stream())
+                     : rmm::device_uvector<edge_t>(property_positions.size(), handle.get_stream());
         thrust::gather(handle.get_thrust_policy(),
-                       property_position.begin(),
-                       property_position.end(),
+                       property_positions.begin(),
+                       property_positions.end(),
                        (*edge_partition_edgelist_edge_ids)[i].begin(),
                        tmp.begin());
         (*edge_partition_edgelist_edge_ids)[i] = std::move(tmp);
       }
       if (edge_partition_edgelist_edge_types) {
-        rmm::device_uvector<edge_type_t> tmp(property_position.size(), handle.get_stream());
+        auto tmp =
+          large_edge_buffer_type
+            ? large_buffer_manager::allocate_memory_buffer<edge_type_t>(property_positions.size(),
+                                                                        handle.get_stream())
+            : rmm::device_uvector<edge_type_t>(property_positions.size(), handle.get_stream());
         thrust::gather(handle.get_thrust_policy(),
-                       property_position.begin(),
-                       property_position.end(),
+                       property_positions.begin(),
+                       property_positions.end(),
                        (*edge_partition_edgelist_edge_types)[i].begin(),
                        tmp.begin());
         (*edge_partition_edgelist_edge_types)[i] = std::move(tmp);
       }
       if (edge_partition_edgelist_edge_end_times) {
-        rmm::device_uvector<edge_time_t> tmp(property_position.size(), handle.get_stream());
+        auto tmp =
+          large_edge_buffer_type
+            ? large_buffer_manager::allocate_memory_buffer<edge_time_t>(property_positions.size(),
+                                                                        handle.get_stream())
+            : rmm::device_uvector<edge_time_t>(property_positions.size(), handle.get_stream());
         thrust::gather(handle.get_thrust_policy(),
-                       property_position.begin(),
-                       property_position.end(),
+                       property_positions.begin(),
+                       property_positions.end(),
                        (*edge_partition_edgelist_edge_end_times)[i].begin(),
                        tmp.begin());
         (*edge_partition_edgelist_edge_end_times)[i] = std::move(tmp);
       }
       if (edge_partition_edgelist_edge_end_times) {
-        rmm::device_uvector<edge_time_t> tmp(property_position.size(), handle.get_stream());
+        auto tmp =
+          large_edge_buffer_type
+            ? large_buffer_manager::allocate_memory_buffer<edge_time_t>(property_positions.size(),
+                                                                        handle.get_stream())
+            : rmm::device_uvector<edge_time_t>(property_positions.size(), handle.get_stream());
         thrust::gather(handle.get_thrust_policy(),
-                       property_position.begin(),
-                       property_position.end(),
+                       property_positions.begin(),
+                       property_positions.end(),
                        (*edge_partition_edgelist_edge_end_times)[i].begin(),
                        tmp.begin());
         (*edge_partition_edgelist_edge_end_times)[i] = std::move(tmp);
@@ -949,6 +1021,8 @@ create_graph_from_edgelist_impl(
   std::optional<rmm::device_uvector<edge_time_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check)
 {
   auto& major_comm           = handle.get_subcomm(cugraph::partition_manager::major_comm_name());
@@ -977,6 +1051,10 @@ create_graph_from_edgelist_impl(
     "edgelist_srcs.size() != (*edgelist_edge_end_times).size().");
   CUGRAPH_EXPECTS(renumber,
                   "Invalid input arguments: renumber should be true if multi_gpu is true.");
+
+  CUGRAPH_EXPECTS((!large_vertex_buffer_type && !large_edge_buffer_type) ||
+                    cugraph::large_buffer_manager::memory_buffer_initialized(),
+                  "Invalid input argument: large memory buffer is not initialized.");
 
   if (do_expensive_check) {
     expensive_check_edgelist<vertex_t, multi_gpu>(handle,
@@ -1008,6 +1086,7 @@ create_graph_from_edgelist_impl(
 
   // 1. groupby edges to their target local adjacency matrix partition (and further groupby within
   // the local partition by applying the compute_gpu_id_from_vertex_t to minor vertex IDs).
+
   std::vector<arithmetic_device_span_t> edgelist_properties{};
 
   if (edgelist_weights)
@@ -1034,7 +1113,8 @@ create_graph_from_edgelist_impl(
                      : raft::device_span<vertex_t>{edgelist_dsts.data(), edgelist_dsts.size()},
     raft::host_span<cugraph::arithmetic_device_span_t>{edgelist_properties.data(),
                                                        edgelist_properties.size()},
-    true);
+    true,
+    large_edge_buffer_type);
 
   std::vector<size_t> h_edge_counts(d_edge_counts.size());
   raft::update_host(
@@ -1058,10 +1138,14 @@ create_graph_from_edgelist_impl(
                    edgelist_displacements.begin() + 1);
 
   // 2. split the input edges to local partitions
+
   std::vector<rmm::device_uvector<vertex_t>> edge_partition_edgelist_srcs{};
   edge_partition_edgelist_srcs.reserve(minor_comm_size);
   for (int i = 0; i < minor_comm_size; ++i) {
-    rmm::device_uvector<vertex_t> tmp_srcs(edgelist_edge_counts[i], handle.get_stream());
+    auto tmp_srcs = large_edge_buffer_type
+                      ? large_buffer_manager::allocate_memory_buffer<vertex_t>(
+                          edgelist_edge_counts[i], handle.get_stream())
+                      : rmm::device_uvector<vertex_t>(edgelist_edge_counts[i], handle.get_stream());
     thrust::copy(handle.get_thrust_policy(),
                  edgelist_srcs.begin() + edgelist_displacements[i],
                  edgelist_srcs.begin() + edgelist_displacements[i] + edgelist_edge_counts[i],
@@ -1074,7 +1158,10 @@ create_graph_from_edgelist_impl(
   std::vector<rmm::device_uvector<vertex_t>> edge_partition_edgelist_dsts{};
   edge_partition_edgelist_dsts.reserve(minor_comm_size);
   for (int i = 0; i < minor_comm_size; ++i) {
-    rmm::device_uvector<vertex_t> tmp_dsts(edgelist_edge_counts[i], handle.get_stream());
+    auto tmp_dsts = large_edge_buffer_type
+                      ? large_buffer_manager::allocate_memory_buffer<vertex_t>(
+                          edgelist_edge_counts[i], handle.get_stream())
+                      : rmm::device_uvector<vertex_t>(edgelist_edge_counts[i], handle.get_stream());
     thrust::copy(handle.get_thrust_policy(),
                  edgelist_dsts.begin() + edgelist_displacements[i],
                  edgelist_dsts.begin() + edgelist_displacements[i] + edgelist_edge_counts[i],
@@ -1089,7 +1176,11 @@ create_graph_from_edgelist_impl(
     edge_partition_edgelist_weights = std::vector<rmm::device_uvector<weight_t>>{};
     (*edge_partition_edgelist_weights).reserve(minor_comm_size);
     for (int i = 0; i < minor_comm_size; ++i) {
-      rmm::device_uvector<weight_t> tmp_weights(edgelist_edge_counts[i], handle.get_stream());
+      auto tmp_weights =
+        large_edge_buffer_type
+          ? large_buffer_manager::allocate_memory_buffer<weight_t>(edgelist_edge_counts[i],
+                                                                   handle.get_stream())
+          : rmm::device_uvector<weight_t>(edgelist_edge_counts[i], handle.get_stream());
       thrust::copy(
         handle.get_thrust_policy(),
         (*edgelist_weights).begin() + edgelist_displacements[i],
@@ -1106,7 +1197,11 @@ create_graph_from_edgelist_impl(
     edge_partition_edgelist_edge_ids = std::vector<rmm::device_uvector<edge_t>>{};
     (*edge_partition_edgelist_edge_ids).reserve(minor_comm_size);
     for (int i = 0; i < minor_comm_size; ++i) {
-      rmm::device_uvector<edge_t> tmp_edge_ids(edgelist_edge_counts[i], handle.get_stream());
+      auto tmp_edge_ids =
+        large_edge_buffer_type
+          ? large_buffer_manager::allocate_memory_buffer<edge_t>(edgelist_edge_counts[i],
+                                                                 handle.get_stream())
+          : rmm::device_uvector<edge_t>(edgelist_edge_counts[i], handle.get_stream());
       thrust::copy(
         handle.get_thrust_policy(),
         (*edgelist_edge_ids).begin() + edgelist_displacements[i],
@@ -1123,7 +1218,11 @@ create_graph_from_edgelist_impl(
     edge_partition_edgelist_edge_types = std::vector<rmm::device_uvector<edge_type_t>>{};
     (*edge_partition_edgelist_edge_types).reserve(minor_comm_size);
     for (int i = 0; i < minor_comm_size; ++i) {
-      rmm::device_uvector<edge_type_t> tmp_edge_types(edgelist_edge_counts[i], handle.get_stream());
+      auto tmp_edge_types =
+        large_edge_buffer_type
+          ? large_buffer_manager::allocate_memory_buffer<edge_type_t>(edgelist_edge_counts[i],
+                                                                      handle.get_stream())
+          : rmm::device_uvector<edge_type_t>(edgelist_edge_counts[i], handle.get_stream());
       thrust::copy(
         handle.get_thrust_policy(),
         (*edgelist_edge_types).begin() + edgelist_displacements[i],
@@ -1141,8 +1240,11 @@ create_graph_from_edgelist_impl(
     edge_partition_edgelist_edge_start_times = std::vector<rmm::device_uvector<edge_time_t>>{};
     (*edge_partition_edgelist_edge_start_times).reserve(minor_comm_size);
     for (int i = 0; i < minor_comm_size; ++i) {
-      rmm::device_uvector<edge_time_t> tmp_edge_start_times(edgelist_edge_counts[i],
-                                                            handle.get_stream());
+      auto tmp_edge_start_times =
+        large_edge_buffer_type
+          ? large_buffer_manager::allocate_memory_buffer<edge_time_t>(edgelist_edge_counts[i],
+                                                                      handle.get_stream())
+          : rmm::device_uvector<edge_time_t>(edgelist_edge_counts[i], handle.get_stream());
       thrust::copy(
         handle.get_thrust_policy(),
         (*edgelist_edge_start_times).begin() + edgelist_displacements[i],
@@ -1160,8 +1262,11 @@ create_graph_from_edgelist_impl(
     edge_partition_edgelist_edge_end_times = std::vector<rmm::device_uvector<edge_time_t>>{};
     (*edge_partition_edgelist_edge_end_times).reserve(minor_comm_size);
     for (int i = 0; i < minor_comm_size; ++i) {
-      rmm::device_uvector<edge_time_t> tmp_edge_end_times(edgelist_edge_counts[i],
-                                                          handle.get_stream());
+      auto tmp_edge_end_times =
+        large_edge_buffer_type
+          ? large_buffer_manager::allocate_memory_buffer<edge_time_t>(edgelist_edge_counts[i],
+                                                                      handle.get_stream())
+          : rmm::device_uvector<edge_time_t>(edgelist_edge_counts[i], handle.get_stream());
       thrust::copy(
         handle.get_thrust_policy(),
         (*edgelist_edge_end_times).begin() + edgelist_displacements[i],
@@ -1172,6 +1277,7 @@ create_graph_from_edgelist_impl(
     (*edgelist_edge_end_times).resize(0, handle.get_stream());
     (*edgelist_edge_end_times).shrink_to_fit(handle.get_stream());
   }
+
   return create_graph_from_partitioned_edgelist<vertex_t,
                                                 edge_t,
                                                 weight_t,
@@ -1190,7 +1296,9 @@ create_graph_from_edgelist_impl(
     std::move(edge_partition_edgelist_edge_end_times),
     edgelist_intra_partition_segment_offset_vectors,
     graph_properties,
-    renumber);
+    renumber,
+    large_vertex_buffer_type,
+    large_edge_buffer_type);
 }
 
 template <typename vertex_t,
@@ -1220,6 +1328,8 @@ create_graph_from_edgelist_impl(
   std::optional<std::vector<rmm::device_uvector<edge_time_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check)
 {
   auto& major_comm           = handle.get_subcomm(cugraph::partition_manager::major_comm_name());
@@ -1271,6 +1381,10 @@ create_graph_from_edgelist_impl(
   }
   CUGRAPH_EXPECTS(renumber,
                   "Invalid input arguments: renumber should be true if multi_gpu is true.");
+
+  CUGRAPH_EXPECTS((!large_vertex_buffer_type && !large_edge_buffer_type) ||
+                    cugraph::large_buffer_manager::memory_buffer_initialized(),
+                  "Invalid input argument: large memory buffer is not initialized.");
 
   if (do_expensive_check) {
     edge_t aggregate_edge_count{0};
@@ -1338,21 +1452,23 @@ create_graph_from_edgelist_impl(
   if constexpr (sizeof(vertex_t) == 8) {        // 64 bit vertex ID
     static_assert(std::is_signed_v<vertex_t>);  // __clzll takes a signed integer
 
-    auto total_global_mem = handle.get_device_properties().totalGlobalMem;
-    size_t element_size   = sizeof(vertex_t) * 2;
-    if (edgelist_weights) { element_size += sizeof(weight_t); }
-    if (edgelist_edge_ids) { element_size += sizeof(edge_t); }
-    if (edgelist_edge_types) { element_size += sizeof(edge_type_t); }
-    if (edgelist_edge_start_times) { element_size += sizeof(edge_time_t); }
-    if (edgelist_edge_end_times) { element_size += sizeof(edge_time_t); }
-    edge_t num_edges{0};
-    for (size_t i = 0; i < edgelist_srcs.size(); ++i) {
-      num_edges += edgelist_srcs[i].size();
-    }
     bool compress{false};
-    if (static_cast<size_t>(num_edges) * element_size >
-        static_cast<size_t>(total_global_mem * 0.5 /* tuning parameter */)) {
-      compress = true;
+    if (!large_edge_buffer_type) {
+      auto total_global_mem = handle.get_device_properties().totalGlobalMem;
+      size_t element_size   = sizeof(vertex_t) * 2;
+      if (edgelist_weights) { element_size += sizeof(weight_t); }
+      if (edgelist_edge_ids) { element_size += sizeof(edge_t); }
+      if (edgelist_edge_types) { element_size += sizeof(edge_type_t); }
+      if (edgelist_edge_start_times) { element_size += sizeof(edge_time_t); }
+      if (edgelist_edge_end_times) { element_size += sizeof(edge_time_t); }
+      edge_t num_edges{0};
+      for (size_t i = 0; i < edgelist_srcs.size(); ++i) {
+        num_edges += edgelist_srcs[i].size();
+      }
+      if (static_cast<size_t>(num_edges) * element_size >
+          static_cast<size_t>(total_global_mem * 0.5 /* tuning parameter */)) {
+        compress = true;
+      }
     }
 
     if (compress) {
@@ -1378,6 +1494,7 @@ create_graph_from_edgelist_impl(
   // 2. groupby each edge chunks to their target local adjacency matrix partition (and further
   // groupby within the local partition by applying the compute_gpu_id_from_vertex_t to minor vertex
   // IDs).
+
   std::vector<std::vector<edge_t>> edgelist_edge_offset_vectors(num_chunks);
   for (size_t i = 0; i < num_chunks; ++i) {  // iterate over input edge chunks
     std::vector<arithmetic_device_span_t> this_chunk_edgelist_properties{};
@@ -1409,7 +1526,8 @@ create_graph_from_edgelist_impl(
           : raft::device_span<vertex_t>{edgelist_dsts[i].data(), edgelist_dsts[i].size()},
         raft::host_span<cugraph::arithmetic_device_span_t>{this_chunk_edgelist_properties.data(),
                                                            this_chunk_edgelist_properties.size()},
-        true);
+        true,
+        large_edge_buffer_type);
 
     std::vector<size_t> h_this_chunk_edge_counts(d_this_chunk_edge_counts.size());
     raft::update_host(h_this_chunk_edge_counts.data(),
@@ -1428,6 +1546,7 @@ create_graph_from_edgelist_impl(
   }
 
   // 3. compress edge chunk source/destination vertices to cut intermediate peak memory requirement
+
   std::optional<std::vector<rmm::device_uvector<std::byte>>> edgelist_compressed_srcs{std::nullopt};
   std::optional<std::vector<rmm::device_uvector<std::byte>>> edgelist_compressed_dsts{std::nullopt};
   if (compressed_v_size < sizeof(vertex_t)) {
@@ -1437,8 +1556,11 @@ create_graph_from_edgelist_impl(
     (*edgelist_compressed_dsts).reserve(num_chunks);
     for (size_t i = 0; i < num_chunks; ++i) {  // iterate over input edge chunks
                                                // compress source values
-      auto tmp_srcs = rmm::device_uvector<std::byte>(edgelist_srcs[i].size() * compressed_v_size,
-                                                     handle.get_stream());
+      auto num_bytes = edgelist_srcs[i].size() * compressed_v_size;
+      auto tmp_srcs =
+        large_edge_buffer_type
+          ? large_buffer_manager::allocate_memory_buffer<std::byte>(num_bytes, handle.get_stream())
+          : rmm::device_uvector<std::byte>(num_bytes, handle.get_stream());
       auto input_src_first = thrust::make_transform_iterator(
         thrust::make_counting_iterator(size_t{0}),
         cuda::proclaim_return_type<std::byte>(
@@ -1456,8 +1578,11 @@ create_graph_from_edgelist_impl(
 
       // compress destination values
 
-      auto tmp_dsts = rmm::device_uvector<std::byte>(edgelist_dsts[i].size() * compressed_v_size,
-                                                     handle.get_stream());
+      num_bytes = edgelist_dsts[i].size() * compressed_v_size;
+      auto tmp_dsts =
+        large_edge_buffer_type
+          ? large_buffer_manager::allocate_memory_buffer<std::byte>(num_bytes, handle.get_stream())
+          : rmm::device_uvector<std::byte>(num_bytes, handle.get_stream());
       auto input_dst_first = thrust::make_transform_iterator(
         thrust::make_counting_iterator(size_t{0}),
         cuda::proclaim_return_type<std::byte>(
@@ -1476,6 +1601,7 @@ create_graph_from_edgelist_impl(
   }
 
   // 4. compute additional copy_offset vectors
+
   std::vector<edge_t> edge_partition_edge_counts(minor_comm_size);
   std::vector<std::vector<edge_t>> edge_partition_intra_partition_segment_offset_vectors(
     minor_comm_size);
@@ -1509,6 +1635,7 @@ create_graph_from_edgelist_impl(
   }
 
   // 5. split the grouped edge chunks to local partitions
+
   std::vector<rmm::device_uvector<vertex_t>> edge_partition_edgelist_srcs{};
   std::vector<rmm::device_uvector<vertex_t>> edge_partition_edgelist_dsts{};
   std::optional<std::vector<rmm::device_uvector<weight_t>>> edge_partition_edgelist_weights{
@@ -1536,7 +1663,8 @@ create_graph_from_edgelist_impl(
         edge_partition_edge_counts,
         edge_partition_intra_partition_segment_offset_vectors,
         edge_partition_intra_segment_copy_output_displacement_vectors,
-        compressed_v_size);
+        compressed_v_size,
+        large_edge_buffer_type);
 
     edge_partition_edgelist_compressed_dsts =
       split_edge_chunk_compressed_elements_to_local_edge_partitions<edge_t>(
@@ -1546,7 +1674,8 @@ create_graph_from_edgelist_impl(
         edge_partition_edge_counts,
         edge_partition_intra_partition_segment_offset_vectors,
         edge_partition_intra_segment_copy_output_displacement_vectors,
-        compressed_v_size);
+        compressed_v_size,
+        large_edge_buffer_type);
   } else {
     edge_partition_edgelist_srcs =
       split_edge_chunk_elements_to_local_edge_partitions<edge_t, vertex_t>(
@@ -1555,7 +1684,8 @@ create_graph_from_edgelist_impl(
         edgelist_edge_offset_vectors,
         edge_partition_edge_counts,
         edge_partition_intra_partition_segment_offset_vectors,
-        edge_partition_intra_segment_copy_output_displacement_vectors);
+        edge_partition_intra_segment_copy_output_displacement_vectors,
+        large_edge_buffer_type);
 
     edge_partition_edgelist_dsts =
       split_edge_chunk_elements_to_local_edge_partitions<edge_t, vertex_t>(
@@ -1564,7 +1694,8 @@ create_graph_from_edgelist_impl(
         edgelist_edge_offset_vectors,
         edge_partition_edge_counts,
         edge_partition_intra_partition_segment_offset_vectors,
-        edge_partition_intra_segment_copy_output_displacement_vectors);
+        edge_partition_intra_segment_copy_output_displacement_vectors,
+        large_edge_buffer_type);
   }
 
   if (edgelist_weights) {
@@ -1575,7 +1706,8 @@ create_graph_from_edgelist_impl(
         edgelist_edge_offset_vectors,
         edge_partition_edge_counts,
         edge_partition_intra_partition_segment_offset_vectors,
-        edge_partition_intra_segment_copy_output_displacement_vectors);
+        edge_partition_intra_segment_copy_output_displacement_vectors,
+        large_edge_buffer_type);
   }
   if (edgelist_edge_ids) {
     edge_partition_edgelist_edge_ids =
@@ -1585,7 +1717,8 @@ create_graph_from_edgelist_impl(
         edgelist_edge_offset_vectors,
         edge_partition_edge_counts,
         edge_partition_intra_partition_segment_offset_vectors,
-        edge_partition_intra_segment_copy_output_displacement_vectors);
+        edge_partition_intra_segment_copy_output_displacement_vectors,
+        large_edge_buffer_type);
   }
   if (edgelist_edge_types) {
     edge_partition_edgelist_edge_types =
@@ -1595,7 +1728,8 @@ create_graph_from_edgelist_impl(
         edgelist_edge_offset_vectors,
         edge_partition_edge_counts,
         edge_partition_intra_partition_segment_offset_vectors,
-        edge_partition_intra_segment_copy_output_displacement_vectors);
+        edge_partition_intra_segment_copy_output_displacement_vectors,
+        large_edge_buffer_type);
   }
   if (edgelist_edge_start_times) {
     edge_partition_edgelist_edge_start_times =
@@ -1605,7 +1739,8 @@ create_graph_from_edgelist_impl(
         edgelist_edge_offset_vectors,
         edge_partition_edge_counts,
         edge_partition_intra_partition_segment_offset_vectors,
-        edge_partition_intra_segment_copy_output_displacement_vectors);
+        edge_partition_intra_segment_copy_output_displacement_vectors,
+        large_edge_buffer_type);
   }
   if (edgelist_edge_end_times) {
     edge_partition_edgelist_edge_end_times =
@@ -1615,11 +1750,13 @@ create_graph_from_edgelist_impl(
         edgelist_edge_offset_vectors,
         edge_partition_edge_counts,
         edge_partition_intra_partition_segment_offset_vectors,
-        edge_partition_intra_segment_copy_output_displacement_vectors);
+        edge_partition_intra_segment_copy_output_displacement_vectors,
+        large_edge_buffer_type);
   }
 
   // 6. decompress edge chunk source/destination vertices to cut intermediate peak memory
   // requirement
+
   if (compressed_v_size < sizeof(vertex_t)) {
     assert(edge_partition_edgelist_compressed_srcs);
     assert(edge_partition_edgelist_compressed_dsts);
@@ -1628,7 +1765,11 @@ create_graph_from_edgelist_impl(
     edge_partition_edgelist_dsts.reserve(minor_comm_size);
 
     for (int i = 0; i < minor_comm_size; ++i) {
-      rmm::device_uvector<vertex_t> tmp_srcs(edge_partition_edge_counts[i], handle.get_stream());
+      auto tmp_srcs =
+        large_edge_buffer_type
+          ? large_buffer_manager::allocate_memory_buffer<vertex_t>(edge_partition_edge_counts[i],
+                                                                   handle.get_stream())
+          : rmm::device_uvector<vertex_t>(edge_partition_edge_counts[i], handle.get_stream());
       decompress_vertices(
         handle,
         raft::device_span<std::byte const>((*edge_partition_edgelist_compressed_srcs)[i].data(),
@@ -1639,7 +1780,11 @@ create_graph_from_edgelist_impl(
       (*edge_partition_edgelist_compressed_srcs)[i].resize(0, handle.get_stream());
       (*edge_partition_edgelist_compressed_srcs)[i].shrink_to_fit(handle.get_stream());
 
-      rmm::device_uvector<vertex_t> tmp_dsts(edge_partition_edge_counts[i], handle.get_stream());
+      auto tmp_dsts =
+        large_edge_buffer_type
+          ? large_buffer_manager::allocate_memory_buffer<vertex_t>(edge_partition_edge_counts[i],
+                                                                   handle.get_stream())
+          : rmm::device_uvector<vertex_t>(edge_partition_edge_counts[i], handle.get_stream());
       decompress_vertices(
         handle,
         raft::device_span<std::byte const>((*edge_partition_edgelist_compressed_dsts)[i].data(),
@@ -1670,7 +1815,9 @@ create_graph_from_edgelist_impl(
     std::move(edge_partition_edgelist_edge_end_times),
     edge_partition_intra_partition_segment_offset_vectors,
     graph_properties,
-    renumber);
+    renumber,
+    large_vertex_buffer_type,
+    large_edge_buffer_type);
 }
 
 template <typename vertex_t,
@@ -1700,6 +1847,8 @@ create_graph_from_edgelist_impl(
   std::optional<rmm::device_uvector<edge_time_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check)
 {
   CUGRAPH_EXPECTS(
@@ -1724,6 +1873,10 @@ create_graph_from_edgelist_impl(
     !edgelist_edge_end_times || (edgelist_srcs.size() == (*edgelist_edge_end_times).size()),
     "Invalid input arguments: edgelist_srcs.size() != "
     "(*edgelist_edge_end_times).size().");
+
+  CUGRAPH_EXPECTS((!large_vertex_buffer_type && !large_edge_buffer_type) ||
+                    cugraph::large_buffer_manager::memory_buffer_initialized(),
+                  "Invalid input argument: large memory buffer is not initialized.");
 
   if (do_expensive_check) {
     expensive_check_edgelist<vertex_t, multi_gpu>(handle,
@@ -1756,18 +1909,19 @@ create_graph_from_edgelist_impl(
   }
 
   // 1. renumber
-  auto renumber_map_labels =
-    renumber ? std::make_optional<rmm::device_uvector<vertex_t>>(0, handle.get_stream())
-             : std::nullopt;
+
+  std::optional<rmm::device_uvector<vertex_t>> renumber_map_labels{std::nullopt};
   renumber_meta_t<vertex_t, edge_t, multi_gpu> meta{};
   if (renumber) {
-    std::tie(*renumber_map_labels, meta) = cugraph::renumber_edgelist<vertex_t, edge_t, multi_gpu>(
+    std::tie(renumber_map_labels, meta) = cugraph::renumber_edgelist<vertex_t, edge_t, multi_gpu>(
       handle,
       std::move(vertices),
       edgelist_srcs.data(),
       edgelist_dsts.data(),
       static_cast<edge_t>(edgelist_srcs.size()),
-      store_transposed);
+      store_transposed,
+      large_vertex_buffer_type,
+      large_edge_buffer_type);
   }
 
   vertex_t num_vertices{};
@@ -1787,6 +1941,7 @@ create_graph_from_edgelist_impl(
   }
 
   // 2. convert edge list (COO) to compressed sparse format (CSR or CSC)
+
   int edge_property_count = 0;
   size_t element_size     = sizeof(vertex_t) * 2;
 
@@ -1814,12 +1969,15 @@ create_graph_from_edgelist_impl(
 
   if (edge_property_count > 1) { element_size = sizeof(vertex_t) * 2 + sizeof(size_t); }
 
-  auto total_global_mem = handle.get_device_properties().totalGlobalMem;
-  auto constexpr mem_frugal_ratio =
-    0.25;  // if the expected temporary buffer size exceeds the mem_frugal_ratio of the
-           // total_global_mem, switch to the memory frugal approach
-  auto mem_frugal_threshold =
-    static_cast<size_t>(static_cast<double>(total_global_mem / element_size) * mem_frugal_ratio);
+  auto mem_frugal_threshold = std::numeric_limits<size_t>::max();
+  if (!large_edge_buffer_type) {
+    auto total_global_mem = handle.get_device_properties().totalGlobalMem;
+    auto constexpr mem_frugal_ratio =
+      0.25;  // if the expected temporary buffer size exceeds the mem_frugal_ratio of the
+             // total_global_mem, switch to the memory frugal approach
+    mem_frugal_threshold =
+      static_cast<size_t>(static_cast<double>(total_global_mem / element_size) * mem_frugal_ratio);
+  }
 
   rmm::device_uvector<edge_t> offsets(size_t{0}, handle.get_stream());
   rmm::device_uvector<vertex_t> indices(size_t{0}, handle.get_stream());
@@ -1832,6 +1990,7 @@ create_graph_from_edgelist_impl(
   if (edge_property_count == 0) {
     std::forward_as_tuple(offsets, indices, std::ignore) =
       detail::sort_and_compress_edgelist<vertex_t, edge_t, store_transposed>(
+        handle,
         std::move(edgelist_srcs),
         std::move(edgelist_dsts),
         vertex_t{0},
@@ -1840,11 +1999,13 @@ create_graph_from_edgelist_impl(
         vertex_t{0},
         num_vertices,
         mem_frugal_threshold,
-        handle.get_stream());
+        large_vertex_buffer_type,
+        large_edge_buffer_type);
   } else if (edge_property_count == 1) {
     if (edgelist_weights) {
       std::forward_as_tuple(offsets, indices, weights, std::ignore) =
         detail::sort_and_compress_edgelist<vertex_t, edge_t, weight_t, store_transposed>(
+          handle,
           std::move(edgelist_srcs),
           std::move(edgelist_dsts),
           std::move(*edgelist_weights),
@@ -1854,10 +2015,12 @@ create_graph_from_edgelist_impl(
           vertex_t{0},
           num_vertices,
           mem_frugal_threshold,
-          handle.get_stream());
+          large_vertex_buffer_type,
+          large_edge_buffer_type);
     } else if (edgelist_edge_ids) {
       std::forward_as_tuple(offsets, indices, ids, std::ignore) =
         detail::sort_and_compress_edgelist<vertex_t, edge_t, edge_t, store_transposed>(
+          handle,
           std::move(edgelist_srcs),
           std::move(edgelist_dsts),
           std::move(*edgelist_edge_ids),
@@ -1867,10 +2030,12 @@ create_graph_from_edgelist_impl(
           vertex_t{0},
           num_vertices,
           mem_frugal_threshold,
-          handle.get_stream());
+          large_vertex_buffer_type,
+          large_edge_buffer_type);
     } else if (edgelist_edge_types) {
       std::forward_as_tuple(offsets, indices, types, std::ignore) =
         detail::sort_and_compress_edgelist<vertex_t, edge_t, edge_type_t, store_transposed>(
+          handle,
           std::move(edgelist_srcs),
           std::move(edgelist_dsts),
           std::move(*edgelist_edge_types),
@@ -1880,10 +2045,12 @@ create_graph_from_edgelist_impl(
           vertex_t{0},
           num_vertices,
           mem_frugal_threshold,
-          handle.get_stream());
+          large_vertex_buffer_type,
+          large_edge_buffer_type);
     } else if (edgelist_edge_start_times) {
       std::forward_as_tuple(offsets, indices, start_times, std::ignore) =
         detail::sort_and_compress_edgelist<vertex_t, edge_t, edge_time_t, store_transposed>(
+          handle,
           std::move(edgelist_srcs),
           std::move(edgelist_dsts),
           std::move(*edgelist_edge_start_times),
@@ -1893,10 +2060,12 @@ create_graph_from_edgelist_impl(
           vertex_t{0},
           num_vertices,
           mem_frugal_threshold,
-          handle.get_stream());
+          large_vertex_buffer_type,
+          large_edge_buffer_type);
     } else if (edgelist_edge_end_times) {
       std::forward_as_tuple(offsets, indices, end_times, std::ignore) =
         detail::sort_and_compress_edgelist<vertex_t, edge_t, edge_time_t, store_transposed>(
+          handle,
           std::move(edgelist_srcs),
           std::move(edgelist_dsts),
           std::move(*edgelist_edge_end_times),
@@ -1906,68 +2075,87 @@ create_graph_from_edgelist_impl(
           vertex_t{0},
           num_vertices,
           mem_frugal_threshold,
-          handle.get_stream());
+          large_vertex_buffer_type,
+          large_edge_buffer_type);
     }
   } else {
-    rmm::device_uvector<edge_t> property_position(edgelist_srcs.size(), handle.get_stream());
+    auto property_positions =
+      large_edge_buffer_type
+        ? large_buffer_manager::allocate_memory_buffer<edge_t>(edgelist_srcs.size(),
+                                                               handle.get_stream())
+        : rmm::device_uvector<edge_t>(edgelist_srcs.size(), handle.get_stream());
     detail::sequence_fill(
-      handle.get_stream(), property_position.data(), property_position.size(), edge_t{0});
+      handle.get_stream(), property_positions.data(), property_positions.size(), edge_t{0});
 
-    std::tie(offsets, indices, property_position, std::ignore) =
+    std::tie(offsets, indices, property_positions, std::ignore) =
       detail::sort_and_compress_edgelist<vertex_t, edge_t, edge_t, store_transposed>(
+        handle,
         std::move(edgelist_srcs),
         std::move(edgelist_dsts),
-        std::move(property_position),
+        std::move(property_positions),
         vertex_t{0},
         std::optional<vertex_t>{std::nullopt},
         num_vertices,
         vertex_t{0},
         num_vertices,
         mem_frugal_threshold,
-        handle.get_stream());
+        large_vertex_buffer_type,
+        large_edge_buffer_type);
 
     if (edgelist_weights) {
-      weights = std::make_optional<rmm::device_uvector<weight_t>>(property_position.size(),
-                                                                  handle.get_stream());
+      weights = large_edge_buffer_type
+                  ? large_buffer_manager::allocate_memory_buffer<weight_t>(
+                      property_positions.size(), handle.get_stream())
+                  : rmm::device_uvector<weight_t>(property_positions.size(), handle.get_stream());
       thrust::gather(handle.get_thrust_policy(),
-                     property_position.begin(),
-                     property_position.end(),
+                     property_positions.begin(),
+                     property_positions.end(),
                      edgelist_weights->begin(),
                      weights->begin());
     }
     if (edgelist_edge_ids) {
-      ids = std::make_optional<rmm::device_uvector<edge_t>>(property_position.size(),
-                                                            handle.get_stream());
+      ids = large_edge_buffer_type
+              ? large_buffer_manager::allocate_memory_buffer<edge_t>(property_positions.size(),
+                                                                     handle.get_stream())
+              : rmm::device_uvector<edge_t>(property_positions.size(), handle.get_stream());
       thrust::gather(handle.get_thrust_policy(),
-                     property_position.begin(),
-                     property_position.end(),
+                     property_positions.begin(),
+                     property_positions.end(),
                      edgelist_edge_ids->begin(),
                      ids->begin());
     }
     if (edgelist_edge_types) {
-      types = std::make_optional<rmm::device_uvector<edge_type_t>>(property_position.size(),
-                                                                   handle.get_stream());
+      types = large_edge_buffer_type
+                ? large_buffer_manager::allocate_memory_buffer<edge_type_t>(
+                    property_positions.size(), handle.get_stream())
+                : rmm::device_uvector<edge_type_t>(property_positions.size(), handle.get_stream());
       thrust::gather(handle.get_thrust_policy(),
-                     property_position.begin(),
-                     property_position.end(),
+                     property_positions.begin(),
+                     property_positions.end(),
                      edgelist_edge_types->begin(),
                      types->begin());
     }
     if (edgelist_edge_start_times) {
-      start_times = std::make_optional<rmm::device_uvector<edge_time_t>>(property_position.size(),
-                                                                         handle.get_stream());
+      start_times =
+        large_edge_buffer_type
+          ? large_buffer_manager::allocate_memory_buffer<edge_time_t>(property_positions.size(),
+                                                                      handle.get_stream())
+          : rmm::device_uvector<edge_time_t>(property_positions.size(), handle.get_stream());
       thrust::gather(handle.get_thrust_policy(),
-                     property_position.begin(),
-                     property_position.end(),
+                     property_positions.begin(),
+                     property_positions.end(),
                      edgelist_edge_start_times->begin(),
                      start_times->begin());
     }
     if (edgelist_edge_end_times) {
-      end_times = std::make_optional<rmm::device_uvector<edge_time_t>>(property_position.size(),
-                                                                       handle.get_stream());
+      end_times =
+        large_edge_buffer_type
+          ? large_buffer_manager::allocate_memory_buffer<edge_time_t>(property_positions.size(),
+                                                                      handle.get_stream())
+          : rmm::device_uvector<edge_time_t>(property_positions.size(), handle.get_stream());
       thrust::gather(handle.get_thrust_policy(),
-                     property_position.begin(),
-                     property_position.end(),
+                     property_positions.begin(),
+                     property_positions.end(),
                      edgelist_edge_end_times->begin(),
                      end_times->begin());
     }
@@ -2057,6 +2245,8 @@ create_graph_from_edgelist_impl(
   std::optional<std::vector<rmm::device_uvector<edge_time_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check)
 {
   CUGRAPH_EXPECTS(edgelist_srcs.size() == edgelist_dsts.size(),
@@ -2102,6 +2292,10 @@ create_graph_from_edgelist_impl(
       "edgelist_srcs[i].size() != (*edgelist_edge_end_times)[i].size().");
   }
 
+  CUGRAPH_EXPECTS((!large_vertex_buffer_type && !large_edge_buffer_type) ||
+                    cugraph::large_buffer_manager::memory_buffer_initialized(),
+                  "Invalid input argument: large memory buffer is not initialized.");
+
   std::vector<edge_t> chunk_edge_counts(edgelist_srcs.size());
   for (size_t i = 0; i < edgelist_srcs.size(); ++i) {
     chunk_edge_counts[i] = edgelist_srcs[i].size();
@@ -2113,7 +2307,11 @@ create_graph_from_edgelist_impl(
                       edge_t{0});
   auto aggregate_edge_count = chunk_edge_displacements.back() + chunk_edge_counts.back();
 
-  rmm::device_uvector<vertex_t> aggregate_edgelist_srcs(aggregate_edge_count, handle.get_stream());
+  auto aggregate_edgelist_srcs =
+    large_edge_buffer_type
+      ? large_buffer_manager::allocate_memory_buffer<vertex_t>(aggregate_edge_count,
+                                                               handle.get_stream())
+      : rmm::device_uvector<vertex_t>(aggregate_edge_count, handle.get_stream());
   for (size_t i = 0; i < edgelist_srcs.size(); ++i) {
     thrust::copy(handle.get_thrust_policy(),
                  edgelist_srcs[i].begin(),
@@ -2124,7 +2322,11 @@ create_graph_from_edgelist_impl(
   }
   edgelist_srcs.clear();
 
-  rmm::device_uvector<vertex_t> aggregate_edgelist_dsts(aggregate_edge_count, handle.get_stream());
+  auto aggregate_edgelist_dsts =
+    large_edge_buffer_type
+      ? large_buffer_manager::allocate_memory_buffer<vertex_t>(aggregate_edge_count,
+                                                               handle.get_stream())
+      : rmm::device_uvector<vertex_t>(aggregate_edge_count, handle.get_stream());
   for (size_t i = 0; i < edgelist_dsts.size(); ++i) {
     thrust::copy(handle.get_thrust_policy(),
                  edgelist_dsts[i].begin(),
@@ -2135,10 +2337,14 @@ create_graph_from_edgelist_impl(
   }
   edgelist_dsts.clear();
 
-  auto aggregate_edgelist_weights =
-    edgelist_weights
-      ? std::make_optional<rmm::device_uvector<weight_t>>(aggregate_edge_count, handle.get_stream())
-      : std::nullopt;
+  std::optional<rmm::device_uvector<weight_t>> aggregate_edgelist_weights{std::nullopt};
+  if (edgelist_weights) {
+    aggregate_edgelist_weights =
+      large_edge_buffer_type
+        ? large_buffer_manager::allocate_memory_buffer<weight_t>(aggregate_edge_count,
+                                                                 handle.get_stream())
+        : rmm::device_uvector<weight_t>(aggregate_edge_count, handle.get_stream());
+  }
   if (aggregate_edgelist_weights) {
     for (size_t i = 0; i < (*edgelist_weights).size(); ++i) {
       thrust::copy(handle.get_thrust_policy(),
@@ -2151,10 +2357,14 @@ create_graph_from_edgelist_impl(
     (*edgelist_weights).clear();
   }
 
-  auto aggregate_edgelist_edge_ids =
-    edgelist_edge_ids
-      ? std::make_optional<rmm::device_uvector<edge_t>>(aggregate_edge_count, handle.get_stream())
-      : std::nullopt;
+  std::optional<rmm::device_uvector<edge_t>> aggregate_edgelist_edge_ids{std::nullopt};
+  if (edgelist_edge_ids) {
+    aggregate_edgelist_edge_ids =
+      large_edge_buffer_type
+        ? large_buffer_manager::allocate_memory_buffer<edge_t>(aggregate_edge_count,
+                                                               handle.get_stream())
+        : rmm::device_uvector<edge_t>(aggregate_edge_count, handle.get_stream());
+  }
   if (aggregate_edgelist_edge_ids) {
     for (size_t i = 0; i < (*edgelist_edge_ids).size(); ++i) {
       thrust::copy(handle.get_thrust_policy(),
@@ -2167,10 +2377,14 @@ create_graph_from_edgelist_impl(
     (*edgelist_edge_ids).clear();
   }
 
-  auto aggregate_edgelist_edge_types = edgelist_edge_types
-                                         ? std::make_optional<rmm::device_uvector<edge_type_t>>(
-                                             aggregate_edge_count, handle.get_stream())
-                                         : std::nullopt;
+  std::optional<rmm::device_uvector<edge_type_t>> aggregate_edgelist_edge_types{std::nullopt};
+  if (edgelist_edge_types) {
+    aggregate_edgelist_edge_types =
+      large_edge_buffer_type
+        ? large_buffer_manager::allocate_memory_buffer<edge_type_t>(aggregate_edge_count,
+                                                                    handle.get_stream())
+        : rmm::device_uvector<edge_type_t>(aggregate_edge_count, handle.get_stream());
+  }
   if (aggregate_edgelist_edge_types) {
     for (size_t i = 0; i < (*edgelist_edge_types).size(); ++i) {
       thrust::copy(handle.get_thrust_policy(),
@@ -2183,10 +2397,14 @@ create_graph_from_edgelist_impl(
     (*edgelist_edge_types).clear();
   }
 
-  auto aggregate_edgelist_edge_start_times =
-    edgelist_edge_start_times ? std::make_optional<rmm::device_uvector<edge_time_t>>(
-                                  aggregate_edge_count, handle.get_stream())
-                              : std::nullopt;
+  std::optional<rmm::device_uvector<edge_time_t>> aggregate_edgelist_edge_start_times{std::nullopt};
+  if (edgelist_edge_start_times) {
+    aggregate_edgelist_edge_start_times =
+      large_edge_buffer_type
+        ? large_buffer_manager::allocate_memory_buffer<edge_time_t>(aggregate_edge_count,
+                                                                    handle.get_stream())
+        : rmm::device_uvector<edge_time_t>(aggregate_edge_count, handle.get_stream());
+  }
   if (aggregate_edgelist_edge_start_times) {
     for (size_t i = 0; i < (*edgelist_edge_start_times).size(); ++i) {
       thrust::copy(handle.get_thrust_policy(),
@@ -2199,10 +2417,14 @@ create_graph_from_edgelist_impl(
     (*edgelist_edge_start_times).clear();
   }
 
-  auto aggregate_edgelist_edge_end_times = edgelist_edge_end_times
-                                             ? std::make_optional<rmm::device_uvector<edge_time_t>>(
-                                                 aggregate_edge_count, handle.get_stream())
-                                             : std::nullopt;
+  std::optional<rmm::device_uvector<edge_time_t>> aggregate_edgelist_edge_end_times{std::nullopt};
+  if (edgelist_edge_end_times) {
+    aggregate_edgelist_edge_end_times =
+      large_edge_buffer_type
+        ? large_buffer_manager::allocate_memory_buffer<edge_time_t>(aggregate_edge_count,
+                                                                    handle.get_stream())
+        : rmm::device_uvector<edge_time_t>(aggregate_edge_count, handle.get_stream());
+  }
   if (aggregate_edgelist_edge_end_times) {
     for (size_t i = 0; i < (*edgelist_edge_end_times).size(); ++i) {
       thrust::copy(handle.get_thrust_policy(),
@@ -2265,6 +2487,8 @@ create_graph_from_edgelist_impl(
                                                     std::move(aggregate_edgelist_edge_end_times),
                                                     graph_properties,
                                                     renumber,
+                                                    large_vertex_buffer_type,
+                                                    large_edge_buffer_type,
                                                     do_expensive_check);
 }
 
@@ -2290,6 +2514,8 @@ create_graph_from_edgelist(raft::handle_t const& handle,
                            std::optional<rmm::device_uvector<edge_type_t>>&& edgelist_edge_types,
                            graph_properties_t graph_properties,
                            bool renumber,
+                           std::optional<large_buffer_type_t> large_vertex_buffer_type,
+                           std::optional<large_buffer_type_t> large_edge_buffer_type,
                            bool do_expensive_check)
 {
   auto [graph, weights, edge_ids, edge_types, edge_start_times, edge_end_times, number_map] =
@@ -2310,6 +2536,8 @@ create_graph_from_edgelist(raft::handle_t const& handle,
                                                std::nullopt,
                                                graph_properties,
                                                renumber,
+                                               large_vertex_buffer_type,
+                                               large_edge_buffer_type,
                                                do_expensive_check);
 
   return std::make_tuple(std::move(graph),
@@ -2340,6 +2568,8 @@ create_graph_from_edgelist(
   std::optional<std::vector<rmm::device_uvector<edge_type_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check)
 {
   auto [graph, weights, edge_ids, edge_types, edge_start_times, edge_end_times, number_map] =
@@ -2360,6 +2590,8 @@ create_graph_from_edgelist(
                                                std::nullopt,
                                                graph_properties,
                                                renumber,
+                                               large_vertex_buffer_type,
+                                               large_edge_buffer_type,
                                                do_expensive_check);
 
   return std::make_tuple(std::move(graph),
@@ -2395,6 +2627,8 @@ create_graph_from_edgelist(
   std::optional<rmm::device_uvector<edge_time_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check)
 {
   return create_graph_from_edgelist_impl<vertex_t,
@@ -2414,6 +2648,8 @@ create_graph_from_edgelist(
                                                     std::move(edgelist_edge_end_times),
                                                     graph_properties,
                                                     renumber,
+                                                    large_vertex_buffer_type,
+                                                    large_edge_buffer_type,
                                                     do_expensive_check);
 }
 
@@ -2443,6 +2679,8 @@ create_graph_from_edgelist(
   std::optional<std::vector<rmm::device_uvector<edge_time_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check)
 {
   return create_graph_from_edgelist_impl<vertex_t,
@@ -2462,6 +2700,8 @@ create_graph_from_edgelist(
                                                     std::move(edgelist_edge_end_times),
                                                     graph_properties,
                                                     renumber,
+                                                    large_vertex_buffer_type,
+                                                    large_edge_buffer_type,
                                                     do_expensive_check);
 }
 

--- a/cpp/src/structure/create_graph_from_edgelist_mg_v32_e32.cu
+++ b/cpp/src/structure/create_graph_from_edgelist_mg_v32_e32.cu
@@ -34,6 +34,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, false, true>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, true>,
@@ -51,6 +53,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, true, true>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, true>,
@@ -68,6 +72,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, false, true>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, true>,
@@ -85,6 +91,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, true, true>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, true>,
@@ -102,6 +110,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, false, true>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, true>,
@@ -119,6 +129,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, true, true>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, true>,
@@ -136,6 +148,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, false, true>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, true>,
@@ -153,6 +167,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, true, true>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/create_graph_from_edgelist_mg_v32_e32_t32.cu
+++ b/cpp/src/structure/create_graph_from_edgelist_mg_v32_e32_t32.cu
@@ -38,6 +38,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int32_t, false, tru
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<graph_t<int32_t, int32_t, true, true>,
@@ -59,6 +61,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int32_t, true, true
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<graph_t<int32_t, int32_t, false, true>,
@@ -80,6 +84,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int32_t, false, tr
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<graph_t<int32_t, int32_t, true, true>,
@@ -101,6 +107,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int32_t, true, tru
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<graph_t<int32_t, int32_t, false, true>,
@@ -122,6 +130,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int32_t, false, tru
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<graph_t<int32_t, int32_t, true, true>,
@@ -143,6 +153,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int32_t, true, true
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<graph_t<int32_t, int32_t, false, true>,
@@ -164,6 +176,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int32_t, false, tr
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<graph_t<int32_t, int32_t, true, true>,
@@ -185,6 +199,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int32_t, true, tru
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/create_graph_from_edgelist_mg_v32_e32_t64.cu
+++ b/cpp/src/structure/create_graph_from_edgelist_mg_v32_e32_t64.cu
@@ -38,6 +38,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int32_t, false, tru
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, true>,
@@ -59,6 +61,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int32_t, true, true
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, true>,
@@ -80,6 +84,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int32_t, false, tr
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, true>,
@@ -101,6 +107,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int32_t, true, tru
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, true>,
@@ -122,6 +130,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int32_t, false, tru
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, true>,
@@ -143,6 +153,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int32_t, true, true
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, true>,
@@ -164,6 +176,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int32_t, false, tr
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, true>,
@@ -185,6 +199,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int32_t, true, tru
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, true>,
@@ -206,6 +222,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int64_t, false, tru
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, true>,
@@ -227,6 +245,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int64_t, true, true
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, true>,
@@ -248,6 +268,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int64_t, false, tr
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, true>,
@@ -269,6 +291,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int64_t, true, tru
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, true>,
@@ -290,6 +314,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int64_t, false, tru
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, true>,
@@ -311,6 +337,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int64_t, true, true
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, true>,
@@ -332,6 +360,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int64_t, false, tr
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, true>,
@@ -353,6 +383,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int64_t, true, tru
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/create_graph_from_edgelist_mg_v64_e64.cu
+++ b/cpp/src/structure/create_graph_from_edgelist_mg_v64_e64.cu
@@ -34,6 +34,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, false, true>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, true>,
@@ -51,6 +53,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, true, true>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, true>,
@@ -68,6 +72,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, false, true>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, true>,
@@ -85,6 +91,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, true, true>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, true>,
@@ -102,6 +110,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, false, true>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, true>,
@@ -119,6 +129,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, true, true>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, true>,
@@ -136,6 +148,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, false, true>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, true>,
@@ -153,6 +167,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, true, true>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/create_graph_from_edgelist_mg_v64_e64_t32.cu
+++ b/cpp/src/structure/create_graph_from_edgelist_mg_v64_e64_t32.cu
@@ -38,6 +38,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int32_t, false, tru
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, true>,
@@ -59,6 +61,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int32_t, true, true
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, true>,
@@ -80,6 +84,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int32_t, false, tr
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, true>,
@@ -101,6 +107,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int32_t, true, tru
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, true>,
@@ -122,6 +130,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int32_t, false, tru
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, true>,
@@ -143,6 +153,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int32_t, true, true
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, true>,
@@ -164,6 +176,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int32_t, false, tr
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, true>,
@@ -185,6 +199,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int32_t, true, tru
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/create_graph_from_edgelist_mg_v64_e64_t64.cu
+++ b/cpp/src/structure/create_graph_from_edgelist_mg_v64_e64_t64.cu
@@ -38,6 +38,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int64_t, false, tru
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, true>,
@@ -59,6 +61,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int64_t, true, true
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, true>,
@@ -80,6 +84,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int64_t, false, tr
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, true>,
@@ -101,6 +107,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int64_t, true, tru
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, true>,
@@ -122,6 +130,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int64_t, false, tru
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, true>,
@@ -143,6 +153,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int64_t, true, true
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, true>,
@@ -164,6 +176,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int64_t, false, tr
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, true>,
@@ -185,6 +199,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int64_t, true, tru
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/create_graph_from_edgelist_sg_v32_e32.cu
+++ b/cpp/src/structure/create_graph_from_edgelist_sg_v32_e32.cu
@@ -34,6 +34,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, false, false>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, false>,
@@ -51,6 +53,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, true, false>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, false>,
@@ -68,6 +72,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, false, false>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, false>,
@@ -85,6 +91,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, true, false>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, false>,
@@ -102,6 +110,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, false, false>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, false>,
@@ -119,6 +129,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, true, false>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, false>,
@@ -136,6 +148,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, false, false>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, false>,
@@ -153,6 +167,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, true, false>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/create_graph_from_edgelist_sg_v32_e32_t32.cu
+++ b/cpp/src/structure/create_graph_from_edgelist_sg_v32_e32_t32.cu
@@ -38,6 +38,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int32_t, false, fal
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<graph_t<int32_t, int32_t, true, false>,
@@ -59,6 +61,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int32_t, true, fals
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<graph_t<int32_t, int32_t, false, false>,
@@ -80,6 +84,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int32_t, false, fa
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<graph_t<int32_t, int32_t, true, false>,
@@ -101,6 +107,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int32_t, true, fal
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<graph_t<int32_t, int32_t, false, false>,
@@ -122,6 +130,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int32_t, false, fal
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<graph_t<int32_t, int32_t, true, false>,
@@ -143,6 +153,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int32_t, true, fals
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<graph_t<int32_t, int32_t, false, false>,
@@ -164,6 +176,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int32_t, false, fa
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<graph_t<int32_t, int32_t, true, false>,
@@ -185,6 +199,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int32_t, true, fal
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/create_graph_from_edgelist_sg_v32_e32_t64.cu
+++ b/cpp/src/structure/create_graph_from_edgelist_sg_v32_e32_t64.cu
@@ -38,6 +38,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int64_t, false, fal
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, false>,
@@ -59,6 +61,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int64_t, true, fals
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, false>,
@@ -80,6 +84,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int64_t, false, fa
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, false>,
@@ -101,6 +107,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int64_t, true, fal
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, false>,
@@ -122,6 +130,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int64_t, false, fal
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, false>,
@@ -143,6 +153,8 @@ create_graph_from_edgelist<int32_t, int32_t, float, int32_t, int64_t, true, fals
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, false>,
@@ -164,6 +176,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int64_t, false, fa
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, false>,
@@ -185,6 +199,8 @@ create_graph_from_edgelist<int32_t, int32_t, double, int32_t, int64_t, true, fal
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/create_graph_from_edgelist_sg_v64_e64.cu
+++ b/cpp/src/structure/create_graph_from_edgelist_sg_v64_e64.cu
@@ -34,6 +34,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, false, false>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, false>,
@@ -51,6 +53,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, true, false>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, false>,
@@ -68,6 +72,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, false, false>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, false>,
@@ -85,6 +91,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, true, false>(
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, false>,
@@ -102,6 +110,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, false, false>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, false>,
@@ -119,6 +129,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, true, false>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, false>,
@@ -136,6 +148,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, false, false>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, false>,
@@ -153,6 +167,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, true, false>(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/create_graph_from_edgelist_sg_v64_e64_t32.cu
+++ b/cpp/src/structure/create_graph_from_edgelist_sg_v64_e64_t32.cu
@@ -38,6 +38,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int32_t, false, fal
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, false>,
@@ -59,6 +61,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int32_t, true, fals
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, false>,
@@ -80,6 +84,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int32_t, false, fa
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, false>,
@@ -101,6 +107,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int32_t, true, fal
   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, false>,
@@ -122,6 +130,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int32_t, false, fal
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, false>,
@@ -143,6 +153,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int32_t, true, fals
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, false>,
@@ -164,6 +176,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int32_t, false, fa
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, false>,
@@ -185,6 +199,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int32_t, true, fal
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/create_graph_from_edgelist_sg_v64_e64_t64.cu
+++ b/cpp/src/structure/create_graph_from_edgelist_sg_v64_e64_t64.cu
@@ -38,6 +38,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int64_t, false, fal
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, false>,
@@ -59,6 +61,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int64_t, true, fals
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, false>,
@@ -80,6 +84,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int64_t, false, fa
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, false>,
@@ -101,6 +107,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int64_t, true, fal
   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, false>,
@@ -122,6 +130,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int64_t, false, fal
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, false>,
@@ -143,6 +153,8 @@ create_graph_from_edgelist<int64_t, int64_t, float, int32_t, int64_t, true, fals
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, false>,
@@ -164,6 +176,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int64_t, false, fa
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, false>,
@@ -185,6 +199,8 @@ create_graph_from_edgelist<int64_t, int64_t, double, int32_t, int64_t, true, fal
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
   graph_properties_t graph_properties,
   bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/detail/structure_utils.cuh
+++ b/cpp/src/structure/detail/structure_utils.cuh
@@ -53,38 +53,87 @@ namespace detail {
 
 template <typename edge_t, typename VertexIterator>
 rmm::device_uvector<edge_t> compute_sparse_offsets(
+  raft::handle_t const& handle,
   VertexIterator edgelist_major_first,
   VertexIterator edgelist_major_last,
   typename thrust::iterator_traits<VertexIterator>::value_type major_range_first,
   typename thrust::iterator_traits<VertexIterator>::value_type major_range_last,
   bool edgelist_major_sorted,
-  rmm::cuda_stream_view stream_view)
+  std::optional<large_buffer_type_t> large_buffer_type = std::nullopt)
 {
-  rmm::device_uvector<edge_t> offsets(static_cast<size_t>(major_range_last - major_range_first) + 1,
-                                      stream_view);
+  using vertex_t = typename thrust::iterator_traits<VertexIterator>::value_type;
+
+  auto offset_array_size = static_cast<size_t>(major_range_last - major_range_first) + 1;
+  auto offsets =
+    large_buffer_type
+      ? large_buffer_manager::allocate_memory_buffer<edge_t>(offset_array_size, handle.get_stream())
+      : rmm::device_uvector<edge_t>(offset_array_size, handle.get_stream());
   if (edgelist_major_sorted) {
-    offsets.set_element_to_zero_async(0, stream_view);
-    thrust::upper_bound(rmm::exec_policy(stream_view),
+    offsets.set_element_to_zero_async(0, handle.get_stream());
+    thrust::upper_bound(handle.get_thrust_policy(),
                         edgelist_major_first,
                         edgelist_major_last,
                         thrust::make_counting_iterator(major_range_first),
                         thrust::make_counting_iterator(major_range_last),
                         offsets.begin() + 1);
   } else {
-    thrust::fill(rmm::exec_policy(stream_view), offsets.begin(), offsets.end(), edge_t{0});
+    thrust::fill(handle.get_thrust_policy(), offsets.begin(), offsets.end(), edge_t{0});
 
-    auto offset_view = raft::device_span<edge_t>(offsets.data(), offsets.size());
-    thrust::for_each(rmm::exec_policy(stream_view),
-                     edgelist_major_first,
-                     edgelist_major_last,
-                     [offset_view, major_range_first] __device__(auto v) {
-                       cuda::atomic_ref<edge_t, cuda::thread_scope_device> atomic_counter(
-                         offset_view[v - major_range_first]);
-                       atomic_counter.fetch_add(edge_t{1}, cuda::std::memory_order_relaxed);
-                     });
+    if (large_buffer_type) {
+      auto num_edges =
+        static_cast<size_t>(cuda::std::distance(edgelist_major_first, edgelist_major_last));
+      auto max_edges_to_process_per_iteration = std::min(
+        static_cast<size_t>(handle.get_device_properties().multiProcessorCount) * (1 << 20),
+        num_edges);
+
+      rmm::device_uvector<vertex_t> indices(max_edges_to_process_per_iteration,
+                                            handle.get_stream());
+      rmm::device_uvector<vertex_t> output_indices(max_edges_to_process_per_iteration,
+                                                   handle.get_stream());
+      rmm::device_uvector<edge_t> output_counts(max_edges_to_process_per_iteration,
+                                                handle.get_stream());
+
+      size_t num_edges_processed{0};
+      while (num_edges_processed < num_edges) {
+        auto num_edges_to_process =
+          std::min(num_edges - num_edges_processed, max_edges_to_process_per_iteration);
+        thrust::transform(
+          handle.get_thrust_policy(),
+          edgelist_major_first + num_edges_processed,
+          edgelist_major_first + (num_edges_processed + num_edges_to_process),
+          indices.begin(),
+          cuda::proclaim_return_type<vertex_t>(
+            [major_range_first] __device__(auto major) { return major - major_range_first; }));
+        thrust::sort(
+          handle.get_thrust_policy(), indices.begin(), indices.begin() + num_edges_to_process);
+        auto it          = thrust::reduce_by_key(handle.get_thrust_policy(),
+                                        indices.begin(),
+                                        indices.begin() + num_edges_to_process,
+                                        thrust::make_constant_iterator(edge_t{1}),
+                                        output_indices.begin(),
+                                        output_counts.begin());
+        auto input_first = thrust::make_zip_iterator(output_indices.begin(), output_counts.begin());
+        thrust::for_each(
+          handle.get_thrust_policy(),
+          input_first,
+          input_first + cuda::std::distance(output_indices.begin(), thrust::get<0>(it)),
+          [offsets = raft::device_span<edge_t>(offsets.data(), offsets.size())] __device__(
+            auto pair) { offsets[thrust::get<0>(pair)] += thrust::get<1>(pair); });
+      }
+    } else {
+      thrust::for_each(handle.get_thrust_policy(),
+                       edgelist_major_first,
+                       edgelist_major_last,
+                       [offsets = raft::device_span<edge_t>(offsets.data(), offsets.size()),
+                        major_range_first] __device__(auto major) {
+                         cuda::atomic_ref<edge_t, cuda::thread_scope_device> atomic_counter(
+                           offsets[major - major_range_first]);
+                         atomic_counter.fetch_add(edge_t{1}, cuda::std::memory_order_relaxed);
+                       });
+    }
 
     thrust::exclusive_scan(
-      rmm::exec_policy(stream_view), offsets.begin(), offsets.end(), offsets.begin());
+      handle.get_thrust_policy(), offsets.begin(), offsets.end(), offsets.begin());
   }
 
   return offsets;
@@ -92,18 +141,22 @@ rmm::device_uvector<edge_t> compute_sparse_offsets(
 
 template <typename vertex_t, typename edge_t>
 std::tuple<rmm::device_uvector<edge_t>, rmm::device_uvector<vertex_t>> compress_hypersparse_offsets(
+  raft::handle_t const& handle,
   rmm::device_uvector<edge_t>&& offsets,
   vertex_t major_range_first,
   vertex_t major_hypersparse_first,
   vertex_t major_range_last,
-  rmm::cuda_stream_view stream_view)
+  std::optional<large_buffer_type_t> large_buffer_type = std::nullopt)
 {
   auto constexpr invalid_vertex = invalid_vertex_id<vertex_t>::value;
 
-  rmm::device_uvector<vertex_t> dcs_nzd_vertices =
-    rmm::device_uvector<vertex_t>(major_range_last - major_hypersparse_first, stream_view);
+  auto dcs_nzd_vertices = large_buffer_type
+                            ? large_buffer_manager::allocate_memory_buffer<vertex_t>(
+                                major_range_last - major_hypersparse_first, handle.get_stream())
+                            : rmm::device_uvector<vertex_t>(
+                                major_range_last - major_hypersparse_first, handle.get_stream());
 
-  thrust::transform(rmm::exec_policy(stream_view),
+  thrust::transform(handle.get_thrust_policy(),
                     thrust::make_counting_iterator(major_hypersparse_first),
                     thrust::make_counting_iterator(major_range_last),
                     dcs_nzd_vertices.begin(),
@@ -113,31 +166,31 @@ std::tuple<rmm::device_uvector<edge_t>, rmm::device_uvector<vertex_t>> compress_
                                                                                    : invalid_vertex;
                     });
 
-  auto pair_first = thrust::make_zip_iterator(thrust::make_tuple(
-    dcs_nzd_vertices.begin(), offsets.begin() + (major_hypersparse_first - major_range_first)));
+  auto pair_first = thrust::make_zip_iterator(
+    dcs_nzd_vertices.begin(), offsets.begin() + (major_hypersparse_first - major_range_first));
   CUGRAPH_EXPECTS(
     dcs_nzd_vertices.size() < static_cast<size_t>(std::numeric_limits<int32_t>::max()),
     "remove_if will fail (https://github.com/NVIDIA/thrust/issues/1302), work-around required.");
   dcs_nzd_vertices.resize(
     cuda::std::distance(pair_first,
-                        thrust::remove_if(rmm::exec_policy(stream_view),
+                        thrust::remove_if(handle.get_thrust_policy(),
                                           pair_first,
                                           pair_first + dcs_nzd_vertices.size(),
                                           [] __device__(auto pair) {
                                             return thrust::get<0>(pair) == invalid_vertex;
                                           })),
-    stream_view);
-  dcs_nzd_vertices.shrink_to_fit(stream_view);
+    handle.get_stream());
+  dcs_nzd_vertices.shrink_to_fit(handle.get_stream());
   if (static_cast<vertex_t>(dcs_nzd_vertices.size()) < major_range_last - major_hypersparse_first) {
     // copying offsets.back() to the new last position
     thrust::copy(
-      rmm::exec_policy(stream_view),
+      handle.get_thrust_policy(),
       offsets.begin() + (major_range_last - major_range_first),
       offsets.end(),
       offsets.begin() + (major_hypersparse_first - major_range_first) + dcs_nzd_vertices.size());
     offsets.resize((major_hypersparse_first - major_range_first) + dcs_nzd_vertices.size() + 1,
-                   stream_view);
-    offsets.shrink_to_fit(stream_view);
+                   handle.get_stream());
+    offsets.shrink_to_fit(handle.get_stream());
   }
 
   return std::make_tuple(std::move(offsets), std::move(dcs_nzd_vertices));
@@ -147,82 +200,96 @@ std::tuple<rmm::device_uvector<edge_t>, rmm::device_uvector<vertex_t>> compress_
 template <typename vertex_t, typename edge_t, typename edge_value_t, bool store_transposed>
 std::tuple<rmm::device_uvector<edge_t>,
            rmm::device_uvector<vertex_t>,
-           decltype(allocate_dataframe_buffer<edge_value_t>(size_t{0}, rmm::cuda_stream_view{})),
+           dataframe_buffer_type_t<edge_value_t>,
            std::optional<rmm::device_uvector<vertex_t>>>
 sort_and_compress_edgelist(
+  raft::handle_t const& handle,
   rmm::device_uvector<vertex_t>&& edgelist_srcs,
   rmm::device_uvector<vertex_t>&& edgelist_dsts,
-  decltype(allocate_dataframe_buffer<edge_value_t>(0, rmm::cuda_stream_view{}))&& edgelist_values,
+  dataframe_buffer_type_t<edge_value_t>&& edgelist_values,
   vertex_t major_range_first,
   std::optional<vertex_t> major_hypersparse_first,
   vertex_t major_range_last,
   vertex_t /* minor_range_first */,
   vertex_t /* minor_range_last */,
   size_t mem_frugal_threshold,
-  rmm::cuda_stream_view stream_view)
+  std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt,
+  std::optional<large_buffer_type_t> large_edge_buffer_type   = std::nullopt)
 {
+  CUGRAPH_EXPECTS((!large_vertex_buffer_type && !large_edge_buffer_type) ||
+                    cugraph::large_buffer_manager::memory_buffer_initialized(),
+                  "Invalid input argument: large memory buffer is not initialized.");
+
   auto edgelist_majors = std::move(store_transposed ? edgelist_dsts : edgelist_srcs);
   auto edgelist_minors = std::move(store_transposed ? edgelist_srcs : edgelist_dsts);
 
-  rmm::device_uvector<edge_t> offsets(0, stream_view);
-  rmm::device_uvector<vertex_t> indices(0, stream_view);
-  auto values     = allocate_dataframe_buffer<edge_value_t>(0, stream_view);
+  rmm::device_uvector<edge_t> offsets(0, handle.get_stream());
+  rmm::device_uvector<vertex_t> indices(0, handle.get_stream());
+  auto values     = allocate_dataframe_buffer<edge_value_t>(0, handle.get_stream());
   auto pair_first = thrust::make_zip_iterator(edgelist_majors.begin(), edgelist_minors.begin());
   if (edgelist_minors.size() > mem_frugal_threshold) {
-    offsets = compute_sparse_offsets<edge_t>(edgelist_majors.begin(),
+    offsets = compute_sparse_offsets<edge_t>(handle,
+                                             edgelist_majors.begin(),
                                              edgelist_majors.end(),
                                              major_range_first,
                                              major_range_last,
-                                             false,
-                                             stream_view);
+                                             false /* edgelist_major_sorted */,
+                                             large_vertex_buffer_type);
 
-    auto pivot = major_range_first + static_cast<vertex_t>(cuda::std::distance(
-                                       offsets.begin(),
-                                       thrust::lower_bound(rmm::exec_policy(stream_view),
-                                                           offsets.begin(),
-                                                           offsets.end(),
-                                                           edgelist_minors.size() / 2)));
+    auto pivot =
+      major_range_first +
+      static_cast<vertex_t>(cuda::std::distance(
+        offsets.begin(),
+        thrust::lower_bound(
+          handle.get_thrust_policy(), offsets.begin(), offsets.end(), edgelist_minors.size() / 2)));
     auto second_first =
       detail::mem_frugal_partition(pair_first,
                                    pair_first + edgelist_minors.size(),
                                    get_dataframe_buffer_begin(edgelist_values),
                                    thrust_tuple_get<thrust::tuple<vertex_t, vertex_t>, 0>{},
                                    pivot,
-                                   stream_view);
-    thrust::sort_by_key(rmm::exec_policy(stream_view),
+                                   handle.get_stream(),
+                                   large_edge_buffer_type);
+    thrust::sort_by_key(handle.get_thrust_policy(),
                         pair_first,
                         std::get<0>(second_first),
                         get_dataframe_buffer_begin(edgelist_values));
-    thrust::sort_by_key(rmm::exec_policy(stream_view),
+    thrust::sort_by_key(handle.get_thrust_policy(),
                         std::get<0>(second_first),
                         pair_first + edgelist_minors.size(),
                         std::get<1>(second_first));
   } else {
-    thrust::sort_by_key(rmm::exec_policy(stream_view),
+    auto exec_policy =
+      large_edge_buffer_type
+        ? rmm::exec_policy_nosync(handle.get_stream(), large_buffer_manager::memory_buffer_mr())
+        : handle.get_thrust_policy();
+    thrust::sort_by_key(exec_policy,
                         pair_first,
                         pair_first + edgelist_minors.size(),
                         get_dataframe_buffer_begin(edgelist_values));
 
-    offsets = compute_sparse_offsets<edge_t>(edgelist_majors.begin(),
+    offsets = compute_sparse_offsets<edge_t>(handle,
+                                             edgelist_majors.begin(),
                                              edgelist_majors.end(),
                                              major_range_first,
                                              major_range_last,
-                                             true,
-                                             stream_view);
+                                             true /* edgelist_major_sorted */,
+                                             large_vertex_buffer_type);
   }
   indices = std::move(edgelist_minors);
   values  = std::move(edgelist_values);
 
-  edgelist_majors.resize(0, stream_view);
-  edgelist_majors.shrink_to_fit(stream_view);
+  edgelist_majors.resize(0, handle.get_stream());
+  edgelist_majors.shrink_to_fit(handle.get_stream());
 
   std::optional<rmm::device_uvector<vertex_t>> dcs_nzd_vertices{std::nullopt};
   if (major_hypersparse_first) {
-    std::tie(offsets, dcs_nzd_vertices) = compress_hypersparse_offsets(std::move(offsets),
+    std::tie(offsets, dcs_nzd_vertices) = compress_hypersparse_offsets(handle,
+                                                                       std::move(offsets),
                                                                        major_range_first,
                                                                        *major_hypersparse_first,
                                                                        major_range_last,
-                                                                       stream_view);
+                                                                       large_vertex_buffer_type);
   }
 
   return std::make_tuple(
@@ -234,49 +301,57 @@ template <typename vertex_t, typename edge_t, bool store_transposed>
 std::tuple<rmm::device_uvector<edge_t>,
            rmm::device_uvector<vertex_t>,
            std::optional<rmm::device_uvector<vertex_t>>>
-sort_and_compress_edgelist(rmm::device_uvector<vertex_t>&& edgelist_srcs,
-                           rmm::device_uvector<vertex_t>&& edgelist_dsts,
-                           vertex_t major_range_first,
-                           std::optional<vertex_t> major_hypersparse_first,
-                           vertex_t major_range_last,
-                           vertex_t /* minor_range_first */,
-                           vertex_t /* minor_range_last */,
-                           size_t mem_frugal_threshold,
-                           rmm::cuda_stream_view stream_view)
+sort_and_compress_edgelist(
+  raft::handle_t const& handle,
+  rmm::device_uvector<vertex_t>&& edgelist_srcs,
+  rmm::device_uvector<vertex_t>&& edgelist_dsts,
+  vertex_t major_range_first,
+  std::optional<vertex_t> major_hypersparse_first,
+  vertex_t major_range_last,
+  vertex_t /* minor_range_first */,
+  vertex_t /* minor_range_last */,
+  size_t mem_frugal_threshold,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt,
+  std::optional<large_buffer_type_t> large_edge_buffer_type   = std::nullopt)
 {
   auto edgelist_majors = std::move(store_transposed ? edgelist_dsts : edgelist_srcs);
   auto edgelist_minors = std::move(store_transposed ? edgelist_srcs : edgelist_dsts);
 
-  rmm::device_uvector<edge_t> offsets(0, stream_view);
-  rmm::device_uvector<vertex_t> indices(0, stream_view);
+  rmm::device_uvector<edge_t> offsets(0, handle.get_stream());
+  rmm::device_uvector<vertex_t> indices(0, handle.get_stream());
   if (edgelist_minors.size() > mem_frugal_threshold) {
     static_assert((sizeof(vertex_t) == 4) || (sizeof(vertex_t) == 8));
     if ((sizeof(vertex_t) == 8) && (static_cast<size_t>(major_range_last - major_range_first) <=
                                     static_cast<size_t>(std::numeric_limits<uint32_t>::max()))) {
-      rmm::device_uvector<uint32_t> edgelist_major_offsets(edgelist_majors.size(), stream_view);
+      auto edgelist_major_offsets =
+        large_edge_buffer_type
+          ? large_buffer_manager::allocate_memory_buffer<uint32_t>(edgelist_majors.size(),
+                                                                   handle.get_stream())
+          : rmm::device_uvector<uint32_t>(edgelist_majors.size(), handle.get_stream());
       thrust::transform(
-        rmm::exec_policy_nosync(stream_view),
+        handle.get_thrust_policy(),
         edgelist_majors.begin(),
         edgelist_majors.end(),
         edgelist_major_offsets.begin(),
         cuda::proclaim_return_type<uint32_t>([major_range_first] __device__(vertex_t major) {
           return static_cast<uint32_t>(major - major_range_first);
         }));
-      edgelist_majors.resize(0, stream_view);
-      edgelist_majors.shrink_to_fit(stream_view);
+      edgelist_majors.resize(0, handle.get_stream());
+      edgelist_majors.shrink_to_fit(handle.get_stream());
 
       offsets =
-        compute_sparse_offsets<edge_t>(edgelist_major_offsets.begin(),
+        compute_sparse_offsets<edge_t>(handle,
+                                       edgelist_major_offsets.begin(),
                                        edgelist_major_offsets.end(),
                                        uint32_t{0},
                                        static_cast<uint32_t>(major_range_last - major_range_first),
                                        false,
-                                       stream_view);
+                                       large_vertex_buffer_type);
       std::array<uint32_t, 3> pivots{};
       for (size_t i = 0; i < 3; ++i) {
         pivots[i] = static_cast<uint32_t>(cuda::std::distance(
           offsets.begin(),
-          thrust::lower_bound(rmm::exec_policy(stream_view),
+          thrust::lower_bound(handle.get_thrust_policy(),
                               offsets.begin(),
                               offsets.end(),
                               static_cast<edge_t>((edgelist_major_offsets.size() * (i + 1)) / 4))));
@@ -289,39 +364,42 @@ sort_and_compress_edgelist(rmm::device_uvector<vertex_t>&& edgelist_srcs,
                                      pair_first + edgelist_major_offsets.size(),
                                      thrust_tuple_get<thrust::tuple<uint32_t, vertex_t>, 0>{},
                                      pivots[1],
-                                     stream_view);
+                                     handle.get_stream(),
+                                     large_edge_buffer_type);
       auto second_quarter_first =
         detail::mem_frugal_partition(pair_first,
                                      second_half_first,
                                      thrust_tuple_get<thrust::tuple<uint32_t, vertex_t>, 0>{},
                                      pivots[0],
-                                     stream_view);
+                                     handle.get_stream(),
+                                     large_edge_buffer_type);
       auto last_quarter_first =
         detail::mem_frugal_partition(second_half_first,
                                      pair_first + edgelist_major_offsets.size(),
                                      thrust_tuple_get<thrust::tuple<uint32_t, vertex_t>, 0>{},
                                      pivots[2],
-                                     stream_view);
-      thrust::sort(rmm::exec_policy(stream_view), pair_first, second_quarter_first);
-      thrust::sort(rmm::exec_policy(stream_view), second_quarter_first, second_half_first);
-      thrust::sort(rmm::exec_policy(stream_view), second_half_first, last_quarter_first);
-      thrust::sort(rmm::exec_policy(stream_view),
-                   last_quarter_first,
-                   pair_first + edgelist_major_offsets.size());
+                                     handle.get_stream(),
+                                     large_edge_buffer_type);
+      thrust::sort(handle.get_thrust_policy(), pair_first, second_quarter_first);
+      thrust::sort(handle.get_thrust_policy(), second_quarter_first, second_half_first);
+      thrust::sort(handle.get_thrust_policy(), second_half_first, last_quarter_first);
+      thrust::sort(
+        handle.get_thrust_policy(), last_quarter_first, pair_first + edgelist_major_offsets.size());
     } else {
-      offsets = compute_sparse_offsets<edge_t>(edgelist_majors.begin(),
+      offsets = compute_sparse_offsets<edge_t>(handle,
+                                               edgelist_majors.begin(),
                                                edgelist_majors.end(),
                                                major_range_first,
                                                major_range_last,
                                                false,
-                                               stream_view);
+                                               large_vertex_buffer_type);
       std::array<vertex_t, 3> pivots{};
       for (size_t i = 0; i < 3; ++i) {
         pivots[i] =
           major_range_first +
           static_cast<vertex_t>(cuda::std::distance(
             offsets.begin(),
-            thrust::lower_bound(rmm::exec_policy(stream_view),
+            thrust::lower_bound(handle.get_thrust_policy(),
                                 offsets.begin(),
                                 offsets.end(),
                                 static_cast<edge_t>((edgelist_minors.size() * (i + 1)) / 4))));
@@ -332,48 +410,57 @@ sort_and_compress_edgelist(rmm::device_uvector<vertex_t>&& edgelist_srcs,
                                      edge_first + edgelist_majors.size(),
                                      thrust_tuple_get<thrust::tuple<vertex_t, vertex_t>, 0>{},
                                      pivots[1],
-                                     stream_view);
+                                     handle.get_stream(),
+                                     large_edge_buffer_type);
       auto second_quarter_first =
         detail::mem_frugal_partition(edge_first,
                                      second_half_first,
                                      thrust_tuple_get<thrust::tuple<vertex_t, vertex_t>, 0>{},
                                      pivots[0],
-                                     stream_view);
+                                     handle.get_stream(),
+                                     large_edge_buffer_type);
       auto last_quarter_first =
         detail::mem_frugal_partition(second_half_first,
                                      edge_first + edgelist_majors.size(),
                                      thrust_tuple_get<thrust::tuple<vertex_t, vertex_t>, 0>{},
                                      pivots[2],
-                                     stream_view);
-      thrust::sort(rmm::exec_policy(stream_view), edge_first, second_quarter_first);
-      thrust::sort(rmm::exec_policy(stream_view), second_quarter_first, second_half_first);
-      thrust::sort(rmm::exec_policy(stream_view), second_half_first, last_quarter_first);
+                                     handle.get_stream(),
+                                     large_edge_buffer_type);
+      thrust::sort(handle.get_thrust_policy(), edge_first, second_quarter_first);
+      thrust::sort(handle.get_thrust_policy(), second_quarter_first, second_half_first);
+      thrust::sort(handle.get_thrust_policy(), second_half_first, last_quarter_first);
       thrust::sort(
-        rmm::exec_policy(stream_view), last_quarter_first, edge_first + edgelist_majors.size());
-      edgelist_majors.resize(0, stream_view);
-      edgelist_majors.shrink_to_fit(stream_view);
+        handle.get_thrust_policy(), last_quarter_first, edge_first + edgelist_majors.size());
+      edgelist_majors.resize(0, handle.get_stream());
+      edgelist_majors.shrink_to_fit(handle.get_stream());
     }
   } else {
     auto edge_first = thrust::make_zip_iterator(edgelist_majors.begin(), edgelist_minors.begin());
-    thrust::sort(rmm::exec_policy(stream_view), edge_first, edge_first + edgelist_minors.size());
-    offsets = compute_sparse_offsets<edge_t>(edgelist_majors.begin(),
+    auto exec_policy =
+      large_edge_buffer_type
+        ? rmm::exec_policy_nosync(handle.get_stream(), large_buffer_manager::memory_buffer_mr())
+        : handle.get_thrust_policy();
+    thrust::sort(exec_policy, edge_first, edge_first + edgelist_minors.size());
+    offsets = compute_sparse_offsets<edge_t>(handle,
+                                             edgelist_majors.begin(),
                                              edgelist_majors.end(),
                                              major_range_first,
                                              major_range_last,
                                              true,
-                                             stream_view);
-    edgelist_majors.resize(0, stream_view);
-    edgelist_majors.shrink_to_fit(stream_view);
+                                             large_vertex_buffer_type);
+    edgelist_majors.resize(0, handle.get_stream());
+    edgelist_majors.shrink_to_fit(handle.get_stream());
   }
   indices = std::move(edgelist_minors);
 
   std::optional<rmm::device_uvector<vertex_t>> dcs_nzd_vertices{std::nullopt};
   if (major_hypersparse_first) {
-    std::tie(offsets, dcs_nzd_vertices) = compress_hypersparse_offsets(std::move(offsets),
+    std::tie(offsets, dcs_nzd_vertices) = compress_hypersparse_offsets(handle,
+                                                                       std::move(offsets),
                                                                        major_range_first,
                                                                        *major_hypersparse_first,
                                                                        major_range_last,
-                                                                       stream_view);
+                                                                       large_vertex_buffer_type);
   }
 
   return std::make_tuple(std::move(offsets), std::move(indices), std::move(dcs_nzd_vertices));
@@ -577,12 +664,17 @@ void sort_adjacency_list(raft::handle_t const& handle,
 }
 
 template <typename comparison_t>
-std::tuple<size_t, rmm::device_uvector<uint32_t>> mark_entries(raft::handle_t const& handle,
-                                                               size_t num_entries,
-                                                               comparison_t comparison)
+std::tuple<size_t, rmm::device_uvector<uint32_t>> mark_entries(
+  raft::handle_t const& handle,
+  size_t num_entries,
+  comparison_t comparison,
+  std::optional<large_buffer_type_t> large_buffer_type = std::nullopt)
 {
-  rmm::device_uvector<uint32_t> marked_entries(cugraph::packed_bool_size(num_entries),
-                                               handle.get_stream());
+  auto marked_entries =
+    large_buffer_type
+      ? large_buffer_manager::allocate_memory_buffer<uint32_t>(
+          cugraph::packed_bool_size(num_entries), handle.get_stream())
+      : rmm::device_uvector<uint32_t>(cugraph::packed_bool_size(num_entries), handle.get_stream());
 
   thrust::tabulate(handle.get_thrust_policy(),
                    marked_entries.begin(),
@@ -608,12 +700,16 @@ std::tuple<size_t, rmm::device_uvector<uint32_t>> mark_entries(raft::handle_t co
 }
 
 template <typename T>
-rmm::device_uvector<T> keep_flagged_elements(raft::handle_t const& handle,
-                                             rmm::device_uvector<T>&& vector,
-                                             raft::device_span<uint32_t const> keep_flags,
-                                             size_t keep_count)
+rmm::device_uvector<T> keep_flagged_elements(
+  raft::handle_t const& handle,
+  rmm::device_uvector<T>&& vector,
+  raft::device_span<uint32_t const> keep_flags,
+  size_t keep_count,
+  std::optional<large_buffer_type_t> large_buffer_type = std::nullopt)
 {
-  rmm::device_uvector<T> result(keep_count, handle.get_stream());
+  auto result = large_buffer_type
+                  ? large_buffer_manager::allocate_memory_buffer<T>(keep_count, handle.get_stream())
+                  : rmm::device_uvector<T>(keep_count, handle.get_stream());
 
   detail::copy_if_mask_set(
     handle, vector.begin(), vector.end(), keep_flags.begin(), result.begin());

--- a/cpp/src/structure/induced_subgraph_impl.cuh
+++ b/cpp/src/structure/induced_subgraph_impl.cuh
@@ -196,12 +196,12 @@ extract_induced_subgraphs(
                  thrust::make_zip_iterator(graph_ids_v.end(), dst_subgraph_vertices_v.end()));
 
     dst_subgraph_offsets_v =
-      detail::compute_sparse_offsets<size_t>(graph_ids_v.begin(),
+      detail::compute_sparse_offsets<size_t>(handle,
+                                             graph_ids_v.begin(),
                                              graph_ids_v.end(),
                                              size_t{0},
                                              size_t{subgraph_offsets.size() - 1},
-                                             true,
-                                             handle.get_stream());
+                                             true);
 
     dst_subgraph_offsets =
       raft::device_span<size_t const>(dst_subgraph_offsets_v.data(), dst_subgraph_offsets_v.size());
@@ -286,12 +286,12 @@ extract_induced_subgraphs(
   }
 
   auto subgraph_edge_offsets =
-    detail::compute_sparse_offsets<size_t>(subgraph_edge_graph_ids.begin(),
+    detail::compute_sparse_offsets<size_t>(handle,
+                                           subgraph_edge_graph_ids.begin(),
                                            subgraph_edge_graph_ids.end(),
                                            size_t{0},
                                            size_t{subgraph_offsets.size() - 1},
-                                           true,
-                                           handle.get_stream());
+                                           true);
 
   return std::make_tuple(std::move(edge_majors),
                          std::move(edge_minors),

--- a/cpp/src/structure/remove_multi_edges_sg_v32_e32.cu
+++ b/cpp/src/structure/remove_multi_edges_sg_v32_e32.cu
@@ -32,7 +32,8 @@ remove_multi_edges(raft::handle_t const& handle,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_start_times,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
-                   bool keep_min_value_edge);
+                   bool keep_min_value_edge,
+                   std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
@@ -49,7 +50,8 @@ remove_multi_edges(raft::handle_t const& handle,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_start_times,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
-                   bool keep_min_value_edge);
+                   bool keep_min_value_edge,
+                   std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
@@ -66,7 +68,8 @@ remove_multi_edges(raft::handle_t const& handle,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                    std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_start_times,
                    std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
-                   bool keep_min_value_edge);
+                   bool keep_min_value_edge,
+                   std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
@@ -83,7 +86,8 @@ remove_multi_edges(raft::handle_t const& handle,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                    std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_start_times,
                    std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
-                   bool keep_min_value_edge);
+                   bool keep_min_value_edge,
+                   std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<std::vector<rmm::device_uvector<int32_t>>,
                     std::vector<rmm::device_uvector<int32_t>>,
@@ -101,7 +105,8 @@ remove_multi_edges(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_start_times,
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
-  bool keep_min_value_edge);
+  bool keep_min_value_edge,
+  std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<std::vector<rmm::device_uvector<int32_t>>,
                     std::vector<rmm::device_uvector<int32_t>>,
@@ -119,7 +124,8 @@ remove_multi_edges(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_start_times,
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
-  bool keep_min_value_edge);
+  bool keep_min_value_edge,
+  std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<std::vector<rmm::device_uvector<int32_t>>,
                     std::vector<rmm::device_uvector<int32_t>>,
@@ -137,7 +143,8 @@ remove_multi_edges(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_start_times,
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
-  bool keep_min_value_edge);
+  bool keep_min_value_edge,
+  std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<std::vector<rmm::device_uvector<int32_t>>,
                     std::vector<rmm::device_uvector<int32_t>>,
@@ -155,6 +162,7 @@ remove_multi_edges(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_start_times,
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
-  bool keep_min_value_edge);
+  bool keep_min_value_edge,
+  std::optional<large_buffer_type_t> large_buffer_type);
 
 }  // namespace cugraph

--- a/cpp/src/structure/remove_multi_edges_sg_v64_e64.cu
+++ b/cpp/src/structure/remove_multi_edges_sg_v64_e64.cu
@@ -32,7 +32,8 @@ remove_multi_edges(raft::handle_t const& handle,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_start_times,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
-                   bool keep_min_value_edge);
+                   bool keep_min_value_edge,
+                   std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
@@ -49,7 +50,8 @@ remove_multi_edges(raft::handle_t const& handle,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_start_times,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
-                   bool keep_min_value_edge);
+                   bool keep_min_value_edge,
+                   std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
@@ -66,7 +68,8 @@ remove_multi_edges(raft::handle_t const& handle,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                    std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_start_times,
                    std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
-                   bool keep_min_value_edge);
+                   bool keep_min_value_edge,
+                   std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
@@ -83,7 +86,8 @@ remove_multi_edges(raft::handle_t const& handle,
                    std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                    std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_start_times,
                    std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
-                   bool keep_min_value_edge);
+                   bool keep_min_value_edge,
+                   std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<std::vector<rmm::device_uvector<int64_t>>,
                     std::vector<rmm::device_uvector<int64_t>>,
@@ -101,7 +105,8 @@ remove_multi_edges(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_start_times,
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
-  bool keep_min_value_edge);
+  bool keep_min_value_edge,
+  std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<std::vector<rmm::device_uvector<int64_t>>,
                     std::vector<rmm::device_uvector<int64_t>>,
@@ -119,7 +124,8 @@ remove_multi_edges(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_start_times,
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_end_times,
-  bool keep_min_value_edge);
+  bool keep_min_value_edge,
+  std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<std::vector<rmm::device_uvector<int64_t>>,
                     std::vector<rmm::device_uvector<int64_t>>,
@@ -137,7 +143,8 @@ remove_multi_edges(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_start_times,
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
-  bool keep_min_value_edge);
+  bool keep_min_value_edge,
+  std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<std::vector<rmm::device_uvector<int64_t>>,
                     std::vector<rmm::device_uvector<int64_t>>,
@@ -155,6 +162,7 @@ remove_multi_edges(
   std::optional<std::vector<rmm::device_uvector<int32_t>>>&& edgelist_edge_types,
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_start_times,
   std::optional<std::vector<rmm::device_uvector<int64_t>>>&& edgelist_edge_end_times,
-  bool keep_min_value_edge);
+  bool keep_min_value_edge,
+  std::optional<large_buffer_type_t> large_buffer_type);
 
 }  // namespace cugraph

--- a/cpp/src/structure/remove_self_loops_impl.cuh
+++ b/cpp/src/structure/remove_self_loops_impl.cuh
@@ -51,60 +51,70 @@ remove_self_loops(raft::handle_t const& handle,
                   std::optional<rmm::device_uvector<edge_t>>&& edgelist_edge_ids,
                   std::optional<rmm::device_uvector<edge_type_t>>&& edgelist_edge_types,
                   std::optional<rmm::device_uvector<edge_time_t>>&& edgelist_edge_start_times,
-                  std::optional<rmm::device_uvector<edge_time_t>>&& edgelist_edge_end_times)
+                  std::optional<rmm::device_uvector<edge_time_t>>&& edgelist_edge_end_times,
+                  std::optional<large_buffer_type_t> large_buffer_type)
 {
-  auto [keep_count, keep_flags] =
-    detail::mark_entries(handle,
-                         edgelist_srcs.size(),
-                         [d_srcs = edgelist_srcs.data(), d_dsts = edgelist_dsts.data()] __device__(
-                           size_t i) { return d_srcs[i] != d_dsts[i]; });
+  auto [keep_count, keep_flags] = detail::mark_entries(
+    handle,
+    edgelist_srcs.size(),
+    [d_srcs = edgelist_srcs.data(), d_dsts = edgelist_dsts.data()] __device__(size_t i) {
+      return d_srcs[i] != d_dsts[i];
+    },
+    large_buffer_type);
 
   if (keep_count < edgelist_srcs.size()) {
     edgelist_srcs = detail::keep_flagged_elements(
       handle,
       std::move(edgelist_srcs),
       raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
-      keep_count);
+      keep_count,
+      large_buffer_type);
     edgelist_dsts = detail::keep_flagged_elements(
       handle,
       std::move(edgelist_dsts),
       raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
-      keep_count);
+      keep_count,
+      large_buffer_type);
 
     if (edgelist_weights)
       edgelist_weights = detail::keep_flagged_elements(
         handle,
         std::move(*edgelist_weights),
         raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
-        keep_count);
+        keep_count,
+        large_buffer_type);
 
     if (edgelist_edge_ids)
       edgelist_edge_ids = detail::keep_flagged_elements(
         handle,
         std::move(*edgelist_edge_ids),
         raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
-        keep_count);
+        keep_count,
+        large_buffer_type);
 
     if (edgelist_edge_types)
       edgelist_edge_types = detail::keep_flagged_elements(
         handle,
         std::move(*edgelist_edge_types),
         raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
-        keep_count);
+        keep_count,
+        large_buffer_type);
 
     if (edgelist_edge_start_times)
       edgelist_edge_start_times = detail::keep_flagged_elements(
         handle,
         std::move(*edgelist_edge_start_times),
         raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
-        keep_count);
+        keep_count,
+        large_buffer_type);
 
     if (edgelist_edge_end_times)
       edgelist_edge_end_times = detail::keep_flagged_elements(
         handle,
         std::move(*edgelist_edge_end_times),
         raft::device_span<uint32_t const>{keep_flags.data(), keep_flags.size()},
-        keep_count);
+        keep_count,
+        large_buffer_type);
   }
 
   return std::make_tuple(std::move(edgelist_srcs),

--- a/cpp/src/structure/remove_self_loops_sg_v32_e32.cu
+++ b/cpp/src/structure/remove_self_loops_sg_v32_e32.cu
@@ -31,7 +31,8 @@ remove_self_loops(raft::handle_t const& handle,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_ids,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_start_times,
-                  std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times);
+                  std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
+                  std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
@@ -47,7 +48,8 @@ remove_self_loops(raft::handle_t const& handle,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_ids,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_start_times,
-                  std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times);
+                  std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
+                  std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
@@ -63,7 +65,8 @@ remove_self_loops(raft::handle_t const& handle,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_ids,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_start_times,
-                  std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times);
+                  std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
+                  std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
@@ -79,6 +82,7 @@ remove_self_loops(raft::handle_t const& handle,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_ids,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_start_times,
-                  std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times);
+                  std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
+                  std::optional<large_buffer_type_t> large_buffer_type);
 
 }  // namespace cugraph

--- a/cpp/src/structure/remove_self_loops_sg_v64_e64.cu
+++ b/cpp/src/structure/remove_self_loops_sg_v64_e64.cu
@@ -31,7 +31,8 @@ remove_self_loops(raft::handle_t const& handle,
                   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_ids,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_start_times,
-                  std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times);
+                  std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
+                  std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
@@ -47,7 +48,8 @@ remove_self_loops(raft::handle_t const& handle,
                   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_ids,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_start_times,
-                  std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times);
+                  std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_end_times,
+                  std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
@@ -63,7 +65,8 @@ remove_self_loops(raft::handle_t const& handle,
                   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_ids,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_start_times,
-                  std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times);
+                  std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
+                  std::optional<large_buffer_type_t> large_buffer_type);
 
 template std::tuple<rmm::device_uvector<int64_t>,
                     rmm::device_uvector<int64_t>,
@@ -79,6 +82,7 @@ remove_self_loops(raft::handle_t const& handle,
                   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_ids,
                   std::optional<rmm::device_uvector<int32_t>>&& edgelist_edge_types,
                   std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_start_times,
-                  std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times);
+                  std::optional<rmm::device_uvector<int64_t>>&& edgelist_edge_end_times,
+                  std::optional<large_buffer_type_t> large_buffer_type);
 
 }  // namespace cugraph

--- a/cpp/src/structure/renumber_edgelist_mg_v32_e32.cu
+++ b/cpp/src/structure/renumber_edgelist_mg_v32_e32.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/renumber_edgelist_mg_v32_e32.cu
+++ b/cpp/src/structure/renumber_edgelist_mg_v32_e32.cu
@@ -28,6 +28,8 @@ renumber_edgelist<int32_t, int32_t, true>(
   std::vector<int32_t> const& edgelist_edge_counts,
   std::optional<std::vector<std::vector<int32_t>>> const& edgelist_intra_partition_segment_offsets,
   bool store_transposed,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/renumber_edgelist_mg_v64_e64.cu
+++ b/cpp/src/structure/renumber_edgelist_mg_v64_e64.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/renumber_edgelist_mg_v64_e64.cu
+++ b/cpp/src/structure/renumber_edgelist_mg_v64_e64.cu
@@ -28,6 +28,8 @@ renumber_edgelist<int64_t, int64_t, true>(
   std::vector<int64_t> const& edgelist_edge_counts,
   std::optional<std::vector<std::vector<int64_t>>> const& edgelist_intra_partition_segment_offsets,
   bool store_transposed,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/renumber_edgelist_sg_v32_e32.cu
+++ b/cpp/src/structure/renumber_edgelist_sg_v32_e32.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/renumber_edgelist_sg_v32_e32.cu
+++ b/cpp/src/structure/renumber_edgelist_sg_v32_e32.cu
@@ -20,12 +20,15 @@ namespace cugraph {
 // SG instantiation
 
 template std::tuple<rmm::device_uvector<int32_t>, renumber_meta_t<int32_t, int32_t, false>>
-renumber_edgelist<int32_t, int32_t, false>(raft::handle_t const& handle,
-                                           std::optional<rmm::device_uvector<int32_t>>&& vertices,
-                                           int32_t* edgelist_srcs /* [INOUT] */,
-                                           int32_t* edgelist_dsts /* [INOUT] */,
-                                           int32_t num_edgelist_edges,
-                                           bool store_transposed,
-                                           bool do_expensive_check);
+renumber_edgelist<int32_t, int32_t, false>(
+  raft::handle_t const& handle,
+  std::optional<rmm::device_uvector<int32_t>>&& vertices,
+  int32_t* edgelist_srcs /* [INOUT] */,
+  int32_t* edgelist_dsts /* [INOUT] */,
+  int32_t num_edgelist_edges,
+  bool store_transposed,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
+  bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/renumber_edgelist_sg_v64_e64.cu
+++ b/cpp/src/structure/renumber_edgelist_sg_v64_e64.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/renumber_edgelist_sg_v64_e64.cu
+++ b/cpp/src/structure/renumber_edgelist_sg_v64_e64.cu
@@ -20,12 +20,15 @@ namespace cugraph {
 // SG instantiation
 
 template std::tuple<rmm::device_uvector<int64_t>, renumber_meta_t<int64_t, int64_t, false>>
-renumber_edgelist<int64_t, int64_t, false>(raft::handle_t const& handle,
-                                           std::optional<rmm::device_uvector<int64_t>>&& vertices,
-                                           int64_t* edgelist_srcs /* [INOUT] */,
-                                           int64_t* edgelist_dsts /* [INOUT] */,
-                                           int64_t num_edgelist_edges,
-                                           bool store_transposed,
-                                           bool do_expensive_check);
+renumber_edgelist<int64_t, int64_t, false>(
+  raft::handle_t const& handle,
+  std::optional<rmm::device_uvector<int64_t>>&& vertices,
+  int64_t* edgelist_srcs /* [INOUT] */,
+  int64_t* edgelist_dsts /* [INOUT] */,
+  int64_t num_edgelist_edges,
+  bool store_transposed,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type,
+  bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/tests/community/mg_egonet_test.cu
+++ b/cpp/tests/community/mg_egonet_test.cu
@@ -215,12 +215,12 @@ class Tests_MGEgonet
 
       if (handle_->get_comms().get_rank() == 0) {
         auto d_mg_aggregate_edgelist_offsets =
-          cugraph::detail::compute_sparse_offsets<size_t>(graph_ids_v.begin(),
+          cugraph::detail::compute_sparse_offsets<size_t>(*handle_,
+                                                          graph_ids_v.begin(),
                                                           graph_ids_v.end(),
                                                           size_t{0},
                                                           d_mg_edgelist_offsets.size() - 1,
-                                                          true,
-                                                          handle_->get_stream());
+                                                          true);
 
         auto [d_reference_src, d_reference_dst, d_reference_wgt, d_reference_offsets] =
           cugraph::extract_ego(

--- a/cpp/tests/generators/generate_rmat_test.cpp
+++ b/cpp/tests/generators/generate_rmat_test.cpp
@@ -206,8 +206,8 @@ class Tests_GenerateRmat : public ::testing::TestWithParam<GenerateRmat_Usecase>
         configuration.clip_and_flip);
 
       if (scramble == 1) {
-        std::tie(d_srcs, d_dsts) = cugraph::scramble_vertex_ids(
-          handle, std::move(d_srcs), std::move(d_dsts), configuration.scale);
+        d_srcs = cugraph::scramble_vertex_ids(handle, std::move(d_srcs), configuration.scale);
+        d_dsts = cugraph::scramble_vertex_ids(handle, std::move(d_dsts), configuration.scale);
       }
 
       if (cugraph::test::g_perf) {

--- a/cpp/tests/generators/generators_test.cpp
+++ b/cpp/tests/generators/generators_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/generators/generators_test.cpp
+++ b/cpp/tests/generators/generators_test.cpp
@@ -616,8 +616,8 @@ TEST_F(GeneratorsTest, ScrambleTest)
   raft::update_device(d_dst_v.data(), input_dst_v.data(), input_dst_v.size(), handle.get_stream());
 
   auto lgN = static_cast<size_t>(std::ceil(std::log2(num_vertices)));
-  std::tie(d_src_v, d_dst_v) =
-    cugraph::scramble_vertex_ids(handle, std::move(d_src_v), std::move(d_dst_v), lgN);
+  d_src_v  = cugraph::scramble_vertex_ids(handle, std::move(d_src_v), lgN);
+  d_dst_v  = cugraph::scramble_vertex_ids(handle, std::move(d_dst_v), lgN);
 
   auto output_src_v = cugraph::test::to_host(handle, d_src_v);
   auto output_dst_v = cugraph::test::to_host(handle, d_dst_v);

--- a/cpp/tests/mtmg/multi_node_threaded_test.cpp
+++ b/cpp/tests/mtmg/multi_node_threaded_test.cpp
@@ -398,7 +398,9 @@ class Tests_Multithreaded
                                                    std::nullopt,
                                                    std::nullopt,
                                                    cugraph::graph_properties_t{is_symmetric, true},
-                                                   true);
+                                                   true,
+                                                   std::nullopt,
+                                                   std::nullopt);
 
       auto [sg_pageranks, meta] = cugraph::pagerank<vertex_t, edge_t, weight_t, weight_t, false>(
         handle,

--- a/cpp/tests/structure/mg_induced_subgraph_test.cu
+++ b/cpp/tests/structure/mg_induced_subgraph_test.cu
@@ -219,12 +219,12 @@ class Tests_MGInducedSubgraph
       }
 
       auto d_subgraph_edgelist_offsets =
-        cugraph::detail::compute_sparse_offsets<size_t>(graph_ids_v.begin(),
+        cugraph::detail::compute_sparse_offsets<size_t>(*handle_,
+                                                        graph_ids_v.begin(),
                                                         graph_ids_v.end(),
                                                         size_t{0},
                                                         size_t{d_subgraph_offsets.size() - 1},
-                                                        true,
-                                                        handle_->get_stream());
+                                                        true);
 
       cugraph::graph_t<vertex_t, edge_t, false, false> sg_graph(*handle_);
       std::optional<cugraph::edge_property_t<edge_t, weight_t>> sg_edge_weights{std::nullopt};

--- a/cpp/tests/utilities/conversion_utilities_impl.cuh
+++ b/cpp/tests/utilities/conversion_utilities_impl.cuh
@@ -98,6 +98,7 @@ graph_to_host_compressed_sparse(
   if (d_wgt) {
     std::tie(d_offsets, d_dst, *d_wgt, std::ignore) =
       detail::sort_and_compress_edgelist<vertex_t, edge_t, weight_t, output_store_transposed>(
+        handle,
         std::move(d_src),
         std::move(d_dst),
         std::move(*d_wgt),
@@ -106,11 +107,11 @@ graph_to_host_compressed_sparse(
         graph_view.number_of_vertices(),
         vertex_t{0},
         graph_view.number_of_vertices(),
-        mem_frugal_threshold,
-        handle.get_stream());
+        mem_frugal_threshold);
   } else {
     std::tie(d_offsets, d_dst, std::ignore) =
       detail::sort_and_compress_edgelist<vertex_t, edge_t, output_store_transposed>(
+        handle,
         std::move(d_src),
         std::move(d_dst),
         vertex_t{0},
@@ -118,8 +119,7 @@ graph_to_host_compressed_sparse(
         graph_view.number_of_vertices(),
         vertex_t{0},
         graph_view.number_of_vertices(),
-        mem_frugal_threshold,
-        handle.get_stream());
+        mem_frugal_threshold);
   }
 
   return std::make_tuple(

--- a/cpp/tests/utilities/csv_file_utilities.cu
+++ b/cpp/tests/utilities/csv_file_utilities.cu
@@ -152,7 +152,9 @@ read_edgelist_from_csv_file(raft::handle_t const& handle,
                             bool test_weighted,
                             bool store_transposed,
                             bool multi_gpu,
-                            bool shuffle)
+                            bool shuffle,
+                            std::optional<large_buffer_type_t> large_vertex_buffer_type,
+                            std::optional<large_buffer_type_t> large_edge_buffer_type)
 {
   std::ifstream file(graph_file_full_path);
   CUGRAPH_EXPECTS(file.is_open(), "File open (%s) failure.", graph_file_full_path.c_str());
@@ -219,11 +221,24 @@ read_edgelist_from_csv_file(raft::handle_t const& handle,
   CUGRAPH_EXPECTS(!test_weighted || (h_edgelist_weights.size() > 0),
                   "test_weighted set but weights are not provided.");
 
-  rmm::device_uvector<vertex_t> d_edgelist_srcs(h_edgelist_srcs.size(), handle.get_stream());
-  rmm::device_uvector<vertex_t> d_edgelist_dsts(h_edgelist_dsts.size(), handle.get_stream());
-  auto d_edgelist_weights = test_weighted ? std::make_optional<rmm::device_uvector<weight_t>>(
-                                              h_edgelist_weights.size(), handle.get_stream())
-                                          : std::nullopt;
+  auto d_edgelist_srcs =
+    large_edge_buffer_type
+      ? large_buffer_manager::allocate_memory_buffer<vertex_t>(h_edgelist_srcs.size(),
+                                                               handle.get_stream())
+      : rmm::device_uvector<vertex_t>(h_edgelist_srcs.size(), handle.get_stream());
+  auto d_edgelist_dsts =
+    large_edge_buffer_type
+      ? large_buffer_manager::allocate_memory_buffer<vertex_t>(h_edgelist_dsts.size(),
+                                                               handle.get_stream())
+      : rmm::device_uvector<vertex_t>(h_edgelist_dsts.size(), handle.get_stream());
+  std::optional<rmm::device_uvector<weight_t>> d_edgelist_weights{std::nullopt};
+  if (test_weighted) {
+    d_edgelist_weights =
+      large_edge_buffer_type
+        ? large_buffer_manager::allocate_memory_buffer<weight_t>(h_edgelist_weights.size(),
+                                                                 handle.get_stream())
+        : rmm::device_uvector<weight_t>(h_edgelist_weights.size(), handle.get_stream());
+  }
 
   raft::update_device(
     d_edgelist_srcs.data(), h_edgelist_srcs.data(), h_edgelist_srcs.size(), handle.get_stream());
@@ -342,11 +357,19 @@ std::tuple<cugraph::graph_t<vertex_t, edge_t, store_transposed, multi_gpu>,
 read_graph_from_csv_file(raft::handle_t const& handle,
                          std::string const& graph_file_full_path,
                          bool test_weighted,
-                         bool renumber)
+                         bool renumber,
+                         std::optional<large_buffer_type_t> large_vertex_buffer_type,
+                         std::optional<large_buffer_type_t> large_edge_buffer_type)
 {
   auto [d_edgelist_srcs, d_edgelist_dsts, d_edgelist_weights, is_symmetric] =
-    read_edgelist_from_csv_file<vertex_t, weight_t>(
-      handle, graph_file_full_path, test_weighted, store_transposed, multi_gpu);
+    read_edgelist_from_csv_file<vertex_t, weight_t>(handle,
+                                                    graph_file_full_path,
+                                                    test_weighted,
+                                                    store_transposed,
+                                                    multi_gpu,
+                                                    true /* shuffle */,
+                                                    large_vertex_buffer_type,
+                                                    large_edge_buffer_type);
 
   graph_t<vertex_t, edge_t, store_transposed, multi_gpu> graph(handle);
   std::optional<cugraph::edge_property_t<edge_t, weight_t>> edge_weights{std::nullopt};
@@ -361,7 +384,9 @@ read_graph_from_csv_file(raft::handle_t const& handle,
       std::nullopt,
       std::nullopt,
       cugraph::graph_properties_t{is_symmetric, false},
-      renumber);
+      renumber,
+      large_vertex_buffer_type,
+      large_edge_buffer_type);
 
   return std::make_tuple(std::move(graph), std::move(edge_weights), std::move(renumber_map));
 }
@@ -372,12 +397,29 @@ template std::tuple<rmm::device_uvector<int32_t>,
                     rmm::device_uvector<int32_t>,
                     std::optional<rmm::device_uvector<float>>,
                     bool>
-read_edgelist_from_csv_file<int32_t, float>(raft::handle_t const& handle,
-                                            std::string const& graph_file_full_path,
-                                            bool test_weighted,
-                                            bool store_transposed,
-                                            bool multi_gpu,
-                                            bool shuffle);
+read_edgelist_from_csv_file<int32_t, float>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool store_transposed,
+  bool multi_gpu,
+  bool shuffle,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
+
+template std::tuple<rmm::device_uvector<int64_t>,
+                    rmm::device_uvector<int64_t>,
+                    std::optional<rmm::device_uvector<float>>,
+                    bool>
+read_edgelist_from_csv_file<int64_t, float>(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool store_transposed,
+  bool multi_gpu,
+  bool shuffle,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, false>,
                     std::optional<cugraph::edge_property_t<int32_t, float>>,
@@ -386,7 +428,9 @@ read_graph_from_csv_file<int32_t, int32_t, float, false, false>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, true>,
                     std::optional<cugraph::edge_property_t<int32_t, float>>,
@@ -395,7 +439,9 @@ read_graph_from_csv_file<int32_t, int32_t, float, false, true>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, false>,
                     std::optional<cugraph::edge_property_t<int32_t, float>>,
@@ -404,7 +450,9 @@ read_graph_from_csv_file<int32_t, int32_t, float, true, false>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, true>,
                     std::optional<cugraph::edge_property_t<int32_t, float>>,
@@ -413,7 +461,9 @@ read_graph_from_csv_file<int32_t, int32_t, float, true, true>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, false>,
                     std::optional<cugraph::edge_property_t<int32_t, double>>,
@@ -422,7 +472,9 @@ read_graph_from_csv_file<int32_t, int32_t, double, false, false>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, false, true>,
                     std::optional<cugraph::edge_property_t<int32_t, double>>,
@@ -431,7 +483,9 @@ read_graph_from_csv_file<int32_t, int32_t, double, false, true>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, false>,
                     std::optional<cugraph::edge_property_t<int32_t, double>>,
@@ -440,7 +494,9 @@ read_graph_from_csv_file<int32_t, int32_t, double, true, false>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int32_t, int32_t, true, true>,
                     std::optional<cugraph::edge_property_t<int32_t, double>>,
@@ -449,7 +505,9 @@ read_graph_from_csv_file<int32_t, int32_t, double, true, true>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, false>,
                     std::optional<cugraph::edge_property_t<int64_t, float>>,
@@ -458,7 +516,9 @@ read_graph_from_csv_file<int64_t, int64_t, float, false, false>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, true>,
                     std::optional<cugraph::edge_property_t<int64_t, float>>,
@@ -467,7 +527,9 @@ read_graph_from_csv_file<int64_t, int64_t, float, false, true>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, false>,
                     std::optional<cugraph::edge_property_t<int64_t, float>>,
@@ -476,7 +538,9 @@ read_graph_from_csv_file<int64_t, int64_t, float, true, false>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, true>,
                     std::optional<cugraph::edge_property_t<int64_t, float>>,
@@ -485,7 +549,9 @@ read_graph_from_csv_file<int64_t, int64_t, float, true, true>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, false>,
                     std::optional<cugraph::edge_property_t<int64_t, double>>,
@@ -494,7 +560,9 @@ read_graph_from_csv_file<int64_t, int64_t, double, false, false>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, false, true>,
                     std::optional<cugraph::edge_property_t<int64_t, double>>,
@@ -503,7 +571,9 @@ read_graph_from_csv_file<int64_t, int64_t, double, false, true>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, false>,
                     std::optional<cugraph::edge_property_t<int64_t, double>>,
@@ -512,7 +582,9 @@ read_graph_from_csv_file<int64_t, int64_t, double, true, false>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 template std::tuple<cugraph::graph_t<int64_t, int64_t, true, true>,
                     std::optional<cugraph::edge_property_t<int64_t, double>>,
@@ -521,7 +593,9 @@ read_graph_from_csv_file<int64_t, int64_t, double, true, true>(
   raft::handle_t const& handle,
   std::string const& graph_file_full_path,
   bool test_weighted,
-  bool renumber);
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type,
+  std::optional<large_buffer_type_t> large_edge_buffer_type);
 
 }  // namespace test
 }  // namespace cugraph

--- a/cpp/tests/utilities/csv_file_utilities.hpp
+++ b/cpp/tests/utilities/csv_file_utilities.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cugraph/graph.hpp>
+#include <cugraph/large_buffer_manager.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -34,12 +35,15 @@ std::tuple<rmm::device_uvector<vertex_t>,
            rmm::device_uvector<vertex_t>,
            std::optional<rmm::device_uvector<weight_t>>,
            bool>
-read_edgelist_from_csv_file(raft::handle_t const& handle,
-                            std::string const& graph_file_full_path,
-                            bool test_weighted,
-                            bool store_transposed,
-                            bool multi_gpu,
-                            bool shuffle = true);
+read_edgelist_from_csv_file(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool store_transposed,
+  bool multi_gpu,
+  bool shuffle                                                = true,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt,
+  std::optional<large_buffer_type_t> large_edge_buffer_type   = std::nullopt);
 
 template <typename vertex_t,
           typename edge_t,
@@ -52,7 +56,9 @@ std::tuple<cugraph::graph_t<vertex_t, edge_t, store_transposed, multi_gpu>,
 read_graph_from_csv_file(raft::handle_t const& handle,
                          std::string const& graph_file_full_path,
                          bool test_weighted,
-                         bool renumber);
+                         bool renumber,
+                         std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt,
+                         std::optional<large_buffer_type_t> large_edge_buffer_type = std::nullopt);
 
 }  // namespace test
 }  // namespace cugraph

--- a/cpp/tests/utilities/matrix_market_file_utilities.hpp
+++ b/cpp/tests/utilities/matrix_market_file_utilities.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cugraph/graph.hpp>
+#include <cugraph/large_buffer_manager.hpp>
 #include <cugraph/legacy/graph.hpp>
 
 #include <raft/core/handle.hpp>
@@ -96,12 +97,15 @@ std::tuple<rmm::device_uvector<vertex_t>,
            std::optional<rmm::device_uvector<weight_t>>,
            rmm::device_uvector<vertex_t>,
            bool>
-read_edgelist_from_matrix_market_file(raft::handle_t const& handle,
-                                      std::string const& graph_file_full_path,
-                                      bool test_weighted,
-                                      bool store_transposed,
-                                      bool multi_gpu,
-                                      bool shuffle = true);
+read_edgelist_from_matrix_market_file(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool store_transposed,
+  bool multi_gpu,
+  bool shuffle                                                = true,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt,
+  std::optional<large_buffer_type_t> large_edge_buffer_type   = std::nullopt);
 
 // renumber must be true if multi_gpu is true
 template <typename vertex_t,
@@ -112,10 +116,13 @@ template <typename vertex_t,
 std::tuple<cugraph::graph_t<vertex_t, edge_t, store_transposed, multi_gpu>,
            std::optional<cugraph::edge_property_t<edge_t, weight_t>>,
            std::optional<rmm::device_uvector<vertex_t>>>
-read_graph_from_matrix_market_file(raft::handle_t const& handle,
-                                   std::string const& graph_file_full_path,
-                                   bool test_weighted,
-                                   bool renumber);
+read_graph_from_matrix_market_file(
+  raft::handle_t const& handle,
+  std::string const& graph_file_full_path,
+  bool test_weighted,
+  bool renumber,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt,
+  std::optional<large_buffer_type_t> large_edge_buffer_type   = std::nullopt);
 
 }  // namespace test
 }  // namespace cugraph

--- a/cpp/tests/utilities/test_graphs.hpp
+++ b/cpp/tests/utilities/test_graphs.hpp
@@ -261,15 +261,21 @@ class File_Usecase : public detail::TranslateGraph_Usecase {
              std::optional<std::vector<rmm::device_uvector<weight_t>>>,
              std::optional<rmm::device_uvector<vertex_t>>,
              bool>
-  construct_edgelist(
-    raft::handle_t const& handle,
-    bool test_weighted,
-    bool store_transposed,
-    bool multi_gpu,
-    bool shuffle                                                = true,
-    std::optional<large_buffer_type_t> large_edge_buffer_type   = std::nullopt,
-    std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt) const
+  construct_edgelist(raft::handle_t const& handle,
+                     bool test_weighted,
+                     bool store_transposed,
+                     bool multi_gpu,
+                     bool shuffle                                                = true,
+                     std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt,
+                     std::optional<large_buffer_type_t> large_edge_buffer_type = std::nullopt) const
   {
+    CUGRAPH_EXPECTS(
+      !large_vertex_buffer_type || cugraph::large_buffer_manager::memory_buffer_initialized(),
+      "Invalid input argument: large memory buffer is not initialized.");
+    CUGRAPH_EXPECTS(
+      !large_edge_buffer_type || cugraph::large_buffer_manager::memory_buffer_initialized(),
+      "Invalid input argument: large memory buffer is not initialized.");
+
     rmm::device_uvector<vertex_t> srcs(0, handle.get_stream());
     rmm::device_uvector<vertex_t> dsts(0, handle.get_stream());
     std::optional<rmm::device_uvector<weight_t>> weights{};
@@ -278,11 +284,24 @@ class File_Usecase : public detail::TranslateGraph_Usecase {
     auto extension = graph_file_full_path_.substr(graph_file_full_path_.find_last_of(".") + 1);
     if (extension == "mtx") {
       std::tie(srcs, dsts, weights, vertices, is_symmetric) =
-        read_edgelist_from_matrix_market_file<vertex_t, weight_t>(
-          handle, graph_file_full_path_, test_weighted, store_transposed, multi_gpu, shuffle);
+        read_edgelist_from_matrix_market_file<vertex_t, weight_t>(handle,
+                                                                  graph_file_full_path_,
+                                                                  test_weighted,
+                                                                  store_transposed,
+                                                                  multi_gpu,
+                                                                  shuffle,
+                                                                  large_vertex_buffer_type,
+                                                                  large_edge_buffer_type);
     } else if (extension == "csv") {
-      std::tie(srcs, dsts, weights, is_symmetric) = read_edgelist_from_csv_file<vertex_t, weight_t>(
-        handle, graph_file_full_path_, test_weighted, store_transposed, multi_gpu, shuffle);
+      std::tie(srcs, dsts, weights, is_symmetric) =
+        read_edgelist_from_csv_file<vertex_t, weight_t>(handle,
+                                                        graph_file_full_path_,
+                                                        test_weighted,
+                                                        store_transposed,
+                                                        multi_gpu,
+                                                        shuffle,
+                                                        large_vertex_buffer_type,
+                                                        large_edge_buffer_type);
     }
 
     translate(handle, srcs, dsts);
@@ -562,13 +581,20 @@ construct_graph(
   std::optional<
     std::function<rmm::device_uvector<edge_time_t>(raft::handle_t const&, size_t, size_t)>>
     edge_end_times_functor,
-  bool renumber         = true,
-  bool drop_self_loops  = false,
-  bool drop_multi_edges = false)
+  bool renumber                                               = true,
+  bool drop_self_loops                                        = false,
+  bool drop_multi_edges                                       = false,
+  std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt,
+  std::optional<large_buffer_type_t> large_edge_buffer_type   = std::nullopt)
 {
   auto [edge_src_chunks, edge_dst_chunks, edge_weight_chunks, d_vertices_v, is_symmetric] =
-    input_usecase.template construct_edgelist<vertex_t, weight_t>(
-      handle, test_weighted, store_transposed, multi_gpu);
+    input_usecase.template construct_edgelist<vertex_t, weight_t>(handle,
+                                                                  test_weighted,
+                                                                  store_transposed,
+                                                                  multi_gpu,
+                                                                  true /* shuffle */,
+                                                                  large_vertex_buffer_type,
+                                                                  large_edge_buffer_type);
 
   size_t num_edges{0};
   for (size_t i = 0; i < edge_src_chunks.size(); ++i) {
@@ -642,8 +668,13 @@ construct_graph(
           edge_start_time_chunks ? std::make_optional(std::move((*edge_start_time_chunks)[i]))
                                  : std::nullopt,
           edge_end_time_chunks ? std::make_optional(std::move((*edge_end_time_chunks)[i]))
-                               : std::nullopt);
+                               : std::nullopt,
+          large_edge_buffer_type);
       if (tmp_weights) { (*edge_weight_chunks)[i] = std::move(*tmp_weights); }
+      if (tmp_ids) { (*edge_id_chunks)[i] = std::move(*tmp_ids); }
+      if (tmp_types) { (*edge_type_chunks)[i] = std::move(*tmp_types); }
+      if (tmp_start_times) { (*edge_start_time_chunks)[i] = std::move(*tmp_start_times); }
+      if (tmp_end_times) { (*edge_end_time_chunks)[i] = std::move(*tmp_end_times); }
     }
   }
 
@@ -667,7 +698,8 @@ construct_graph(
         std::move(edge_types),
         std::move(edge_start_times),
         std::move(edge_end_times),
-        is_symmetric ? true /* keep minimum weight edges to maintain symmetry */ : false);
+        is_symmetric ? true /* keep minimum weight edges to maintain symmetry */ : false,
+        large_edge_buffer_type);
     edge_src_chunks = std::vector<rmm::device_uvector<vertex_t>>{};
     edge_src_chunks.push_back(std::move(srcs));
     edge_dst_chunks = std::vector<rmm::device_uvector<vertex_t>>{};
@@ -724,7 +756,9 @@ construct_graph(
         edge_end_time_chunks ? std::make_optional(std::move((*edge_end_time_chunks)[0]))
                              : std::nullopt,
         cugraph::graph_properties_t{is_symmetric, drop_multi_edges ? false : true},
-        renumber);
+        renumber,
+        large_vertex_buffer_type,
+        large_edge_buffer_type);
   } else {
     std::tie(
       graph, edge_weights, edge_ids, edge_types, edge_start_times, edge_end_times, renumber_map) =
@@ -745,7 +779,9 @@ construct_graph(
         std::move(edge_start_time_chunks),
         std::move(edge_end_time_chunks),
         cugraph::graph_properties_t{is_symmetric, drop_multi_edges ? false : true},
-        renumber);
+        renumber,
+        large_vertex_buffer_type,
+        large_edge_buffer_type);
   }
 
   return std::make_tuple(std::move(graph),
@@ -769,9 +805,11 @@ std::tuple<cugraph::graph_t<vertex_t, edge_t, store_transposed, multi_gpu>,
 construct_graph(raft::handle_t const& handle,
                 input_usecase_t const& input_usecase,
                 bool test_weighted,
-                bool renumber         = true,
-                bool drop_self_loops  = false,
-                bool drop_multi_edges = false)
+                bool renumber                                               = true,
+                bool drop_self_loops                                        = false,
+                bool drop_multi_edges                                       = false,
+                std::optional<large_buffer_type_t> large_vertex_buffer_type = std::nullopt,
+                std::optional<large_buffer_type_t> large_edge_buffer_type   = std::nullopt)
 {
   cugraph::graph_t<vertex_t, edge_t, store_transposed, multi_gpu> graph(handle);
   std::optional<cugraph::edge_property_t<edge_t, weight_t>> edge_weights{std::nullopt};
@@ -794,7 +832,9 @@ construct_graph(raft::handle_t const& handle,
                                      std::nullopt,
                                      renumber,
                                      drop_self_loops,
-                                     drop_multi_edges);
+                                     drop_multi_edges,
+                                     large_vertex_buffer_type,
+                                     large_edge_buffer_type);
 
   return std::make_tuple(std::move(graph), std::move(edge_weights), std::move(renumber_map));
 }


### PR DESCRIPTION
This PR allows optionally creating a graph object in a large memory buffer (currently, large memory buffer means host pinned memory buffer but this may change in the future).

Breaking as new parameters (large_buffer_type or large_vertex_buffer_type & large_edge_buffer_type pairs) are added to public functions (but their default values are provided, so the older code may still compile without changes).