### PR TITLE
Remove `NO_CUDART_DEP` property

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -60,7 +60,7 @@ message(VERBOSE "CUGRAPH: CUGRAPH_USE_CUVS_STATIC=${CUGRAPH_USE_CUVS_STATIC}")
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 # CUDA runtime
-rapids_cuda_init_runtime(USE_STATIC OFF)
+rapids_cuda_init_runtime(USE_STATIC ON)
 
 rapids_find_package(CUDAToolkit REQUIRED
     BUILD_EXPORT_SET    cugraph-exports
@@ -527,11 +527,6 @@ SECTIONS
 }
 ]=])
 
-set_property(TARGET cugraph PROPERTY NO_CUDART_DEP ON)
-set_property(TARGET cugraph_mg PROPERTY NO_CUDART_DEP ON)
-set_property(TARGET cugraph_mtmg PROPERTY NO_CUDART_DEP ON)
-set_property(TARGET cugraph_common PROPERTY NO_CUDART_DEP ON)
-
 set_target_properties(cugraph_common
     PROPERTIES BUILD_RPATH                         "\$ORIGIN"
                INSTALL_RPATH                       "\$ORIGIN"
@@ -586,7 +581,6 @@ foreach(suffix IN LISTS cugraph_suffixes)
                    CUDA_STANDARD_REQUIRED              ON
                    POSITION_INDEPENDENT_CODE           ON
                    INTERFACE_POSITION_INDEPENDENT_CODE ON
-                   NO_CUDART_DEP                       ON
     )
 
     ################################################################################

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -47,7 +47,6 @@ target_compile_options(cugraphtestutil
 )
 
 set_property(TARGET cugraphtestutil PROPERTY POSITION_INDEPENDENT_CODE ON)
-set_property(TARGET cugraphtestutil PROPERTY NO_CUDART_DEP ON)
 
 target_include_directories(cugraphtestutil
     PUBLIC
@@ -84,7 +83,6 @@ target_include_directories(cugraph_c_testutil
 )
 
 set_property(TARGET cugraph_c_testutil PROPERTY POSITION_INDEPENDENT_CODE ON)
-set_property(TARGET cugraph_c_testutil PROPERTY NO_CUDART_DEP ON)
 
 target_link_libraries(cugraph_c_testutil
     PUBLIC
@@ -118,7 +116,6 @@ if(BUILD_CUGRAPH_MG_TESTS)
                 )
 
     set_property(TARGET cugraphmgtestutil PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET cugraphmgtestutil PROPERTY NO_CUDART_DEP ON)
 
     target_compile_options(cugraphmgtestutil
                 PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${CUGRAPH_CXX_FLAGS}>"


### PR DESCRIPTION
This property, add to rmm in https://github.com/rapidsai/rmm/pull/2317 and used in cugraph in https://github.com/rapidsai/cugraph/pull/5483, is a holdover from when rmm enforced linking of dynamic cudart. https://github.com/rapidsai/rmm/pull/2375 switched to static cudart and stopped querying the property, so remove it.

Issue: https://github.com/rapidsai/build-planning/issues/235