### PR TITLE
cugraph tests failing due to missing JIT function on CUDA 12

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -11,6 +11,7 @@ dependencies:
 - certifi
 - cmake>=3.30.4
 - cuda-nvcc
+- cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
 - cuda-python>=12.9.2,<13.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -11,6 +11,7 @@ dependencies:
 - certifi
 - cmake>=3.30.4
 - cuda-nvcc
+- cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
 - cuda-python>=12.9.2,<13.0

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -11,6 +11,7 @@ dependencies:
 - certifi
 - cmake>=3.30.4
 - cuda-nvcc
+- cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
 - cuda-python>=13.0.1,<14.0

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -11,6 +11,7 @@ dependencies:
 - certifi
 - cmake>=3.30.4
 - cuda-nvcc
+- cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
 - cuda-python>=13.0.1,<14.0

--- a/conda/recipes/libcugraph/recipe.yaml
+++ b/conda/recipes/libcugraph/recipe.yaml
@@ -171,13 +171,16 @@ outputs:
         - cuda-version =${{ cuda_version }}
         - libcudf =${{ minor_version }}
         - librmm =${{ minor_version }}
+        - cuda-cudart-dev
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - ${{ pin_subpackage("libcugraph", exact=True) }}
         - libcudf =${{ minor_version }}
         - librmm =${{ minor_version }}
+        - cuda-cudart
       ignore_run_exports:
         by_name:
+          - cuda-cudart
           - cuda-nvtx
           - cuda-version
           - libcublas

--- a/conda/recipes/libcugraph/recipe.yaml
+++ b/conda/recipes/libcugraph/recipe.yaml
@@ -123,6 +123,7 @@ outputs:
         - libraft =${{ minor_version }}
         - librmm =${{ minor_version }}
         - nccl ${{ nccl_version }}
+        - cuda-cudart
         - cuda-profiler-api
         - libcublas
         - libcurand
@@ -213,6 +214,7 @@ outputs:
       host:
         - ${{ pin_subpackage("libcugraph", exact=True) }}
         - cuda-version =${{ cuda_version }}
+        - cuda-cudart-dev
         - nccl ${{ nccl_version }}
         - openmpi <5.0.3 # Required for building cpp-mgtests (multi-GPU tests)
         - rapids-logger =0.2
@@ -220,8 +222,10 @@ outputs:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - ${{ pin_subpackage("libcugraph", exact=True) }}
         - ${{ pin_subpackage("libcugraph_etl", exact=True) }}
+        - cuda-cudart
       ignore_run_exports:
         by_name:
+          - cuda-cudart
           - cuda-nvtx
           - cuda-version
           - libcublas

--- a/conda/recipes/libcugraph/recipe.yaml
+++ b/conda/recipes/libcugraph/recipe.yaml
@@ -114,6 +114,7 @@ outputs:
         - librmm =${{ minor_version }}
         - rapids-logger =0.2
         - cuda-cudart-dev
+        - cuda-nvrtc-dev
         - libcublas-dev
         - libcurand-dev
         - libcusolver-dev
@@ -124,6 +125,7 @@ outputs:
         - librmm =${{ minor_version }}
         - nccl ${{ nccl_version }}
         - cuda-cudart
+        - cuda-nvrtc
         - cuda-profiler-api
         - libcublas
         - libcurand
@@ -132,6 +134,7 @@ outputs:
       ignore_run_exports:
         by_name:
           - cuda-cudart
+          - cuda-nvrtc
           - cuda-nvtx
           - cuda-version
           - libcublas
@@ -172,15 +175,18 @@ outputs:
         - libcudf =${{ minor_version }}
         - librmm =${{ minor_version }}
         - cuda-cudart-dev
+        - cuda-nvrtc-dev
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - ${{ pin_subpackage("libcugraph", exact=True) }}
         - libcudf =${{ minor_version }}
         - librmm =${{ minor_version }}
         - cuda-cudart
+        - cuda-nvrtc
       ignore_run_exports:
         by_name:
           - cuda-cudart
+          - cuda-nvrtc
           - cuda-nvtx
           - cuda-version
           - libcublas
