### PR TITLE
Fix warning in unreachable device code

### DIFF
--- a/cpp/include/cugraph/utilities/assert.cuh
+++ b/cpp/include/cugraph/utilities/assert.cuh
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+/**
+ * @brief Macro indicating that a location in the code is unreachable.
+ *
+ * The CUGRAPH_UNREACHABLE macro should only be used where CUGRAPH_FAIL cannot
+ * be used due to performance or due to being used in device code. In the
+ * majority of host code situations, an exception should be thrown in
+ * "unreachable" code paths as those usually aren't tight inner loops like they
+ * are in device code.
+ *
+ * One example where this macro may be used is in conjunction with dispatchers
+ * to indicate that a function does not need to return a default value because
+ * it has already exhausted all possible cases in a `switch` statement.
+ *
+ * The assert in this macro can be used when compiling in debug mode to help
+ * debug functions that may reach the supposedly unreachable code.
+ *
+ * Example usage:
+ * ```
+ * CUGRAPH_UNREACHABLE("Invalid enum value.");
+ * ```
+ */
+#define CUGRAPH_UNREACHABLE(msg)          \
+  do {                                    \
+    assert(false && "Unreachable: " msg); \
+    __builtin_unreachable();              \
+  } while (0)

--- a/cpp/src/sampling/detail/gather_one_hop_impl.cuh
+++ b/cpp/src/sampling/detail/gather_one_hop_impl.cuh
@@ -28,6 +28,7 @@
 #include <cugraph/arithmetic_variant_types.hpp>
 #include <cugraph/edge_property.hpp>
 #include <cugraph/sampling_functions.hpp>
+#include <cugraph/utilities/assert.cuh>
 #include <cugraph/utilities/mask_utils.cuh>
 
 #include <raft/util/cudart_utils.hpp>
@@ -554,7 +555,7 @@ temporal_gather_one_hop_edgelist(
                                    case temporal_sampling_comparison_t::MONOTONICALLY_DECREASING:
                                      return (edge_time <= key_time);
                                  }
-                                 assert(false);
+                                 CUGRAPH_UNREACHABLE("Unsupported temporal sampling comparison");
                                })
         : detail::mark_entries(handle,
                                edge_times.size(),
@@ -574,7 +575,7 @@ temporal_gather_one_hop_edgelist(
                                    case temporal_sampling_comparison_t::MONOTONICALLY_DECREASING:
                                      return (edge_time <= key_time);
                                  }
-                                 assert(false);
+                                 CUGRAPH_UNREACHABLE("Unsupported temporal sampling comparison");
                                });
 
     raft::device_span<uint32_t const> marked_entry_span{marked_entries.data(),


### PR DESCRIPTION
cuGraph C++ builds have been issuing a warning in a dispatch that is unreachable. This fixes the warning by marking the code as unreachable with a macro borrowed from cuDF.

Warnings look like:

```cpp
/home/coder/cugraph/cpp/src/sampling/detail/gather_one_hop_impl.cuh(558): warning #940-D: missing return statement at end of non-void function "lambda [](auto)->auto [with <auto-1>=unsigned long]"
```
