### PR TITLE
fix pytorch requirement for CUDA 13 builds

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -582,9 +582,9 @@ dependencies:
           - matrix:
               cuda: "13.*"
             packages:
-              # TODO: remove this 'a0' (which allows nightlies) once there are pytorch CUDA 13 released packages
+              # TODO: remove this '.dev0' (which allows nightlies) once there are pytorch CUDA 13 released packages
               #  ref: https://github.com/pytorch/pytorch/issues/159779
-              - &pytorch_pip torch>=2.9.0a0
+              - &pytorch_pip torch>=2.9.0.dev0
               - &tensordict tensordict>=0.1.2
           - {matrix: null, packages: [*pytorch_pip, *tensordict]}
   depends_on_libcudf:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -580,7 +580,7 @@ dependencies:
               - torch>=2.3
               - tensordict>=0.1.2
           - matrix:
-              cuda: "12.*"
+              cuda: "13.*"
             packages:
               # TODO: remove this 'a0' (which allows nightlies) once there are pytorch CUDA 13 released packages
               #  ref: https://github.com/pytorch/pytorch/issues/159779


### PR DESCRIPTION
Follow-up to #5236

There, I intended to introduce a dependency on `torch` nightly wheels for CUDA 13, but made a typo in the `dependencies.yaml` filter. This fixes that, so that wheels for the correct `torch` variant + version will be installed in wheel-testing CI jobs here.