@@ -218,6 +224,7 @@ outputs:
         - ${{ pin_subpackage("libcugraph", exact=True) }}
         - cuda-version =${{ cuda_version }}
         - cuda-cudart-dev
+        - cuda-nvrtc-dev
         - nccl ${{ nccl_version }}
         - openmpi <5.0.3 # Required for building cpp-mgtests (multi-GPU tests)
         - rapids-logger =0.2
@@ -226,9 +233,11 @@ outputs:
         - ${{ pin_subpackage("libcugraph", exact=True) }}
         - ${{ pin_subpackage("libcugraph_etl", exact=True) }}
         - cuda-cudart
+        - cuda-nvrtc
       ignore_run_exports:
         by_name:
           - cuda-cudart
+          - cuda-nvrtc
           - cuda-nvtx
           - cuda-version
           - libcublas

--- a/conda/recipes/libcugraph/recipe.yaml
+++ b/conda/recipes/libcugraph/recipe.yaml
@@ -130,6 +130,7 @@ outputs:
         - libcusparse
       ignore_run_exports:
         by_name:
+          - cuda-cudart
           - cuda-nvtx
           - cuda-version
           - libcublas

--- a/conda/recipes/libcugraph/recipe.yaml
+++ b/conda/recipes/libcugraph/recipe.yaml
@@ -113,6 +113,7 @@ outputs:
         - cuda-version =${{ cuda_version }}
         - librmm =${{ minor_version }}
         - rapids-logger =0.2
+        - cuda-cudart-dev
         - libcublas-dev
         - libcurand-dev
         - libcusolver-dev

--- a/conda/recipes/libcugraph/recipe.yaml
+++ b/conda/recipes/libcugraph/recipe.yaml
@@ -79,6 +79,8 @@ cache:
       - nccl ${{ nccl_version }}
       - openmpi <5.0.3 # Required for building cpp-mgtests (multi-GPU tests)
       - rapids-build-backend >=0.4.0,<0.5.0
+      - cuda-cudart-dev
+      - cuda-nvrtc-dev
       - cuda-nvtx-dev
       - cuda-profiler-api
       - libcublas-dev

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -471,9 +471,6 @@ SECTIONS
 }
 ]=])
 
-set_property(TARGET cugraph PROPERTY NO_CUDART_DEP ON)
-set_property(TARGET cugraph_mg PROPERTY NO_CUDART_DEP ON)
-
 set(cugraph_suffixes "" "_mg")
 foreach(suffix IN LISTS cugraph_suffixes)
     set_target_properties(cugraph${suffix}

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -471,6 +471,9 @@ SECTIONS
 }
 ]=])
 
+set_property(TARGET cugraph PROPERTY NO_CUDART_DEP ON)
+set_property(TARGET cugraph_mg PROPERTY NO_CUDART_DEP ON)
+
 set(cugraph_suffixes "" "_mg")
 foreach(suffix IN LISTS cugraph_suffixes)
     set_target_properties(cugraph${suffix}

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -471,6 +471,9 @@ SECTIONS
 }
 ]=])
 
