### PR TITLE
Update rapids-dependency-file-generator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
     rev: v1.20.0
     hooks:
         - id: rapids-dependency-file-generator
-          args: ["--clean"]
+          args: ["--clean", "--warn-all", "--strict"]
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1
     hooks:


### PR DESCRIPTION
This PR updates the rapids-dependency-file-generator hook to get https://github.com/rapidsai/dependency-file-generator/pull/163.