### PR TITLE
remove references to DGL

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -3,8 +3,6 @@
 
 set -euo pipefail
 
-DGL_CHANNEL="dglteam/label/th23_cu121"
-
 rapids-logger "Downloading artifacts from previous jobs"
 CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
 PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
@@ -26,7 +24,6 @@ rapids-dependency-file-generator \
   --prepend-channel "${CPP_CHANNEL}" \
   --prepend-channel "${PYTHON_CHANNEL}" \
   --prepend-channel conda-forge \
-  --prepend-channel "${DGL_CHANNEL}" \
   | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n docs

--- a/python/cugraph/cugraph/tests/sampling/test_uniform_neighbor_sample_mg.py
+++ b/python/cugraph/cugraph/tests/sampling/test_uniform_neighbor_sample_mg.py
@@ -954,7 +954,7 @@ def test_uniform_neighbor_sample_deduplicate_sources_email_eu_core(dask_client):
 def test_uniform_neighbor_sample_renumber(dask_client, hops):
     # FIXME This test is not very good because there is a lot of
     # non-deterministic behavior that still exists despite passing
-    # a random seed. Right now, there are tests in cuGraph-DGL and
+    # a random seed. Right now, there are tests in
     # cuGraph-PyG that provide better coverage, but a better test
     # should eventually be written to augment or replace this one.
 


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/203

Removes references to DGL and `cugraph-dgl`, now that we are no longer publishing `cugraph-dgl` packages.

## Notes for reviewers

Found these like this:

```shell
git grep -i dgl
```