### PR TITLE
Update update_edge_src|dst_property behavior (with vertex list)

### DIFF
--- a/cpp/src/components/weakly_connected_components_impl.cuh
+++ b/cpp/src/components/weakly_connected_components_impl.cuh
@@ -30,6 +30,7 @@
 #include <cugraph/graph_view.hpp>
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/device_comm.hpp>
+#include <cugraph/utilities/device_functors.cuh>
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
 
@@ -47,6 +48,7 @@
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/merge.h>
 #include <thrust/partition.h>
@@ -702,9 +704,9 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
         if constexpr (GraphViewType::is_multi_gpu) {
           rmm::device_uvector<vertex_t> gathered_level_components(
             vertex_frontier.bucket(bucket_idx_cur).size(), handle.get_stream());
-          auto map_first = thrust::make_transfrom_iterator(
+          auto map_first = thrust::make_transform_iterator(
             thrust::get<0>(vertex_frontier.bucket(bucket_idx_cur).begin().get_iterator_tuple()),
-            shift_left_t<vertex_t>{graph_view.local_vertex_partition_range_first()});
+            detail::shift_left_t<vertex_t>{level_graph_view.local_vertex_partition_range_first()});
           thrust::gather(handle.get_thrust_policy(),
                          map_first,
                          map_first + vertex_frontier.bucket(bucket_idx_cur).size(),

--- a/cpp/src/prims/per_v_pair_transform_dst_nbr_intersection.cuh
+++ b/cpp/src/prims/per_v_pair_transform_dst_nbr_intersection.cuh
@@ -201,14 +201,16 @@ struct call_intersection_op_t {
  * @param handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator, and
  * handles to various CUDA libraries) to run graph algorithms.
  * @param graph_view Non-owning graph object.
+ * @param edge_value_input Wrapper used to access edge input property values (for the edges assigned
+ * to this process in multi-GPU). Use either cugraph::edge_property_t::view() (if @p e_op needs to
+ * access edge property values) or cugraph::edge_dummy_property_t::view() (if @p e_op does not
+ * access edge property values).
  * @param vertex_pair_first Iterator pointing to the first (inclusive) input vertex pair.
  * @param vertex_pair_last Iterator pointing to the last (exclusive) input vertex pair.
- * @param vertex_src_value_input Wrapper used to access vertex input property values (for the
- * vertices assigned to this process in multi-GPU).
- * @param edge_value_input Wrapper used to access edge input property values (for the edges assigned
- * to this process in multi-GPU). Use either cugraph::edge_property_t::view() (if @p intersection_op
- * needs to access edge property values) or cugraph::edge_dummy_property_t::view() (if @p
- * intersection_op does not access edge property values).
+ * @param vertex_value_input_first Iterator pointing to the vertex property value for the first
+ * (inclusive) vertex (of the vertex partition assigned to this process in multi-GPU).
+ * `vertex_value_input_last` (exclusive) is deduced as @p vertex_value_input_first + @p
+ * graph_view.local_vertex_partition_range_size().
  * @param intersection_op quinary operator takes first vertex of the pair, second vertex of the
  * pair, property values for the first vertex, property values for the second vertex, and a list of
  * vertices in the intersection of the first & second vertices' destination neighbors and returns an
@@ -216,18 +218,18 @@ struct call_intersection_op_t {
  * @param vertex_pair_value_output_first Iterator pointing to the vertex pair property variables for
  * the first vertex pair (inclusive). `vertex_pair_value_output_last` (exclusive) is deduced as @p
  * vertex_pair_value_output_first + @p cuda::std::distance(vertex_pair_first, vertex_pair_last).
- * @param A flag to run expensive checks for input arguments (if set to `true`).
+ * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
  */
 template <typename GraphViewType,
           typename VertexPairIterator,
           typename VertexValueInputIterator,
-          typename EdgeValueInputIterator,
+          typename EdgeValueInputWrapper,
           typename IntersectionOp,
           typename VertexPairValueOutputIterator>
 void per_v_pair_transform_dst_nbr_intersection(
   raft::handle_t const& handle,
   GraphViewType const& graph_view,
-  EdgeValueInputIterator edge_value_input,
+  EdgeValueInputWrapper edge_value_input,
   VertexPairIterator vertex_pair_first,
   VertexPairIterator vertex_pair_last,
   VertexValueInputIterator vertex_value_input_first,

--- a/cpp/src/prims/per_v_pair_transform_dst_nbr_intersection.cuh
+++ b/cpp/src/prims/per_v_pair_transform_dst_nbr_intersection.cuh
@@ -242,7 +242,7 @@ void per_v_pair_transform_dst_nbr_intersection(
   using vertex_t   = typename GraphViewType::vertex_type;
   using edge_t     = typename GraphViewType::edge_type;
   using property_t = typename thrust::iterator_traits<VertexValueInputIterator>::value_type;
-  using edge_property_value_t = typename EdgeValueInputIterator::value_type;
+  using edge_property_value_t = typename EdgeValueInputWrapper::value_type;
   using result_t = typename thrust::iterator_traits<VertexPairValueOutputIterator>::value_type;
 
   if (do_expensive_check) {

--- a/cpp/src/prims/update_edge_src_dst_property.cuh
+++ b/cpp/src/prims/update_edge_src_dst_property.cuh
@@ -264,12 +264,13 @@ template <typename GraphViewType,
           typename VertexIterator,
           typename VertexPropertyInputIterator,
           typename EdgeMajorPropertyOutputWrapper>
-void update_edge_major_property(raft::handle_t const& handle,
-                                GraphViewType const& graph_view,
-                                VertexIterator sorted_unique_vertex_first,
-                                VertexIterator sorted_unique_vertex_last,
-                                VertexPropertyInputIterator vertex_property_input_first,
-                                EdgeMajorPropertyOutputWrapper edge_major_property_output)
+void update_edge_major_property(
+  raft::handle_t const& handle,
+  GraphViewType const& graph_view,
+  VertexIterator sorted_unique_vertex_first,
+  VertexIterator sorted_unique_vertex_last,
+  VertexPropertyInputIterator sorted_unique_vertex_property_input_first,
+  EdgeMajorPropertyOutputWrapper edge_major_property_output)
 {
   constexpr bool contains_packed_bool_element =
     cugraph::has_packed_bool_element<typename EdgeMajorPropertyOutputWrapper::value_iterator,
@@ -318,34 +319,17 @@ void update_edge_major_property(raft::handle_t const& handle,
           vertex_partition_device_view_t<vertex_t, GraphViewType::is_multi_gpu>(
             graph_view.local_vertex_partition_view());
         if constexpr (contains_packed_bool_element) {
-          auto bool_first = thrust::make_transform_iterator(
-            sorted_unique_vertex_first,
-            cuda::proclaim_return_type<bool>([vertex_property_input_first,
-                                              vertex_partition] __device__(auto v) {
-              auto v_offset = vertex_partition.local_vertex_partition_offset_from_vertex_nocheck(v);
-              return static_cast<bool>(
-                *(vertex_property_input_first + packed_bool_offset(v_offset)) &
-                packed_bool_mask(v_offset));
-            }));
-          pack_bools(
-            handle,
-            bool_first,
-            bool_first + cuda::std::distance(sorted_unique_vertex_first, sorted_unique_vertex_last),
-            rx_value_first);
+          pack_bools(handle,
+                     sorted_unique_vertex_property_input_first,
+                     sorted_unique_vertex_property_input_first +
+                       cuda::std::distance(sorted_unique_vertex_first, sorted_unique_vertex_last),
+                     rx_value_first);
         } else {
-          auto map_first = thrust::make_transform_iterator(
-            sorted_unique_vertex_first,
-            cuda::proclaim_return_type<vertex_t>([vertex_partition] __device__(auto v) {
-              return vertex_partition.local_vertex_partition_offset_from_vertex_nocheck(v);
-            }));
-          // FIXME: this gather (and temporary buffer) is unnecessary if NCCL directly takes a
-          // permutation iterator (and directly gathers to the internal buffer)
-          thrust::gather(
-            handle.get_thrust_policy(),
-            map_first,
-            map_first + cuda::std::distance(sorted_unique_vertex_first, sorted_unique_vertex_last),
-            vertex_property_input_first,
-            rx_value_first);
+          thrust::copy(handle.get_thrust_policy(),
+                       sorted_unique_vertex_property_input_first,
+                       sorted_unique_vertex_property_input_first +
+                         cuda::std::distance(sorted_unique_vertex_first, sorted_unique_vertex_last),
+                       rx_value_first);
         }
       }
 
@@ -428,23 +412,24 @@ void update_edge_major_property(raft::handle_t const& handle,
              : graph_view.local_edge_partition_src_range_size());
     assert(edge_partition_value_firsts.size() == size_t{1});
     if constexpr (contains_packed_bool_element) {
-      thrust::for_each(handle.get_thrust_policy(),
-                       sorted_unique_vertex_first,
-                       sorted_unique_vertex_last,
-                       [vertex_property_input_first,
-                        output_value_first = edge_partition_value_firsts[0]] __device__(auto v) {
-                         bool val = static_cast<bool>(*(vertex_property_input_first + v));
-                         packed_bool_atomic_set(output_value_first, v, val);
-                       });
-    } else {
-      auto val_first =
-        thrust::make_permutation_iterator(vertex_property_input_first, sorted_unique_vertex_first);
-      thrust::scatter(
+      auto pair_first = thrust::make_zip_iterator(sorted_unique_vertex_first,
+                                                  sorted_unique_vertex_property_input_first);
+      thrust::for_each(
         handle.get_thrust_policy(),
-        val_first,
-        val_first + cuda::std::distance(sorted_unique_vertex_first, sorted_unique_vertex_last),
-        sorted_unique_vertex_first,
-        edge_partition_value_firsts[0]);
+        pair_first,
+        pair_first + cuda::std::distance(sorted_unique_vertex_first, sorted_unique_vertex_last),
+        [output_value_first = edge_partition_value_firsts[0]] __device__(auto pair) {
+          auto v   = thrust::get<0>(pair);
+          auto val = static_cast<bool>(thrust::get<1>(pair));
+          packed_bool_atomic_set(output_value_first, v, val);
+        });
+    } else {
+      thrust::scatter(handle.get_thrust_policy(),
+                      sorted_unique_vertex_property_input_first,
+                      sorted_unique_vertex_property_input_first +
+                        cuda::std::distance(sorted_unique_vertex_first, sorted_unique_vertex_last),
+                      sorted_unique_vertex_first,
+                      edge_partition_value_firsts[0]);
     }
   }
 }
@@ -692,12 +677,13 @@ template <typename GraphViewType,
           typename VertexIterator,
           typename VertexPropertyInputIterator,
           typename EdgeMinorPropertyOutputWrapper>
-void update_edge_minor_property(raft::handle_t const& handle,
-                                GraphViewType const& graph_view,
-                                VertexIterator sorted_unique_vertex_first,
-                                VertexIterator sorted_unique_vertex_last,
-                                VertexPropertyInputIterator vertex_property_input_first,
-                                EdgeMinorPropertyOutputWrapper edge_minor_property_output)
+void update_edge_minor_property(
+  raft::handle_t const& handle,
+  GraphViewType const& graph_view,
+  VertexIterator sorted_unique_vertex_first,
+  VertexIterator sorted_unique_vertex_last,
+  VertexPropertyInputIterator sorted_unique_vertex_property_input_first,
+  EdgeMinorPropertyOutputWrapper edge_minor_property_output)
 {
   constexpr bool contains_packed_bool_element =
     cugraph::has_packed_bool_element<typename EdgeMinorPropertyOutputWrapper::value_iterator,
@@ -788,34 +774,17 @@ void update_edge_minor_property(raft::handle_t const& handle,
           vertex_partition_device_view_t<vertex_t, GraphViewType::is_multi_gpu>(
             graph_view.local_vertex_partition_view());
         if constexpr (contains_packed_bool_element) {
-          auto bool_first = thrust::make_transform_iterator(
-            sorted_unique_vertex_first,
-            cuda::proclaim_return_type<bool>([vertex_property_input_first,
-                                              vertex_partition] __device__(auto v) {
-              auto v_offset = vertex_partition.local_vertex_partition_offset_from_vertex_nocheck(v);
-              return static_cast<bool>(
-                *(vertex_property_input_first + packed_bool_offset(v_offset)) &
-                packed_bool_mask(v_offset));
-            }));
-          pack_bools(
-            handle,
-            bool_first,
-            bool_first + cuda::std::distance(sorted_unique_vertex_first, sorted_unique_vertex_last),
-            rx_value_first);
+          pack_bools(handle,
+                     sorted_unique_vertex_property_input_first,
+                     sorted_unique_vertex_property_input_first +
+                       cuda::std::distance(sorted_unique_vertex_first, sorted_unique_vertex_last),
+                     rx_value_first);
         } else {
-          auto map_first = thrust::make_transform_iterator(
-            sorted_unique_vertex_first,
-            cuda::proclaim_return_type<vertex_t>([vertex_partition] __device__(auto v) {
-              return vertex_partition.local_vertex_partition_offset_from_vertex_nocheck(v);
-            }));
-          // FIXME: this gather (and temporary buffer) is unnecessary if NCCL directly takes a
-          // permutation iterator (and directly gathers to the internal buffer)
-          thrust::gather(
-            handle.get_thrust_policy(),
-            map_first,
-            map_first + cuda::std::distance(sorted_unique_vertex_first, sorted_unique_vertex_last),
-            vertex_property_input_first,
-            rx_value_first);
+          thrust::copy(handle.get_thrust_policy(),
+                       sorted_unique_vertex_property_input_first,
+                       sorted_unique_vertex_property_input_first +
+                         cuda::std::distance(sorted_unique_vertex_first, sorted_unique_vertex_last),
+                       rx_value_first);
         }
       }
 
@@ -910,23 +879,24 @@ void update_edge_minor_property(raft::handle_t const& handle,
     assert(graph_view.local_vertex_partition_range_size() ==
            graph_view.local_edge_partition_src_range_size());
     if constexpr (contains_packed_bool_element) {
-      thrust::for_each(handle.get_thrust_policy(),
-                       sorted_unique_vertex_first,
-                       sorted_unique_vertex_last,
-                       [vertex_property_input_first,
-                        output_value_first = edge_partition_value_first] __device__(auto v) {
-                         bool val = static_cast<bool>(*(vertex_property_input_first + v));
-                         packed_bool_atomic_set(output_value_first, v, val);
-                       });
-    } else {
-      auto val_first =
-        thrust::make_permutation_iterator(vertex_property_input_first, sorted_unique_vertex_first);
-      thrust::scatter(
+      auto pair_first = thrust::make_zip_iterator(sorted_unique_vertex_first,
+                                                  sorted_unique_vertex_property_input_first);
+      thrust::for_each(
         handle.get_thrust_policy(),
-        val_first,
-        val_first + cuda::std::distance(sorted_unique_vertex_first, sorted_unique_vertex_last),
-        sorted_unique_vertex_first,
-        edge_partition_value_first);
+        pair_first,
+        pair_first + cuda::std::distance(sorted_unique_vertex_first, sorted_unique_vertex_last),
+        [output_value_first = edge_partition_value_first] __device__(auto pair) {
+          auto v   = thrust::get<0>(pair);
+          auto val = static_cast<bool>(thrust::get<1>(pair));
+          packed_bool_atomic_set(output_value_first, v, val);
+        });
+    } else {
+      thrust::scatter(handle.get_thrust_policy(),
+                      sorted_unique_vertex_property_input_first,
+                      sorted_unique_vertex_property_input_first +
+                        cuda::std::distance(sorted_unique_vertex_first, sorted_unique_vertex_last),
+                      sorted_unique_vertex_first,
+                      edge_partition_value_first);
     }
   }
 }
@@ -995,10 +965,11 @@ void update_edge_src_property(raft::handle_t const& handle,
  * multi-GPU), otherwise undefined behavior.
  * @param sorted_unique_vertex_last Iterator pointing to the last (exclusive) vertex with a new
  * value.
- * @param vertex_property_input_first Iterator pointing to the vertex property value for the first
- * (inclusive) vertex (of the vertex partition assigned to this process in multi-GPU).
- * `vertex_property_input_last` (exclusive) is deduced as @p vertex_property_input_first + @p
- * graph_view.local_vertex_partition_range_size().
+ * @param sorted_unique_vertex_property_input_first Iterator pointing to the vertex property values
+ * for the first (inclusive) vertex in [@p sorted_unique_vertex_first, @psorted_unique_vertex_last).
+ * `sorted_unique_vertex_property_input_last` (exclusive) is deduced as @p
+ * sorted_unique_vertex_property_input_first + cuda::std::distance(@p sorted_unique_vertex_first, @p
+ * sorted_unique_vertex_last).
  * @param edge_partition_src_property_output edge_src_property_view_t class object to store source
  * property values (for the edge sources assigned to this process in multi-GPU).
  * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
@@ -1011,7 +982,7 @@ void update_edge_src_property(raft::handle_t const& handle,
                               GraphViewType const& graph_view,
                               VertexIterator sorted_unique_vertex_first,
                               VertexIterator sorted_unique_vertex_last,
-                              VertexPropertyInputIterator vertex_property_input_first,
+                              VertexPropertyInputIterator sorted_unique_vertex_property_input_first,
                               EdgeSrcValueOutputWrapper edge_src_property_output,
                               bool do_expensive_check = false)
 {
@@ -1040,14 +1011,14 @@ void update_edge_src_property(raft::handle_t const& handle,
                                        graph_view,
                                        sorted_unique_vertex_first,
                                        sorted_unique_vertex_last,
-                                       vertex_property_input_first,
+                                       sorted_unique_vertex_property_input_first,
                                        edge_src_property_output);
   } else {
     detail::update_edge_major_property(handle,
                                        graph_view,
                                        sorted_unique_vertex_first,
                                        sorted_unique_vertex_last,
-                                       vertex_property_input_first,
+                                       sorted_unique_vertex_property_input_first,
                                        edge_src_property_output);
   }
 }
@@ -1116,10 +1087,11 @@ void update_edge_dst_property(raft::handle_t const& handle,
  * multi-GPU), otherwise undefined behavior.
  * @param sorted_unique_vertex_last Iterator pointing to the last (exclusive) vertex with a new
  * value.
- * @param vertex_property_input_first Iterator pointing to the vertex property value for the first
- * (inclusive) vertex (of the vertex partition assigned to this process in multi-GPU).
- * `vertex_property_input_last` (exclusive) is deduced as @p vertex_property_input_first + @p
- * graph_view.local_vertex_partition_range_size().
+ * @param sorted_unique_vertex_property_input_first Iterator pointing to the vertex property values
+ * for the first (inclusive) vertex in [@p sorted_unique_vertex_first, @psorted_unique_vertex_last).
+ * `sorted_unique_vertex_property_input_last` (exclusive) is deduced as @p
+ * sorted_unique_vertex_property_input_first + cuda::std::distance(@p sorted_unique_vertex_first, @p
+ * sorted_unique_vertex_last).
  * @param edge_partition_dst_property_output edge_dst_property_view_t class object to store
  * destination property values (for the edge destinations assigned to this process in multi-GPU).
  * @param do_expensive_check A flag to run expensive checks for input arguments (if set to `true`).
@@ -1132,7 +1104,7 @@ void update_edge_dst_property(raft::handle_t const& handle,
                               GraphViewType const& graph_view,
                               VertexIterator sorted_unique_vertex_first,
                               VertexIterator sorted_unique_vertex_last,
-                              VertexPropertyInputIterator vertex_property_input_first,
+                              VertexPropertyInputIterator sorted_unique_vertex_property_input_first,
                               EdgeDstValueOutputWrapper edge_dst_property_output,
                               bool do_expensive_check = false)
 {
@@ -1161,14 +1133,14 @@ void update_edge_dst_property(raft::handle_t const& handle,
                                        graph_view,
                                        sorted_unique_vertex_first,
                                        sorted_unique_vertex_last,
-                                       vertex_property_input_first,
+                                       sorted_unique_vertex_property_input_first,
                                        edge_dst_property_output);
   } else {
     detail::update_edge_minor_property(handle,
                                        graph_view,
                                        sorted_unique_vertex_first,
                                        sorted_unique_vertex_last,
-                                       vertex_property_input_first,
+                                       sorted_unique_vertex_property_input_first,
                                        edge_dst_property_output);
   }
 }

--- a/cpp/src/sampling/detail/update_temporal_edge_mask_impl.cuh
+++ b/cpp/src/sampling/detail/update_temporal_edge_mask_impl.cuh
@@ -52,22 +52,6 @@ void update_temporal_edge_mask(
   // for each value so that we can reset everything back more efficiently.
   fill_edge_src_property(handle, graph_view, edge_src_times.mutable_view(), STARTING_TIME);
 
-  rmm::device_uvector<edge_time_t> local_frontier_vertex_times(
-    graph_view.local_vertex_partition_range_size(), handle.get_stream());
-
-  thrust::scatter(
-    handle.get_thrust_policy(),
-    vertex_times.begin(),
-    vertex_times.end(),
-    thrust::make_transform_iterator(
-      vertices.begin(),
-      cuda::proclaim_return_type<vertex_t>(
-        [vertex_partition = vertex_partition_device_view_t<vertex_t, multi_gpu>(
-           graph_view.local_vertex_partition_view())] __device__(auto v) {
-          return vertex_partition.local_vertex_partition_offset_from_vertex_nocheck(v);
-        })),
-    local_frontier_vertex_times.begin());
-
   update_edge_src_property(handle,
                            graph_view,
                            vertices.begin(),

--- a/cpp/src/sampling/random_walks_impl.cuh
+++ b/cpp/src/sampling/random_walks_impl.cuh
@@ -269,13 +269,24 @@ struct biased_selector {
 
     vertex_frontier.bucket(0).insert(current_vertices.begin(), current_vertices.end());
 
+    // FIXME: we need to compute weight sums only for the vertices in vertex_frontier.bucket(0)
     auto vertex_weight_sum = compute_out_weight_sums(handle, graph_view, *edge_weight_view);
+    rmm::device_uvector<weight_t> gathered_weight_sums(vertex_frontier.bucket(0).size(),
+                                                       handle.get_stream());
+    auto map_first = thrust::make_transform_iterator(
+      vertex_frontier.bucket(0).begin(),
+      shift_left_t<vertex_t>{graph_view.local_vertex_partition_range_first()});
+    thrust::gather(handle.get_thrust_policy(),
+                   map_first,
+                   map_first + vertex_frontier.bucket(0).size(),
+                   vertex_weight_sum.begin(),
+                   gathered_weight_sums.begin());
     edge_src_property_t<vertex_t, weight_t> edge_src_out_weight_sums(handle, graph_view);
     update_edge_src_property(handle,
                              graph_view,
                              vertex_frontier.bucket(0).begin(),
                              vertex_frontier.bucket(0).end(),
-                             vertex_weight_sum.data(),
+                             gathered_weight_sums.begin(),
                              edge_src_out_weight_sums.mutable_view());
     auto [sample_offsets, sample_e_op_results] = cugraph::per_v_random_select_transform_outgoing_e(
       handle,

--- a/cpp/src/traversal/sssp_impl.cuh
+++ b/cpp/src/traversal/sssp_impl.cuh
@@ -196,7 +196,7 @@ void sssp(raft::handle_t const& handle,
         vertex_frontier.bucket(bucket_idx_cur_near).size(), handle.get_stream());
       auto map_first = thrust::make_transform_iterator(
         vertex_frontier.bucket(bucket_idx_cur_near).begin(),
-        shift_left_t<vertex_t>{graph_view.local_vertex_partition_range_first()});
+        shift_left_t<vertex_t>{push_graph_view.local_vertex_partition_range_first()});
       thrust::gather(handle.get_thrust_policy(),
                      map_first,
                      map_first + vertex_frontier.bucket(bucket_idx_cur_near).size(),

--- a/cpp/src/traversal/sssp_impl.cuh
+++ b/cpp/src/traversal/sssp_impl.cuh
@@ -192,11 +192,21 @@ void sssp(raft::handle_t const& handle,
   auto near_far_threshold = delta;
   while (true) {
     if (GraphViewType::is_multi_gpu) {
+      rmm::device_uvector<weight_t> gathered_distances(
+        vertex_frontier.bucket(bucket_idx_cur_near).size(), handle.get_stream());
+      auto map_first = thrust::make_transform_iterator(
+        vertex_frontier.bucket(bucket_idx_cur_near).begin(),
+        shift_left_t<vertex_t>{graph_view.local_vertex_partition_range_first()});
+      thrust::gather(handle.get_thrust_policy(),
+                     map_first,
+                     map_first + vertex_frontier.bucket(bucket_idx_cur_near).size(),
+                     distances,
+                     gathered_distances.begin());
       update_edge_src_property(handle,
                                push_graph_view,
                                vertex_frontier.bucket(bucket_idx_cur_near).begin(),
                                vertex_frontier.bucket(bucket_idx_cur_near).end(),
-                               distances,
+                               gathered_distances.begin(),
                                edge_src_distances.mutable_view());
     }
 


### PR DESCRIPTION
update_edge_src|dst_property has two versions.

One that updates the values for the entire vertex range, and the second one that takes a vertex list to update.

In the second version, it currently asks users to provide the property values for the entire vertex partition range (same to the first version, the primitives internally gather the values). This behavior is counter intuitive and became the sources of bugs recently.

In this PR, the primitive is updated to take property values in an array which has the size of the vertex list.