### PR TITLE
Drop remaining CUDA 11 references

### DIFF
--- a/cpp/libcugraph_etl/CMakeLists.txt
+++ b/cpp/libcugraph_etl/CMakeLists.txt
@@ -28,8 +28,8 @@ rapids_cuda_init_architectures(CUGRAPH_ETL)
 project(CUGRAPH_ETL VERSION "${RAPIDS_VERSION}" LANGUAGES C CXX CUDA)
 
 if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA" AND
-   CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.0)
-    message(FATAL_ERROR "CUDA compiler version must be at least 11.0")
+   CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.0)
+    message(FATAL_ERROR "CUDA compiler version must be at least 12.0")
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND

--- a/python/cugraph/cugraph/community/ktruss_subgraph.py
+++ b/python/cugraph/cugraph/community/ktruss_subgraph.py
@@ -65,8 +65,6 @@ def ktruss_subgraph(
     """
     Returns the K-Truss subgraph of a graph for a specific k.
 
-    NOTE: this function is currently not available on CUDA 11.4 systems.
-
     The k-truss of a graph is a subgraph where each edge is part of at least
     (k−2) triangles. K-trusses are used for finding tighlty knit groups of
     vertices in a graph. A k-truss is a relaxation of a k-clique in the graph

--- a/python/cugraph/cugraph/tests/docs/test_doctests.py
+++ b/python/cugraph/cugraph/tests/docs/test_doctests.py
@@ -25,21 +25,11 @@ import pytest
 import cugraph
 import pylibcugraph
 import cudf
-from cuda.bindings import runtime
 from cugraph.testing import utils
 
 
 modules_to_skip = ["dask", "proto", "raft"]
 datasets = utils.RAPIDS_DATASET_ROOT_DIR_PATH
-
-
-def _get_cuda_version_string():
-    status, version = runtime.getLocalRuntimeVersion()
-    if status != runtime.cudaError_t.cudaSuccess:
-        raise RuntimeError("Could not get CUDA runtime version.")
-    major = version // 1000
-    minor = (version % 1000) // 10
-    return f"{major}.{minor}"
 
 
 def _is_public_name(name):
@@ -124,25 +114,9 @@ def skip_docstring(docstring_obj):
     Returns a string indicating why the doctest example string should not be
     tested, or None if it should be tested.  This string can be used as the
     "reason" arg to pytest.skip().
-
-    Currently, this function will return a reason string if the docstring
-    contains a line with the following text:
-
-    "currently not available on CUDA <version> systems"
-
-    where <version> is a major.minor version string, such as 12.0, that matches
-    the version of CUDA on the system running the test.  An example of a line
-    in a docstring that would result in a reason string from this function
-    running on a CUDA 12.0 system is:
-
-    NOTE: this function is currently not available on CUDA 12.0 systems.
     """
     docstring = docstring_obj.docstring
-    cuda_version_string = _get_cuda_version_string()
-
     for line in docstring.splitlines():
-        if f"currently not available on CUDA {cuda_version_string} systems" in line:
-            return f"docstring example not supported on CUDA {cuda_version_string}"
         if "random_walks" in line:
             return (
                 "docstring example not supported for random walks"


### PR DESCRIPTION
Part of #5158.

- Require CUDA 12 in `libcugraph_etl`.
- Remove `ktruss_subgraph` warning for CUDA 11.4.
- Remove CUDA version skipping for doctests.
