### PR TITLE
Raise wheel size threshold for libcugraph

### DIFF
--- a/python/libcugraph/pyproject.toml
+++ b/python/libcugraph/pyproject.toml
@@ -53,7 +53,7 @@ select = [
 ]
 
 # detect when package size grows significantly
-max_allowed_size_compressed = '1.4G'
+max_allowed_size_compressed = '1.6G'
 
 [tool.scikit-build]
 build-dir = "build/{wheel_tag}"


### PR DESCRIPTION
RAPIDS added building for more GPU architectures, this increased our library size by about 10%, raising threshold accordingly.

We are generally working toward decreasing the library size, but this will take a while.