### PR TITLE
New sampling flag for disjoint sampling

### DIFF
--- a/cpp/include/cugraph/sampling_functions.hpp
+++ b/cpp/include/cugraph/sampling_functions.hpp
@@ -73,6 +73,11 @@ struct sampling_flags_t {
    */
   temporal_sampling_comparison_t temporal_sampling_comparison{
     temporal_sampling_comparison_t::STRICTLY_INCREASING};
+
+  /**
+   * Specifies if disjoint sampling should be enforced. Default is false.
+   */
+  bool disjoint_sampling{false};
 };
 
 /**

--- a/cpp/include/cugraph_c/sampling_algorithms.h
+++ b/cpp/include/cugraph_c/sampling_algorithms.h
@@ -311,6 +311,15 @@ void cugraph_sampling_set_temporal_sampling_comparison(
 
 /**
  * @ingroup samplingC
+ * @brief   Set flag to perform disjoint sampling
+ *
+ * @param options - opaque pointer to the sampling options
+ * @param value - Boolean value to assign to the option
+ */
+void cugraph_sampling_set_disjoint_sampling(cugraph_sampling_options_t* options, bool_t value);
+
+/**
+ * @ingroup samplingC
  * @brief     Free sampling options object
  *
  * @param [in]   options   Opaque pointer to sampling object

--- a/cpp/include/cugraph_c/sampling_algorithms.h
+++ b/cpp/include/cugraph_c/sampling_algorithms.h
@@ -313,6 +313,8 @@ void cugraph_sampling_set_temporal_sampling_comparison(
  * @ingroup samplingC
  * @brief   Set flag to perform disjoint sampling
  *
+ * Note: This flag is not supported in the current implementation.
+ *
  * @param options - opaque pointer to the sampling options
  * @param value - Boolean value to assign to the option
  */

--- a/cpp/src/c_api/neighbor_sampling.cpp
+++ b/cpp/src/c_api/neighbor_sampling.cpp
@@ -279,10 +279,13 @@ struct neighbor_sampling_functor : public cugraph::c_api::abstract_functor {
                                  : std::nullopt,
               raft::host_span<const int>(fan_out_->as_type<const int>(), fan_out_->size_),
               num_edge_types_,
-              cugraph::sampling_flags_t{options_.prior_sources_behavior_,
-                                        options_.return_hops_ == TRUE,
-                                        options_.dedupe_sources_ == TRUE,
-                                        options_.with_replacement_ == TRUE},
+              cugraph::sampling_flags_t{
+                options_.prior_sources_behavior_,
+                options_.return_hops_ == TRUE,
+                options_.dedupe_sources_ == TRUE,
+                options_.with_replacement_ == TRUE,
+                cugraph::temporal_sampling_comparison_t::STRICTLY_INCREASING,
+                options_.disjoint_sampling_ == TRUE},
               do_expensive_check_);
         } else {
           std::tie(sampled_srcs,
@@ -309,10 +312,13 @@ struct neighbor_sampling_functor : public cugraph::c_api::abstract_functor {
                                  : std::nullopt,
               raft::host_span<const int>(fan_out_->as_type<const int>(), fan_out_->size_),
               num_edge_types_,
-              cugraph::sampling_flags_t{options_.prior_sources_behavior_,
-                                        options_.return_hops_ == TRUE,
-                                        options_.dedupe_sources_ == TRUE,
-                                        options_.with_replacement_ == TRUE},
+              cugraph::sampling_flags_t{
+                options_.prior_sources_behavior_,
+                options_.return_hops_ == TRUE,
+                options_.dedupe_sources_ == TRUE,
+                options_.with_replacement_ == TRUE,
+                cugraph::temporal_sampling_comparison_t::STRICTLY_INCREASING,
+                options_.disjoint_sampling_ == TRUE},
               do_expensive_check_);
         }
       } else {
@@ -342,10 +348,13 @@ struct neighbor_sampling_functor : public cugraph::c_api::abstract_functor {
                                      (*label_to_comm_rank).data(), (*label_to_comm_rank).size()})
                                  : std::nullopt,
               raft::host_span<const int>(fan_out_->as_type<const int>(), fan_out_->size_),
