### PR TITLE
Requires NX 3.5 for edge BC tests

### DIFF
--- a/notebooks/algorithms/centrality/Degree.ipynb
+++ b/notebooks/algorithms/centrality/Degree.ipynb
@@ -150,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G = karate.get_graph()"
+    "G = karate.get_graph(download=True)"
    ]
   },
   {

--- a/python/cugraph/cugraph/tests/centrality/test_batch_betweenness_centrality_mg.py
+++ b/python/cugraph/cugraph/tests/centrality/test_batch_betweenness_centrality_mg.py
@@ -43,7 +43,7 @@ def setup_function():
 
 
 @pytest.mark.mg
-@pytest.mark.requires_nx(version="3.5")
+@pytest.mark.requires_nx(min_ver="3.5")
 @pytest.mark.skipif(is_single_gpu(), reason="skipping MG testing on Single GPU system")
 @pytest.mark.parametrize("dataset", DATASETS)
 @pytest.mark.parametrize("directed", IS_DIRECTED)

--- a/python/cugraph/cugraph/tests/centrality/test_batch_edge_betweenness_centrality_mg.py
+++ b/python/cugraph/cugraph/tests/centrality/test_batch_edge_betweenness_centrality_mg.py
@@ -41,7 +41,7 @@ def setup_function():
 
 # FIXME: Fails for directed = False(bc score twice as much) and normalized = True.
 @pytest.mark.mg
-@pytest.mark.requires_nx(version="3.5")
+@pytest.mark.requires_nx(min_ver="3.5")
 @pytest.mark.skipif(is_single_gpu(), reason="skipping MG testing on Single GPU system")
 @pytest.mark.parametrize("dataset", DATASETS)
 @pytest.mark.parametrize("directed", IS_DIRECTED)

--- a/python/cugraph/cugraph/tests/centrality/test_betweenness_centrality.py
+++ b/python/cugraph/cugraph/tests/centrality/test_betweenness_centrality.py
@@ -300,7 +300,7 @@ def compare_scores(sorted_df, first_key, second_key, epsilon=DEFAULT_EPSILON):
 # Tests
 # =============================================================================
 @pytest.mark.sg
-@pytest.mark.requires_nx(version="3.5")
+@pytest.mark.requires_nx(min_ver="3.5")
 @pytest.mark.parametrize("graph_file", SMALL_DATASETS)
 @pytest.mark.parametrize("directed", [False, True])
 @pytest.mark.parametrize("subset_size", SUBSET_SIZE_OPTIONS)

--- a/python/cugraph/cugraph/tests/centrality/test_edge_betweenness_centrality.py
+++ b/python/cugraph/cugraph/tests/centrality/test_edge_betweenness_centrality.py
@@ -301,7 +301,7 @@ def generate_upper_triangle(dataframe):
 
 
 @pytest.mark.sg
-@pytest.mark.requires_nx(version="3.5")
+@pytest.mark.requires_nx(min_ver="3.5", max_ver="3.5")
 @pytest.mark.parametrize("graph_file", SMALL_DATASETS)
 @pytest.mark.parametrize("directed", DIRECTED_GRAPH_OPTIONS)
 @pytest.mark.parametrize("subset_size", SUBSET_SIZE_OPTIONS)
@@ -332,7 +332,7 @@ def test_edge_betweenness_centrality(
 
 
 @pytest.mark.sg
-@pytest.mark.requires_nx(version="3.5")
+@pytest.mark.requires_nx(min_ver="3.5")
 @pytest.mark.parametrize("graph_file", SMALL_DATASETS)
 @pytest.mark.parametrize("directed", DIRECTED_GRAPH_OPTIONS)
 @pytest.mark.parametrize("subset_size", [None])
@@ -372,7 +372,7 @@ def test_edge_betweenness_centrality_k_full(
 #       to a random sampling over the number of vertices (thus direct offsets)
 #       in the graph structure instead of actual vertices identifiers
 @pytest.mark.sg
-@pytest.mark.requires_nx(version="3.5")
+@pytest.mark.requires_nx(min_ver="3.5", max_ver="3.5")
 @pytest.mark.parametrize("graph_file", [karate_disjoint])
 @pytest.mark.parametrize("directed", DIRECTED_GRAPH_OPTIONS)
 @pytest.mark.parametrize("subset_size", SUBSET_SIZE_OPTIONS)

--- a/python/cugraph/cugraph/tests/conftest.py
+++ b/python/cugraph/cugraph/tests/conftest.py
@@ -36,35 +36,35 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         # Skip tests marked as requiring a specific version of NetworkX if
         # the installed version is too old
-        for mark in item.iter_markers(name="requires_nx"):
-            skip = False
+        for marker in item.iter_markers(name="requires_nx"):
+            set_mark = False
             reason = "Requires "
-            min_ver = mark.kwargs.get(
-                "min_ver", mark.args[0] if len(mark.args) > 0 else None
+            min_ver = marker.kwargs.get(
+                "min_ver", marker.args[0] if len(marker.args) > 0 else None
             )
-            max_ver = mark.kwargs.get(
-                "max_ver", mark.args[1] if len(mark.args) > 1 else None
+            max_ver = marker.kwargs.get(
+                "max_ver", marker.args[1] if len(marker.args) > 1 else None
             )
+            # xfail by default, but allow for a skip if option set.
+            skip = marker.kwargs.get("skip", False)
             if min_ver is None and max_ver is None:
                 raise TypeError("requires_nx marker must specify a min_ver or max_ver")
             if min_ver is not None:
                 min_required_nx_version = packaging.version.parse(min_ver)
                 if installed_nx_version < min_required_nx_version:
-                    skip = True
+                    set_mark = True
                     reason += f"networkx >= {min_required_nx_version}, "
             if max_ver is not None:
                 max_required_nx_version = packaging.version.parse(max_ver)
                 if installed_nx_version > max_required_nx_version:
-                    skip = True
+                    set_mark = True
                     reason += f"networkx <= {max_required_nx_version}, "
-            if skip:
-                item.add_marker(
-                    pytest.mark.skip(
-                        reason=(
-                            reason + f" (version installed: {installed_nx_version})"
-                        )
-                    )
-                )
+            if set_mark:
+                reason_str = reason + f" (version installed: {installed_nx_version})"
+                if skip:
+                    item.add_marker(pytest.mark.skip(reason=reason_str))
+                else:
+                    item.add_marker(pytest.mark.xfail(reason=reason_str))
 
 
 # Fixtures


### PR DESCRIPTION
* Requires that edge BC tests use NX 3.5 for comparisons, otherwise those tests are XFAIL'd.
  * Changes to NX 3.6 caused some comparisons in tests to fail when NX 3.6 is used as the reference. We're essentially skipping for now but will look into those changes (likely [here](https://github.com/networkx/networkx/pull/8256))
* This also updates the `requires_nx` marker to take up to 2 args for min and max required version, and a flag for skip vs. xfail.