### PR TITLE
Update decompress_to_edgelist to take an optional large buffer type as an input parameter.

### DIFF
--- a/cpp/include/cugraph/graph_functions.hpp
+++ b/cpp/include/cugraph/graph_functions.hpp
@@ -390,6 +390,10 @@ void renumber_local_ext_vertices(raft::handle_t const& handle,
  * @param edge_type_view Optional view object holding edge types for @p graph_view.
  * @param renumber_map If valid, return the renumbered edge list based on the provided @p
  * renumber_map
+ * @param large_buffer_type Flag indicating the large buffer type to use when we need to create a
+ * large device-accessible vector object (if the value is std::nullopt, the default RMM per-device
+ * memory resource is used). The returned edge list will also be stored in the buffer type dictated
+ * by this parameter.
  * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
  * @return Tuple of edge sources, destinations, (optional) edge weights (if
  * @p edge_weight_view.has_value() is true) and (optional) edge ids (if
@@ -413,7 +417,8 @@ decompress_to_edgelist(
   std::optional<edge_property_view_t<edge_t, edge_t const*>> edge_id_view,
   std::optional<edge_property_view_t<edge_t, edge_type_t const*>> edge_type_view,
   std::optional<raft::device_span<vertex_t const>> renumber_map,
-  bool do_expensive_check = false);
+  std::optional<large_buffer_type_t> large_buffer_type = std::nullopt,
+  bool do_expensive_check                              = false);
 
 /**
  * @ingroup graph_functions_cpp

--- a/cpp/src/c_api/decompress_to_edgelist.cpp
+++ b/cpp/src/c_api/decompress_to_edgelist.cpp
@@ -99,6 +99,7 @@ struct decompress_to_edgelist_functor : public cugraph::c_api::abstract_functor 
           (number_map != nullptr) ? std::make_optional<raft::device_span<vertex_t const>>(
                                       number_map->data(), number_map->size())
                                   : std::nullopt,
+          std::nullopt,
           do_expensive_check_);
 
       result_ = new cugraph::c_api::cugraph_edgelist_t{

--- a/cpp/src/structure/decompress_to_edgelist_impl.cuh
+++ b/cpp/src/structure/decompress_to_edgelist_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/decompress_to_edgelist_impl.cuh
+++ b/cpp/src/structure/decompress_to_edgelist_impl.cuh
@@ -65,6 +65,7 @@ decompress_to_edgelist_impl(
   std::optional<edge_property_view_t<edge_t, edge_t const*>> edge_id_view,
   std::optional<edge_property_view_t<edge_t, edge_type_t const*>> edge_type_view,
   std::optional<raft::device_span<vertex_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check)
 {
   CUGRAPH_EXPECTS(!renumber_map.has_value() ||
@@ -72,6 +73,8 @@ decompress_to_edgelist_impl(
                      static_cast<size_t>(graph_view.local_vertex_partition_range_size())),
                   "Invalid input arguments: (*renumber_map).size() should match with the local "
                   "vertex partition range size.");
+  CUGRAPH_EXPECTS(!large_buffer_type || cugraph::large_buffer_manager::memory_buffer_initialized(),
+                  "Invalid input argument: large memory_buffer is not initialized.");
 
   if (do_expensive_check) { /* currently, nothing to do */
   }
