### PR TITLE
skip CuPy 14.1.0

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
 - cudf==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dask-cuda==26.6.*,>=0.0.0a0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
 - cudf==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dask-cuda==26.6.*,>=0.0.0a0

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cuda-python>=13.0.1,<14.0
 - cuda-version=13.2
 - cudf==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dask-cuda==26.6.*,>=0.0.0a0

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cuda-python>=13.0.1,<14.0
 - cuda-version=13.2
 - cudf==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dask-cuda==26.6.*,>=0.0.0a0

--- a/conda/recipes/cugraph/recipe.yaml
+++ b/conda/recipes/cugraph/recipe.yaml
@@ -92,7 +92,7 @@ requirements:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
     - aiohttp
     - cudf =${{ minor_version }}
-    - cupy >=13.6.0
+    - cupy >=13.6.0,!=14.0.0,!=14.1.0
     - dask-cuda =${{ minor_version }}
     - dask-cudf =${{ minor_version }}
     - fsspec>=0.6.0

--- a/conda/recipes/pylibcugraph/recipe.yaml
+++ b/conda/recipes/pylibcugraph/recipe.yaml
@@ -79,7 +79,7 @@ requirements:
     - scikit-build-core>=0.11.0
   run:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
-    - cupy >=13.6.0
+    - cupy >=13.6.0,!=14.0.0,!=14.1.0
     - libcugraph =${{ version }}
     - numpy>=1.23,<3.0
     - pylibraft =${{ minor_version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -947,7 +947,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - cupy>=13.6.0
+          - cupy>=13.6.0,!=14.0.0,!=14.1.0
     # NOTE: This is intentionally not broken into groups by a 'cuda_suffixed' selector like
     #       other packages with -cu{nn}x suffixes in this file.
     #       All RAPIDS wheel builds (including in devcontainers) expect cupy to be suffixed.
@@ -957,11 +957,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=13.6.0
+              - cupy-cuda12x>=13.6.0,!=14.0.0,!=14.1.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=13.6.0
+              - cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0
   depends_on_ucxx:
     common:
       - output_types: conda

--- a/python/cugraph/pyproject.toml
+++ b/python/cugraph/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.11"
 dependencies = [
     "cuda-python>=13.0.1,<14.0",
     "cudf==26.6.*,>=0.0.0a0",
-    "cupy-cuda13x>=13.6.0",
+    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
     "dask-cuda==26.6.*,>=0.0.0a0",
     "dask-cudf==26.6.*,>=0.0.0a0",
     "fsspec[http]>=0.6.0",

--- a/python/pylibcugraph/pyproject.toml
+++ b/python/pylibcugraph/pyproject.toml
@@ -23,7 +23,7 @@ authors = [
 license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
-    "cupy-cuda13x>=13.6.0",
+    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
     "libcugraph==26.6.*,>=0.0.0a0",
     "numpy>=1.23,<3.0",
     "pylibraft==26.6.*,>=0.0.0a0",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/284

To reduce the risk of users encountering a known runtime issue with `cupy` and `torch`, RAPIDS 26.06 is taking on a requirement `cupy!=14.1.0`.

See the linked issue for details.
