### PR TITLE
Fix sampling bug introduced by compile time optimizations

### DIFF
--- a/cpp/src/sampling/detail/gather_one_hop_impl.cuh
+++ b/cpp/src/sampling/detail/gather_one_hop_impl.cuh
@@ -199,22 +199,34 @@ simple_gather_one_hop_without_multi_edge_indices(
 template <typename vertex_t, typename edge_t, bool multi_gpu>
 std::tuple<rmm::device_uvector<vertex_t>,
            rmm::device_uvector<vertex_t>,
-           std::optional<rmm::device_uvector<edge_t>>,
+           arithmetic_device_uvector_t,
            std::optional<rmm::device_uvector<int32_t>>>
 filter_edge_by_type(raft::handle_t const& handle,
                     graph_view_t<vertex_t, edge_t, false, multi_gpu> const& graph_view,
                     edge_property_view_t<edge_t, int32_t const*> edge_type_view,
-                    edge_bucket_t<vertex_t, edge_t, true, multi_gpu, false>& edge_list,
                     rmm::device_uvector<vertex_t>&& srcs,
                     rmm::device_uvector<vertex_t>&& dsts,
-                    std::optional<rmm::device_uvector<edge_t>>&& edge_indices,
+                    arithmetic_device_uvector_t&& edge_indices,
                     std::optional<rmm::device_uvector<int32_t>>&& labels,
                     raft::device_span<uint8_t const> gather_flags)
 {
   // Filter by type
   using edge_type_t = int32_t;
 
+  const bool store_transposed = false;
+
   rmm::device_uvector<edge_type_t> edge_type(srcs.size(), handle.get_stream());
+
+  cugraph::edge_bucket_t<vertex_t, edge_t, !store_transposed, multi_gpu, false> edge_list(
+    handle, graph_view.is_multigraph());
+
+  edge_list.insert(
+    srcs.begin(),
+    srcs.end(),
+    dsts.begin(),
+    std::holds_alternative<rmm::device_uvector<edge_t>>(edge_indices)
+      ? std::make_optional(std::get<rmm::device_uvector<edge_t>>(edge_indices).begin())
+      : std::nullopt);
 
   cugraph::transform_gather_e(handle,
                               graph_view,
@@ -234,9 +246,12 @@ filter_edge_by_type(raft::handle_t const& handle,
 
   srcs = detail::keep_marked_entries(handle, std::move(srcs), marked_entry_span, keep_count);
   dsts = detail::keep_marked_entries(handle, std::move(dsts), marked_entry_span, keep_count);
-  if (edge_indices) {
-    *edge_indices =
-      detail::keep_marked_entries(handle, std::move(*edge_indices), marked_entry_span, keep_count);
+  if (std::holds_alternative<rmm::device_uvector<edge_t>>(edge_indices)) {
+    edge_indices =
+      detail::keep_marked_entries(handle,
+                                  std::move(std::get<rmm::device_uvector<edge_t>>(edge_indices)),
+                                  marked_entry_span,
+                                  keep_count);
   }
   if (labels) {
     *labels =
@@ -264,8 +279,6 @@ gather_one_hop_edgelist(
   std::optional<raft::device_span<uint8_t const>> gather_flags,
   bool do_expensive_check)
 {
-  constexpr bool store_transposed = false;
-
   rmm::device_uvector<vertex_t> result_srcs(0, handle.get_stream());
   rmm::device_uvector<vertex_t> result_dsts(0, handle.get_stream());
   std::vector<arithmetic_device_uvector_t> result_properties{};
@@ -280,10 +293,7 @@ gather_one_hop_edgelist(
       simple_gather_one_hop_without_multi_edge_indices(
         handle, graph_view, active_majors, active_major_labels, do_expensive_check);
   } else {
-    cugraph::edge_bucket_t<vertex_t, edge_t, !store_transposed, multi_gpu, false> edge_list(
-      handle, graph_view.is_multigraph());
-
-    std::optional<rmm::device_uvector<edge_t>> tmp_edge_indices{std::nullopt};
+    arithmetic_device_uvector_t tmp_edge_indices{std::monostate{}};
 
     if (graph_view.is_multigraph()) {
       cugraph::edge_multi_index_property_t<edge_t, vertex_t> multi_index_property(handle,
@@ -296,20 +306,10 @@ gather_one_hop_edgelist(
                                                       active_majors,
                                                       active_major_labels,
                                                       do_expensive_check);
-
-      edge_list.insert(result_srcs.begin(),
-                       result_srcs.end(),
-                       result_dsts.begin(),
-                       std::make_optional<edge_t const*>(tmp_edge_indices->begin()));
     } else {
       std::tie(result_srcs, result_dsts, result_labels) =
         simple_gather_one_hop_without_multi_edge_indices(
           handle, graph_view, active_majors, active_major_labels, do_expensive_check);
-
-      edge_list.insert(result_srcs.begin(),
-                       result_srcs.end(),
-                       result_dsts.begin(),
-                       std::optional<edge_t*>{std::nullopt});
     }
 
     if (gather_flags) {
@@ -317,25 +317,19 @@ gather_one_hop_edgelist(
         filter_edge_by_type(handle,
                             graph_view,
                             *edge_type_view,
-                            edge_list,
                             std::move(result_srcs),
                             std::move(result_dsts),
                             std::move(tmp_edge_indices),
                             std::move(result_labels),
                             *gather_flags);
-
-      edge_list.clear();
-      edge_list.insert(result_srcs.begin(),
-                       result_srcs.end(),
-                       result_dsts.begin(),
-                       tmp_edge_indices ? std::optional<edge_t*>{tmp_edge_indices->begin()}
-                                        : std::optional<edge_t*>{std::nullopt});
     }
 
-    result_properties =
+    std::tie(result_srcs, result_dsts, result_properties) =
       gather_sampled_properties(handle,
                                 graph_view,
-                                edge_list,
+                                std::move(result_srcs),
+                                std::move(result_dsts),
+                                std::move(tmp_edge_indices),
                                 raft::host_span<edge_arithmetic_property_view_t<edge_t>>{
                                   edge_property_views.data(), edge_property_views.size()});
   }
@@ -376,9 +370,6 @@ temporal_gather_one_hop_edgelist(
                   "Temporal requires at least one edge property - the time");
   using label_t = int32_t;
 
-  cugraph::edge_bucket_t<vertex_t, edge_t, !store_transposed, multi_gpu, false> edge_list(
-    handle, graph_view.is_multigraph());
-
   // Only used if active_major_labels is set
   kv_store_t<size_t, thrust::tuple<edge_time_t, label_t>, true> kv_store{handle.get_stream()};
   std::optional<rmm::device_uvector<size_t>> tmp_positions{std::nullopt};
@@ -387,7 +378,7 @@ temporal_gather_one_hop_edgelist(
   std::optional<rmm::device_uvector<edge_time_t>> tmp_times{std::nullopt};
 
   // Only used if graph_view is a multi_graph
-  std::optional<rmm::device_uvector<edge_t>> tmp_edge_indices{std::nullopt};
+  arithmetic_device_uvector_t tmp_edge_indices{std::monostate{}};
 
   if (active_major_labels) {
     //
@@ -465,11 +456,6 @@ temporal_gather_one_hop_edgelist(
           std::make_optional(raft::device_span<size_t const>{vertex_label_time_positions.data(),
                                                              vertex_label_time_positions.size()}),
           do_expensive_check);
-
-      edge_list.insert(result_srcs.begin(),
-                       result_srcs.end(),
-                       result_dsts.begin(),
-                       std::make_optional<edge_t const*>(tmp_edge_indices->begin()));
     } else {
       std::tie(result_srcs, result_dsts, tmp_positions) =
         simple_gather_one_hop_without_multi_edge_indices(
@@ -479,11 +465,6 @@ temporal_gather_one_hop_edgelist(
           std::make_optional(raft::device_span<size_t const>{vertex_label_time_positions.data(),
                                                              vertex_label_time_positions.size()}),
           do_expensive_check);
-
-      edge_list.insert(result_srcs.begin(),
-                       result_srcs.end(),
-                       result_dsts.begin(),
-                       std::optional<edge_t*>{std::nullopt});
     }
   } else {
     // Can use time directly
@@ -501,11 +482,6 @@ temporal_gather_one_hop_edgelist(
                                                       active_majors,
                                                       std::make_optional(active_major_times),
                                                       do_expensive_check);
-
-      edge_list.insert(result_srcs.begin(),
-                       result_srcs.end(),
-                       result_dsts.begin(),
-                       std::make_optional<edge_t const*>(tmp_edge_indices->begin()));
     } else {
       std::tie(result_srcs, result_dsts, tmp_times) =
         simple_gather_one_hop_without_multi_edge_indices(handle,
@@ -513,11 +489,6 @@ temporal_gather_one_hop_edgelist(
                                                          active_majors,
                                                          std::make_optional(active_major_times),
                                                          do_expensive_check);
-
-      edge_list.insert(result_srcs.begin(),
-                       result_srcs.end(),
-                       result_dsts.begin(),
-                       std::optional<edge_t*>{std::nullopt});
     }
   }
 
@@ -526,97 +497,101 @@ temporal_gather_one_hop_edgelist(
       filter_edge_by_type(handle,
                           graph_view,
                           *edge_type_view,
-                          edge_list,
                           std::move(result_srcs),
                           std::move(result_dsts),
                           std::move(tmp_edge_indices),
                           std::move(result_labels),
                           *gather_flags);
-
-    edge_list.clear();
-    edge_list.insert(result_srcs.begin(),
-                     result_srcs.end(),
-                     result_dsts.begin(),
-                     tmp_edge_indices ? std::optional<edge_t*>{tmp_edge_indices->begin()}
-                                      : std::optional<edge_t*>{std::nullopt});
   }
 
   // Filter by time
-  rmm::device_uvector<edge_time_t> edge_times(result_srcs.size(), handle.get_stream());
+  {
+    rmm::device_uvector<edge_time_t> edge_times(result_srcs.size(), handle.get_stream());
 
-  cugraph::transform_gather_e(handle,
-                              graph_view,
-                              edge_list,
-                              edge_src_dummy_property_t{}.view(),
-                              edge_dst_dummy_property_t{}.view(),
-                              edge_time_view,
-                              return_edge_property_t{},
-                              edge_times.begin());
+    cugraph::edge_bucket_t<vertex_t, edge_t, !store_transposed, multi_gpu, false> edge_list(
+      handle, graph_view.is_multigraph());
 
-  auto [keep_count, marked_entries] =
-    tmp_positions
-      ? detail::mark_entries(handle,
-                             edge_times.size(),
-                             [d_tmp           = edge_times.data(),
-                              d_tmp_positions = tmp_positions->data(),
-                              kv_store_view =
-                                kv_binary_search_store_device_view_t<decltype(kv_store.view())>{
-                                  kv_store.view()}] __device__(auto index) {
-                               auto edge_time = d_tmp[index];
-                               auto key_time =
-                                 cuda::std::get<0>(kv_store_view.find(d_tmp_positions[index]));
-                               return (edge_time > key_time);
-                             })
-      : detail::mark_entries(
-          handle,
-          edge_times.size(),
-          [d_tmp = edge_times.data(), d_tmp_time = tmp_times->data()] __device__(auto index) {
-            auto edge_time = d_tmp[index];
-            auto key_time  = d_tmp_time[index];
-            return (edge_time > key_time);
-          });
+    edge_list.insert(
+      result_srcs.begin(),
+      result_srcs.end(),
+      result_dsts.begin(),
+      std::holds_alternative<rmm::device_uvector<edge_t>>(tmp_edge_indices)
+        ? std::make_optional(std::get<rmm::device_uvector<edge_t>>(tmp_edge_indices).begin())
+        : std::nullopt);
 
-  raft::device_span<uint32_t const> marked_entry_span{marked_entries.data(), marked_entries.size()};
+    cugraph::transform_gather_e(handle,
+                                graph_view,
+                                edge_list,
+                                edge_src_dummy_property_t{}.view(),
+                                edge_dst_dummy_property_t{}.view(),
+                                edge_time_view,
+                                return_edge_property_t{},
+                                edge_times.begin());
 
-  result_srcs =
-    detail::keep_marked_entries(handle, std::move(result_srcs), marked_entry_span, keep_count);
-  result_dsts =
-    detail::keep_marked_entries(handle, std::move(result_dsts), marked_entry_span, keep_count);
-  if (tmp_edge_indices) {
-    *tmp_edge_indices = detail::keep_marked_entries(
-      handle, std::move(*tmp_edge_indices), marked_entry_span, keep_count);
+    auto [keep_count, marked_entries] =
+      tmp_positions
+        ? detail::mark_entries(handle,
+                               edge_times.size(),
+                               [d_tmp           = edge_times.data(),
+                                d_tmp_positions = tmp_positions->data(),
+                                kv_store_view =
+                                  kv_binary_search_store_device_view_t<decltype(kv_store.view())>{
+                                    kv_store.view()}] __device__(auto index) {
+                                 auto edge_time = d_tmp[index];
+                                 auto key_time =
+                                   cuda::std::get<0>(kv_store_view.find(d_tmp_positions[index]));
+                                 return (edge_time > key_time);
+                               })
+        : detail::mark_entries(
+            handle,
+            edge_times.size(),
+            [d_tmp = edge_times.data(), d_tmp_time = tmp_times->data()] __device__(auto index) {
+              auto edge_time = d_tmp[index];
+              auto key_time  = d_tmp_time[index];
+              return (edge_time > key_time);
+            });
+
+    raft::device_span<uint32_t const> marked_entry_span{marked_entries.data(),
+                                                        marked_entries.size()};
+
+    result_srcs =
+      detail::keep_marked_entries(handle, std::move(result_srcs), marked_entry_span, keep_count);
+    result_dsts =
+      detail::keep_marked_entries(handle, std::move(result_dsts), marked_entry_span, keep_count);
+    if (std::holds_alternative<rmm::device_uvector<edge_t>>(tmp_edge_indices)) {
+      tmp_edge_indices = detail::keep_marked_entries(
+        handle,
+        std::move(std::get<rmm::device_uvector<edge_t>>(tmp_edge_indices)),
+        marked_entry_span,
+        keep_count);
+    }
+    if (tmp_times) {
+      *tmp_times =
+        detail::keep_marked_entries(handle, std::move(*tmp_times), marked_entry_span, keep_count);
+    }
+    if (tmp_positions) {
+      *tmp_positions = detail::keep_marked_entries(
+        handle, std::move(*tmp_positions), marked_entry_span, keep_count);
+    }
+
+    result_labels = rmm::device_uvector<label_t>(keep_count, handle.get_stream());
+    thrust::transform(
+      handle.get_thrust_policy(),
+      tmp_positions->begin(),
+      tmp_positions->end(),
+      result_labels->begin(),
+      [kv_store_view = kv_binary_search_store_device_view_t<decltype(kv_store.view())>{
+         kv_store.view()}] __device__(auto pos) {
+        return cuda::std::get<1>(kv_store_view.find(pos));
+      });
   }
-  if (tmp_times) {
-    *tmp_times =
-      detail::keep_marked_entries(handle, std::move(*tmp_times), marked_entry_span, keep_count);
-  }
-  if (tmp_positions) {
-    *tmp_positions =
-      detail::keep_marked_entries(handle, std::move(*tmp_positions), marked_entry_span, keep_count);
-  }
 
-  result_labels = rmm::device_uvector<label_t>(keep_count, handle.get_stream());
-  thrust::transform(
-    handle.get_thrust_policy(),
-    tmp_positions->begin(),
-    tmp_positions->end(),
-    result_labels->begin(),
-    [kv_store_view = kv_binary_search_store_device_view_t<decltype(kv_store.view())>{
-       kv_store.view()}] __device__(auto pos) {
-      return cuda::std::get<1>(kv_store_view.find(pos));
-    });
-
-  edge_list.clear();
-  edge_list.insert(result_srcs.begin(),
-                   result_srcs.end(),
-                   result_dsts.begin(),
-                   tmp_edge_indices ? std::optional<edge_t*>{tmp_edge_indices->begin()}
-                                    : std::optional<edge_t*>{std::nullopt});
-
-  result_properties =
+  std::tie(result_srcs, result_dsts, result_properties) =
     gather_sampled_properties(handle,
                               graph_view,
-                              edge_list,
+                              std::move(result_srcs),
+                              std::move(result_dsts),
+                              std::move(tmp_edge_indices),
                               raft::host_span<edge_arithmetic_property_view_t<edge_t>>{
                                 edge_property_views.data(), edge_property_views.size()});
 

--- a/cpp/src/sampling/detail/gather_sampled_properties.cu
+++ b/cpp/src/sampling/detail/gather_sampled_properties.cu
@@ -14,14 +14,21 @@
  * limitations under the License.
  */
 
+#include "detail/graph_partition_utils.cuh"
 #include "prims/edge_bucket.cuh"
 #include "prims/transform_gather_e.cuh"
 
 #include <cugraph/arithmetic_variant_types.hpp>
+#include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/graph_view.hpp>
+#include <cugraph/shuffle_functions.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/core/host_span.hpp>
+
+#include <rmm/device_uvector.hpp>
+
+#include <variant>
 
 namespace cugraph {
 namespace detail {
@@ -30,8 +37,8 @@ namespace {
 
 struct return_edge_property_t {
   template <typename key_t, typename vertex_t, typename T>
-  T __device__
-  operator()(key_t, vertex_t, cuda::std::nullopt_t, cuda::std::nullopt_t, T edge_property) const
+  T __device__ operator()(
+    key_t src, vertex_t dst, cuda::std::nullopt_t, cuda::std::nullopt_t, T edge_property) const
   {
     return edge_property;
   }
@@ -40,12 +47,59 @@ struct return_edge_property_t {
 }  // namespace
 
 template <typename vertex_t, typename edge_t, bool multi_gpu>
-std::vector<arithmetic_device_uvector_t> gather_sampled_properties(
+std::tuple<rmm::device_uvector<vertex_t>,
+           rmm::device_uvector<vertex_t>,
+           std::vector<arithmetic_device_uvector_t>>
+gather_sampled_properties(
   raft::handle_t const& handle,
   graph_view_t<vertex_t, edge_t, false, multi_gpu> const& graph_view,
-  edge_bucket_t<vertex_t, edge_t, true, multi_gpu, false>& edge_list,
+  rmm::device_uvector<vertex_t>&& majors,
+  rmm::device_uvector<vertex_t>&& minors,
+  arithmetic_device_uvector_t&& multi_index,
   raft::host_span<edge_arithmetic_property_view_t<edge_t>> edge_property_views)
 {
+  const bool store_transposed = false;
+
+  std::optional<cugraph::edge_multi_index_property_t<edge_t, vertex_t>> multi_edge_indices{
+    std::nullopt};
+
+  cugraph::edge_bucket_t<vertex_t, edge_t, !store_transposed, multi_gpu, false> edge_list(
+    handle, graph_view.is_multigraph());
+
+  // FIXME:  There is a mismatch here.  per_v_random_select_transform_outgoing_e shuffles the
+  // sampled results so that the selected vertices are on the GPU of the major vertex.  But
+  // transform_gather_e expects them to be shuffled by the location of the edge.  It seems like we
+  // could make per_v_random_select_transform_outgoing_e output by the edge location and potentially
+  // save this shuffle (and the one that follows transform_gather_e).  It's not clear that sampling
+  // benefits from gathering the sampled edges in this way.
+
+  //
+  // Shuffle majors/minors/multi-index
+  //
+  if constexpr (multi_gpu) {
+    std::vector<cugraph::arithmetic_device_uvector_t> edge_properties{};
+    if (std::holds_alternative<rmm::device_uvector<edge_t>>(multi_index))
+      edge_properties.push_back(std::move(multi_index));
+
+    std::tie(majors, minors, edge_properties, std::ignore) =
+      shuffle_int_edges(handle,
+                        std::move(majors),
+                        std::move(minors),
+                        std::move(edge_properties),
+                        store_transposed,
+                        graph_view.vertex_partition_range_lasts(),
+                        std::nullopt);
+    if (edge_properties.size() > 0) multi_index = std::move(edge_properties[0]);
+  }
+
+  edge_list.insert(
+    majors.begin(),
+    majors.end(),
+    minors.begin(),
+    (std::holds_alternative<rmm::device_uvector<edge_t>>(multi_index))
+      ? std::make_optional(std::get<rmm::device_uvector<edge_t>>(multi_index).begin())
+      : std::nullopt);
+
   std::vector<arithmetic_device_uvector_t> result_properties{};
 
   std::for_each(edge_property_views.begin(),
@@ -75,31 +129,134 @@ std::vector<arithmetic_device_uvector_t> gather_sampled_properties(
                     });
                 });
 
-  return result_properties;
+  // Now shuffle back
+  if constexpr (multi_gpu) {
+    auto& comm                 = handle.get_comms();
+    auto const comm_size       = comm.get_size();
+    auto& major_comm           = handle.get_subcomm(cugraph::partition_manager::major_comm_name());
+    auto const major_comm_size = major_comm.get_size();
+    auto& minor_comm           = handle.get_subcomm(cugraph::partition_manager::minor_comm_name());
+    auto const minor_comm_size = minor_comm.get_size();
+
+    rmm::device_uvector<size_t> property_position(majors.size(), handle.get_stream());
+    detail::sequence_fill(
+      handle.get_stream(), property_position.data(), property_position.size(), size_t{0});
+
+    rmm::device_uvector<vertex_t> d_vertex_partition_range_lasts(
+      graph_view.vertex_partition_range_lasts().size(), handle.get_stream());
+    raft::update_device(d_vertex_partition_range_lasts.data(),
+                        graph_view.vertex_partition_range_lasts().data(),
+                        graph_view.vertex_partition_range_lasts().size(),
+                        handle.get_stream());
+
+    size_t element_size{sizeof(vertex_t) + sizeof(size_t)};
+    auto total_global_mem = handle.get_device_properties().totalGlobalMem;
+    auto constexpr mem_frugal_ratio =
+      0.1;  // if the expected temporary buffer size exceeds the mem_frugal_ratio of the
+            // total_global_mem, switch to the memory frugal approach (thrust::sort is used to
+            // group-by by default, and thrust::sort requires temporary buffer comparable to the
+            // input data size)
+    auto mem_frugal_threshold =
+      static_cast<size_t>(static_cast<double>(total_global_mem / element_size) * mem_frugal_ratio);
+
+    auto d_tx_value_counts = cugraph::groupby_and_count(
+      majors.begin(),
+      majors.end(),
+      property_position.begin(),
+      cugraph::detail::compute_gpu_id_from_int_vertex_t<vertex_t>{
+        raft::device_span<vertex_t const>(d_vertex_partition_range_lasts.data(),
+                                          d_vertex_partition_range_lasts.size()),
+        major_comm_size,
+        minor_comm_size},
+      comm_size,
+      mem_frugal_threshold,
+      handle.get_stream());
+
+    raft::device_span<size_t const> d_tx_value_counts_span{d_tx_value_counts.data(),
+                                                           d_tx_value_counts.size()};
+
+    std::tie(majors, std::ignore) =
+      shuffle_values(comm, majors.begin(), d_tx_value_counts_span, handle.get_stream());
+
+    {
+      rmm::device_uvector<vertex_t> tmp(minors.size(), handle.get_stream());
+
+      thrust::gather(handle.get_thrust_policy(),
+                     property_position.begin(),
+                     property_position.end(),
+                     minors.begin(),
+                     tmp.begin());
+
+      std::tie(minors, std::ignore) =
+        shuffle_values(comm, tmp.begin(), d_tx_value_counts_span, handle.get_stream());
+    }
+
+    std::for_each(
+      result_properties.begin(),
+      result_properties.end(),
+      [&handle, &comm, &property_position, d_tx_value_counts_span](auto& property) {
+        cugraph::variant_type_dispatch(
+          property, [&handle, &comm, &property_position, d_tx_value_counts_span](auto& prop) {
+            using T = typename std::remove_reference<decltype(prop)>::type::value_type;
+            rmm::device_uvector<T> tmp(prop.size(), handle.get_stream());
+
+            thrust::gather(handle.get_thrust_policy(),
+                           property_position.begin(),
+                           property_position.end(),
+                           prop.begin(),
+                           tmp.begin());
+
+            std::tie(prop, std::ignore) =
+              shuffle_values(comm, tmp.begin(), d_tx_value_counts_span, handle.get_stream());
+          });
+      });
+  }
+
+  return std::make_tuple(std::move(majors), std::move(minors), std::move(result_properties));
 }
 
-template std::vector<arithmetic_device_uvector_t> gather_sampled_properties(
+template std::tuple<rmm::device_uvector<int32_t>,
+                    rmm::device_uvector<int32_t>,
+                    std::vector<arithmetic_device_uvector_t>>
+gather_sampled_properties(
   raft::handle_t const& handle,
   graph_view_t<int32_t, int32_t, false, false> const& graph_view,
-  cugraph::edge_bucket_t<int32_t, int32_t, true, false, false>& edge_list,
+  rmm::device_uvector<int32_t>&& majors,
+  rmm::device_uvector<int32_t>&& minors,
+  arithmetic_device_uvector_t&& multi_index,
   raft::host_span<edge_arithmetic_property_view_t<int32_t>> edge_property_views);
 
-template std::vector<arithmetic_device_uvector_t> gather_sampled_properties(
+template std::tuple<rmm::device_uvector<int64_t>,
+                    rmm::device_uvector<int64_t>,
+                    std::vector<arithmetic_device_uvector_t>>
+gather_sampled_properties(
   raft::handle_t const& handle,
   graph_view_t<int64_t, int64_t, false, false> const& graph_view,
-  cugraph::edge_bucket_t<int64_t, int64_t, true, false, false>& edge_list,
+  rmm::device_uvector<int64_t>&& majors,
+  rmm::device_uvector<int64_t>&& minors,
+  arithmetic_device_uvector_t&& multi_index,
   raft::host_span<edge_arithmetic_property_view_t<int64_t>> edge_property_views);
 
-template std::vector<arithmetic_device_uvector_t> gather_sampled_properties(
+template std::tuple<rmm::device_uvector<int32_t>,
+                    rmm::device_uvector<int32_t>,
+                    std::vector<arithmetic_device_uvector_t>>
+gather_sampled_properties(
   raft::handle_t const& handle,
   graph_view_t<int32_t, int32_t, false, true> const& graph_view,
-  cugraph::edge_bucket_t<int32_t, int32_t, true, true, false>& edge_list,
+  rmm::device_uvector<int32_t>&& majors,
+  rmm::device_uvector<int32_t>&& minors,
+  arithmetic_device_uvector_t&& multi_index,
   raft::host_span<edge_arithmetic_property_view_t<int32_t>> edge_property_views);
 
-template std::vector<arithmetic_device_uvector_t> gather_sampled_properties(
+template std::tuple<rmm::device_uvector<int64_t>,
+                    rmm::device_uvector<int64_t>,
+                    std::vector<arithmetic_device_uvector_t>>
+gather_sampled_properties(
   raft::handle_t const& handle,
   graph_view_t<int64_t, int64_t, false, true> const& graph_view,
-  cugraph::edge_bucket_t<int64_t, int64_t, true, true, false>& edge_list,
+  rmm::device_uvector<int64_t>&& majors,
+  rmm::device_uvector<int64_t>&& minors,
+  arithmetic_device_uvector_t&& multi_index,
   raft::host_span<edge_arithmetic_property_view_t<int64_t>> edge_property_views);
 
 }  // namespace detail

--- a/cpp/src/sampling/detail/gather_sampled_properties.cuh
+++ b/cpp/src/sampling/detail/gather_sampled_properties.cuh
@@ -32,10 +32,15 @@ namespace detail {
  *
  */
 template <typename vertex_t, typename edge_t, bool multi_gpu>
-std::vector<arithmetic_device_uvector_t> gather_sampled_properties(
+std::tuple<rmm::device_uvector<vertex_t>,
+           rmm::device_uvector<vertex_t>,
+           std::vector<arithmetic_device_uvector_t>>
+gather_sampled_properties(
   raft::handle_t const& handle,
   graph_view_t<vertex_t, edge_t, false, multi_gpu> const& graph_view,
-  cugraph::edge_bucket_t<vertex_t, edge_t, true, multi_gpu, false>& edge_list,
+  rmm::device_uvector<vertex_t>&& majors,
+  rmm::device_uvector<vertex_t>&& minors,
+  arithmetic_device_uvector_t&& multi_index,
   raft::host_span<edge_arithmetic_property_view_t<edge_t>> edge_property_views);
 
 }  // namespace detail

--- a/cpp/tests/c_api/mg_uniform_neighbor_sample_test.c
+++ b/cpp/tests/c_api/mg_uniform_neighbor_sample_test.c
@@ -925,6 +925,8 @@ int test_uniform_neighbor_sample_alex_bug(const cugraph_resource_handle_t* handl
 
   cugraph_graph_free(graph);
   cugraph_error_free(ret_error);
+
+  return test_ret_value;
 }
 
 int test_uniform_neighbor_sample_sort_by_hop(const cugraph_resource_handle_t* handle)
@@ -1199,6 +1201,8 @@ int test_uniform_neighbor_sample_sort_by_hop(const cugraph_resource_handle_t* ha
 
   cugraph_graph_free(graph);
   cugraph_error_free(ret_error);
+
+  return test_ret_value;
 }
 
 int test_uniform_neighbor_sample_dedupe_sources(const cugraph_resource_handle_t* handle)


### PR DESCRIPTION
As part of the compile time optimizations, we started using transform_gather_e.  Unfortunately, the relevant C API tests were not properly returning error codes, so we never detected that there was a bug in this code.

The new primitive `transform_gather_e` expects input edges to be shuffled to the proper GPU, but `per_v_random_select_transform_outgoing_e` does not shuffle them that way, they are shuffled by the major vertex.

This PR adds a shuffle prior to the `transform_gather_e` to get the sampled edges on the proper GPU to retrieve their properties, and then shuffles them back to the GPU of the major vertex.

Also added a FIXME to consider a more optimal solution in the future.