### PR TITLE
Fix `G.nodes()` returning internal vertex IDs

### DIFF
--- a/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleGraph.py
@@ -937,9 +937,8 @@ class simpleGraphImpl:
             df_["vertex"] = vertices
             df_ = self.renumber_map.unrenumber(df_, "vertex")
             if len(df_.columns) > 1:
-                vertices = df_
-            else:
-                vertices = df_["vertex"]
+                return df_.sort_values(df_.columns, ignore_index=True)
+            vertices = df_["vertex"]
 
         return vertices.sort_values(ignore_index=True)
 
@@ -1545,7 +1544,7 @@ class simpleGraphImpl:
         If multi columns vertices, return a cudf.DataFrame.
         """
         if self.edgelist is not None:
-            return self.extract_vertex_list(return_unrenumbered_vertices=False)
+            return self.extract_vertex_list(return_unrenumbered_vertices=True)
         if self.adjlist is not None:
             return cudf.Series(np.arange(0, self.number_of_nodes()))
 

--- a/python/cugraph/cugraph/tests/structure/test_graph.py
+++ b/python/cugraph/cugraph/tests/structure/test_graph.py
@@ -1175,6 +1175,19 @@ def test_graph_creation_edges_multi_col_vertices(graph_file, directed):
         )
 
 
+@pytest.mark.sg
+def test_graph_nodes_with_multi_col_vertices():
+    G = cugraph.Graph(directed=True)
+    df = cudf.DataFrame(
+        {"src_0": [1, 2], "src_1": [10, 20], "dst_0": [2, 3], "dst_1": [20, 30]}
+    )
+    G.from_cudf_edgelist(df, source=["src_0", "src_1"], destination=["dst_0", "dst_1"])
+
+    expected_nodes = cudf.DataFrame({"0_vertex": [1, 2, 3], "1_vertex": [10, 20, 30]})
+    nodes = G.nodes()
+    assert_frame_equal(nodes, expected_nodes, check_dtype=False)
+
+
 def test_from_pandas_adjacency_string_columns():
     data = {
         "A": [0, 1, 1, 0],


### PR DESCRIPTION
Closes #5280

This also fixes `extract_vertex_list` when using multiple columns for vertex IDs. A simple regression test was added that covers both fixes.