### PR TITLE
Update rapids-build-backend to 0.4.1

### DIFF
--- a/conda/recipes/cugraph-service/recipe.yaml
+++ b/conda/recipes/cugraph-service/recipe.yaml
@@ -36,7 +36,7 @@ outputs:
       host:
         - pip
         - python =${{ py_version }}
-        - rapids-build-backend >=0.3.0,<0.4.0.dev0
+        - rapids-build-backend >=0.4.0,<0.5.0.dev0
         - setuptools>=61.0.0
       run:
         - python
@@ -67,7 +67,7 @@ outputs:
       host:
         - pip
         - python =${{ py_version }}
-        - rapids-build-backend >=0.3.0,<0.4.0.dev0
+        - rapids-build-backend >=0.4.0,<0.5.0.dev0
         - setuptools>=61.0.0
         - wheel
       run:

--- a/conda/recipes/cugraph/recipe.yaml
+++ b/conda/recipes/cugraph/recipe.yaml
@@ -65,7 +65,7 @@ requirements:
     - python =${{ py_version }}
     - raft-dask =${{ minor_version }}
     - rmm =${{ minor_version }}
-    - rapids-build-backend >=0.3.0,<0.4.0.dev0
+    - rapids-build-backend >=0.4.0,<0.5.0.dev0
     - scikit-build-core >=0.10.0
     - cuda-cudart-dev
   run:

--- a/conda/recipes/libcugraph/recipe.yaml
+++ b/conda/recipes/libcugraph/recipe.yaml
@@ -62,7 +62,7 @@ cache:
       - libucxx ${{ libucxx_version }}
       - nccl ${{ nccl_version }}
       - openmpi <5.0.3 # Required for building cpp-mgtests (multi-GPU tests)
-      - rapids-build-backend >=0.3.1,<0.4.0.dev0
+      - rapids-build-backend >=0.4.0,<0.5.0.dev0
       - cuda-nvtx-dev
       - cuda-profiler-api
       - cuda-cudart-dev

--- a/conda/recipes/pylibcugraph/recipe.yaml
+++ b/conda/recipes/pylibcugraph/recipe.yaml
@@ -54,7 +54,7 @@ requirements:
     - pip
     - pylibraft =${{ minor_version }}
     - python =${{ py_version }}
-    - rapids-build-backend >=0.3.0,<0.4.0.dev0
+    - rapids-build-backend >=0.4.0,<0.5.0.dev0
     - scikit-build-core >=0.10.0
     - cuda-cudart-dev
   run:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -381,7 +381,7 @@ dependencies:
     common:
       - output_types: [conda, pyproject, requirements]
         packages:
-          - rapids-build-backend>=0.3.1,<0.4.0.dev0
+          - rapids-build-backend>=0.4.0,<0.5.0.dev0
   python_build_skbuild:
     common:
       - output_types: conda


### PR DESCRIPTION
This PR updates rapids-build-backend to 0.4.1, and errors out if any MANIFEST.in file is present.
