### PR TITLE
remove cugraph-pyg and wholegraph configuration

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -47,7 +47,6 @@ NEXT_UCXX_SHORT_TAG_PEP440=$(python -c "from packaging.version import Version; p
 DEPENDENCIES=(
   cudf
   cugraph
-  cugraph-pyg
   cugraph-service-server
   cugraph-service-client
   cuxfilter
@@ -61,7 +60,6 @@ DEPENDENCIES=(
   librmm
   pylibcudf
   pylibcugraph
-  pylibwholegraph
   pylibraft
   pyraft
   raft-dask

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -511,25 +511,6 @@ dependencies:
             packages:
               - cugraph-cu12==25.10.*,>=0.0.0a0
           - {matrix: null, packages: [*cugraph_unsuffixed]}
-  depends_on_cugraph_pyg:
-    common:
-      - output_types: conda
-        packages:
-          - &cugraph_pyg_unsuffixed cugraph-pyg==25.10.*,>=0.0.0a0
-      - output_types: requirements
-        packages:
-          # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
-          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
-    specific:
-      - output_types: [requirements, pyproject]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "true"
-            packages:
-              - cugraph-pyg-cu12==25.10.*,>=0.0.0a0
-          - {matrix: null, packages: [*cugraph_pyg_unsuffixed]}
   depends_on_cugraph_service_client:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -583,25 +564,6 @@ dependencies:
               - &pytorch_pip torch>=2.3
               - &tensordict tensordict>=0.1.2
           - {matrix: null, packages: [*pytorch_pip, *tensordict]}
-  depends_on_pylibwholegraph:
-    common:
-      - output_types: conda
-        packages:
-          - &pylibwholegraph_unsuffixed pylibwholegraph==25.10.*,>=0.0.0a0
-      - output_types: requirements
-        packages:
-          # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
-          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
-    specific:
-      - output_types: [requirements, pyproject]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "true"
-            packages:
-              - pylibwholegraph-cu12==25.10.*,>=0.0.0a0
-          - {matrix: null, packages: [*pylibwholegraph_unsuffixed]}
   depends_on_libcudf:
     common:
       - output_types: conda


### PR DESCRIPTION
This project no longer has any dependency on `cugraph-pyg` or `pylibwholegraph`.

This removes some lingering configuration for them in `dependencies.yaml` and `update-version.sh`.

## Notes for Reviewers

Discovered while working on #5236. Getting this merged soon would make the diff there a bit smaller.

Found like this:

```shell
git grep -i pyg
git grep -i wholegraph
```