### PR TITLE
Relax PyTorch pinning to >=2.3.

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -55,7 +55,7 @@ dependencies:
 - pytest-cov
 - pytest-xdist
 - python-louvain
-- pytorch>=2.3,<2.5a0
+- pytorch>=2.3
 - raft-dask==25.8.*,>=0.0.0a0
 - rapids-build-backend>=0.3.1,<0.4.0.dev0
 - rapids-dask-dependency==25.8.*,>=0.0.0a0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -55,7 +55,7 @@ dependencies:
 - pytest-cov
 - pytest-xdist
 - python-louvain
-- pytorch>=2.3,<2.5a0
+- pytorch>=2.3
 - raft-dask==25.8.*,>=0.0.0a0
 - rapids-build-backend>=0.3.1,<0.4.0.dev0
 - rapids-dask-dependency==25.8.*,>=0.0.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -564,7 +564,7 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
-          - pytorch>=2.3,<2.5a0
+          - pytorch>=2.3
           - torchdata
           - pydantic
           - ogb


### PR DESCRIPTION
This removes the PyTorch upper bound to ensure we can test with current versions.