@@ -94,17 +97,37 @@ decompress_to_edgelist_impl(
   auto number_of_local_edges =
     std::reduce(edgelist_edge_counts.begin(), edgelist_edge_counts.end());
 
-  rmm::device_uvector<vertex_t> edgelist_majors(number_of_local_edges, handle.get_stream());
-  rmm::device_uvector<vertex_t> edgelist_minors(edgelist_majors.size(), handle.get_stream());
-  auto edgelist_ids     = edge_id_view ? std::make_optional<rmm::device_uvector<edge_t>>(
-                                       edgelist_majors.size(), handle.get_stream())
-                                       : std::nullopt;
-  auto edgelist_weights = edge_weight_view ? std::make_optional<rmm::device_uvector<weight_t>>(
-                                               edgelist_majors.size(), handle.get_stream())
-                                           : std::nullopt;
-  auto edgelist_types   = edge_type_view ? std::make_optional<rmm::device_uvector<edge_type_t>>(
-                                           edgelist_majors.size(), handle.get_stream())
-                                         : std::nullopt;
+  auto edgelist_majors =
+    large_buffer_type ? large_buffer_manager::allocate_memory_buffer<vertex_t>(
+                          number_of_local_edges, handle.get_stream())
+                      : rmm::device_uvector<vertex_t>(number_of_local_edges, handle.get_stream());
+  auto edgelist_minors =
+    large_buffer_type ? large_buffer_manager::allocate_memory_buffer<vertex_t>(
+                          number_of_local_edges, handle.get_stream())
+                      : rmm::device_uvector<vertex_t>(number_of_local_edges, handle.get_stream());
+  auto edgelist_weights =
+    edge_weight_view
+      ? std::make_optional(
+          large_buffer_type
+            ? large_buffer_manager::allocate_memory_buffer<weight_t>(number_of_local_edges,
+                                                                     handle.get_stream())
+            : rmm::device_uvector<weight_t>(number_of_local_edges, handle.get_stream()))
+      : std::nullopt;
+  auto edgelist_ids =
+    edge_id_view
+      ? std::make_optional(large_buffer_type ? large_buffer_manager::allocate_memory_buffer<edge_t>(
+                                                 number_of_local_edges, handle.get_stream())
+                                             : rmm::device_uvector<edge_t>(number_of_local_edges,
+                                                                           handle.get_stream()))
+      : std::nullopt;
+  auto edgelist_types =
+    edge_type_view
+      ? std::make_optional(
+          large_buffer_type
+            ? large_buffer_manager::allocate_memory_buffer<edge_type_t>(number_of_local_edges,
+                                                                        handle.get_stream())
+            : rmm::device_uvector<edge_type_t>(number_of_local_edges, handle.get_stream()))
+      : std::nullopt;
 
   size_t cur_size{0};
   for (size_t i = 0; i < edgelist_edge_counts.size(); ++i) {
@@ -310,6 +333,7 @@ decompress_to_edgelist_impl(
   std::optional<edge_property_view_t<edge_t, edge_t const*>> edge_id_view,
   std::optional<edge_property_view_t<edge_t, edge_type_t const*>> edge_type_view,
   std::optional<raft::device_span<vertex_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check)
 {
   CUGRAPH_EXPECTS(
@@ -317,6 +341,8 @@ decompress_to_edgelist_impl(
       (*renumber_map).size() == static_cast<size_t>(graph_view.local_vertex_partition_range_size()),
     "Invalid input arguments: if renumber_map.has_value() == true, (*renumber_map).size() should "
     "match with the local vertex partition range size.");
+  CUGRAPH_EXPECTS(!large_buffer_type || cugraph::large_buffer_manager::memory_buffer_initialized(),
+                  "Invalid input argument: large memory_buffer is not initialized.");
 
   if (do_expensive_check) { /* currently, nothing to do */
   }
@@ -327,18 +353,35 @@ decompress_to_edgelist_impl(
       detail::count_set_bits(handle, (*(graph_view.edge_mask_view())).value_firsts()[0], num_edges);
   }
 
-  rmm::device_uvector<vertex_t> edgelist_majors(num_edges, handle.get_stream());
-  rmm::device_uvector<vertex_t> edgelist_minors(edgelist_majors.size(), handle.get_stream());
-  auto edgelist_weights = edge_weight_view ? std::make_optional<rmm::device_uvector<weight_t>>(
-                                               edgelist_majors.size(), handle.get_stream())
-                                           : std::nullopt;
-  auto edgelist_ids     = edge_id_view ? std::make_optional<rmm::device_uvector<edge_t>>(
-                                       edgelist_majors.size(), handle.get_stream())
-                                       : std::nullopt;
-
-  auto edgelist_types = edge_type_view ? std::make_optional<rmm::device_uvector<edge_type_t>>(
-                                           edgelist_majors.size(), handle.get_stream())
-                                       : std::nullopt;
+  auto edgelist_majors =
+    large_buffer_type
+      ? large_buffer_manager::allocate_memory_buffer<vertex_t>(num_edges, handle.get_stream())
+      : rmm::device_uvector<vertex_t>(num_edges, handle.get_stream());
+  auto edgelist_minors =
+    large_buffer_type
+      ? large_buffer_manager::allocate_memory_buffer<vertex_t>(num_edges, handle.get_stream())
+      : rmm::device_uvector<vertex_t>(num_edges, handle.get_stream());
+  auto edgelist_weights =
+    edge_weight_view
+      ? std::make_optional(
+          large_buffer_type
+            ? large_buffer_manager::allocate_memory_buffer<weight_t>(num_edges, handle.get_stream())
+            : rmm::device_uvector<weight_t>(num_edges, handle.get_stream()))
+      : std::nullopt;
+  auto edgelist_ids =
+    edge_id_view
+      ? std::make_optional(
+          large_buffer_type
+            ? large_buffer_manager::allocate_memory_buffer<edge_t>(num_edges, handle.get_stream())
+            : rmm::device_uvector<edge_t>(num_edges, handle.get_stream()))
+      : std::nullopt;
+  auto edgelist_types =
+    edge_type_view
+      ? std::make_optional(large_buffer_type
+                             ? large_buffer_manager::allocate_memory_buffer<edge_type_t>(
+                                 num_edges, handle.get_stream())
+                             : rmm::device_uvector<edge_type_t>(num_edges, handle.get_stream()))
+      : std::nullopt;
 
   detail::decompress_edge_partition_to_edgelist<vertex_t, edge_t, weight_t, int32_t, multi_gpu>(
     handle,
@@ -414,6 +457,7 @@ decompress_to_edgelist(
   std::optional<edge_property_view_t<edge_t, edge_t const*>> edge_id_view,
   std::optional<edge_property_view_t<edge_t, edge_type_t const*>> edge_type_view,
   std::optional<raft::device_span<vertex_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check)
 {
   return decompress_to_edgelist_impl<vertex_t,
@@ -427,6 +471,7 @@ decompress_to_edgelist(
                                                 edge_id_view,
                                                 edge_type_view,
                                                 renumber_map,
+                                                large_buffer_type,
                                                 do_expensive_check);
 }
 

--- a/cpp/src/structure/decompress_to_edgelist_mg_v32_e32.cu
+++ b/cpp/src/structure/decompress_to_edgelist_mg_v32_e32.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/decompress_to_edgelist_mg_v32_e32.cu
+++ b/cpp/src/structure/decompress_to_edgelist_mg_v32_e32.cu
@@ -31,6 +31,7 @@ decompress_to_edgelist<int32_t, int32_t, float, int32_t, false, true>(
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int32_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int32_t>,
@@ -45,6 +46,7 @@ decompress_to_edgelist<int32_t, int32_t, float, int32_t, true, true>(
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int32_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int32_t>,
@@ -59,6 +61,7 @@ decompress_to_edgelist<int32_t, int32_t, double, int32_t, false, true>(
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int32_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int32_t>,
@@ -73,6 +76,7 @@ decompress_to_edgelist<int32_t, int32_t, double, int32_t, true, true>(
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int32_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/decompress_to_edgelist_mg_v64_e64.cu
+++ b/cpp/src/structure/decompress_to_edgelist_mg_v64_e64.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/decompress_to_edgelist_mg_v64_e64.cu
+++ b/cpp/src/structure/decompress_to_edgelist_mg_v64_e64.cu
@@ -31,6 +31,7 @@ decompress_to_edgelist<int64_t, int64_t, float, int32_t, false, true>(
   std::optional<edge_property_view_t<int64_t, int64_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int64_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int64_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int64_t>,
@@ -45,6 +46,7 @@ decompress_to_edgelist<int64_t, int64_t, float, int32_t, true, true>(
   std::optional<edge_property_view_t<int64_t, int64_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int64_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int64_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int64_t>,
@@ -59,6 +61,7 @@ decompress_to_edgelist<int64_t, int64_t, double, int32_t, false, true>(
   std::optional<edge_property_view_t<int64_t, int64_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int64_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int64_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int64_t>,
@@ -73,6 +76,7 @@ decompress_to_edgelist<int64_t, int64_t, double, int32_t, true, true>(
   std::optional<edge_property_view_t<int64_t, int64_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int64_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int64_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/decompress_to_edgelist_sg_v32_e32.cu
+++ b/cpp/src/structure/decompress_to_edgelist_sg_v32_e32.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/decompress_to_edgelist_sg_v32_e32.cu
+++ b/cpp/src/structure/decompress_to_edgelist_sg_v32_e32.cu
@@ -31,6 +31,7 @@ decompress_to_edgelist<int32_t, int32_t, float, int32_t, false, false>(
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int32_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int32_t>,
@@ -45,6 +46,7 @@ decompress_to_edgelist<int32_t, int32_t, float, int32_t, true, false>(
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int32_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int32_t>,
@@ -59,6 +61,7 @@ decompress_to_edgelist<int32_t, int32_t, double, int32_t, false, false>(
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int32_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int32_t>,
@@ -73,6 +76,7 @@ decompress_to_edgelist<int32_t, int32_t, double, int32_t, true, false>(
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int32_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int32_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/src/structure/decompress_to_edgelist_sg_v64_e64.cu
+++ b/cpp/src/structure/decompress_to_edgelist_sg_v64_e64.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structure/decompress_to_edgelist_sg_v64_e64.cu
+++ b/cpp/src/structure/decompress_to_edgelist_sg_v64_e64.cu
@@ -31,6 +31,7 @@ decompress_to_edgelist<int64_t, int64_t, float, int32_t, false, false>(
   std::optional<edge_property_view_t<int64_t, int64_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int64_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int64_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int64_t>,
@@ -45,6 +46,7 @@ decompress_to_edgelist<int64_t, int64_t, float, int32_t, true, false>(
   std::optional<edge_property_view_t<int64_t, int64_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int64_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int64_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int64_t>,
@@ -59,6 +61,7 @@ decompress_to_edgelist<int64_t, int64_t, double, int32_t, false, false>(
   std::optional<edge_property_view_t<int64_t, int64_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int64_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int64_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 template std::tuple<rmm::device_uvector<int64_t>,
@@ -73,6 +76,7 @@ decompress_to_edgelist<int64_t, int64_t, double, int32_t, true, false>(
   std::optional<edge_property_view_t<int64_t, int64_t const*>> edge_id_view,
   std::optional<edge_property_view_t<int64_t, int32_t const*>> edge_type_view,
   std::optional<raft::device_span<int64_t const>> renumber_map,
+  std::optional<large_buffer_type_t> large_buffer_type,
   bool do_expensive_check);
 
 }  // namespace cugraph

--- a/cpp/tests/cores/k_core_validate.cu
+++ b/cpp/tests/cores/k_core_validate.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/cores/k_core_validate.cu
+++ b/cpp/tests/cores/k_core_validate.cu
@@ -72,8 +72,7 @@ void check_correctness(
       edge_weight_view,
       std::optional<edge_property_view_t<edge_t, edge_t const*>>{std::nullopt},
       std::optional<cugraph::edge_property_view_t<edge_t, int32_t const*>>{std::nullopt},
-      std::optional<raft::device_span<vertex_t const>>{std::nullopt},
-      false);
+      std::optional<raft::device_span<vertex_t const>>{std::nullopt});
 
   // Now we'll count how many edges should be in the subgraph
   auto expected_edge_count =


### PR DESCRIPTION
If the optional large buffer type is specified, the decompressed edge list will be placed in a large buffer (which is currently host pinned memory).

This will slightly simplify the current Graph 500 test code (https://github.com/rapidsai/cugraph/blob/branch-25.08/cpp/tests/traversal/mg_graph500_bfs_test.cu#L304); which generates the edge list using the default memory resource and copy to the large memory buffer. With this update, this two steps can be merged to a single step.

Breaking as one additional input parameter is added to a public function. But unless the caller has been explicitly specifying `do_expensive_check`, no change will be necessary as the default value (std::nullopt) is provided.