### PR TITLE
Avoid modifying a std::move-ed out object

### DIFF
--- a/cpp/src/traversal/od_shortest_distances_impl.cuh
+++ b/cpp/src/traversal/od_shortest_distances_impl.cuh
@@ -912,8 +912,8 @@ rmm::device_uvector<weight_t> od_shortest_distances(
                                   h_split_thresholds.size(),
                                   handle.get_stream());
 
-              rmm::device_uvector<key_t> tmp_buffer = std::move(far_buffers.back());
-              far_buffers.back() = rmm::device_uvector<key_t>(0, handle.get_stream());
+              auto tmp_buffer = rmm::device_uvector<key_t>(0, handle.get_stream());
+              std::swap(tmp_buffer, far_buffers.back());
               std::vector<key_t*> h_buffer_ptrs(h_split_thresholds.size() + 1);
               auto old_size = new_near_q_keys.size();
               for (size_t j = 0; j < h_buffer_ptrs.size(); ++j) {


### PR DESCRIPTION
Modifying a std::move-ed out object is an undefined behavior. To re-use the move-ed out object, it should be re-initialized. We may pull these updates to #5383 and just close this PR.