### PR TITLE
Update examples to incorporate the latest changes to the API

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -86,19 +86,19 @@ rapids-logger "pytest cugraph (not mg, with xdist)"
   --cov-report=term
 
 # excludes known failures that will always fail when run in combination
-# FIXME: temporarily disables MG Leiden (dedicated tests and those in docstrings)
-rapids-logger "pytest cugraph (mg, with xdist)"
-./ci/run_cugraph_pytests.sh \
-  --verbose \
-  --junitxml="${RAPIDS_TESTS_DIR}/junit-cugraph.xml" \
-  --numprocesses=8 \
-  --dist=worksteal \
-  -m "mg" \
-  -k "not test_dist_sampler_mg and not test_leiden_mg and not test_doctests_mg" \
-  --cov-config=../../.coveragerc \
-  --cov=cugraph \
-  --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cugraph-coverage.xml" \
-  --cov-report=term
+# FIXME: temporarily disables MG tests due to hang in CI with CUDA 13.1.0
+rapids-logger "pytest cugraph (mg, with xdist) - SKIPPING DUE TO HANG IN CI WITH CUDA 13.1.0"
+#./ci/run_cugraph_pytests.sh \
+#  --verbose \
+#  --junitxml="${RAPIDS_TESTS_DIR}/junit-cugraph.xml" \
+#  --numprocesses=8 \
+#  --dist=worksteal \
+#  -m "mg" \
+#  -k "not test_dist_sampler_mg" \
+#  --cov-config=../../.coveragerc \
+#  --cov=cugraph \
+#  --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cugraph-coverage.xml" \
+#  --cov-report=term
 
 rapids-logger "pytest cugraph (mg dist_sampler and uns)"
 ./ci/run_cugraph_pytests.sh \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -86,6 +86,7 @@ rapids-logger "pytest cugraph (not mg, with xdist)"
   --cov-report=term
 
 # excludes known failures that will always fail when run in combination
+# FIXME: temporarily disables MG Leiden (dedicated tests and those in docstrings)
 rapids-logger "pytest cugraph (mg, with xdist)"
 ./ci/run_cugraph_pytests.sh \
   --verbose \
@@ -93,7 +94,7 @@ rapids-logger "pytest cugraph (mg, with xdist)"
   --numprocesses=8 \
   --dist=worksteal \
   -m "mg" \
-  -k "not test_dist_sampler_mg" \
+  -k "not test_dist_sampler_mg and not test_leiden_mg and not test_doctests_mg" \
   --cov-config=../../.coveragerc \
   --cov=cugraph \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cugraph-coverage.xml" \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -6,29 +6,27 @@ set -eoxu pipefail
 
 package_name=$1
 
