### PR TITLE
Disable codecov comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
-#Configuration File for CodeCov
+# Configuration File for CodeCov
+comment: false
 coverage:
   status:
     project: off


### PR DESCRIPTION
This PR disables codecov comments on PRs. We do not act on this data and it has been considered a small nuisance by several RAPIDS libraries.
