### PR TITLE
One more CCCL fix

### DIFF
--- a/cpp/tests/sampling/detail/nbr_sampling_validate.cu
+++ b/cpp/tests/sampling/detail/nbr_sampling_validate.cu
@@ -77,21 +77,17 @@ struct ArithmeticZipLess {
 // FIXME: Consider moving this to thrust_tuple_utils and making it
 //        generic for any tuple that supports < operator
 struct ArithmeticZipEqual {
-  template <typename vertex_t, typename weight_t>
-  __device__ bool operator()(cuda::std::tuple<vertex_t, vertex_t, weight_t> const& left,
-                             cuda::std::tuple<vertex_t, vertex_t, weight_t> const& right)
+  template <typename left_t, typename right_t>
+  __device__ bool operator()(left_t const& left, right_t const& right) const
   {
-    return (cuda::std::get<0>(left) == cuda::std::get<0>(right)) &&
-           (cuda::std::get<1>(left) == cuda::std::get<1>(right)) &&
-           (cuda::std::get<2>(left) == cuda::std::get<2>(right));
-  }
-
-  template <typename vertex_t>
-  __device__ bool operator()(cuda::std::tuple<vertex_t, vertex_t> const& left,
-                             cuda::std::tuple<vertex_t, vertex_t> const& right)
-  {
-    return (cuda::std::get<0>(left) == cuda::std::get<0>(right)) &&
-           (cuda::std::get<1>(left) == cuda::std::get<1>(right));
+    if constexpr (cuda::std::tuple_size<left_t>::value > 2) {
+      return (cuda::std::get<0>(left) == cuda::std::get<0>(right)) &&
+             (cuda::std::get<1>(left) == cuda::std::get<1>(right)) &&
+             (cuda::std::get<2>(left) == cuda::std::get<2>(right));
+    } else {
+      return (cuda::std::get<0>(left) == cuda::std::get<0>(right)) &&
+             (cuda::std::get<1>(left) == cuda::std::get<1>(right));
+    }
   }
 };
 


### PR DESCRIPTION
The error occurs because CCCL 3.5.0 added an indirect_binary_predicate SFINAE constraint on cub::DeviceSelect::Unique. This constraint checks that the equality operator is invocable with the iterator's reference type. The old ArithmeticZipEqual had overloads taking cuda::std::tuple<vertex_t, vertex_t, weight_t> const& — but thrust::zip_iterator's reference type is a tuple of references (e.g. cuda::std::tuple<int64_t&, int64_t&, float&>), which doesn't match via template deduction.