-python_package_name=${package_name//-/_}
-
 # Run smoke tests for aarch64 pull requests
 arch=$(uname -m)
 if [[ "${arch}" == "aarch64" && ${RAPIDS_BUILD_TYPE} == "pull-request" ]]; then
     python ./ci/wheel_smoke_test_"${package_name}".py
-else
-    # Test runs that include tests that use dask require
-    # --import-mode=append. See test_python.sh for details.
-    # FIXME: Adding PY_IGNORE_IMPORTMISMATCH=1 to workaround conftest.py import
-    # mismatch error seen by nx-cugraph after using pytest 8 and
-    # --import-mode=append.
-    # FIXME: temporarily disables MG Leiden (dedicated tests and those in docstrings)
-    RAPIDS_DATASET_ROOT_DIR=$(pwd)/datasets \
-    PY_IGNORE_IMPORTMISMATCH=1 \
-    DASK_WORKER_DEVICES="0" \
-    DASK_DISTRIBUTED__SCHEDULER__WORKER_TTL="1000s" \
-    DASK_DISTRIBUTED__COMM__TIMEOUTS__CONNECT="1000s" \
-    DASK_CUDA_WAIT_WORKERS_MIN_TIMEOUT="1000s" \
-    python -m pytest \
-       -v \
-       --import-mode=append \
-       --benchmark-disable \
-       -k "not test_leiden_mg and not test_doctests_mg" \
-       "./python/${package_name}/${python_package_name}/tests"
+# FIXME: temporarily disables MG tests due to hang in CI with CUDA 13.1.0
+#else
+#    python_package_name=${package_name//-/_}
+#    # Test runs that include tests that use dask require
+#    # --import-mode=append. See test_python.sh for details.
+#    # FIXME: Adding PY_IGNORE_IMPORTMISMATCH=1 to workaround conftest.py import
+#    # mismatch error seen by nx-cugraph after using pytest 8 and
+#    # --import-mode=append.
+#    RAPIDS_DATASET_ROOT_DIR=$(pwd)/datasets \
+#    PY_IGNORE_IMPORTMISMATCH=1 \
+#    DASK_WORKER_DEVICES="0" \
+#    DASK_DISTRIBUTED__SCHEDULER__WORKER_TTL="1000s" \
+#    DASK_DISTRIBUTED__COMM__TIMEOUTS__CONNECT="1000s" \
+#    DASK_CUDA_WAIT_WORKERS_MIN_TIMEOUT="1000s" \
+#    python -m pytest \
+#       -v \
+#       --import-mode=append \
+#       --benchmark-disable \
+#       "./python/${package_name}/${python_package_name}/tests"
 fi

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -eoxu pipefail
@@ -18,6 +18,7 @@ else
     # FIXME: Adding PY_IGNORE_IMPORTMISMATCH=1 to workaround conftest.py import
     # mismatch error seen by nx-cugraph after using pytest 8 and
     # --import-mode=append.
+    # FIXME: temporarily disables MG Leiden (dedicated tests and those in docstrings)
     RAPIDS_DATASET_ROOT_DIR=$(pwd)/datasets \
     PY_IGNORE_IMPORTMISMATCH=1 \
     DASK_WORKER_DEVICES="0" \
@@ -28,6 +29,6 @@ else
        -v \
        --import-mode=append \
        --benchmark-disable \
-       -k "not test_property_graph_mg" \
+       -k "not test_leiden_mg and not test_doctests_mg" \
        "./python/${package_name}/${python_package_name}/tests"
 fi

--- a/cpp/examples/users/multi_gpu_application/mg_graph_algorithms.cpp
+++ b/cpp/examples/users/multi_gpu_application/mg_graph_algorithms.cpp
@@ -1,10 +1,11 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cugraph/algorithms.hpp>
 #include <cugraph/graph_functions.hpp>
+#include <cugraph/shuffle_functions.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -62,9 +63,7 @@ template <typename vertex_t,
           bool multi_gpu>
 
 std::tuple<cugraph::graph_t<vertex_t, edge_t, store_transposed, multi_gpu>,
-           std::optional<cugraph::edge_property_t<
-             cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
-             weight_t>>,
+           std::optional<cugraph::edge_property_t<edge_t, weight_t>>,
            std::optional<rmm::device_uvector<vertex_t>>>
 create_graph(raft::handle_t const& handle,
              std::vector<vertex_t>&& edge_srcs,
@@ -105,6 +104,9 @@ create_graph(raft::handle_t const& handle,
       (*d_edge_wgts).data(), (*edge_wgts).data() + start, work_size, handle.get_stream());
   }
 
+  std::vector<cugraph::arithmetic_device_uvector_t> edgelist_edge_property_vectors;
+  if (d_edge_wgts) edgelist_edge_property_vectors.push_back(std::move(*d_edge_wgts));
+
   //
   // In cugraph, each vertex and edge is assigned to a specific GPU using hash functions. Before
   // creating a graph from edges, we need to ensure that all edges are already assigned to the
@@ -112,13 +114,12 @@ create_graph(raft::handle_t const& handle,
   //
 
   if (multi_gpu) {
-    std::tie(d_edge_srcs, d_edge_dsts, d_edge_wgts, std::ignore, std::ignore, std::ignore) =
-      cugraph::shuffle_external_edges<vertex_t, vertex_t, weight_t, int32_t>(handle,
-                                                                             std::move(d_edge_srcs),
-                                                                             std::move(d_edge_dsts),
-                                                                             std::move(d_edge_wgts),
-                                                                             std::nullopt,
-                                                                             std::nullopt);
+    std::tie(d_edge_srcs, d_edge_dsts, edgelist_edge_property_vectors, std::ignore) =
+      cugraph::shuffle_ext_edges(handle,
+                                 std::move(d_edge_srcs),
+                                 std::move(d_edge_dsts),
+                                 std::move(edgelist_edge_property_vectors),
+                                 store_transposed);
   }
 
   //
@@ -127,31 +128,30 @@ create_graph(raft::handle_t const& handle,
 
   cugraph::graph_t<vertex_t, edge_t, store_transposed, multi_gpu> graph(handle);
 
-  std::optional<cugraph::edge_property_t<decltype(graph.view()), weight_t>> edge_weights{
-    std::nullopt};
+  std::optional<cugraph::edge_property_t<edge_t, weight_t>> edge_weights{std::nullopt};
 
   std::optional<rmm::device_uvector<vertex_t>> renumber_map{std::nullopt};
 
-  std::tie(graph, edge_weights, std::ignore, std::ignore, renumber_map) =
-    cugraph::create_graph_from_edgelist<vertex_t,
-                                        edge_t,
-                                        weight_t,
-                                        edge_t,
-                                        int32_t,
-                                        store_transposed,
-                                        multi_gpu>(handle,
-                                                   std::nullopt,
-                                                   std::move(d_edge_srcs),
-                                                   std::move(d_edge_dsts),
-                                                   std::move(d_edge_wgts),
-                                                   std::nullopt,
-                                                   std::nullopt,
-                                                   cugraph::graph_properties_t{is_symmetric, false},
-                                                   renumber,
-                                                   true);
+  std::vector<cugraph::edge_arithmetic_property_t<edge_t>> edgelist_edge_properties;
 
-  auto graph_view       = graph.view();
-  auto edge_weight_view = edge_weights ? std::make_optional((*edge_weights).view()) : std::nullopt;
+  std::tie(graph, edgelist_edge_properties, renumber_map) =
+    cugraph::create_graph_from_edgelist<vertex_t, edge_t, store_transposed, multi_gpu>(
+      handle,
+      std::nullopt,
+      std::move(d_edge_srcs),
+      std::move(d_edge_dsts),
+      std::move(edgelist_edge_property_vectors),
+      cugraph::graph_properties_t{is_symmetric, false},
+      renumber,
+      std::nullopt,
+      std::nullopt,
+      true);
+
+  auto graph_view = graph.view();
+  if (edgelist_edge_properties.size() > 0) {
+    edge_weights =
+      std::move(std::get<cugraph::edge_property_t<edge_t, weight_t>>(edgelist_edge_properties[0]));
+  }
 
   return std::make_tuple(std::move(graph), std::move(edge_weights), std::move(renumber_map));
 }

--- a/cpp/examples/users/single_gpu_application/sg_graph_algorithms.cpp
+++ b/cpp/examples/users/single_gpu_application/sg_graph_algorithms.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -34,9 +34,7 @@ template <typename vertex_t,
           bool multi_gpu>
 
 std::tuple<cugraph::graph_t<vertex_t, edge_t, store_transposed, multi_gpu>,
-           std::optional<cugraph::edge_property_t<
-             cugraph::graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu>,
-             weight_t>>,
+           std::optional<cugraph::edge_property_t<edge_t, weight_t>>,
            std::optional<rmm::device_uvector<vertex_t>>>
 create_graph(raft::handle_t const& handle,
              std::vector<vertex_t>&& edge_srcs,
@@ -70,31 +68,32 @@ create_graph(raft::handle_t const& handle,
 
   cugraph::graph_t<vertex_t, edge_t, store_transposed, multi_gpu> graph(handle);
 
-  std::optional<cugraph::edge_property_t<decltype(graph.view()), weight_t>> edge_weights{
-    std::nullopt};
+  std::optional<cugraph::edge_property_t<edge_t, weight_t>> edge_weights{std::nullopt};
 
   std::optional<rmm::device_uvector<vertex_t>> renumber_map{std::nullopt};
 
-  std::tie(graph, edge_weights, std::ignore, std::ignore, renumber_map) =
-    cugraph::create_graph_from_edgelist<vertex_t,
-                                        edge_t,
-                                        weight_t,
-                                        edge_t,
-                                        int32_t,
-                                        store_transposed,
-                                        multi_gpu>(handle,
-                                                   std::nullopt,
-                                                   std::move(d_edge_srcs),
-                                                   std::move(d_edge_dsts),
-                                                   std::move(d_edge_wgts),
-                                                   std::nullopt,
-                                                   std::nullopt,
-                                                   cugraph::graph_properties_t{is_symmetric, false},
-                                                   renumber,
-                                                   true);
+  std::vector<cugraph::arithmetic_device_uvector_t> edgelist_edge_property_vectors;
+  if (d_edge_wgts) edgelist_edge_property_vectors.push_back(std::move(*d_edge_wgts));
+  std::vector<cugraph::edge_arithmetic_property_t<edge_t>> edgelist_edge_properties;
 
-  auto graph_view       = graph.view();
-  auto edge_weight_view = edge_weights ? std::make_optional((*edge_weights).view()) : std::nullopt;
+  std::tie(graph, edgelist_edge_properties, renumber_map) =
+    cugraph::create_graph_from_edgelist<vertex_t, edge_t, store_transposed, multi_gpu>(
+      handle,
+      std::nullopt,
+      std::move(d_edge_srcs),
+      std::move(d_edge_dsts),
+      std::move(edgelist_edge_property_vectors),
+      cugraph::graph_properties_t{is_symmetric, false},
+      renumber,
+      std::nullopt,
+      std::nullopt,
+      true);
+
+  auto graph_view = graph.view();
+  if (edgelist_edge_properties.size() > 0) {
+    edge_weights =
+      std::move(std::get<cugraph::edge_property_t<edge_t, weight_t>>(edgelist_edge_properties[0]));
+  }
 
   return std::make_tuple(std::move(graph), std::move(edge_weights), std::move(renumber_map));
 }


### PR DESCRIPTION
Closes #5323

Also temporarily disables Python MG tests due to a hang with CUDA 13.1.0. These will be re-enabled in a followup PR.