### PR TITLE
cugraph RAPIDS dependency now use the new rapids-cmake branch info

### DIFF
--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -15,14 +15,13 @@
 #=============================================================================
 
 set(CUGRAPH_MIN_VERSION_raft "${CUGRAPH_VERSION_MAJOR}.${CUGRAPH_VERSION_MINOR}.00")
-set(CUGRAPH_BRANCH_VERSION_raft "${CUGRAPH_VERSION_MAJOR}.${CUGRAPH_VERSION_MINOR}")
 
 function(find_and_configure_raft)
 
     set(oneValueArgs VERSION FORK PINNED_TAG CLONE_ON_PIN USE_RAFT_STATIC COMPILE_RAFT_LIB)
     cmake_parse_arguments(PKG "" "${oneValueArgs}" "" ${ARGN} )
 
-    if(PKG_CLONE_ON_PIN AND NOT PKG_PINNED_TAG STREQUAL "branch-${CUGRAPH_BRANCH_VERSION_raft}")
+    if(PKG_CLONE_ON_PIN AND NOT PKG_PINNED_TAG STREQUAL "${rapids-cmake-checkout-tag}")
         message("Pinned tag found: ${PKG_PINNED_TAG}. Cloning raft locally.")
         set(CPM_DOWNLOAD_raft ON)
     elseif(PKG_USE_RAFT_STATIC AND (NOT CPM_raft_SOURCE))
@@ -68,7 +67,7 @@ endfunction()
 # CPM_raft_SOURCE=/path/to/local/raft
 find_and_configure_raft(VERSION    ${CUGRAPH_MIN_VERSION_raft}
                         FORK       rapidsai
-                        PINNED_TAG branch-${CUGRAPH_BRANCH_VERSION_raft}
+                        PINNED_TAG ${rapids-cmake-checkout-tag}
 
                         # When PINNED_TAG above doesn't match cugraph,
                         # force local raft clone in build directory

--- a/cpp/libcugraph_etl/cmake/thirdparty/get_cudf.cmake
+++ b/cpp/libcugraph_etl/cmake/thirdparty/get_cudf.cmake
@@ -37,13 +37,11 @@ function(find_and_configure_cudf)
 endfunction()
 
 set(CUGRAPH_ETL_MIN_VERSION_cudf "${CUGRAPH_ETL_VERSION_MAJOR}.${CUGRAPH_ETL_VERSION_MINOR}.00")
-set(CUGRAPH_ETL_BRANCH_VERSION_cudf "${CUGRAPH_ETL_VERSION_MAJOR}.${CUGRAPH_ETL_VERSION_MINOR}")
-
 
 # Change pinned tag and fork here to test a commit in CI
 # To use a different cuDF locally, set the CMake variable
 # CPM_cudf_SOURCE=/path/to/local/cudf
 find_and_configure_cudf(VERSION    ${CUGRAPH_ETL_MIN_VERSION_cudf}
                         FORK       rapidsai
-                        PINNED_TAG branch-${CUGRAPH_ETL_BRANCH_VERSION_cudf}
+                        PINNED_TAG ${rapids-cmake-checkout-tag}
                         )

--- a/cpp/libcugraph_etl/cmake/thirdparty/get_cugraph.cmake
+++ b/cpp/libcugraph_etl/cmake/thirdparty/get_cugraph.cmake
@@ -35,7 +35,6 @@ function(find_and_configure_cugraph)
 endfunction()
 
 set(CUGRAPH_ETL_MIN_VERSION_cugraph "${CUGRAPH_ETL_VERSION_MAJOR}.${CUGRAPH_ETL_VERSION_MINOR}.00")
-set(CUGRAPH_ETL_BRANCH_VERSION_cugraph "${CUGRAPH_ETL_VERSION_MAJOR}.${CUGRAPH_ETL_VERSION_MINOR}")
 
 
 # Change pinned tag and fork here to test a commit in CI
@@ -43,5 +42,5 @@ set(CUGRAPH_ETL_BRANCH_VERSION_cugraph "${CUGRAPH_ETL_VERSION_MAJOR}.${CUGRAPH_E
 # CPM_cugraph_SOURCE=/path/to/local/cugraph
 find_and_configure_cugraph(VERSION    ${CUGRAPH_ETL_MIN_VERSION_cugraph}
                            FORK       rapidsai
-                           PINNED_TAG branch-${CUGRAPH_ETL_BRANCH_VERSION_cugraph}
+                           PINNED_TAG ${rapids-cmake-checkout-tag}
                            )


### PR DESCRIPTION
This is required to handle when we switch RAPIDS branching strategy