### PR TITLE
`force_atlas2`: allow vertex mass to be given by the user

### DIFF
--- a/cpp/include/cugraph/algorithms.hpp
+++ b/cpp/include/cugraph/algorithms.hpp
@@ -231,6 +231,7 @@ void overlap_list(legacy::GraphCSRView<VT, ET, WT> const& graph,
  * drifting away.
  * @param[in] vertex_mobility_values           Device array containing mobility of each vertex
  * (scaling factor for the displacement at each iteration).
+ * @param[in] vertex_mass_values               Device array containing mass of each vertex
  * @param[in] verbose                          Output convergence info at each interation.
  * @param[in] callback                         An instance of GraphBasedDimRedCallback class to
  * intercept the internal state of positions while they are being trained.
@@ -257,6 +258,7 @@ void force_atlas2(raft::handle_t const& handle,
                   bool strong_gravity_mode                      = false,
                   const float gravity                           = 1.0,
                   float* vertex_mobility_values                 = nullptr,
+                  float* vertex_mass_values                     = nullptr,
                   bool verbose                                  = false,
                   internals::GraphBasedDimRedCallback* callback = nullptr);
 

--- a/cpp/include/cugraph_c/layout_algorithms.h
+++ b/cpp/include/cugraph_c/layout_algorithms.h
@@ -95,6 +95,12 @@ typedef struct {
  * @param [in]   vertex_mobility_values
  *                               Mobility of each vertex, used to scale the displacement at each
  *                               iteration.
+ * @param [in]   vertex_mass_vertices
+ *                               Vertex identities for vertex mass.
+ * @param [in]   vertex_mass_values
+ *                               Mass of each vertex, which controls the attraction to other
+ *                               vertices. If not provided, the mass of each vertex will be its
+ *                               degree plus one.
  * @param [in]   verbose         Output convergence info at each interation.
  * @param [in]   do_expensive_check
  *                               A flag to run expensive checks for input arguments (if set to true)
@@ -126,6 +132,8 @@ cugraph_error_code_t cugraph_force_atlas2(
   double gravity,
   cugraph_type_erased_device_array_view_t* vertex_mobility_vertices,
   cugraph_type_erased_device_array_view_t* vertex_mobility_values,
+  cugraph_type_erased_device_array_view_t* vertex_mass_vertices,
+  cugraph_type_erased_device_array_view_t* vertex_mass_values,
   bool_t verbose,
   bool_t do_expensive_check,
   cugraph_layout_result_t** result,

--- a/cpp/src/layout/legacy/barnes_hut.cuh
+++ b/cpp/src/layout/legacy/barnes_hut.cuh
@@ -55,6 +55,7 @@ void barnes_hut(raft::handle_t const& handle,
                 bool strong_gravity_mode                      = false,
                 const float gravity                           = 1.0,
                 float* vertex_mobility                        = nullptr,
+                float* vertex_mass                            = nullptr,
                 bool verbose                                  = false,
                 internals::GraphBasedDimRedCallback* callback = nullptr)
 {
@@ -94,18 +95,18 @@ void barnes_hut(raft::handle_t const& handle,
 
   rmm::device_uvector<int> d_startl(nnodes + 1, stream_view);
   rmm::device_uvector<int> d_childl((nnodes + 1) * 4, stream_view);
-  // FA2 requires degree + 1
-  rmm::device_uvector<edge_t> d_massl(nnodes + 1, stream_view);
-  thrust::fill(handle.get_thrust_policy(), d_massl.begin(), d_massl.end(), 1);
+  rmm::device_uvector<float> d_massl(nnodes + 1, stream_view);
+  rmm::device_uvector<edge_t> d_massl_edge_t(0, stream_view);
 
   rmm::device_uvector<float> d_maxxl(blocks * FACTOR1, stream_view);
   rmm::device_uvector<float> d_maxyl(blocks * FACTOR1, stream_view);
   rmm::device_uvector<float> d_minxl(blocks * FACTOR1, stream_view);
   rmm::device_uvector<float> d_minyl(blocks * FACTOR1, stream_view);
 
-  int* startl   = d_startl.data();
-  int* childl   = d_childl.data();
-  edge_t* massl = d_massl.data();
+  int* startl  = d_startl.data();
+  int* childl  = d_childl.data();
+  float* massl = d_massl.data();
+  edge_t* massl_edge_t{nullptr};
 
   float* maxxl = d_maxxl.data();
   float* maxyl = d_maxyl.data();
@@ -162,8 +163,25 @@ void barnes_hut(raft::handle_t const& handle,
   sort(graph, stream_view.value());
   RAFT_CHECK_CUDA(stream_view.value());
 
-  graph.degree(massl, cugraph::legacy::DegreeDirection::OUT);
-  RAFT_CHECK_CUDA(stream_view.value());
+  if (vertex_mass != nullptr) {
+    // Fill masses with 1 (because `nnodes + 1 > n`)
+    thrust::fill(handle.get_thrust_policy(), d_massl.begin() + n, d_massl.end(), 1.f);
+    raft::copy(massl, vertex_mass, n, stream_view.value());
+  } else {
+    // FA2 requires degree + 1
+    d_massl_edge_t.resize(nnodes + 1, handle.get_stream());
+    thrust::fill(handle.get_thrust_policy(), d_massl_edge_t.begin(), d_massl_edge_t.end(), 1);
+    massl_edge_t = d_massl_edge_t.data();
+    graph.degree(massl_edge_t, cugraph::legacy::DegreeDirection::OUT);
+    RAFT_CHECK_CUDA(stream_view.value());
+
+    thrust::transform(
+      handle.get_thrust_policy(),
+      d_massl_edge_t.begin(),
+      d_massl_edge_t.end(),
+      d_massl.begin(),
+      cuda::proclaim_return_type<float>([] __device__(edge_t x) { return static_cast<float>(x); }));
+  }
 
   const vertex_t* row = graph.src_indices;
   const vertex_t* col = graph.dst_indices;
@@ -177,20 +195,20 @@ void barnes_hut(raft::handle_t const& handle,
 
   // If outboundAttractionDistribution active, compensate.
   if (outbound_attraction_distribution) {
-    edge_t sum = thrust::reduce(handle.get_thrust_policy(), d_massl.begin(), d_massl.begin() + n);
+    float sum = thrust::reduce(handle.get_thrust_policy(), d_massl.begin(), d_massl.begin() + n);
     outbound_att_compensation = sum / (float)n;
   }
 
   //
   // Set cache levels for faster algorithm execution
   //---------------------------------------------------
-  cudaFuncSetCacheConfig(BoundingBoxKernel<edge_t>, cudaFuncCachePreferShared);
+  cudaFuncSetCacheConfig(BoundingBoxKernel, cudaFuncCachePreferShared);
   cudaFuncSetCacheConfig(TreeBuildingKernel, cudaFuncCachePreferL1);
   cudaFuncSetCacheConfig(ClearKernel1, cudaFuncCachePreferL1);
-  cudaFuncSetCacheConfig(ClearKernel2<edge_t>, cudaFuncCachePreferL1);
-  cudaFuncSetCacheConfig(SummarizationKernel<edge_t>, cudaFuncCachePreferShared);
+  cudaFuncSetCacheConfig(ClearKernel2, cudaFuncCachePreferL1);
+  cudaFuncSetCacheConfig(SummarizationKernel, cudaFuncCachePreferShared);
   cudaFuncSetCacheConfig(SortKernel, cudaFuncCachePreferL1);
-  cudaFuncSetCacheConfig(RepulsionKernel<edge_t>, cudaFuncCachePreferL1);
+  cudaFuncSetCacheConfig(RepulsionKernel, cudaFuncCachePreferL1);
   cudaFuncSetCacheConfig(apply_forces_bh, cudaFuncCachePreferL1);
 
   if (callback) {
@@ -209,21 +227,21 @@ void barnes_hut(raft::handle_t const& handle,
     RAFT_CHECK_CUDA(stream_view.value());
 
     // Compute bounding box arround all bodies
-    BoundingBoxKernel<edge_t>
-      <<<blocks * FACTOR1, THREADS1, 0, stream_view.value()>>>(startl,
-                                                               childl,
-                                                               massl,
-                                                               nodes_pos,
-                                                               nodes_pos + nnodes + 1,
-                                                               maxxl,
-                                                               maxyl,
-                                                               minxl,
-                                                               minyl,
-                                                               FOUR_NNODES,
-                                                               NNODES,
-                                                               n,
-                                                               limiter,
-                                                               radiusd);
+    BoundingBoxKernel<<<blocks * FACTOR1, THREADS1, 0, stream_view.value()>>>(
+      startl,
+      childl,
+      massl,
+      nodes_pos,
+      nodes_pos + nnodes + 1,
+      maxxl,
+      maxyl,
+      minxl,
+      minyl,
+      FOUR_NNODES,
+      NNODES,
+      n,
+      limiter,
+      radiusd);
     RAFT_CHECK_CUDA(stream_view.value());
 
     ClearKernel1<<<blocks, 1024, 0, stream_view.value()>>>(childl, FOUR_NNODES, FOUR_N);
@@ -234,11 +252,11 @@ void barnes_hut(raft::handle_t const& handle,
       childl, nodes_pos, nodes_pos + nnodes + 1, NNODES, n, maxdepthd, bottomd, radiusd);
     RAFT_CHECK_CUDA(stream_view.value());
 
-    ClearKernel2<edge_t><<<blocks, 1024, 0, stream_view.value()>>>(startl, massl, NNODES, bottomd);
+    ClearKernel2<<<blocks, 1024, 0, stream_view.value()>>>(startl, massl, NNODES, bottomd);
     RAFT_CHECK_CUDA(stream_view.value());
 
     // Summarizes mass and position for each cell, bottom up approach
-    SummarizationKernel<edge_t><<<blocks * FACTOR3, THREADS3, 0, stream_view.value()>>>(
+    SummarizationKernel<<<blocks * FACTOR3, THREADS3, 0, stream_view.value()>>>(
       countl, childl, massl, nodes_pos, nodes_pos + nnodes + 1, NNODES, n, bottomd);
     RAFT_CHECK_CUDA(stream_view.value());
 
@@ -248,35 +266,34 @@ void barnes_hut(raft::handle_t const& handle,
     RAFT_CHECK_CUDA(stream_view.value());
 
     // Force computation O(n . log(n))
-    RepulsionKernel<edge_t>
-      <<<blocks * FACTOR5, THREADS5, 0, stream_view.value()>>>(scaling_ratio,
-                                                               theta,
-                                                               epssq,
-                                                               sortl,
-                                                               childl,
-                                                               massl,
-                                                               nodes_pos,
-                                                               nodes_pos + nnodes + 1,
-                                                               rep_forces,
-                                                               rep_forces + nnodes + 1,
-                                                               theta_squared,
-                                                               NNODES,
-                                                               FOUR_NNODES,
-                                                               n,
-                                                               radiusd_squared,
-                                                               maxdepthd);
+    RepulsionKernel<<<blocks * FACTOR5, THREADS5, 0, stream_view.value()>>>(scaling_ratio,
+                                                                            theta,
+                                                                            epssq,
+                                                                            sortl,
+                                                                            childl,
+                                                                            massl,
+                                                                            nodes_pos,
+                                                                            nodes_pos + nnodes + 1,
+                                                                            rep_forces,
+                                                                            rep_forces + nnodes + 1,
+                                                                            theta_squared,
+                                                                            NNODES,
+                                                                            FOUR_NNODES,
+                                                                            n,
+                                                                            radiusd_squared,
+                                                                            maxdepthd);
     RAFT_CHECK_CUDA(stream_view.value());
 
-    apply_gravity<vertex_t, edge_t>(nodes_pos,
-                                    nodes_pos + nnodes + 1,
-                                    attract,
-                                    attract + n,
-                                    massl,
-                                    gravity,
-                                    strong_gravity_mode,
-                                    scaling_ratio,
-                                    n,
-                                    stream_view.value());
+    apply_gravity<vertex_t>(nodes_pos,
+                            nodes_pos + nnodes + 1,
+                            attract,
+                            attract + n,
+                            massl,
+                            gravity,
+                            strong_gravity_mode,
+                            scaling_ratio,
+                            n,
+                            stream_view.value());
 
     apply_attraction<vertex_t, edge_t, weight_t>(row,
                                                  col,
@@ -295,17 +312,17 @@ void barnes_hut(raft::handle_t const& handle,
                                                  vertex_radius,
                                                  stream_view.value());
 
-    compute_local_speed<vertex_t, edge_t>(rep_forces,
-                                          rep_forces + nnodes + 1,
-                                          attract,
-                                          attract + n,
-                                          old_forces,
-                                          old_forces + n,
-                                          massl,
-                                          swinging,
-                                          traction,
-                                          n,
-                                          stream_view.value());
+    compute_local_speed<vertex_t>(rep_forces,
+                                  rep_forces + nnodes + 1,
+                                  attract,
+                                  attract + n,
+                                  old_forces,
+                                  old_forces + n,
+                                  massl,
+                                  swinging,
+                                  traction,
+                                  n,
+                                  stream_view.value());
 
     // Compute global swinging and traction values
     const float s =

--- a/cpp/src/layout/legacy/bh_kernels.cuh
+++ b/cpp/src/layout/legacy/bh_kernels.cuh
@@ -67,11 +67,10 @@ __global__ static void ResetKernel(float* restrict radiusd_squared,
 /**
  * Figures the bounding boxes for every point in the embedding.
  */
-template <typename edge_t>
 __global__ static __launch_bounds__(THREADS1,
                                     FACTOR1) void BoundingBoxKernel(int* restrict startd,
                                                                     int* restrict childd,
-                                                                    edge_t* restrict massd,
+                                                                    float* restrict massd,
                                                                     float* restrict posxd,
                                                                     float* restrict posyd,
                                                                     float* restrict maxxd,
@@ -298,9 +297,8 @@ __global__ static __launch_bounds__(THREADS2,
 /**
  * Clean more state vectors.
  */
-template <typename edge_t>
 __global__ static __launch_bounds__(1024, 1) void ClearKernel2(int* restrict startd,
-                                                               edge_t* restrict massd,
+                                                               float* restrict massd,
                                                                const int NNODES,
                                                                const int* restrict bottomd)
 {
@@ -320,11 +318,10 @@ __global__ static __launch_bounds__(1024, 1) void ClearKernel2(int* restrict sta
 /**
  * Summarize the KD Tree via cell gathering
  */
-template <typename edge_t>
 __global__ static __launch_bounds__(THREADS3, FACTOR3) void SummarizationKernel(
   int* restrict countd,
   const int* restrict childd,
-  volatile edge_t* restrict massd,
+  volatile float* restrict massd,
   float* restrict posxd,
   float* restrict posyd,
   const int NNODES,
@@ -334,7 +331,7 @@ __global__ static __launch_bounds__(THREADS3, FACTOR3) void SummarizationKernel(
   bool flag = 0;
   float cm, px, py;
   __shared__ int child[THREADS3 * 4];
-  __shared__ int mass[THREADS3 * 4];
+  __shared__ float mass[THREADS3 * 4];
 
   const int bottom = bottomd[0];
   const int inc    = blockDim.x * gridDim.x;
@@ -507,7 +504,6 @@ __global__ static __launch_bounds__(THREADS4,
 /**
  * Calculate the repulsive forces using the KD Tree
  */
-template <typename edge_t>
 __global__ static __launch_bounds__(
   THREADS5, FACTOR5) void RepulsionKernel(/* int *restrict errd, */
                                           const float scaling_ratio,
@@ -515,7 +511,7 @@ __global__ static __launch_bounds__(
                                           const float epssqd,  // correction for zero distance
                                           const int* restrict sortd,
                                           const int* restrict childd,
-                                          const edge_t* restrict massd,
+                                          const float* restrict massd,
                                           const float* restrict posxd,
                                           const float* restrict posyd,
                                           float* restrict velxd,

--- a/cpp/src/layout/legacy/exact_fa2.cuh
+++ b/cpp/src/layout/legacy/exact_fa2.cuh
@@ -54,6 +54,7 @@ void exact_fa2(raft::handle_t const& handle,
                bool strong_gravity_mode                      = false,
                const float gravity                           = 1.0,
                float* vertex_mobility                        = nullptr,
+               float* vertex_mass                            = nullptr,
                bool verbose                                  = false,
                internals::GraphBasedDimRedCallback* callback = nullptr)
 {
@@ -64,7 +65,8 @@ void exact_fa2(raft::handle_t const& handle,
   float* d_repel{nullptr};
   float* d_attract{nullptr};
   float* d_old_forces{nullptr};
-  edge_t* d_mass{nullptr};
+  float* d_mass{nullptr};
+  edge_t* d_mass_edge_t{nullptr};
   float* d_swinging{nullptr};
   float* d_traction{nullptr};
 
@@ -72,9 +74,8 @@ void exact_fa2(raft::handle_t const& handle,
   rmm::device_uvector<float> attract(n * 2, stream_view);
   rmm::device_uvector<float> old_forces(n * 2, stream_view);
   thrust::fill(handle.get_thrust_policy(), old_forces.begin(), old_forces.end(), 0.f);
-  // FA2 requires degree + 1.
-  rmm::device_uvector<edge_t> mass(n, stream_view);
-  thrust::fill(handle.get_thrust_policy(), mass.begin(), mass.end(), 1);
+  rmm::device_uvector<edge_t> mass_edge_t(0, stream_view);
+  rmm::device_uvector<float> mass(n, stream_view);
   rmm::device_uvector<float> swinging(n, stream_view);
   rmm::device_uvector<float> traction(n, stream_view);
 
@@ -97,8 +98,23 @@ void exact_fa2(raft::handle_t const& handle,
   sort(graph, stream_view.value());
   RAFT_CHECK_CUDA(stream_view.value());
 
-  graph.degree(d_mass, cugraph::legacy::DegreeDirection::OUT);
-  RAFT_CHECK_CUDA(stream_view.value());
+  if (vertex_mass != nullptr) {
+    raft::copy(d_mass, vertex_mass, n, stream_view.value());
+  } else {
+    // FA2 requires degree + 1.
+    mass_edge_t.resize(n, handle.get_stream());
+    thrust::fill(handle.get_thrust_policy(), mass_edge_t.begin(), mass_edge_t.end(), 1);
+    d_mass_edge_t = mass_edge_t.data();
+    graph.degree(d_mass_edge_t, cugraph::legacy::DegreeDirection::OUT);
+    RAFT_CHECK_CUDA(stream_view.value());
+
+    thrust::transform(
+      handle.get_thrust_policy(),
+      mass_edge_t.begin(),
+      mass_edge_t.end(),
+      mass.begin(),
+      cuda::proclaim_return_type<float>([] __device__(edge_t x) { return static_cast<float>(x); }));
+  }
 
   const vertex_t* row = graph.src_indices;
   const vertex_t* col = graph.dst_indices;
@@ -110,7 +126,7 @@ void exact_fa2(raft::handle_t const& handle,
   float jt                        = 0.f;
 
   if (outbound_attraction_distribution) {
-    edge_t sum = thrust::reduce(handle.get_thrust_policy(), mass.begin(), mass.end());
+    float sum = thrust::reduce(handle.get_thrust_policy(), mass.begin(), mass.end());
     outbound_att_compensation = sum / (float)n;
   }
 
@@ -127,28 +143,28 @@ void exact_fa2(raft::handle_t const& handle,
     thrust::fill(handle.get_thrust_policy(), traction.begin(), traction.end(), 0.f);
 
     // Exact repulsion
-    apply_repulsion<vertex_t, edge_t>(pos,
-                                      pos + n,
-                                      d_repel,
-                                      d_repel + n,
-                                      d_mass,
-                                      scaling_ratio,
-                                      prevent_overlapping,
-                                      vertex_radius,
-                                      overlap_scaling_ratio,
-                                      n,
-                                      stream_view.value());
+    apply_repulsion<vertex_t>(pos,
+                              pos + n,
+                              d_repel,
+                              d_repel + n,
+                              d_mass,
+                              scaling_ratio,
+                              prevent_overlapping,
+                              vertex_radius,
+                              overlap_scaling_ratio,
+                              n,
+                              stream_view.value());
 
-    apply_gravity<vertex_t, edge_t>(pos,
-                                    pos + n,
-                                    d_attract,
-                                    d_attract + n,
-                                    d_mass,
-                                    gravity,
-                                    strong_gravity_mode,
-                                    scaling_ratio,
-                                    n,
-                                    stream_view.value());
+    apply_gravity<vertex_t>(pos,
+                            pos + n,
+                            d_attract,
+                            d_attract + n,
+                            d_mass,
+                            gravity,
+                            strong_gravity_mode,
+                            scaling_ratio,
+                            n,
+                            stream_view.value());
 
     apply_attraction<vertex_t, edge_t, weight_t>(row,
                                                  col,
@@ -167,17 +183,17 @@ void exact_fa2(raft::handle_t const& handle,
                                                  vertex_radius,
                                                  stream_view.value());
 
-    compute_local_speed<vertex_t, edge_t>(d_repel,
-                                          d_repel + n,
-                                          d_attract,
-                                          d_attract + n,
-                                          d_old_forces,
-                                          d_old_forces + n,
-                                          d_mass,
-                                          d_swinging,
-                                          d_traction,
-                                          n,
-                                          stream_view.value());
+    compute_local_speed<vertex_t>(d_repel,
+                                  d_repel + n,
+                                  d_attract,
+                                  d_attract + n,
+                                  d_old_forces,
+                                  d_old_forces + n,
+                                  d_mass,
+                                  d_swinging,
+                                  d_traction,
+                                  n,
+                                  stream_view.value());
 
     // Compute global swinging and traction values.
     const float s = thrust::reduce(handle.get_thrust_policy(), swinging.begin(), swinging.end());

--- a/cpp/src/layout/legacy/exact_repulsion.cuh
+++ b/cpp/src/layout/legacy/exact_repulsion.cuh
@@ -21,12 +21,12 @@
 namespace cugraph {
 namespace detail {
 
-template <typename vertex_t, typename edge_t>
+template <typename vertex_t>
 __global__ static void repulsion_kernel(const float* restrict x_pos,
                                         const float* restrict y_pos,
                                         float* restrict repel_x,
                                         float* restrict repel_y,
-                                        const edge_t* restrict mass,
+                                        const float* restrict mass,
                                         const float scaling_ratio,
                                         bool prevent_overlapping,
                                         const float* restrict vertex_radius,
@@ -65,12 +65,12 @@ __global__ static void repulsion_kernel(const float* restrict x_pos,
   }
 }
 
-template <typename vertex_t, typename edge_t, int TPB_X = 32, int TPB_Y = 32>
+template <typename vertex_t, int TPB_X = 32, int TPB_Y = 32>
 void apply_repulsion(const float* restrict x_pos,
                      const float* restrict y_pos,
                      float* restrict repel_x,
                      float* restrict repel_y,
-                     const edge_t* restrict mass,
+                     const float* restrict mass,
                      const float scaling_ratio,
                      bool prevent_overlapping,
                      const float* restrict vertex_radius,
@@ -86,16 +86,16 @@ void apply_repulsion(const float* restrict x_pos,
                  min(n + static_cast<vertex_t>(nthreads.y) - 1 / static_cast<vertex_t>(nthreads.y),
                      static_cast<vertex_t>(CUDA_MAX_BLOCKS_2D))));
 
-  repulsion_kernel<vertex_t, edge_t><<<nblocks, nthreads, 0, stream>>>(x_pos,
-                                                                       y_pos,
-                                                                       repel_x,
-                                                                       repel_y,
-                                                                       mass,
-                                                                       scaling_ratio,
-                                                                       prevent_overlapping,
-                                                                       vertex_radius,
-                                                                       overlap_scaling_ratio,
-                                                                       n);
+  repulsion_kernel<vertex_t><<<nblocks, nthreads, 0, stream>>>(x_pos,
+                                                               y_pos,
+                                                               repel_x,
+                                                               repel_y,
+                                                               mass,
+                                                               scaling_ratio,
+                                                               prevent_overlapping,
+                                                               vertex_radius,
+                                                               overlap_scaling_ratio,
+                                                               n);
   RAFT_CHECK_CUDA(stream);
 }
 

--- a/cpp/src/layout/legacy/fa2_kernels.cuh
+++ b/cpp/src/layout/legacy/fa2_kernels.cuh
@@ -33,7 +33,7 @@ __global__ static void attraction_kernel(const vertex_t* restrict row,
                                          const float* restrict y_pos,
                                          float* restrict attract_x,
                                          float* restrict attract_y,
-                                         const edge_t* restrict mass,
+                                         const float* restrict mass,
                                          bool outbound_attraction_distribution,
                                          bool lin_log_mode,
                                          const float edge_weight_influence,
@@ -101,7 +101,7 @@ void apply_attraction(const vertex_t* restrict row,
                       const float* restrict y_pos,
                       float* restrict attract_x,
                       float* restrict attract_y,
-                      const edge_t* restrict mass,
+                      const float* restrict mass,
                       bool outbound_attraction_distribution,
                       bool lin_log_mode,
                       const float edge_weight_influence,
@@ -143,12 +143,12 @@ void apply_attraction(const vertex_t* restrict row,
   RAFT_CHECK_CUDA(stream);
 }
 
-template <typename vertex_t, typename edge_t>
+template <typename vertex_t>
 __global__ static void linear_gravity_kernel(const float* restrict x_pos,
                                              const float* restrict y_pos,
                                              float* restrict attract_x,
                                              float* restrict attract_y,
-                                             const edge_t* restrict mass,
+                                             const float* restrict mass,
                                              const float gravity,
                                              const vertex_t n)
 {
@@ -163,12 +163,12 @@ __global__ static void linear_gravity_kernel(const float* restrict x_pos,
   }
 }
 
-template <typename vertex_t, typename edge_t>
+template <typename vertex_t>
 __global__ static void strong_gravity_kernel(const float* restrict x_pos,
                                              const float* restrict y_pos,
                                              float* restrict attract_x,
                                              float* restrict attract_y,
-                                             const edge_t* restrict mass,
+                                             const float* restrict mass,
                                              const float gravity,
                                              const float scaling_ratio,
                                              const vertex_t n)
@@ -184,12 +184,12 @@ __global__ static void strong_gravity_kernel(const float* restrict x_pos,
   }
 }
 
-template <typename vertex_t, typename edge_t>
+template <typename vertex_t>
 void apply_gravity(const float* restrict x_pos,
                    const float* restrict y_pos,
                    float* restrict attract_x,
                    float* restrict attract_y,
-                   const edge_t* restrict mass,
+                   const float* restrict mass,
                    const float gravity,
                    bool strong_gravity_mode,
                    const float scaling_ratio,
@@ -207,23 +207,23 @@ void apply_gravity(const float* restrict x_pos,
   nblocks.z = 1;
 
   if (strong_gravity_mode) {
-    strong_gravity_kernel<vertex_t, edge_t><<<nblocks, nthreads, 0, stream>>>(
+    strong_gravity_kernel<vertex_t><<<nblocks, nthreads, 0, stream>>>(
       x_pos, y_pos, attract_x, attract_y, mass, gravity, scaling_ratio, n);
   } else {
-    linear_gravity_kernel<vertex_t, edge_t>
+    linear_gravity_kernel<vertex_t>
       <<<nblocks, nthreads, 0, stream>>>(x_pos, y_pos, attract_x, attract_y, mass, gravity, n);
   }
   RAFT_CHECK_CUDA(stream);
 }
 
-template <typename vertex_t, typename edge_t>
+template <typename vertex_t>
 __global__ static void local_speed_kernel(const float* restrict repel_x,
                                           const float* restrict repel_y,
                                           const float* restrict attract_x,
                                           const float* restrict attract_y,
                                           const float* restrict old_dx,
                                           const float* restrict old_dy,
-                                          const edge_t* restrict mass,
+                                          const float* restrict mass,
                                           float* restrict swinging,
                                           float* restrict traction,
                                           const vertex_t n)
@@ -239,14 +239,14 @@ __global__ static void local_speed_kernel(const float* restrict repel_x,
   }
 }
 
-template <typename vertex_t, typename edge_t>
+template <typename vertex_t>
 void compute_local_speed(const float* restrict repel_x,
                          const float* restrict repel_y,
                          const float* restrict attract_x,
                          const float* restrict attract_y,
                          float* restrict old_dx,
                          float* restrict old_dy,
-                         const edge_t* restrict mass,
+                         const float* restrict mass,
                          float* restrict swinging,
                          float* restrict traction,
                          const vertex_t n,
@@ -262,7 +262,7 @@ void compute_local_speed(const float* restrict repel_x,
   nblocks.y = 1;
   nblocks.z = 1;
 
-  local_speed_kernel<vertex_t, edge_t><<<nblocks, nthreads, 0, stream>>>(
+  local_speed_kernel<vertex_t><<<nblocks, nthreads, 0, stream>>>(
     repel_x, repel_y, attract_x, attract_y, old_dx, old_dy, mass, swinging, traction, n);
   RAFT_CHECK_CUDA(stream);
 }

--- a/cpp/src/layout/legacy/force_atlas2.cu
+++ b/cpp/src/layout/legacy/force_atlas2.cu
@@ -40,6 +40,7 @@ void force_atlas2(raft::handle_t const& handle,
                   bool strong_gravity_mode,
                   const float gravity,
                   float* vertex_mobility,
+                  float* vertex_mass,
                   bool verbose,
                   internals::GraphBasedDimRedCallback* callback)
 {
@@ -65,6 +66,7 @@ void force_atlas2(raft::handle_t const& handle,
                                                            strong_gravity_mode,
                                                            gravity,
                                                            vertex_mobility,
+                                                           vertex_mass,
                                                            verbose,
                                                            callback);
   } else {
@@ -87,6 +89,7 @@ void force_atlas2(raft::handle_t const& handle,
                                                             strong_gravity_mode,
                                                             gravity,
                                                             vertex_mobility,
+                                                            vertex_mass,
                                                             verbose,
                                                             callback);
   }
@@ -113,6 +116,7 @@ template void force_atlas2<int32_t, int32_t, float>(
   bool strong_gravity_mode,
   const float gravity,
   float* vertex_mobility,
+  float* vertex_mass,
   bool verbose,
   internals::GraphBasedDimRedCallback* callback);
 
@@ -137,6 +141,7 @@ template void force_atlas2<int32_t, int32_t, double>(
   bool strong_gravity_mode,
   const float gravity,
   float* vertex_mobility,
+  float* vertex_mass,
   bool verbose,
   internals::GraphBasedDimRedCallback* callback);
 
@@ -161,6 +166,7 @@ template void force_atlas2<int64_t, int64_t, float>(
   bool strong_gravity_mode,
   const float gravity,
   float* vertex_mobility,
+  float* vertex_mass,
   bool verbose,
   internals::GraphBasedDimRedCallback* callback);
 
@@ -185,6 +191,7 @@ template void force_atlas2<int64_t, int64_t, double>(
   bool strong_gravity_mode,
   const float gravity,
   float* vertex_mobility,
+  float* vertex_mass,
   bool verbose,
   internals::GraphBasedDimRedCallback* callback);
 

--- a/cpp/tests/layout/legacy/force_atlas2_test.cu
+++ b/cpp/tests/layout/legacy/force_atlas2_test.cu
@@ -157,6 +157,7 @@ class Tests_Force_Atlas2 : public ::testing::TestWithParam<Force_Atlas2_Usecase>
     bool strong_gravity_mode              = false;
     const float gravity                   = 1.0;
     float* vertex_mobility                = nullptr;
+    float* vertex_mass                    = nullptr;
     bool verbose                          = false;
 
     unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
@@ -185,6 +186,7 @@ class Tests_Force_Atlas2 : public ::testing::TestWithParam<Force_Atlas2_Usecase>
                                            strong_gravity_mode,
                                            gravity,
                                            vertex_mobility,
+                                           vertex_mass,
                                            verbose);
         cudaDeviceSynchronize();
       }
@@ -212,6 +214,7 @@ class Tests_Force_Atlas2 : public ::testing::TestWithParam<Force_Atlas2_Usecase>
                                          strong_gravity_mode,
                                          gravity,
                                          vertex_mobility,
+                                         vertex_mass,
                                          verbose);
       cudaProfilerStop();
       cudaDeviceSynchronize();

--- a/python/cugraph/cugraph/tests/layout/test_force_atlas2.py
+++ b/python/cugraph/cugraph/tests/layout/test_force_atlas2.py
@@ -73,6 +73,7 @@ def cugraph_call(
     strong_gravity_mode,
     gravity,
     vertex_mobility,
+    vertex_mass,
     callback=None,
     renumber=False,
 ):
@@ -103,6 +104,7 @@ def cugraph_call(
         strong_gravity_mode=strong_gravity_mode,
         gravity=gravity,
         vertex_mobility=vertex_mobility,
+        vertex_mass=vertex_mass,
         callback=callback,
     )
     t2 = time.time() - t1
@@ -188,6 +190,7 @@ def test_force_atlas2(graph_file, score, max_iter, barnes_hut_optimize):
             strong_gravity_mode=False,
             gravity=1.0,
             vertex_mobility=None,
+            vertex_mass=None,
             callback=test_callback,
         )
     """
@@ -270,6 +273,7 @@ def test_force_atlas2_noverlap(graph_file, radius, max_overlaps, max_iter):
         strong_gravity_mode=False,
         gravity=1.0,
         vertex_mobility=None,
+        vertex_mass=None,
         callback=None,
     )
 
@@ -315,6 +319,7 @@ def test_force_atlas2_mobility(graph_file, max_iter, fixed_node_cnt):
         strong_gravity_mode=False,
         gravity=1.0,
         vertex_mobility=None,
+        vertex_mass=None,
         callback=None,
     )
 
@@ -336,6 +341,7 @@ def test_force_atlas2_mobility(graph_file, max_iter, fixed_node_cnt):
         strong_gravity_mode=False,
         gravity=1.0,
         vertex_mobility=mobility_df,
+        vertex_mass=None,
         callback=None,
     )
 

--- a/python/cugraph/cugraph/tests/layout/test_force_atlas2.py
+++ b/python/cugraph/cugraph/tests/layout/test_force_atlas2.py
@@ -357,3 +357,88 @@ def test_force_atlas2_mobility(graph_file, max_iter, fixed_node_cnt):
     assert fixed_nodes.sum() == fixed_node_cnt
     assert (pos_difference.loc[fixed_nodes, "move_dist"] == 0.0).all()
     assert (pos_difference.loc[~fixed_nodes, "move_dist"] > 0.0).all()
+
+
+@pytest.mark.sg
+@pytest.mark.parametrize("max_iter", MAX_ITERATIONS)
+@pytest.mark.parametrize("barnes_hut_optimize", BARNES_HUT_OPTIMIZE)
+def test_force_atlas2_mass(max_iter, barnes_hut_optimize):
+    (v0, v1, v2, v3) = range(4)
+    edge_dict = {
+        "src": [v0, v0, v0, v1, v2, v3],
+        "dst": [v1, v3, v2, v0, v0, v0],
+        "wgt": 6 * [1.0],
+    }
+    edgelist_df = cudf.DataFrame(edge_dict)
+
+    # v1, v2, v3 should be approximately equidistant from v0 and each other
+    default_pos = cugraph_call(
+        edgelist_df,
+        max_iter=max_iter,
+        pos_list=None,
+        outbound_attraction_distribution=True,
+        lin_log_mode=False,
+        prevent_overlapping=False,
+        vertex_radius=None,
+        overlap_scaling_ratio=100.0,
+        edge_weight_influence=1.0,
+        jitter_tolerance=1.0,
+        barnes_hut_optimize=barnes_hut_optimize,
+        barnes_hut_theta=0.5,
+        scaling_ratio=2.0,
+        strong_gravity_mode=False,
+        gravity=1.0,
+        vertex_mobility=None,
+        vertex_mass=None,
+        callback=None,
+    )
+    data = default_pos.set_index("vertex").sort_index().values.get()
+    distances = scipy.spatial.distance.cdist(data, data)
+
+    # Within 10% is close enough
+    rel = 0.1
+    # Equidistance from v0
+    assert pytest.approx(distances[0, 1], rel=rel) == distances[0, 2]
+    assert pytest.approx(distances[0, 1], rel=rel) == distances[0, 3]
+    assert pytest.approx(distances[0, 2], rel=rel) == distances[0, 3]
+    # Equidistance from each other (v1, v2, v3)
+    assert pytest.approx(distances[1, 2], rel=rel) == distances[1, 3]
+    assert pytest.approx(distances[1, 2], rel=rel) == distances[2, 3]
+    assert pytest.approx(distances[1, 3], rel=rel) == distances[2, 3]
+
+    # Now make v3 much larger (repels other vertices)
+    vertex_mass = cudf.DataFrame({"vertex": [v0, v1, v2, v3], "mass": [4, 2, 2, 20.0]})
+    vertex_mass["mass"] = vertex_mass["mass"].astype("float32")
+
+    pos_2 = cugraph_call(
+        edgelist_df,
+        max_iter=max_iter,
+        pos_list=None,
+        outbound_attraction_distribution=True,
+        lin_log_mode=False,
+        prevent_overlapping=False,
+        vertex_radius=None,
+        overlap_scaling_ratio=100.0,
+        edge_weight_influence=1.0,
+        jitter_tolerance=1.0,
+        barnes_hut_optimize=barnes_hut_optimize,
+        barnes_hut_theta=0.5,
+        scaling_ratio=2.0,
+        strong_gravity_mode=False,
+        gravity=1.0,
+        vertex_mobility=None,
+        vertex_mass=vertex_mass,
+        callback=None,
+    )
+    data = pos_2.set_index("vertex").sort_index().values.get()
+    distances = scipy.spatial.distance.cdist(data, data)
+
+    # v1 and v2 should be equidistance from v0
+    assert pytest.approx(distances[0, 1], rel=rel) == distances[0, 2]
+    # and from v3
+    assert pytest.approx(distances[3, 1], rel=rel) == distances[3, 2]
+    # v3 should be much further from v0 than v1 or v2
+    assert distances[0, 3] / distances[0, 1] > 4.0
+    assert distances[0, 3] / distances[0, 2] > 4.0
+    assert distances[1, 3] / distances[1, 0] > 4.0
+    assert distances[2, 3] / distances[2, 0] > 4.0

--- a/python/pylibcugraph/pylibcugraph/_cugraph_c/layout_algorithms.pxd
+++ b/python/pylibcugraph/pylibcugraph/_cugraph_c/layout_algorithms.pxd
@@ -84,6 +84,8 @@ cdef extern from "cugraph_c/layout_algorithms.h":
         double gravity,
         cugraph_type_erased_device_array_view_t* vertex_mobility_vertices,
         cugraph_type_erased_device_array_view_t* vertex_mobility_values,
+        cugraph_type_erased_device_array_view_t* vertex_mass_vertices,
+        cugraph_type_erased_device_array_view_t* vertex_mass_values,
         bool_t verbose,
         bool_t do_expensive_check,
         cugraph_layout_result_t** result,

--- a/python/pylibcugraph/pylibcugraph/force_atlas2.pyx
+++ b/python/pylibcugraph/pylibcugraph/force_atlas2.pyx
@@ -84,6 +84,8 @@ def force_atlas2(ResourceHandle resource_handle,
                  double gravity,
                  vertex_mobility_vertices,
                  vertex_mobility_values,
+                 vertex_mass_vertices,
+                 vertex_mass_values,
                  bool_t verbose,
                  bool_t do_expensive_check,
                 ):
@@ -170,6 +172,13 @@ def force_atlas2(ResourceHandle resource_handle,
         Mobility of each vertex, scaling its speed in each iteration.
         If not provided, all vertices will have a mobility of 1.0.
 
+    vertex_mass_vertices : device array type, optional (default=None)
+        Vertices of graph for vertex_mass_values.
+
+    vertex_mass_values : device array type, optional (default=None)
+        Mass of each vertex, which controls the attraction to other vertices.
+        If not provided, the mass of each vertex will be its degree plus one.
+
     verbose : bool_t
         Output convergence info at each interation.
 
@@ -196,14 +205,16 @@ def force_atlas2(ResourceHandle resource_handle,
     ...     resource_handle, graph_props, srcs, dsts, weight_array=weights,
     ...     store_transposed=False, renumber=False, do_expensive_check=False)
     >>> (vertices, x_axis, y_axis) = pylibcugraph.force_atlas2(
-    ...     resource_handle, None, G, 500, None, None, None, True, False, False, None,
-    ...     1.0, 1.0, True, 0.5, 2.0, False, None, 1.0, False, False)
+    ...     resource_handle, 42, G, 500, None, None, None, True, False, False,
+    ...     None, None, 100.0, 1.0, 1.0, False, 0.5, 2.0, False, 1.0, None, None,
+    ...     None, None, False, False)
     >>> vertices
     [   0  1   2   3   4   5    ]
     >>> x_axis
-    [ 5.444471    0.4794112   1.2495936  -0.01039529 -1.1892298  -1.5889403 ]
+    [-7.7015705   7.6763854  -2.7651896  -0.02446137  1.6971487  -1.2822613 ]
     >>> y_axis
-    [-1.4304754e+01 -3.8182523e+00  3.8365445e+00  8.3183739e-03 -8.3009762e-01 -1.9155006e-01
+    [ 23.276543     7.9067745   13.618961    -0.07172047  -6.8321953  -11.90544   ]
+
 
     """
 
@@ -262,6 +273,20 @@ def force_atlas2(ResourceHandle resource_handle,
             create_cugraph_type_erased_device_array_view_from_py_obj(
                 vertex_mobility_values)
 
+    assert_CAI_type(vertex_mass_vertices, "vertex_mass_vertices", True)
+
+    cdef cugraph_type_erased_device_array_view_t* \
+        vertex_mass_vertices_view_ptr = \
+            create_cugraph_type_erased_device_array_view_from_py_obj(
+                vertex_mass_vertices)
+
+    assert_CAI_type(vertex_mass_values, "vertex_mass_values", True)
+
+    cdef cugraph_type_erased_device_array_view_t* \
+        vertex_mass_values_view_ptr = \
+            create_cugraph_type_erased_device_array_view_from_py_obj(
+                vertex_mass_values)
+
     cdef cugraph_layout_result_t* result_ptr
     cdef cugraph_error_code_t error_code
     cdef cugraph_error_t* error_ptr
@@ -292,6 +317,8 @@ def force_atlas2(ResourceHandle resource_handle,
                                       gravity,
                                       vertex_mobility_vertices_view_ptr,
                                       vertex_mobility_values_view_ptr,
+                                      vertex_mass_vertices_view_ptr,
+                                      vertex_mass_values_view_ptr,
                                       verbose,
                                       do_expensive_check,
                                       &result_ptr,


### PR DESCRIPTION
This is a "quick" follow-up to https://github.com/rapidsai/cugraph/pull/5260 (and https://github.com/rapidsai/cugraph/pull/5213) and https://github.com/rapidsai/nx-cugraph/pull/191 to add vertex mass to the API. This will allow `nx-cugraph` to better match the networkx API.

This required changing the dtype of the mass arrays from integral to float32.

As time permits, I plan to add a test to show that increasing mass of a vertex increases its distance to other vertices. The plan is to also update `nx-cugraph` to use this parameter.