-              cugraph::sampling_flags_t{options_.prior_sources_behavior_,
-                                        options_.return_hops_ == TRUE,
-                                        options_.dedupe_sources_ == TRUE,
-                                        options_.with_replacement_ == TRUE},
+              cugraph::sampling_flags_t{
+                options_.prior_sources_behavior_,
+                options_.return_hops_ == TRUE,
+                options_.dedupe_sources_ == TRUE,
+                options_.with_replacement_ == TRUE,
+                cugraph::temporal_sampling_comparison_t::STRICTLY_INCREASING,
+                options_.disjoint_sampling_ == TRUE},
               do_expensive_check_);
         } else {
           std::tie(sampled_srcs,
@@ -371,10 +380,13 @@ struct neighbor_sampling_functor : public cugraph::c_api::abstract_functor {
                                      (*label_to_comm_rank).data(), (*label_to_comm_rank).size()})
                                  : std::nullopt,
               raft::host_span<const int>(fan_out_->as_type<const int>(), fan_out_->size_),
-              cugraph::sampling_flags_t{options_.prior_sources_behavior_,
-                                        options_.return_hops_ == TRUE,
-                                        options_.dedupe_sources_ == TRUE,
-                                        options_.with_replacement_ == TRUE},
+              cugraph::sampling_flags_t{
+                options_.prior_sources_behavior_,
+                options_.return_hops_ == TRUE,
+                options_.dedupe_sources_ == TRUE,
+                options_.with_replacement_ == TRUE,
+                cugraph::temporal_sampling_comparison_t::STRICTLY_INCREASING,
+                options_.disjoint_sampling_ == TRUE},
               do_expensive_check_);
         }
       }

