### PR TITLE
Remove a couple of variant branches to shrink libcugraph_mg about 6%

### DIFF
--- a/cpp/src/detail/groupby_and_count.cuh
+++ b/cpp/src/detail/groupby_and_count.cuh
@@ -109,38 +109,6 @@ rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
                                           handle.get_stream(),
                                           large_buffer_type);
     }
-  } else if (edgelist_properties.size() == 1) {
-    counts = cugraph::variant_type_dispatch(
-      edgelist_properties[0],
-      [&handle,
-       large_buffer_type,
-       pair_first,
-       size = edgelist_majors.size(),
-       local_edge_partition_include_minor_op,
-       local_edge_partition_op,
-       comm_size,
-       mem_frugal_threshold,
-       groupby_and_count_local_partition_by_minor](auto& prop) {
-        if (groupby_and_count_local_partition_by_minor) {
-          return cugraph::groupby_and_count(pair_first,
-                                            pair_first + size,
-                                            prop.begin(),
-                                            local_edge_partition_include_minor_op,
-                                            comm_size,
-                                            mem_frugal_threshold,
-                                            handle.get_stream(),
-                                            large_buffer_type);
-        } else {
-          return cugraph::groupby_and_count(pair_first,
-                                            pair_first + size,
-                                            prop.begin(),
-                                            local_edge_partition_op,
-                                            comm_size,
-                                            mem_frugal_threshold,
-                                            handle.get_stream(),
-                                            large_buffer_type);
-        }
-      });
   } else {
     auto property_positions =
       large_buffer_type ? large_buffer_manager::allocate_memory_buffer<size_t>(

--- a/cpp/src/utilities/shuffle_vertex_pairs.cuh
+++ b/cpp/src/utilities/shuffle_vertex_pairs.cuh
@@ -145,25 +145,6 @@ shuffle_vertex_pairs_with_values_by_gpu_id_impl(
                                    mem_frugal_threshold,
                                    handle.get_stream(),
                                    large_buffer_type);
-    } else if (edge_properties.size() == 1) {
-      d_tx_value_counts = cugraph::variant_type_dispatch(
-        edge_properties[0],
-        [&handle,
-         &majors,
-         &minors,
-         &groupby_functor,
-         &large_buffer_type,
-         this_step_comm_size,
-         mem_frugal_threshold](auto& prop) {
-          return cugraph::groupby_and_count(
-            thrust::make_zip_iterator(majors.begin(), minors.begin(), prop.begin()),
-            thrust::make_zip_iterator(majors.end(), minors.end(), prop.end()),
-            groupby_functor,
-            this_step_comm_size,
-            mem_frugal_threshold,
-            handle.get_stream(),
-            large_buffer_type);
-        });
     } else {
       rmm::device_uvector<size_t> property_position(majors.size(), handle.get_stream());
       detail::sequence_fill(


### PR DESCRIPTION
Part of the effort for #5473 

A couple of the variant paths add a significant amount to our binary size, don't expect there to be a big performance difference.