+set_property(TARGET cugraph PROPERTY NO_CUDART_DEP ON)
+set_property(TARGET cugraph_mg PROPERTY NO_CUDART_DEP ON)
+
 set(cugraph_suffixes "" "_mg")
 foreach(suffix IN LISTS cugraph_suffixes)
     set_target_properties(cugraph${suffix}
@@ -511,13 +514,14 @@ foreach(suffix IN LISTS cugraph_suffixes)
     # - link libraries -------------------------------------------------------------
     target_link_libraries(cugraph${suffix}
         PUBLIC
-            rmm::rmm
             raft::raft
             $<BUILD_LOCAL_INTERFACE:CUDA::toolkit>
         PRIVATE
             ${COMPILED_RAFT_LIB}
             $<IF:$<BOOL:${CUGRAPH_USE_CUVS_STATIC}>,cuvs::cuvs_static,cuvs::cuvs> #
             cuco::cuco
+            rmm::rmm
+        INTERFACE $<COMPILE_ONLY:rmm::rmm>
     )
 
     ################################################################################

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ target_compile_options(cugraphtestutil
 )
 
 set_property(TARGET cugraphtestutil PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET cugraphtestutil PROPERTY NO_CUDART_DEP ON)
 
 target_include_directories(cugraphtestutil
     PUBLIC
@@ -83,6 +84,7 @@ target_include_directories(cugraph_c_testutil
 )
 
 set_property(TARGET cugraph_c_testutil PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET cugraph_c_testutil PROPERTY NO_CUDART_DEP ON)
 
 target_link_libraries(cugraph_c_testutil
     PUBLIC
@@ -114,6 +116,7 @@ if(BUILD_CUGRAPH_MG_TESTS)
                 )
 
     set_property(TARGET cugraphmgtestutil PROPERTY POSITION_INDEPENDENT_CODE ON)
+    set_property(TARGET cugraphmgtestutil PROPERTY NO_CUDART_DEP ON)
 
     target_compile_options(cugraphmgtestutil
                 PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${CUGRAPH_CXX_FLAGS}>"

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -47,7 +47,6 @@ target_compile_options(cugraphtestutil
 )
 
 set_property(TARGET cugraphtestutil PROPERTY POSITION_INDEPENDENT_CODE ON)
-set_property(TARGET cugraphtestutil PROPERTY NO_CUDART_DEP ON)
 
 target_include_directories(cugraphtestutil
     PUBLIC
@@ -84,7 +83,6 @@ target_include_directories(cugraph_c_testutil
 )
 
 set_property(TARGET cugraph_c_testutil PROPERTY POSITION_INDEPENDENT_CODE ON)
-set_property(TARGET cugraph_c_testutil PROPERTY NO_CUDART_DEP ON)
 
 target_link_libraries(cugraph_c_testutil
     PUBLIC
@@ -116,7 +114,6 @@ if(BUILD_CUGRAPH_MG_TESTS)
                 )
 
     set_property(TARGET cugraphmgtestutil PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET cugraphmgtestutil PROPERTY NO_CUDART_DEP ON)
 
     target_compile_options(cugraphmgtestutil
                 PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${CUGRAPH_CXX_FLAGS}>"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -299,6 +299,7 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
+          - cuda-nvrtc-dev
           - cuda-nvtx-dev
           - cuda-profiler-api
           - libcublas-dev
@@ -328,13 +329,13 @@ dependencies:
               cuda: "12.9"
               use_cuda_wheels: "true"
             packages:
-              - cuda-toolkit[cublas,curand,cusolver,cusparse]==12.*
+              - cuda-toolkit[cublas,curand,cusolver,cusparse,nvrtc]==12.*
               - nvidia-nvjitlink-cu12>=12.9,<13
           - matrix:
               cuda: "13.*"
               use_cuda_wheels: "true"
             packages:
-              - &ctk_cu13 cuda-toolkit[cublas,curand,cusolver,cusparse]==13.*
+              - &ctk_cu13 cuda-toolkit[cublas,curand,cusolver,cusparse,nvrtc]==13.*
               - &nvjitlink_cu13 nvidia-nvjitlink>=13.0,<14
           # if no matching matrix selectors passed, list the CUDA 13 requirement
           # (just as a source of documentation, as this populates pyproject.toml in source control)

--- a/python/libcugraph/pyproject.toml
+++ b/python/libcugraph/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Environment :: GPU :: NVIDIA CUDA",
 ]
 dependencies = [
-    "cuda-toolkit[cublas,curand,cusolver,cusparse]==13.*",
+    "cuda-toolkit[cublas,curand,cusolver,cusparse,nvrtc]==13.*",
     "libraft==26.6.*,>=0.0.0a0",
     "librmm==26.6.*,>=0.0.0a0",
     "nvidia-nvjitlink>=13.0,<14",


### PR DESCRIPTION
Failure message:
```
./../../..//bin/gtests/libcugraph/HOMOGENEOUS_BIASED_NEIGHBOR_SAMPLING_TEST: symbol lookup error: /opt/conda/envs/test/bin/gtests/libcugraph/../../../lib/libcugraph.so: undefined symbol: cudaLibraryGetKernel, version libcudart.so.12
```

Some slack conversations have suggested adding some parameters to CMake to work around this issue.