### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -298,10 +298,6 @@ dependencies:
       - output_types: [conda]
         matrices:
           - matrix:
-              py: "3.10"
-            packages:
-              - python=3.10
-          - matrix:
               py: "3.11"
             packages:
               - python=3.11
@@ -315,7 +311,7 @@ dependencies:
               - python=3.13
           - matrix:
             packages:
-              - python>=3.10,<3.14
+              - python>=3.11,<3.14
   python_build_rapids:
     common:
       - output_types: [conda, pyproject, requirements]

--- a/python/cugraph/pyproject.toml
+++ b/python/cugraph/pyproject.toml
@@ -22,7 +22,7 @@ authors = [
     { name = "NVIDIA Corporation" },
 ]
 license = "Apache-2.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "cuda-python>=13.0.1,<14.0",
     "cudf==26.4.*,>=0.0.0a0",
@@ -44,7 +44,6 @@ dependencies = [
 classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]

--- a/python/libcugraph/pyproject.toml
+++ b/python/libcugraph/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
     { name = "NVIDIA Corporation" },
 ]
 license = "Apache-2.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Database",

--- a/python/pylibcugraph/pyproject.toml
+++ b/python/pylibcugraph/pyproject.toml
@@ -21,7 +21,7 @@ authors = [
     { name = "NVIDIA Corporation" },
 ]
 license = "Apache-2.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "cupy-cuda13x>=13.6.0",
     "libcugraph==26.4.*,>=0.0.0a0",
@@ -32,7 +32,6 @@ dependencies = [
 classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/246

Finishes the work of dropping Python 3.10 support.

This project stopped building / testing against Python 3.10 as of https://github.com/rapidsai/shared-workflows/pull/494
This PR updates configuration and docs to reflect that.

## Followups before merging

Check that there are no remaining uses like this:

```shell
git grep -E '3\.10'
git grep '310'
git grep 'py310'
```
