### PR TITLE
 refactored update-version.sh to handle new branching strategy

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -159,7 +159,7 @@ for FILE in .github/workflows/*.yaml; do
   sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_SHORT_TAG}-/g" "${FILE}"
 done
 
-# Documentation references - context-aware  
+# Documentation references - context-aware
 if [[ "${RUN_CONTEXT}" == "main" ]]; then
   # In main context, keep documentation on main (no changes needed)
   :

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -119,7 +119,7 @@ for FILE in dependencies.yaml conda/environments/*.yaml; do
     sed_runner "/-.* ${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*/==${NEXT_UCXX_SHORT_TAG_PEP440}.*,>=0.0.0a0/g" "${FILE}"
   done
 done
-for FILE in python/**/pyproject.toml python/**/**/pyproject.toml; do
+for FILE in python/*/pyproject.toml; do
   for DEP in "${DEPENDENCIES[@]}"; do
     sed_runner "/\"${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*\"/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\"/g" "${FILE}"
   done

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -130,8 +130,8 @@ done
 
 # ucxx version
 for FILE in conda/recipes/*/conda_build_config.yaml; do
-  sed_runner "/^libucxx_version:$/ {n;s/.*/  - \"${NEXT_UCXX_SHORT_TAG_PEP440}.*\"/}" "${FILE}"
-  sed_runner "/^ucxx_version:$/ {n;s/.*/  - \"${NEXT_UCXX_SHORT_TAG_PEP440}.*\"/}" "${FILE}"
+  sed_runner "/^libucxx_version:\$/ {n;s|.*|  - \"${NEXT_UCXX_SHORT_TAG_PEP440}.*\"|;}" "${FILE}"
+  sed_runner "/^ucxx_version:\$/ {n;s|.*|  - \"${NEXT_UCXX_SHORT_TAG_PEP440}.*\"|;}" "${FILE}"
 done
 
 # CI files - context-aware branch references

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -15,6 +15,19 @@
 #   ./ci/release/update-version.sh --run-context=release 25.12.00
 #   RAPIDS_RUN_CONTEXT=main ./ci/release/update-version.sh 25.12.00
 
+# Verify we're running from the repository root
+if [[ ! -f "VERSION" ]] || [[ ! -f "ci/release/update-version.sh" ]] || [[ ! -d "python" ]]; then
+    echo "Error: This script must be run from the root of the cugraph repository"
+    echo ""
+    echo "Usage:"
+    echo "  cd /path/to/cugraph"
+    echo "  ./ci/release/update-version.sh --run-context=main|release <new_version>"
+    echo ""
+    echo "Example:"
+    echo "  ./ci/release/update-version.sh --run-context=main 25.12.00"
+    exit 1
+fi
+
 # Parse command line arguments
 POSITIONAL_ARGS=()
 while [[ $# -gt 0 ]]; do

--- a/notebooks/demo/mg_property_graph.ipynb
+++ b/notebooks/demo/mg_property_graph.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Import needed libraries. We recommend using the [cugraph_dev](https://github.com/rapidsai/cugraph/tree/branch-23.02/conda/environments) env through conda\n",
+    "# Import needed libraries. We recommend using the [cugraph_dev](https://github.com/rapidsai/cugraph/tree/main/conda/environments) env through conda\n",
     "from dask.distributed import Client, wait\n",
     "from dask_cuda import LocalCUDACluster\n",
     "from cugraph.dask.comms import comms as Comms\n",

--- a/notebooks/modules/mag240m_pg.ipynb
+++ b/notebooks/modules/mag240m_pg.ipynb
@@ -60,8 +60,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Import needed libraries.\n",
-    "# We recommend using the [cugraph_dev](https://github.com/rapidsai/cugraph/tree/branch-22.10/conda/environments) env through conda\n",
+    "# Import needed libraries. \n",
+    "# We recommend using the [cugraph_dev](https://github.com/rapidsai/cugraph/tree/main/conda/environments) env through conda\n",
     "\n",
     "from dask.distributed import Client, wait\n",
     "from dask_cuda import LocalCUDACluster\n",

--- a/notebooks/modules/mag240m_pg.ipynb
+++ b/notebooks/modules/mag240m_pg.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Import needed libraries. \n",
+    "# Import needed libraries.\n",
     "# We recommend using the [cugraph_dev](https://github.com/rapidsai/cugraph/tree/main/conda/environments) env through conda\n",
     "\n",
     "from dask.distributed import Client, wait\n",


### PR DESCRIPTION
## Description
This PR supports handling the new main branch strategy outlined below:

* [RSN 47 - Changes to RAPIDS branching strategy in 25.12](https://docs.rapids.ai/notices/rsn0047/)

The `update-version.sh` script should now supports two modes controlled via  `CLI` params or `ENV` vars:

CLI arguments: `--run-context=main|release`
ENV var `RAPIDS_RUN_CONTEXT=main|release`

xref: https://github.com/rapidsai/build-planning/issues/224