### PR TITLE
[HOTFIX] Skips PG benchmarks for cyber datasets

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -76,7 +76,7 @@ rapids-logger "pytest cugraph (not mg, with xdist)"
   --numprocesses=8 \
   --dist=worksteal \
   -m "not mg" \
-  -k "not test_bulk_sampler and not test_create_undirected_graph_from_asymmetric_adj_list and not test_uniform_neighbor_sample and not test_node2vec" \
+  -k "not test_bulk_sampler and not test_create_undirected_graph_from_asymmetric_adj_list and not test_uniform_neighbor_sample and not test_node2vec and not(test_property_graph.py and cyber)" \
   --cov-config=../../.coveragerc \
   --cov=cugraph \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cugraph-coverage.xml" \


### PR DESCRIPTION
Skips PG benchmarks for cyber datasets.
This is temporary until a better fix that allows these tests to run with `pytest-xdist` is done.