--- a/cpp/src/c_api/sampling_common.hpp
+++ b/cpp/src/c_api/sampling_common.hpp
@@ -23,6 +23,7 @@ struct cugraph_sampling_options_t {
   bool_t retain_seeds_{FALSE};
   cugraph_temporal_sampling_comparison_t temporal_sampling_comparison_{
     cugraph_temporal_sampling_comparison_t::STRICTLY_INCREASING};
+  bool_t disjoint_sampling_{FALSE};
 };
 
 struct sampling_flags_t {

--- a/cpp/src/c_api/sampling_result.cpp
+++ b/cpp/src/c_api/sampling_result.cpp
@@ -99,6 +99,13 @@ extern "C" void cugraph_sampling_set_temporal_sampling_comparison(
   internal_pointer->temporal_sampling_comparison_ = value;
 }
 
+extern "C" void cugraph_sampling_set_disjoint_sampling(cugraph_sampling_options_t* options,
+                                                       bool_t value)
+{
+  auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_sampling_options_t*>(options);
+  internal_pointer->disjoint_sampling_ = value;
+}
+
 extern "C" void cugraph_sampling_options_free(cugraph_sampling_options_t* options)
 {
   auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_sampling_options_t*>(options);

--- a/cpp/src/c_api/temporal_neighbor_sampling.cpp
+++ b/cpp/src/c_api/temporal_neighbor_sampling.cpp
@@ -364,10 +364,11 @@ struct temporal_neighbor_sampling_functor : public cugraph::c_api::abstract_func
               raft::host_span<const int>(fan_out_->as_type<const int>(), fan_out_->size_),
               num_edge_types_,
               cugraph::sampling_flags_t{options_.prior_sources_behavior_,
-                                        options_.return_hops_,
-                                        options_.dedupe_sources_,
-                                        options_.with_replacement_,
-                                        temporal_sampling_comparison},
+                                        options_.return_hops_ == TRUE,
+                                        options_.dedupe_sources_ == TRUE,
+                                        options_.with_replacement_ == TRUE,
+                                        temporal_sampling_comparison,
+                                        options_.disjoint_sampling_ == TRUE},
               do_expensive_check_);
         } else {
           std::tie(sampled_edge_srcs,
@@ -404,10 +405,11 @@ struct temporal_neighbor_sampling_functor : public cugraph::c_api::abstract_func
               raft::host_span<const int>(fan_out_->as_type<const int>(), fan_out_->size_),
               num_edge_types_,
               cugraph::sampling_flags_t{options_.prior_sources_behavior_,
-                                        options_.return_hops_,
-                                        options_.dedupe_sources_,
-                                        options_.with_replacement_,
-                                        temporal_sampling_comparison},
+                                        options_.return_hops_ == TRUE,
+                                        options_.dedupe_sources_ == TRUE,
+                                        options_.with_replacement_ == TRUE,
+                                        temporal_sampling_comparison,
+                                        options_.disjoint_sampling_ == TRUE},
               do_expensive_check_);
         }
       } else {
@@ -447,10 +449,11 @@ struct temporal_neighbor_sampling_functor : public cugraph::c_api::abstract_func
                                  : std::nullopt,
               raft::host_span<const int>(fan_out_->as_type<const int>(), fan_out_->size_),
               cugraph::sampling_flags_t{options_.prior_sources_behavior_,
-                                        options_.return_hops_,
-                                        options_.dedupe_sources_,
-                                        options_.with_replacement_,
-                                        temporal_sampling_comparison},
+                                        options_.return_hops_ == TRUE,
+                                        options_.dedupe_sources_ == TRUE,
+                                        options_.with_replacement_ == TRUE,
+                                        temporal_sampling_comparison,
+                                        options_.disjoint_sampling_ == TRUE},
               do_expensive_check_);
         } else {
           std::tie(sampled_edge_srcs,
@@ -486,10 +489,11 @@ struct temporal_neighbor_sampling_functor : public cugraph::c_api::abstract_func
                                  : std::nullopt,
               raft::host_span<const int>(fan_out_->as_type<const int>(), fan_out_->size_),
               cugraph::sampling_flags_t{options_.prior_sources_behavior_,
-                                        options_.return_hops_,
-                                        options_.dedupe_sources_,
-                                        options_.with_replacement_,
-                                        temporal_sampling_comparison},
+                                        options_.return_hops_ == TRUE,
+                                        options_.dedupe_sources_ == TRUE,
+                                        options_.with_replacement_ == TRUE,
+                                        temporal_sampling_comparison,
+                                        options_.disjoint_sampling_ == TRUE},
               do_expensive_check_);
         }
       }

--- a/python/pylibcugraph/pylibcugraph/_cugraph_c/algorithms.pxd
+++ b/python/pylibcugraph/pylibcugraph/_cugraph_c/algorithms.pxd
@@ -341,6 +341,12 @@ cdef extern from "cugraph_c/algorithms.h":
         )
 
     cdef void \
+        cugraph_sampling_set_disjoint_sampling(
+            cugraph_sampling_options_t* options,
+            bool_t value,
+        )
+
+    cdef void \
         cugraph_sampling_options_free(
             cugraph_sampling_options_t* options,
         )

--- a/python/pylibcugraph/pylibcugraph/heterogeneous_biased_neighbor_sample.pyx
+++ b/python/pylibcugraph/pylibcugraph/heterogeneous_biased_neighbor_sample.pyx
@@ -45,6 +45,7 @@ from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_sampling_set_compress_per_hop,
     cugraph_sampling_set_compression_type,
     cugraph_sampling_set_retain_seeds,
