### PR TITLE
Bump up minimum NCCL version from 2.19 to 2.28

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -37,7 +37,7 @@ dependencies:
 - libraft==26.8.*,>=0.0.0a0
 - librmm==26.8.*,>=0.0.0a0
 - nbsphinx
-- nccl>=2.19
+- nccl>=2.28
 - networkx>=2.5.1
 - ninja
 - notebook>=0.5.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -37,7 +37,7 @@ dependencies:
 - libraft==26.8.*,>=0.0.0a0
 - librmm==26.8.*,>=0.0.0a0
 - nbsphinx
-- nccl>=2.19
+- nccl>=2.28
 - networkx>=2.5.1
 - ninja
 - notebook>=0.5.0

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -37,7 +37,7 @@ dependencies:
 - libraft==26.8.*,>=0.0.0a0
 - librmm==26.8.*,>=0.0.0a0
 - nbsphinx
-- nccl>=2.19
+- nccl>=2.28
 - networkx>=2.5.1
 - ninja
 - notebook>=0.5.0

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -37,7 +37,7 @@ dependencies:
 - libraft==26.8.*,>=0.0.0a0
 - librmm==26.8.*,>=0.0.0a0
 - nbsphinx
-- nccl>=2.19
+- nccl>=2.28
 - networkx>=2.5.1
 - ninja
 - notebook>=0.5.0

--- a/conda/recipes/libcugraph/conda_build_config.yaml
+++ b/conda/recipes/libcugraph/conda_build_config.yaml
@@ -14,7 +14,7 @@ doxygen_version:
   - ">=1.8.11"
 
 nccl_version:
-  - ">=2.19"
+  - ">=2.28"
 
 c_stdlib:
   - sysroot

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -463,7 +463,7 @@ dependencies:
           - aiohttp
           - fsspec>=0.6.0
           - requests
-          - nccl>=2.19
+          - nccl>=2.28
       - output_types: [pyproject, requirements]
         packages:
           # cudf uses fsspec but is protocol independent. cugraph


### PR DESCRIPTION
ncclGather/ncclScatter/ncclAlltoAll are added in NCCL 2.28 (the most recent NCCL version is 2.30). Now we are using these functions (https://github.com/rapidsai/cugraph/pull/5491), we need to bump up the minimum NCCL version to at least 2.28.