### PR TITLE
update dependencies: numba (>=0.60.0)

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -39,7 +39,7 @@ dependencies:
 - networkx>=2.5.1
 - ninja
 - notebook>=0.5.0
-- numba>=0.59.1,<0.62.0a0
+- numba>=0.60.0,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - ogb

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -39,7 +39,7 @@ dependencies:
 - networkx>=2.5.1
 - ninja
 - notebook>=0.5.0
-- numba>=0.59.1,<0.62.0a0
+- numba>=0.60.0,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - ogb

--- a/conda/environments/all_cuda-130_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-130_arch-aarch64.yaml
@@ -39,7 +39,7 @@ dependencies:
 - networkx>=2.5.1
 - ninja
 - notebook>=0.5.0
-- numba>=0.59.1,<0.62.0a0
+- numba>=0.60.0,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - ogb

--- a/conda/environments/all_cuda-130_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-130_arch-x86_64.yaml
@@ -39,7 +39,7 @@ dependencies:
 - networkx>=2.5.1
 - ninja
 - notebook>=0.5.0
-- numba>=0.59.1,<0.62.0a0
+- numba>=0.60.0,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - ogb

--- a/conda/recipes/cugraph-service/recipe.yaml
+++ b/conda/recipes/cugraph-service/recipe.yaml
@@ -77,7 +77,7 @@ outputs:
         - cupy >=13.6.0
         - dask-cuda =${{ minor_version }}
         - dask-cudf =${{ minor_version }}
-        - numba >=0.59.1,<0.62.0a0
+        - numba >=0.60.0,<0.62.0a0
         - numpy >=1.23,<3.0a0
         - python
         - rapids-dask-dependency =${{ minor_version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -404,7 +404,7 @@ dependencies:
       - output_types: [conda, pyproject, requirements]
         packages:
           - &dask rapids-dask-dependency==25.10.*,>=0.0.0a0
-          - &numba numba>=0.59.1,<0.62.0a0
+          - &numba numba>=0.60.0,<0.62.0a0
           - &numpy numpy>=1.23,<3.0a0
       - output_types: conda
         packages:

--- a/python/cugraph/pyproject.toml
+++ b/python/cugraph/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "dask-cudf==25.10.*,>=0.0.0a0",
     "fsspec[http]>=0.6.0",
     "libcugraph==25.10.*,>=0.0.0a0",
-    "numba>=0.59.1,<0.62.0a0",
+    "numba>=0.60.0,<0.62.0a0",
     "numpy>=1.23,<3.0a0",
     "pylibcudf==25.10.*,>=0.0.0a0",
     "pylibcugraph==25.10.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/214, updating pins to match the rest of RAPIDS:

* numba `>=0.60.0,<0.62.0a0`

## Notes for Reviewers

### Benefits of these changes

`numba` update just makes the pins here consistent with the rest of RAPIDS, and therefore a little easier to change with automation. This should not affect `cugraph` at all... this new pin is already being carried by some of its strong dependencies, like `cudf`.