+    cugraph_sampling_set_disjoint_sampling,
 )
 from pylibcugraph._cugraph_c.sampling_algorithms cimport (
     cugraph_heterogeneous_biased_neighbor_sample,
@@ -85,6 +86,7 @@ def heterogeneous_biased_neighbor_sample(ResourceHandle resource_handle,
                                          bool_t do_expensive_check,
                                          prior_sources_behavior=None,
                                          deduplicate_sources=False,
+                                         disjoint_sampling=False,
                                          return_hops=False,
                                          renumber=False,
                                          retain_seeds=False,
@@ -173,6 +175,10 @@ def heterogeneous_biased_neighbor_sample(ResourceHandle resource_handle,
         entire batch.
         If True, will create a separate compressed edgelist per hop within
         a batch.
+
+    disjoint_sampling: bool (Optional)
+        If True, enables disjoint sampling between seeds per hop when supported.
+        Defaults to False.
 
     random_state: int (Optional)
         Random state to use when generating samples.  Optional argument,
@@ -357,6 +363,7 @@ def heterogeneous_biased_neighbor_sample(ResourceHandle resource_handle,
     cugraph_sampling_set_compression_type(sampling_options, compression_behavior_e)
     cugraph_sampling_set_compress_per_hop(sampling_options, c_compress_per_hop)
     cugraph_sampling_set_retain_seeds(sampling_options, retain_seeds)
+    cugraph_sampling_set_disjoint_sampling(sampling_options, disjoint_sampling)
 
     error_code = cugraph_heterogeneous_biased_neighbor_sample(
         c_resource_handle_ptr,

--- a/python/pylibcugraph/pylibcugraph/heterogeneous_biased_temporal_neighbor_sample.pyx
+++ b/python/pylibcugraph/pylibcugraph/heterogeneous_biased_temporal_neighbor_sample.pyx
@@ -45,6 +45,7 @@ from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_sampling_set_compress_per_hop,
     cugraph_sampling_set_compression_type,
     cugraph_sampling_set_retain_seeds,
+    cugraph_sampling_set_disjoint_sampling,
 )
 from pylibcugraph._cugraph_c.sampling_algorithms cimport (
     cugraph_heterogeneous_biased_temporal_neighbor_sample,
@@ -87,6 +88,7 @@ def heterogeneous_biased_temporal_neighbor_sample(ResourceHandle resource_handle
                                                    bool_t do_expensive_check,
                                                    prior_sources_behavior=None,
                                                    deduplicate_sources=False,
+                                                   disjoint_sampling=False,
                                                    return_hops=False,
                                                    renumber=False,
                                                    retain_seeds=False,
@@ -196,6 +198,10 @@ def heterogeneous_biased_temporal_neighbor_sample(ResourceHandle resource_handle
         Random state to use when generating samples.  Optional argument,
         defaults to a hash of process id, time, and hostname.
         (See pylibcugraph.random.CuGraphRandomState)
+
+    disjoint_sampling: bool (Optional)
+        If True, enables disjoint sampling between seeds per hop when supported.
+        Defaults to False.
 
     Returns
     -------
@@ -396,6 +402,7 @@ def heterogeneous_biased_temporal_neighbor_sample(ResourceHandle resource_handle
     cugraph_sampling_set_compression_type(sampling_options, compression_behavior_e)
     cugraph_sampling_set_compress_per_hop(sampling_options, c_compress_per_hop)
     cugraph_sampling_set_retain_seeds(sampling_options, retain_seeds)
+    cugraph_sampling_set_disjoint_sampling(sampling_options, disjoint_sampling)
 
     error_code = cugraph_heterogeneous_biased_temporal_neighbor_sample(
         c_resource_handle_ptr,

--- a/python/pylibcugraph/pylibcugraph/heterogeneous_uniform_neighbor_sample.pyx
+++ b/python/pylibcugraph/pylibcugraph/heterogeneous_uniform_neighbor_sample.pyx
@@ -42,6 +42,7 @@ from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_sampling_set_compress_per_hop,
     cugraph_sampling_set_compression_type,
     cugraph_sampling_set_retain_seeds,
+    cugraph_sampling_set_disjoint_sampling,
 )
 from pylibcugraph._cugraph_c.sampling_algorithms cimport (
     cugraph_heterogeneous_uniform_neighbor_sample,
@@ -82,6 +83,7 @@ def heterogeneous_uniform_neighbor_sample(ResourceHandle resource_handle,
                                           bool_t do_expensive_check,
                                           prior_sources_behavior=None,
                                           deduplicate_sources=False,
+                                          disjoint_sampling=False,
                                           return_hops=False,
                                           renumber=False,
                                           retain_seeds=False,
@@ -168,6 +170,10 @@ def heterogeneous_uniform_neighbor_sample(ResourceHandle resource_handle,
         entire batch.
         If True, will create a separate compressed edgelist per hop within
         a batch.
+
+    disjoint_sampling: bool (Optional)
+        If True, enables disjoint sampling between seeds per hop when supported.
+        Defaults to False.
 
     random_state: int (Optional)
         Random state to use when generating samples.  Optional argument,
@@ -350,6 +356,7 @@ def heterogeneous_uniform_neighbor_sample(ResourceHandle resource_handle,
     cugraph_sampling_set_compression_type(sampling_options, compression_behavior_e)
     cugraph_sampling_set_compress_per_hop(sampling_options, c_compress_per_hop)
     cugraph_sampling_set_retain_seeds(sampling_options, retain_seeds)
+    cugraph_sampling_set_disjoint_sampling(sampling_options, disjoint_sampling)
 
     error_code = cugraph_heterogeneous_uniform_neighbor_sample(
         c_resource_handle_ptr,

--- a/python/pylibcugraph/pylibcugraph/heterogeneous_uniform_temporal_neighbor_sample.pyx
+++ b/python/pylibcugraph/pylibcugraph/heterogeneous_uniform_temporal_neighbor_sample.pyx
@@ -42,6 +42,7 @@ from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_sampling_set_compress_per_hop,
     cugraph_sampling_set_compression_type,
     cugraph_sampling_set_retain_seeds,
+    cugraph_sampling_set_disjoint_sampling,
 )
 from pylibcugraph._cugraph_c.sampling_algorithms cimport (
     cugraph_heterogeneous_uniform_temporal_neighbor_sample,
@@ -84,6 +85,7 @@ def heterogeneous_uniform_temporal_neighbor_sample(ResourceHandle resource_handl
                                                    bool_t do_expensive_check,
                                                    prior_sources_behavior=None,
                                                    deduplicate_sources=False,
+                                                   disjoint_sampling=False,
                                                    return_hops=False,
                                                    renumber=False,
                                                    retain_seeds=False,
@@ -191,6 +193,10 @@ def heterogeneous_uniform_temporal_neighbor_sample(ResourceHandle resource_handl
         Random state to use when generating samples.  Optional argument,
         defaults to a hash of process id, time, and hostname.
         (See pylibcugraph.random.CuGraphRandomState)
+
+    disjoint_sampling: bool (Optional)
+        If True, enables disjoint sampling between seeds per hop when supported.
+        Defaults to False.
 
     Returns
     -------
@@ -392,6 +398,7 @@ def heterogeneous_uniform_temporal_neighbor_sample(ResourceHandle resource_handl
     cugraph_sampling_set_compression_type(sampling_options, compression_behavior_e)
     cugraph_sampling_set_compress_per_hop(sampling_options, c_compress_per_hop)
     cugraph_sampling_set_retain_seeds(sampling_options, retain_seeds)
+    cugraph_sampling_set_disjoint_sampling(sampling_options, disjoint_sampling)
 
     error_code = cugraph_heterogeneous_uniform_temporal_neighbor_sample(
         c_resource_handle_ptr,

--- a/python/pylibcugraph/pylibcugraph/homogeneous_biased_neighbor_sample.pyx
+++ b/python/pylibcugraph/pylibcugraph/homogeneous_biased_neighbor_sample.pyx
@@ -45,6 +45,7 @@ from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_sampling_set_compress_per_hop,
     cugraph_sampling_set_compression_type,
     cugraph_sampling_set_retain_seeds,
+    cugraph_sampling_set_disjoint_sampling,
 )
 from pylibcugraph._cugraph_c.sampling_algorithms cimport (
     cugraph_homogeneous_biased_neighbor_sample,
@@ -83,6 +84,7 @@ def homogeneous_biased_neighbor_sample(ResourceHandle resource_handle,
                                        bool_t do_expensive_check,
                                        prior_sources_behavior=None,
                                        deduplicate_sources=False,
+                                       disjoint_sampling=False,
                                        return_hops=False,
                                        renumber=False,
                                        retain_seeds=False,
@@ -161,6 +163,10 @@ def homogeneous_biased_neighbor_sample(ResourceHandle resource_handle,
         entire batch.
         If True, will create a separate compressed edgelist per hop within
         a batch.
+
+    disjoint_sampling: bool (Optional)
+        If True, enables disjoint sampling between seeds per hop when supported.
+        Defaults to False.
 
     random_state: int (Optional)
         Random state to use when generating samples.  Optional argument,
@@ -331,6 +337,7 @@ def homogeneous_biased_neighbor_sample(ResourceHandle resource_handle,
     cugraph_sampling_set_compression_type(sampling_options, compression_behavior_e)
     cugraph_sampling_set_compress_per_hop(sampling_options, c_compress_per_hop)
     cugraph_sampling_set_retain_seeds(sampling_options, retain_seeds)
+    cugraph_sampling_set_disjoint_sampling(sampling_options, disjoint_sampling)
 
     error_code = cugraph_homogeneous_biased_neighbor_sample(
         c_resource_handle_ptr,

--- a/python/pylibcugraph/pylibcugraph/homogeneous_biased_temporal_neighbor_sample.pyx
+++ b/python/pylibcugraph/pylibcugraph/homogeneous_biased_temporal_neighbor_sample.pyx
@@ -45,6 +45,7 @@ from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_sampling_set_compress_per_hop,
     cugraph_sampling_set_compression_type,
     cugraph_sampling_set_retain_seeds,
+    cugraph_sampling_set_disjoint_sampling,
 )
 from pylibcugraph._cugraph_c.sampling_algorithms cimport (
     cugraph_homogeneous_biased_temporal_neighbor_sample,
@@ -85,6 +86,7 @@ def homogeneous_biased_temporal_neighbor_sample(ResourceHandle resource_handle,
                                                  bool_t do_expensive_check,
                                                  prior_sources_behavior=None,
                                                  deduplicate_sources=False,
+                                                 disjoint_sampling=False,
                                                  return_hops=False,
                                                  renumber=False,
                                                  retain_seeds=False,
@@ -179,6 +181,10 @@ def homogeneous_biased_temporal_neighbor_sample(ResourceHandle resource_handle,
         entire batch.
         If True, will create a separate compressed edgelist per hop within
         a batch.
+
+    disjoint_sampling: bool (Optional)
+        If True, enables disjoint sampling between seeds per hop when supported.
+        Defaults to False.
 
     random_state: int (Optional)
         Random state to use when generating samples.  Optional argument,
@@ -372,6 +378,7 @@ def homogeneous_biased_temporal_neighbor_sample(ResourceHandle resource_handle,
     cugraph_sampling_set_compression_type(sampling_options, compression_behavior_e)
     cugraph_sampling_set_compress_per_hop(sampling_options, c_compress_per_hop)
     cugraph_sampling_set_retain_seeds(sampling_options, retain_seeds)
+    cugraph_sampling_set_disjoint_sampling(sampling_options, disjoint_sampling)
 
     error_code = cugraph_homogeneous_biased_temporal_neighbor_sample(
         c_resource_handle_ptr,

--- a/python/pylibcugraph/pylibcugraph/homogeneous_uniform_neighbor_sample.pyx
+++ b/python/pylibcugraph/pylibcugraph/homogeneous_uniform_neighbor_sample.pyx
@@ -42,6 +42,7 @@ from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_sampling_set_compress_per_hop,
     cugraph_sampling_set_compression_type,
     cugraph_sampling_set_retain_seeds,
+    cugraph_sampling_set_disjoint_sampling,
 )
 from pylibcugraph._cugraph_c.sampling_algorithms cimport (
     cugraph_homogeneous_uniform_neighbor_sample,
@@ -80,6 +81,7 @@ def homogeneous_uniform_neighbor_sample(ResourceHandle resource_handle,
                                           bool_t do_expensive_check,
                                           prior_sources_behavior=None,
                                           deduplicate_sources=False,
+                                          disjoint_sampling=False,
                                           return_hops=False,
                                           renumber=False,
                                           retain_seeds=False,
@@ -156,6 +158,10 @@ def homogeneous_uniform_neighbor_sample(ResourceHandle resource_handle,
         entire batch.
         If True, will create a separate compressed edgelist per hop within
         a batch.
+
+    disjoint_sampling: bool (Optional)
+        If True, enables disjoint sampling between seeds per hop when supported.
+        Defaults to False.
 
     random_state: int (Optional)
         Random state to use when generating samples.  Optional argument,
@@ -327,6 +333,7 @@ def homogeneous_uniform_neighbor_sample(ResourceHandle resource_handle,
     cugraph_sampling_set_compression_type(sampling_options, compression_behavior_e)
     cugraph_sampling_set_compress_per_hop(sampling_options, c_compress_per_hop)
     cugraph_sampling_set_retain_seeds(sampling_options, retain_seeds)
+    cugraph_sampling_set_disjoint_sampling(sampling_options, disjoint_sampling)
 
     error_code = cugraph_homogeneous_uniform_neighbor_sample(
         c_resource_handle_ptr,

--- a/python/pylibcugraph/pylibcugraph/homogeneous_uniform_temporal_neighbor_sample.pyx
+++ b/python/pylibcugraph/pylibcugraph/homogeneous_uniform_temporal_neighbor_sample.pyx
@@ -42,6 +42,7 @@ from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_sampling_set_compress_per_hop,
     cugraph_sampling_set_compression_type,
     cugraph_sampling_set_retain_seeds,
+    cugraph_sampling_set_disjoint_sampling,
 )
 from pylibcugraph._cugraph_c.sampling_algorithms cimport (
     cugraph_homogeneous_uniform_temporal_neighbor_sample,
@@ -82,6 +83,7 @@ def homogeneous_uniform_temporal_neighbor_sample(ResourceHandle resource_handle,
                                                  bool_t do_expensive_check,
                                                  prior_sources_behavior=None,
                                                  deduplicate_sources=False,
+                                                 disjoint_sampling=False,
                                                  return_hops=False,
                                                  renumber=False,
                                                  retain_seeds=False,
@@ -174,6 +176,10 @@ def homogeneous_uniform_temporal_neighbor_sample(ResourceHandle resource_handle,
         entire batch.
         If True, will create a separate compressed edgelist per hop within
         a batch.
+
+    disjoint_sampling: bool (Optional)
+        If True, enables disjoint sampling between seeds per hop when supported.
+        Defaults to False.
 
     random_state: int (Optional)
         Random state to use when generating samples.  Optional argument,
@@ -371,6 +377,7 @@ def homogeneous_uniform_temporal_neighbor_sample(ResourceHandle resource_handle,
     cugraph_sampling_set_compression_type(sampling_options, compression_behavior_e)
     cugraph_sampling_set_compress_per_hop(sampling_options, c_compress_per_hop)
     cugraph_sampling_set_retain_seeds(sampling_options, retain_seeds)
+    cugraph_sampling_set_disjoint_sampling(sampling_options, disjoint_sampling)
 
     error_code = cugraph_homogeneous_uniform_temporal_neighbor_sample(
         c_resource_handle_ptr,


### PR DESCRIPTION
This PR modifies PLC, C and C++ APIs to support a flag for disjoint sampling.  The use of that parameter is going to part of a follow-up PR.

Supports #5042
