### PR TITLE
Remove incorrect documentation main-to-release replacements

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -160,18 +160,6 @@ for FILE in .github/workflows/*.yaml; do
   sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_SHORT_TAG}-/g" "${FILE}"
 done
 
-# Documentation references - context-aware
-if [[ "${RUN_CONTEXT}" == "main" ]]; then
-  # In main context, keep documentation on main (no changes needed)
-  :
-elif [[ "${RUN_CONTEXT}" == "release" ]]; then
-  # In release context, use release branch for documentation links (word boundaries to avoid partial matches)
-  sed_runner "s|\\bmain\\b|release/${NEXT_SHORT_TAG}|g" readme_pages/CONTRIBUTING.md
-  sed_runner "s|\\bmain\\b|release/${NEXT_SHORT_TAG}|g" notebooks/modules/mag240m_pg.ipynb
-  sed_runner "s|\\bmain\\b|release/${NEXT_SHORT_TAG}|g" notebooks/demo/mg_property_graph.ipynb
-  sed_runner "s|\\bmain\\b|release/${NEXT_SHORT_TAG}|g" notebooks/README.md
-fi
-
 # .devcontainer files
 find .devcontainer/ -type f -name devcontainer.json -print0 | while IFS= read -r -d '' filename; do
     sed_runner "s@rapidsai/devcontainers:[0-9.]*@rapidsai/devcontainers:${NEXT_SHORT_TAG}@g" "${filename}"


### PR DESCRIPTION
## Summary
Removes the documentation "main" to "release/X.Y" replacement block from `update-version.sh`.

The script was incorrectly replacing the word "main" in documentation where it's used as an adjective (e.g., "Visit the main RAPIDS notebooks repo") or as a branch name in explanatory text (e.g., "not main or a future branch"). It also referenced non-existent notebook files.

The version number updates in `notebooks/README.md` are already handled correctly by line 184.

## Test plan
- [x] Verified both `--run-context=release` and `--run-context=main` work correctly