### PR TITLE
[REVIEW] Add experimental DAWN BFS C API

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -323,6 +323,8 @@ set(CUGRAPH_SG_SOURCES
     src/traversal/extract_bfs_paths_sg_v32_e32.cu
     src/traversal/bfs_sg_v64_e64.cu
     src/traversal/bfs_sg_v32_e32.cu
+    src/traversal/dawn_bfs_sg_v64_e64.cu
+    src/traversal/dawn_bfs_sg_v32_e32.cu
     src/traversal/sssp_sg_v64_e64.cu
     src/traversal/sssp_sg_v32_e32.cu
     src/traversal/od_shortest_distances_sg_v64_e64.cu

--- a/cpp/include/cugraph/algorithms.hpp
+++ b/cpp/include/cugraph/algorithms.hpp
@@ -1097,6 +1097,24 @@ void bfs(raft::handle_t const& handle,
          bool do_expensive_check   = false);
 
 /**
+ * @ingroup traversal_cpp
+ * @brief Run DAWN breadth-first search from one or more sources.
+ *
+ * This experimental API computes hop distances using the DAWN standard traversal path. It is
+ * currently instantiated for single-GPU int32/int32 and int64/int64 vertex/edge IDs. For
+ * multi-source input, all sources are used as one initial frontier and @p distances contains one
+ * graph-sized nearest-source distance vector.
+ */
+template <typename vertex_t, typename edge_t, bool multi_gpu>
+void dawn_bfs(raft::handle_t const& handle,
+              graph_view_t<vertex_t, edge_t, false, multi_gpu> const& graph_view,
+              vertex_t* distances,
+              vertex_t const* sources,
+              size_t n_sources        = 1,
+              vertex_t depth_limit    = std::numeric_limits<vertex_t>::max(),
+              bool do_expensive_check = false);
+
+/**
  * @ingroup dag_cpp
  * @brief Compute a topological ordering of a directed acyclic graph (DAG).
  * For every directed edge (u, v), u appears before v in the returned ordering.

--- a/cpp/include/cugraph_c/traversal_algorithms.h
+++ b/cpp/include/cugraph_c/traversal_algorithms.h
@@ -109,6 +109,57 @@ cugraph_bfs(const cugraph_resource_handle_t* handle,
             cugraph_error_t** error);
 
 /**
+ * @brief     Perform DAWN breadth first search from one or more seed vertices.
+ *
+ * This experimental API computes hop distances using DAWN standard. It currently supports
+ * single-GPU int32/int32 and int64/int64 vertex/edge IDs and does not compute predecessors.
+ * For multi-source input, all sources are used as one initial frontier and distances contain
+ * one graph-sized vector with the nearest-source hop count for each vertex.
+ *
+ * @param [in]  handle       Handle for accessing resources
+ * @param [in]  graph        Pointer to graph
+ * @param [in]  sources      Array containing one or more source vertices
+ * @param depth_limit Maximum number of BFS iterations. SIZE_MAX means unlimited.
+ * @param [in] do_expensive_check A flag to run expensive checks for input arguments.
+ * @param [out] result       Opaque pointer to paths results
+ * @param [out] error        Pointer to an error object storing details of any error.
+ * @return error code
+ */
+CUGRAPH_EXPORT cugraph_error_code_t
+cugraph_dawn_bfs(const cugraph_resource_handle_t* handle,
+                 cugraph_graph_t* graph,
+                 cugraph_type_erased_device_array_view_t* sources,
+                 size_t depth_limit,
+                 bool_t do_expensive_check,
+                 cugraph_paths_result_t** result,
+                 cugraph_error_t** error);
+
+/**
+ * @brief     Perform DAWN breadth first search into a caller-owned distance buffer.
+ *
+ * This is the DAWN performance API. It assumes an unrenumbered single-GPU graph with contiguous
+ * vertex IDs and writes distances in vertex-id order to @p distances. It does not allocate a
+ * paths result object and does not materialize result vertex IDs.
+ *
+ * @param [in]  handle       Handle for accessing resources
+ * @param [in]  graph        Pointer to graph
+ * @param [in]  sources      Array containing one or more source vertices
+ * @param depth_limit Maximum number of BFS iterations. SIZE_MAX means unlimited.
+ * @param [in] do_expensive_check A flag to run expensive checks for input arguments.
+ * @param [out] distances    Caller-owned graph-sized output distance array
+ * @param [out] error        Pointer to an error object storing details of any error.
+ * @return error code
+ */
+CUGRAPH_EXPORT cugraph_error_code_t
+cugraph_dawn_bfs_distances(const cugraph_resource_handle_t* handle,
+                           cugraph_graph_t* graph,
+                           cugraph_type_erased_device_array_view_t* sources,
+                           size_t depth_limit,
+                           bool_t do_expensive_check,
+                           cugraph_type_erased_device_array_view_t* distances,
+                           cugraph_error_t** error);
+
+/**
  * @brief     Perform single-source shortest-path to compute the minimum distances
  *            (and predecessors) from the source vertex.
  *

--- a/cpp/src/c_api/bfs.cpp
+++ b/cpp/src/c_api/bfs.cpp
@@ -16,6 +16,9 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/shuffle_functions.hpp>
 
+#include <limits>
+#include <memory>
+
 namespace cugraph {
 namespace c_api {
 
@@ -213,4 +216,295 @@ extern "C" cugraph_error_code_t cugraph_bfs(const cugraph_resource_handle_t* han
                                       do_expensive_check);
 
   return cugraph::c_api::run_algorithm(graph, functor, result, error);
+}
+
+namespace cugraph {
+namespace c_api {
+
+struct dawn_bfs_functor {
+  raft::handle_t const& handle_;
+  cugraph_graph_t* graph_;
+  cugraph_type_erased_device_array_view_t* sources_;
+  size_t depth_limit_;
+  bool do_expensive_check_;
+  cugraph_paths_result_t* result_{};
+  std::unique_ptr<cugraph_error_t> error_ = {std::make_unique<cugraph_error_t>("")};
+  cugraph_error_code_t error_code_{CUGRAPH_SUCCESS};
+
+  dawn_bfs_functor(::cugraph_resource_handle_t const* handle,
+                   ::cugraph_graph_t* graph,
+                   ::cugraph_type_erased_device_array_view_t* sources,
+                   size_t depth_limit,
+                   bool do_expensive_check)
+    : handle_(*reinterpret_cast<cugraph::c_api::cugraph_resource_handle_t const*>(handle)->handle_),
+      graph_(reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(graph)),
+      sources_(reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t*>(sources)),
+      depth_limit_(depth_limit),
+      do_expensive_check_(do_expensive_check)
+  {
+  }
+
+  void mark_error(cugraph_error_code_t error_code, std::string const& error_message)
+  {
+    error_code_ = error_code;
+    error_->error_message_ = error_message;
+  }
+
+  void operator()()
+  {
+    if (graph_->multi_gpu_) {
+      mark_error(CUGRAPH_UNSUPPORTED_TYPE_COMBINATION,
+                 "DAWN BFS currently supports only single-GPU graphs");
+      return;
+    }
+    if (graph_->store_transposed_) {
+      mark_error(CUGRAPH_UNSUPPORTED_TYPE_COMBINATION,
+                 "DAWN BFS currently requires store_transposed=false");
+      return;
+    }
+    if (graph_->renumber_) {
+      mark_error(CUGRAPH_UNSUPPORTED_TYPE_COMBINATION,
+                 "DAWN BFS currently requires renumber=false");
+      return;
+    }
+    if (graph_->vertex_type_ == INT32 && graph_->edge_type_ == INT32) {
+      run<int32_t, int32_t>();
+    } else if (graph_->vertex_type_ == INT64 && graph_->edge_type_ == INT64) {
+      run<int64_t, int64_t>();
+    } else {
+      mark_error(CUGRAPH_UNSUPPORTED_TYPE_COMBINATION,
+                 "DAWN BFS currently supports only int32/int32 and int64/int64 graphs");
+      return;
+    }
+  }
+
+  template <typename vertex_t, typename edge_t>
+  void run()
+  {
+    constexpr bool multi_gpu = false;
+    auto graph =
+      reinterpret_cast<cugraph::graph_t<vertex_t, edge_t, false, multi_gpu>*>(graph_->graph_);
+    auto graph_view = graph->view();
+
+    if (sources_->size_ == 0) {
+      mark_error(CUGRAPH_INVALID_INPUT, "DAWN BFS requires at least one source");
+      return;
+    }
+    if (depth_limit_ != std::numeric_limits<size_t>::max() &&
+        depth_limit_ > static_cast<size_t>(std::numeric_limits<vertex_t>::max())) {
+      mark_error(CUGRAPH_INVALID_INPUT, "DAWN BFS depth_limit does not fit the vertex type");
+      return;
+    }
+
+    rmm::device_uvector<vertex_t> sources(sources_->size_, handle_.get_stream());
+    raft::copy(sources.data(), sources_->as_type<vertex_t>(), sources_->size_, handle_.get_stream());
+
+    // DAWN's performance path assumes an unrenumbered graph with contiguous vertex IDs.
+    // Source IDs are therefore already internal IDs and should not be remapped here.
+
+    rmm::device_uvector<vertex_t> distances(graph_view.local_vertex_partition_range_size(),
+                                            handle_.get_stream());
+    rmm::device_uvector<vertex_t> predecessors(0, handle_.get_stream());
+
+    auto depth_limit = depth_limit_ == std::numeric_limits<size_t>::max()
+                         ? std::numeric_limits<vertex_t>::max()
+                         : static_cast<vertex_t>(depth_limit_);
+
+    cugraph::dawn_bfs<vertex_t, edge_t, multi_gpu>(handle_,
+                                                   graph_view,
+                                                   distances.data(),
+                                                   sources.data(),
+                                                   sources.size(),
+                                                   depth_limit,
+                                                   do_expensive_check_);
+
+    // DAWN returns distances in contiguous unrenumbered vertex-id order.  Avoid materializing a
+    // graph-sized vertex_ids array in this compatibility wrapper; performance benchmarks should
+    // consume distances directly.
+    rmm::device_uvector<vertex_t> vertex_ids(0, handle_.get_stream());
+
+    result_ = new cugraph_paths_result_t{
+      new cugraph_type_erased_device_array_t(vertex_ids, graph_->vertex_type_),
+      new cugraph_type_erased_device_array_t(distances, graph_->vertex_type_),
+      new cugraph_type_erased_device_array_t(predecessors, graph_->vertex_type_)};
+  }
+};
+
+struct dawn_bfs_distances_functor {
+  raft::handle_t const& handle_;
+  cugraph_graph_t* graph_;
+  cugraph_type_erased_device_array_view_t* sources_;
+  cugraph_type_erased_device_array_view_t* distances_;
+  size_t depth_limit_;
+  bool do_expensive_check_;
+  std::unique_ptr<cugraph_error_t> error_ = {std::make_unique<cugraph_error_t>("")};
+  cugraph_error_code_t error_code_{CUGRAPH_SUCCESS};
+
+  dawn_bfs_distances_functor(::cugraph_resource_handle_t const* handle,
+                             ::cugraph_graph_t* graph,
+                             ::cugraph_type_erased_device_array_view_t* sources,
+                             size_t depth_limit,
+                             bool do_expensive_check,
+                             ::cugraph_type_erased_device_array_view_t* distances)
+    : handle_(*reinterpret_cast<cugraph::c_api::cugraph_resource_handle_t const*>(handle)->handle_),
+      graph_(reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(graph)),
+      sources_(reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t*>(sources)),
+      distances_(
+        reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t*>(distances)),
+      depth_limit_(depth_limit),
+      do_expensive_check_(do_expensive_check)
+  {
+  }
+
+  void mark_error(cugraph_error_code_t error_code, std::string const& error_message)
+  {
+    error_code_ = error_code;
+    error_->error_message_ = error_message;
+  }
+
+  void operator()()
+  {
+    if (graph_->multi_gpu_) {
+      mark_error(CUGRAPH_UNSUPPORTED_TYPE_COMBINATION,
+                 "DAWN BFS currently supports only single-GPU graphs");
+      return;
+    }
+    if (graph_->store_transposed_) {
+      mark_error(CUGRAPH_UNSUPPORTED_TYPE_COMBINATION,
+                 "DAWN BFS currently requires store_transposed=false");
+      return;
+    }
+    if (graph_->renumber_) {
+      mark_error(CUGRAPH_UNSUPPORTED_TYPE_COMBINATION,
+                 "DAWN BFS currently requires renumber=false");
+      return;
+    }
+    if (graph_->vertex_type_ == INT32 && graph_->edge_type_ == INT32) {
+      run<int32_t, int32_t>();
+    } else if (graph_->vertex_type_ == INT64 && graph_->edge_type_ == INT64) {
+      run<int64_t, int64_t>();
+    } else {
+      mark_error(CUGRAPH_UNSUPPORTED_TYPE_COMBINATION,
+                 "DAWN BFS currently supports only int32/int32 and int64/int64 graphs");
+    }
+  }
+
+  template <typename vertex_t, typename edge_t>
+  void run()
+  {
+    constexpr bool multi_gpu = false;
+    auto graph =
+      reinterpret_cast<cugraph::graph_t<vertex_t, edge_t, false, multi_gpu>*>(graph_->graph_);
+    auto graph_view = graph->view();
+
+    if (sources_->size_ == 0) {
+      mark_error(CUGRAPH_INVALID_INPUT, "DAWN BFS requires at least one source");
+      return;
+    }
+    if (distances_->size_ != graph_view.local_vertex_partition_range_size()) {
+      mark_error(CUGRAPH_INVALID_INPUT,
+                 "DAWN BFS distances output must be graph local vertex partition sized");
+      return;
+    }
+    if (depth_limit_ != std::numeric_limits<size_t>::max() &&
+        depth_limit_ > static_cast<size_t>(std::numeric_limits<vertex_t>::max())) {
+      mark_error(CUGRAPH_INVALID_INPUT, "DAWN BFS depth_limit does not fit the vertex type");
+      return;
+    }
+
+    rmm::device_uvector<vertex_t> sources(sources_->size_, handle_.get_stream());
+    raft::copy(sources.data(), sources_->as_type<vertex_t>(), sources_->size_, handle_.get_stream());
+
+    auto depth_limit = depth_limit_ == std::numeric_limits<size_t>::max()
+                         ? std::numeric_limits<vertex_t>::max()
+                         : static_cast<vertex_t>(depth_limit_);
+
+    cugraph::dawn_bfs<vertex_t, edge_t, multi_gpu>(handle_,
+                                                   graph_view,
+                                                   distances_->as_type<vertex_t>(),
+                                                   sources.data(),
+                                                   sources.size(),
+                                                   depth_limit,
+                                                   do_expensive_check_);
+  }
+};
+
+}  // namespace c_api
+}  // namespace cugraph
+
+extern "C" cugraph_error_code_t cugraph_dawn_bfs(
+  const cugraph_resource_handle_t* handle,
+  cugraph_graph_t* graph,
+  cugraph_type_erased_device_array_view_t* sources,
+  size_t depth_limit,
+  bool_t do_expensive_check,
+  cugraph_paths_result_t** result,
+  cugraph_error_t** error)
+{
+  *result = nullptr;
+  *error  = nullptr;
+
+  if (reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(graph)->vertex_type_ !=
+      reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(sources)
+        ->type_) {
+    *error = reinterpret_cast<::cugraph_error_t*>(
+      new cugraph::c_api::cugraph_error_t{"vertex type of graph and sources must match"});
+    return CUGRAPH_INVALID_INPUT;
+  }
+
+  try {
+    cugraph::c_api::dawn_bfs_functor functor(
+      handle, graph, sources, depth_limit, do_expensive_check);
+    functor();
+    if (functor.error_code_ != CUGRAPH_SUCCESS) {
+      *error = reinterpret_cast<::cugraph_error_t*>(functor.error_.release());
+      return functor.error_code_;
+    }
+    *result = reinterpret_cast<cugraph_paths_result_t*>(functor.result_);
+  } catch (std::exception const& ex) {
+    *error = reinterpret_cast<::cugraph_error_t*>(new cugraph::c_api::cugraph_error_t{ex.what()});
+    return CUGRAPH_UNKNOWN_ERROR;
+  }
+
+  return CUGRAPH_SUCCESS;
+}
+
+extern "C" cugraph_error_code_t cugraph_dawn_bfs_distances(
+  const cugraph_resource_handle_t* handle,
+  cugraph_graph_t* graph,
+  cugraph_type_erased_device_array_view_t* sources,
+  size_t depth_limit,
+  bool_t do_expensive_check,
+  cugraph_type_erased_device_array_view_t* distances,
+  cugraph_error_t** error)
+{
+  *error = nullptr;
+
+  auto internal_graph = reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(graph);
+  auto internal_sources =
+    reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(sources);
+  auto internal_distances =
+    reinterpret_cast<cugraph::c_api::cugraph_type_erased_device_array_view_t const*>(distances);
+
+  if (internal_graph->vertex_type_ != internal_sources->type_ ||
+      internal_graph->vertex_type_ != internal_distances->type_) {
+    *error = reinterpret_cast<::cugraph_error_t*>(new cugraph::c_api::cugraph_error_t{
+      "vertex type of graph, sources, and distances must match"});
+    return CUGRAPH_INVALID_INPUT;
+  }
+
+  try {
+    cugraph::c_api::dawn_bfs_distances_functor functor(
+      handle, graph, sources, depth_limit, do_expensive_check, distances);
+    functor();
+    if (functor.error_code_ != CUGRAPH_SUCCESS) {
+      *error = reinterpret_cast<::cugraph_error_t*>(functor.error_.release());
+      return functor.error_code_;
+    }
+  } catch (std::exception const& ex) {
+    *error = reinterpret_cast<::cugraph_error_t*>(new cugraph::c_api::cugraph_error_t{ex.what()});
+    return CUGRAPH_UNKNOWN_ERROR;
+  }
+
+  return CUGRAPH_SUCCESS;
 }

--- a/cpp/src/c_api/graph.hpp
+++ b/cpp/src/c_api/graph.hpp
@@ -59,6 +59,7 @@ struct cugraph_graph_t {
   void* edge_types_;        // edge_property_t<edge_t, edge_type_t>*
   void* edge_start_times_;  // edge_property_t<edge_t, time_stamp_t>*
   void* edge_end_times_;    // edge_property_t<edge_t, time_stamp_t>*
+  bool renumber_;
 };
 
 template <typename vertex_t,

--- a/cpp/src/c_api/graph_mg.cpp
+++ b/cpp/src/c_api/graph_mg.cpp
@@ -314,7 +314,8 @@ struct create_graph_functor : public cugraph::c_api::abstract_functor {
                                             edge_ids_property,
                                             edge_types_property,
                                             edge_start_times_property,
-                                            edge_end_times_property};
+                                            edge_end_times_property,
+                                            true};
 
       result_ = reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(result);
     }

--- a/cpp/src/c_api/graph_sg.cpp
+++ b/cpp/src/c_api/graph_sg.cpp
@@ -381,7 +381,8 @@ struct create_graph_functor : public cugraph::c_api::abstract_functor {
                                             edge_ids,
                                             edge_types,
                                             edge_start_times,
-                                            edge_end_times};
+                                            edge_end_times,
+                                            renumber_};
 
       result_ = reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(result);
     }
@@ -631,7 +632,8 @@ struct create_graph_csr_functor : public cugraph::c_api::abstract_functor {
         edge_ids_property,
         edge_types_property,
         edge_start_times_property,
-        edge_end_times_property};
+        edge_end_times_property,
+        renumber_};
 
       result_ = reinterpret_cast<cugraph::c_api::cugraph_graph_t*>(result);
     }

--- a/cpp/src/traversal/dawn_bfs_impl.cuh
+++ b/cpp/src/traversal/dawn_bfs_impl.cuh
@@ -1,0 +1,1112 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <cugraph/algorithms.hpp>
+#include <cugraph/graph_view.hpp>
+#include <cugraph/utilities/error.hpp>
+
+#include <raft/core/handle.hpp>
+#include <raft/util/cudart_utils.hpp>
+
+#include <rmm/device_uvector.hpp>
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstring>
+#include <cstdint>
+#include <exception>
+#include <limits>
+#include <mutex>
+#include <type_traits>
+#include <thread>
+#include <vector>
+
+namespace cugraph {
+namespace detail {
+namespace dawn {
+
+constexpr int block_size = 256;
+constexpr int tile_vertices = 1024;
+constexpr int words_per_dirty = tile_vertices / 32;
+constexpr int dirty_words_per_super = 32;
+constexpr int compact_entries_per_block = 32;
+constexpr int compact_dirty_words_per_block = 2;
+constexpr int bitset_warp_degree_threshold = 8;
+constexpr int bitset_subwarp_width = 4;
+constexpr int bitset_subwarp_max_active = 0;
+constexpr int bitset_offset_preload_min_active = 33;
+constexpr int defer_high_degree_threshold = 512;
+constexpr int deferred_edge_chunk_size = 256;
+constexpr int deferred_edge_chunk_blocks = 256;
+
+template <typename vertex_t, typename edge_t>
+struct raw_csr_view_t {
+  edge_t const* row_offsets{};
+  vertex_t const* column_indices{};
+  vertex_t num_vertices{};
+  edge_t num_edges{};
+};
+
+template <typename vertex_t, typename edge_t>
+struct workspace_t {
+  explicit workspace_t(raw_csr_view_t<vertex_t, edge_t> raw, rmm::cuda_stream_view stream)
+    : dense_words((static_cast<size_t>(raw.num_vertices) + 31) / 32, stream),
+      dense_dirty((dense_words.size() + words_per_dirty - 1) / words_per_dirty, stream),
+      dense_dirty_super((dense_dirty.size() + dirty_words_per_super - 1) / dirty_words_per_super,
+                        stream),
+      active_super_list(dense_dirty_super.size(), stream),
+      masks_a(dense_words.size(), stream),
+      masks_b(dense_words.size(), stream),
+      gamma_a(dense_words.size(), stream),
+      gamma_b(dense_words.size(), stream),
+      state(8, stream),
+      deferred_begins((static_cast<size_t>(raw.num_edges) + deferred_edge_chunk_size - 1) /
+                        deferred_edge_chunk_size +
+                      dense_words.size(),
+                      stream),
+      deferred_ends(deferred_begins.size(), stream)
+  {
+  }
+
+  rmm::device_uvector<uint32_t> dense_words;
+  rmm::device_uvector<uint32_t> dense_dirty;
+  rmm::device_uvector<uint32_t> dense_dirty_super;
+  rmm::device_uvector<vertex_t> active_super_list;
+  rmm::device_uvector<uint32_t> masks_a;
+  rmm::device_uvector<uint32_t> masks_b;
+  rmm::device_uvector<vertex_t> gamma_a;
+  rmm::device_uvector<vertex_t> gamma_b;
+  rmm::device_uvector<vertex_t> state;
+  rmm::device_uvector<edge_t> deferred_begins;
+  rmm::device_uvector<edge_t> deferred_ends;
+  cudaGraph_t graph{nullptr};
+  cudaGraphExec_t graph_exec{nullptr};
+
+  ~workspace_t()
+  {
+    if (graph_exec != nullptr) { cudaGraphExecDestroy(graph_exec); }
+    if (graph != nullptr) { cudaGraphDestroy(graph); }
+  }
+};
+
+enum state_index_t {
+  state_depth = 0,
+  state_changed = 1,
+  state_frontier_parity = 2,
+  state_source_has_frontier = 3,
+  state_alpha_word_count = 4,
+  state_beta_word_count = 5,
+  state_beta_super_count = 6,
+  state_edge_chunk_count = 7,
+  state_count = 8,
+};
+
+template <typename vertex_t, typename edge_t>
+static __global__ void init_kernel(raw_csr_view_t<vertex_t, edge_t> graph,
+                                   vertex_t source,
+                                   vertex_t* distances,
+                                   uint32_t* dense_words,
+                                   uint32_t* dense_dirty,
+                                   uint32_t* dense_dirty_super,
+                                   vertex_t* active_super_list,
+                                   uint32_t* masks_a,
+                                   uint32_t* masks_b,
+                                   vertex_t* gamma_a,
+                                   vertex_t* gamma_b,
+                                   vertex_t* state,
+                                   vertex_t word_count,
+                                   vertex_t dirty_count,
+                                   vertex_t dirty_super_count)
+{
+  auto tid    = static_cast<vertex_t>(blockIdx.x * blockDim.x + threadIdx.x);
+  auto stride = static_cast<vertex_t>(blockDim.x * gridDim.x);
+  for (vertex_t v = tid; v < graph.num_vertices; v += stride) {
+    distances[v] = std::numeric_limits<vertex_t>::max();
+  }
+  for (vertex_t w = tid; w < word_count; w += stride) { dense_words[w] = 0; }
+  for (vertex_t d = tid; d < dirty_count; d += stride) { dense_dirty[d] = 0; }
+  for (vertex_t s = tid; s < dirty_super_count; s += stride) {
+    dense_dirty_super[s] = 0;
+    active_super_list[s] = 0;
+  }
+  for (vertex_t i = tid; i < state_count; i += stride) { state[i] = 0; }
+
+  if (tid == 0) {
+    distances[source] = 0;
+    auto word = static_cast<vertex_t>(source >> 5);
+    auto mask = static_cast<uint32_t>(1u << (source & 31));
+    auto dirty_word = static_cast<vertex_t>(word / words_per_dirty);
+    auto dirty_super = static_cast<vertex_t>(dirty_word / dirty_words_per_super);
+    dense_words[word] = mask;
+    dense_dirty[dirty_word] = 1u;
+    dense_dirty_super[dirty_super] = 1u;
+    active_super_list[0] = dirty_super;
+    masks_a[0] = mask;
+    gamma_a[0] = word;
+    masks_b[0] = 0;
+    gamma_b[0] = 0;
+    state[state_depth] = 0;
+    state[state_changed] = 1;
+    state[state_frontier_parity] = 0;
+    state[state_source_has_frontier] =
+      (graph.row_offsets[source + 1] > graph.row_offsets[source]) ? 1 : 0;
+    state[state_alpha_word_count] = 1;
+    state[state_beta_word_count] = 0;
+    state[state_beta_super_count] = 1;
+    state[state_edge_chunk_count] = 0;
+  }
+}
+
+template <typename vertex_t>
+static __global__ void init_multi_source_workspace_kernel(vertex_t* distances,
+                                                          uint32_t* dense_words,
+                                                          uint32_t* dense_dirty,
+                                                          uint32_t* dense_dirty_super,
+                                                          vertex_t* active_super_list,
+                                                          uint32_t* masks_a,
+                                                          uint32_t* masks_b,
+                                                          vertex_t* gamma_a,
+                                                          vertex_t* gamma_b,
+                                                          vertex_t* state,
+                                                          vertex_t num_vertices,
+                                                          vertex_t word_count,
+                                                          vertex_t dirty_count,
+                                                          vertex_t dirty_super_count)
+{
+  auto tid    = static_cast<vertex_t>(blockIdx.x * blockDim.x + threadIdx.x);
+  auto stride = static_cast<vertex_t>(blockDim.x * gridDim.x);
+  for (vertex_t v = tid; v < num_vertices; v += stride) {
+    distances[v] = std::numeric_limits<vertex_t>::max();
+  }
+  for (vertex_t w = tid; w < word_count; w += stride) {
+    dense_words[w] = 0;
+    masks_a[w]     = 0;
+    masks_b[w]     = 0;
+    gamma_a[w]     = 0;
+    gamma_b[w]     = 0;
+  }
+  for (vertex_t d = tid; d < dirty_count; d += stride) { dense_dirty[d] = 0; }
+  for (vertex_t s = tid; s < dirty_super_count; s += stride) {
+    dense_dirty_super[s] = 0;
+    active_super_list[s] = 0;
+  }
+  for (vertex_t i = tid; i < state_count; i += stride) { state[i] = 0; }
+
+  if (tid == 0) {
+    state[state_depth]           = 0;
+    state[state_changed]         = 0;
+    state[state_frontier_parity] = 0;
+  }
+}
+
+template <typename vertex_t>
+__device__ __forceinline__ vertex_t atomic_cas_distance(vertex_t* address,
+                                                        vertex_t compare,
+                                                        vertex_t value);
+
+template <typename vertex_t>
+__device__ __forceinline__ vertex_t atomic_add_value(vertex_t* address, vertex_t value);
+
+template <typename vertex_t>
+__device__ __forceinline__ vertex_t atomic_exch_value(vertex_t* address, vertex_t value);
+
+template <typename vertex_t>
+__device__ __forceinline__ void mark_candidate(vertex_t dst,
+                                               vertex_t depth,
+                                               vertex_t* distances,
+                                               uint32_t* dense_words,
+                                               uint32_t* dense_dirty,
+                                               vertex_t* state);
+
+template <typename vertex_t>
+static __global__ void seed_source_distances_kernel(vertex_t const* sources,
+                                                    vertex_t n_sources,
+                                                    vertex_t* distances)
+{
+  auto tid    = static_cast<vertex_t>(blockIdx.x * blockDim.x + threadIdx.x);
+  auto stride = static_cast<vertex_t>(blockDim.x * gridDim.x);
+  for (vertex_t i = tid; i < n_sources; i += stride) {
+    atomic_cas_distance(
+      distances + sources[i], std::numeric_limits<vertex_t>::max(), vertex_t{0});
+  }
+}
+
+template <typename vertex_t, typename edge_t>
+static __global__ void seed_multi_source_neighbors_kernel(raw_csr_view_t<vertex_t, edge_t> graph,
+                                                          vertex_t const* sources,
+                                                          vertex_t n_sources,
+                                                          vertex_t* distances,
+                                                          uint32_t* dense_words,
+                                                          uint32_t* dense_dirty,
+                                                          vertex_t* state)
+{
+  if (blockIdx.x == 0 && threadIdx.x == 0) { state[state_depth] = 1; }
+  for (vertex_t source_idx = static_cast<vertex_t>(blockIdx.x); source_idx < n_sources;
+       source_idx += static_cast<vertex_t>(gridDim.x)) {
+    auto source = sources[source_idx];
+    auto begin = graph.row_offsets[source];
+    auto end = graph.row_offsets[source + 1];
+    for (auto edge = begin + static_cast<edge_t>(threadIdx.x); edge < end;
+         edge += static_cast<edge_t>(blockDim.x)) {
+      mark_candidate(
+        graph.column_indices[edge], vertex_t{1}, distances, dense_words, dense_dirty, state);
+    }
+  }
+}
+
+template <typename vertex_t>
+static __global__ void reset_iteration_kernel(vertex_t* state)
+{
+  state[state_beta_word_count]  = 0;
+  state[state_beta_super_count] = 0;
+  state[state_edge_chunk_count] = 0;
+}
+
+template <typename vertex_t>
+__device__ __forceinline__ vertex_t atomic_cas_distance(vertex_t* address,
+                                                        vertex_t compare,
+                                                        vertex_t value)
+{
+  if constexpr (std::is_same_v<vertex_t, int32_t>) {
+    return atomicCAS(address, compare, value);
+  } else {
+    auto old = atomicCAS(reinterpret_cast<unsigned long long*>(address),
+                         static_cast<unsigned long long>(compare),
+                         static_cast<unsigned long long>(value));
+    return static_cast<vertex_t>(old);
+  }
+}
+
+template <typename vertex_t>
+__device__ __forceinline__ vertex_t atomic_add_value(vertex_t* address, vertex_t value)
+{
+  if constexpr (std::is_same_v<vertex_t, int32_t>) {
+    return atomicAdd(address, value);
+  } else {
+    auto old = atomicAdd(reinterpret_cast<unsigned long long*>(address),
+                         static_cast<unsigned long long>(value));
+    return static_cast<vertex_t>(old);
+  }
+}
+
+template <typename vertex_t>
+__device__ __forceinline__ vertex_t atomic_exch_value(vertex_t* address, vertex_t value)
+{
+  if constexpr (std::is_same_v<vertex_t, int32_t>) {
+    return atomicExch(address, value);
+  } else {
+    auto old = atomicExch(reinterpret_cast<unsigned long long*>(address),
+                          static_cast<unsigned long long>(value));
+    return static_cast<vertex_t>(old);
+  }
+}
+
+template <typename vertex_t>
+__device__ __forceinline__ void mark_candidate(vertex_t dst,
+                                               vertex_t depth,
+                                               vertex_t* distances,
+                                               uint32_t* dense_words,
+                                               uint32_t* dense_dirty,
+                                               vertex_t* state)
+{
+  auto old =
+    atomic_cas_distance(distances + dst, std::numeric_limits<vertex_t>::max(), depth);
+  if (old == std::numeric_limits<vertex_t>::max()) {
+    auto word = static_cast<vertex_t>(dst >> 5);
+    auto bit = static_cast<uint32_t>(1u << (dst & 31));
+    auto old_word = atomicOr(dense_words + word, bit);
+    if (old_word == 0u) {
+      auto dirty_word = static_cast<vertex_t>(word / words_per_dirty);
+      auto dirty_mask = static_cast<uint32_t>(1u << (word & (words_per_dirty - 1)));
+      atomicOr(dense_dirty + dirty_word, dirty_mask);
+    }
+    atomic_exch_value(state + state_changed, vertex_t{1});
+  }
+}
+
+template <typename vertex_t, typename edge_t>
+static __global__ void consume_frontier_kernel(raw_csr_view_t<vertex_t, edge_t> graph,
+                                               vertex_t* distances,
+                                               uint32_t* dense_words,
+                                               uint32_t* dense_dirty,
+                                               uint32_t const* masks_a,
+                                               uint32_t const* masks_b,
+                                               vertex_t const* gamma_a,
+                                               vertex_t const* gamma_b,
+                                               edge_t* deferred_begins,
+                                               edge_t* deferred_ends,
+                                               vertex_t deferred_capacity,
+                                               vertex_t* state)
+{
+  __shared__ vertex_t next_entry;
+  auto lane = static_cast<vertex_t>(threadIdx.x & (warpSize - 1));
+  auto active_lanes = static_cast<vertex_t>(
+    bitset_subwarp_width < bitset_warp_degree_threshold ? bitset_subwarp_width
+                                                        : bitset_warp_degree_threshold);
+  auto frontier_count = state[state_alpha_word_count];
+  auto chunk_begin = static_cast<vertex_t>(blockIdx.x) * compact_entries_per_block;
+  if (chunk_begin >= frontier_count) { return; }
+  auto chunk_end = std::min<vertex_t>(chunk_begin + compact_entries_per_block, frontier_count);
+  auto depth = state[state_depth] + vertex_t{1};
+  auto read_a = state[state_frontier_parity] == 0;
+  auto const* masks = read_a ? masks_a : masks_b;
+  auto const* gamma = read_a ? gamma_a : gamma_b;
+
+  if (threadIdx.x == 0) { next_entry = chunk_begin; }
+  __syncthreads();
+
+  while (true) {
+    vertex_t entry = 0;
+    if (lane == 0) { entry = atomic_add_value(&next_entry, vertex_t{1}); }
+    entry = __shfl_sync(0xffffffffu, entry, 0);
+    if (entry >= chunk_end) { break; }
+
+    auto word = gamma[entry];
+    auto mask = masks[entry];
+    if (mask == 0u) { continue; }
+
+    auto base_vertex = static_cast<vertex_t>(word << 5);
+    auto vertex = base_vertex + lane;
+    auto active_vertex = ((mask & (1u << static_cast<uint32_t>(lane))) != 0u) &&
+                         vertex < graph.num_vertices;
+    auto valid_vertices =
+      graph.num_vertices > base_vertex ? graph.num_vertices - base_vertex : vertex_t{0};
+    auto valid_mask = valid_vertices >= 32
+                        ? 0xffffffffu
+                        : (valid_vertices > 0
+                             ? ((1u << static_cast<uint32_t>(valid_vertices)) - 1u)
+                             : 0u);
+    auto active_mask = mask & valid_mask;
+    auto active_count = static_cast<vertex_t>(__popc(active_mask));
+    auto preload_offsets = active_count >= bitset_offset_preload_min_active;
+
+    edge_t lane_offset = 0;
+    if (preload_offsets && base_vertex + lane <= graph.num_vertices) {
+      lane_offset = graph.row_offsets[base_vertex + lane];
+    }
+    auto shuffled_next_offset =
+      preload_offsets ? __shfl_down_sync(0xffffffffu, lane_offset, 1) : edge_t{0};
+
+    edge_t edge_begin = 0;
+    edge_t edge_end = 0;
+    edge_t degree = 0;
+    if (active_vertex) {
+      edge_begin = preload_offsets ? lane_offset : graph.row_offsets[vertex];
+      edge_end = (preload_offsets && lane < 31) ? shuffled_next_offset
+                                                : graph.row_offsets[vertex + 1];
+      degree = edge_end - edge_begin;
+    }
+
+    if (active_count <= bitset_subwarp_max_active) {
+      auto low_degree_mask =
+        __ballot_sync(0xffffffffu,
+                      active_vertex && degree > 0 &&
+                        degree < static_cast<edge_t>(bitset_warp_degree_threshold));
+      while (low_degree_mask != 0u) {
+        auto owner_lane = static_cast<vertex_t>(__ffs(low_degree_mask) - 1);
+        auto owner_group = owner_lane / active_lanes;
+        auto group_lane = lane - owner_group * active_lanes;
+        auto in_group = group_lane >= 0 && group_lane < active_lanes;
+        auto low_begin = __shfl_sync(0xffffffffu, edge_begin, owner_lane);
+        auto low_end = __shfl_sync(0xffffffffu, edge_end, owner_lane);
+        if (in_group) {
+          for (auto edge = low_begin + static_cast<edge_t>(group_lane); edge < low_end;
+               edge += static_cast<edge_t>(active_lanes)) {
+            mark_candidate(
+              graph.column_indices[edge], depth, distances, dense_words, dense_dirty, state);
+          }
+        }
+        low_degree_mask &= low_degree_mask - 1u;
+      }
+    } else if (active_vertex && degree > 0 &&
+               degree < static_cast<edge_t>(bitset_warp_degree_threshold)) {
+      for (auto edge = edge_begin; edge < edge_end; ++edge) {
+        mark_candidate(
+          graph.column_indices[edge], depth, distances, dense_words, dense_dirty, state);
+      }
+    }
+
+    auto high_degree_mask =
+      __ballot_sync(0xffffffffu,
+                    active_vertex &&
+                      degree >= static_cast<edge_t>(bitset_warp_degree_threshold));
+    while (high_degree_mask != 0u) {
+      auto owner_lane = static_cast<vertex_t>(__ffs(high_degree_mask) - 1);
+      auto high_begin = __shfl_sync(0xffffffffu, edge_begin, owner_lane);
+      auto high_end = __shfl_sync(0xffffffffu, edge_end, owner_lane);
+      auto high_degree = high_end - high_begin;
+      if (high_degree >= static_cast<edge_t>(defer_high_degree_threshold)) {
+        auto chunk_count = static_cast<vertex_t>(
+          (high_degree + deferred_edge_chunk_size - 1) / deferred_edge_chunk_size);
+        vertex_t base_slot = 0;
+        if (lane == 0) {
+          base_slot = atomic_add_value(state + state_edge_chunk_count, chunk_count);
+        }
+        base_slot = __shfl_sync(0xffffffffu, base_slot, 0);
+        for (auto chunk = lane; chunk < chunk_count; chunk += 32) {
+          auto slot = base_slot + chunk;
+          if (slot < deferred_capacity) {
+            auto begin = high_begin + static_cast<edge_t>(chunk) * deferred_edge_chunk_size;
+            auto limit = begin + deferred_edge_chunk_size;
+            deferred_begins[slot] = begin;
+            deferred_ends[slot] = limit < high_end ? limit : high_end;
+          }
+        }
+      } else {
+        for (auto edge = high_begin + static_cast<edge_t>(lane); edge < high_end;
+             edge += static_cast<edge_t>(warpSize)) {
+          mark_candidate(
+            graph.column_indices[edge], depth, distances, dense_words, dense_dirty, state);
+        }
+      }
+      high_degree_mask &= high_degree_mask - 1u;
+    }
+  }
+}
+
+template <typename vertex_t, typename edge_t>
+static __global__ void consume_deferred_edges_kernel(raw_csr_view_t<vertex_t, edge_t> graph,
+                                                     vertex_t* distances,
+                                                     uint32_t* dense_words,
+                                                     uint32_t* dense_dirty,
+                                                     edge_t const* deferred_begins,
+                                                     edge_t const* deferred_ends,
+                                                     vertex_t deferred_capacity,
+                                                     vertex_t* state)
+{
+  auto deferred_count = state[state_edge_chunk_count];
+  auto chunk_limit = deferred_count < deferred_capacity ? deferred_count : deferred_capacity;
+  auto depth = state[state_depth] + vertex_t{1};
+  for (vertex_t chunk = blockIdx.x; chunk < chunk_limit; chunk += gridDim.x) {
+    auto begin = deferred_begins[chunk];
+    auto end = deferred_ends[chunk];
+    for (auto edge = begin + static_cast<edge_t>(threadIdx.x); edge < end;
+         edge += static_cast<edge_t>(blockDim.x)) {
+      mark_candidate(
+        graph.column_indices[edge], depth, distances, dense_words, dense_dirty, state);
+    }
+  }
+}
+
+template <typename vertex_t>
+static __global__ void compact_dense_frontier_kernel(vertex_t word_count,
+                                                     uint32_t* dense_words,
+                                                     uint32_t* dense_dirty,
+                                                     uint32_t* masks_a,
+                                                     uint32_t* masks_b,
+                                                     vertex_t* gamma_a,
+                                                     vertex_t* gamma_b,
+                                                     vertex_t* state,
+                                                     vertex_t output_count_index)
+{
+  __shared__ vertex_t warp_counts[compact_dirty_words_per_block];
+  __shared__ vertex_t warp_bases[compact_dirty_words_per_block];
+  __shared__ vertex_t block_base;
+
+  auto lane = static_cast<vertex_t>(threadIdx.x & (warpSize - 1));
+  auto warp_id = static_cast<vertex_t>(threadIdx.x >> 5);
+  auto warps_per_block = static_cast<vertex_t>(blockDim.x >> 5);
+  auto dirty_count = (word_count + words_per_dirty - 1) / words_per_dirty;
+  auto dirty_index = static_cast<vertex_t>(blockIdx.x) * compact_dirty_words_per_block + warp_id;
+
+  uint32_t dirty_word = 0u;
+  if (warp_id < compact_dirty_words_per_block && warp_id < warps_per_block &&
+      dirty_index < dirty_count) {
+    dirty_word = dense_dirty[dirty_index];
+  }
+
+  auto read_a = state[state_frontier_parity] == 0;
+  auto* output_masks = read_a ? masks_b : masks_a;
+  auto* output_gamma = read_a ? gamma_b : gamma_a;
+  if (output_count_index == state_alpha_word_count) {
+    output_masks = masks_a;
+    output_gamma = gamma_a;
+  }
+
+  auto active_word = warp_id < compact_dirty_words_per_block && warp_id < warps_per_block &&
+                     dirty_word != 0u &&
+                     ((dirty_word & (1u << static_cast<uint32_t>(lane))) != 0u);
+  auto word_index = dirty_index * words_per_dirty + lane;
+  uint32_t mask = 0u;
+  if (active_word && word_index < word_count) { mask = dense_words[word_index]; }
+  auto has_output = active_word && word_index < word_count && mask != 0u;
+  auto active_mask = __ballot_sync(0xffffffffu, has_output);
+  auto active_count = static_cast<vertex_t>(__popc(active_mask));
+
+  if (lane == 0 && warp_id < compact_dirty_words_per_block && warp_id < warps_per_block) {
+    warp_counts[warp_id] = active_count;
+  }
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    vertex_t total_count = 0;
+    for (vertex_t i = 0; i < compact_dirty_words_per_block; ++i) {
+      warp_bases[i] = total_count;
+      if (i < warps_per_block) { total_count += warp_counts[i]; }
+    }
+    block_base =
+      total_count > 0 ? atomic_add_value(state + output_count_index, total_count) : vertex_t{0};
+  }
+  __syncthreads();
+
+  if (has_output) {
+    auto lower_mask = active_mask & ((1u << static_cast<uint32_t>(lane)) - 1u);
+    auto slot = block_base + warp_bases[warp_id] + static_cast<vertex_t>(__popc(lower_mask));
+    output_gamma[slot] = word_index;
+    output_masks[slot] = mask;
+    dense_words[word_index] = 0u;
+  }
+
+  if (lane == 0 && warp_id < compact_dirty_words_per_block && warp_id < warps_per_block &&
+      dirty_index < dirty_count) {
+    dense_dirty[dirty_index] = 0u;
+  }
+}
+
+template <typename vertex_t>
+static __global__ void start_iteration_kernel(cudaGraphConditionalHandle handle,
+                                              vertex_t* state,
+                                              vertex_t depth_limit)
+{
+  auto alpha_count = state[state_alpha_word_count];
+  if (alpha_count != 0 && state[state_depth] < depth_limit) {
+    cudaGraphSetConditional(handle, 1);
+  } else {
+    cudaGraphSetConditional(handle, 0);
+  }
+}
+
+template <typename vertex_t>
+static __global__ void finalize_iteration_kernel(cudaGraphConditionalHandle handle,
+                                                 vertex_t* state,
+                                                 vertex_t depth_limit)
+{
+  auto beta_count = state[state_beta_word_count];
+  if (beta_count != 0 && state[state_depth] + 1 < depth_limit) {
+    state[state_depth] += 1;
+    state[state_frontier_parity] = 1 - state[state_frontier_parity];
+    state[state_alpha_word_count] = beta_count;
+    state[state_beta_word_count] = 0;
+    state[state_changed] = 1;
+    cudaGraphSetConditional(handle, 1);
+  } else {
+    state[state_alpha_word_count] = 0;
+    state[state_beta_word_count] = 0;
+    state[state_changed] = 0;
+    cudaGraphSetConditional(handle, 0);
+  }
+}
+
+inline cudaError_t add_kernel_node(cudaGraph_t graph,
+                                   cudaGraphNode_t* node,
+                                   const cudaGraphNode_t* dependencies,
+                                   size_t dependency_count,
+                                   void* function,
+                                   dim3 grid,
+                                   dim3 block,
+                                   unsigned int shared_memory,
+                                   void** kernel_arguments)
+{
+  cudaKernelNodeParams params;
+  std::memset(&params, 0, sizeof(params));
+  params.func = function;
+  params.gridDim = grid;
+  params.blockDim = block;
+  params.sharedMemBytes = shared_memory;
+  params.kernelParams = kernel_arguments;
+  return cudaGraphAddKernelNode(node, graph, dependencies, dependency_count, &params);
+}
+
+template <typename vertex_t, typename edge_t>
+inline void create_initialized_frontier_graph(raw_csr_view_t<vertex_t, edge_t> raw,
+                                             vertex_t* distances,
+                                             uint32_t* dense_words,
+                                             uint32_t* dense_dirty,
+                                             uint32_t* dense_dirty_super,
+                                             vertex_t* active_super_list,
+                                             uint32_t* masks_a,
+                                             uint32_t* masks_b,
+                                             vertex_t* gamma_a,
+                                             vertex_t* gamma_b,
+                                             vertex_t* state,
+                                             edge_t* deferred_begins,
+                                             edge_t* deferred_ends,
+                                             vertex_t word_count,
+                                             vertex_t dirty_count,
+                                             vertex_t dirty_super_count,
+                                             vertex_t deferred_capacity,
+                                             vertex_t depth_limit,
+                                             cudaGraph_t* graph,
+                                             cudaGraphExec_t* graph_exec)
+{
+  (void)dense_dirty_super;
+  (void)active_super_list;
+  (void)dirty_super_count;
+
+  if (*graph_exec != nullptr) { return; }
+
+  RAFT_CUDA_TRY(cudaGraphCreate(graph, 0));
+
+  cudaGraphConditionalHandle conditional_handle = 0;
+  RAFT_CUDA_TRY(cudaGraphConditionalHandleCreate(
+    &conditional_handle, *graph, 1, cudaGraphCondAssignDefault));
+
+  cudaGraphNode_t while_node = nullptr;
+  cudaGraphNodeParams while_params = {};
+  std::memset(&while_params, 0, sizeof(while_params));
+  while_params.type = cudaGraphNodeTypeConditional;
+  while_params.conditional.handle = conditional_handle;
+  while_params.conditional.type = cudaGraphCondTypeWhile;
+  while_params.conditional.size = 1;
+
+  cudaGraphNode_t start_node = nullptr;
+  cudaGraphConditionalHandle start_handle = conditional_handle;
+  void* start_args[] = {&start_handle, &state, &depth_limit};
+  RAFT_CUDA_TRY(add_kernel_node(*graph,
+                                &start_node,
+                                nullptr,
+                                0,
+                                reinterpret_cast<void*>(start_iteration_kernel<vertex_t>),
+                                dim3(1),
+                                dim3(1),
+                                0,
+                                start_args));
+
+  RAFT_CUDA_TRY(cudaGraphAddNode(&while_node, *graph, &start_node, nullptr, 1, &while_params));
+  cudaGraph_t body_graph = while_params.conditional.phGraph_out[0];
+
+  cudaGraphNode_t reset_node = nullptr;
+  void* reset_args[] = {&state};
+  RAFT_CUDA_TRY(add_kernel_node(body_graph,
+                                &reset_node,
+                                nullptr,
+                                0,
+                                reinterpret_cast<void*>(reset_iteration_kernel<vertex_t>),
+                                dim3(1),
+                                dim3(1),
+                                0,
+                                reset_args));
+
+  cudaGraphNode_t consume_node = nullptr;
+  auto consume_blocks = std::max(
+    1, static_cast<int>((word_count + compact_entries_per_block - 1) / compact_entries_per_block));
+  raw_csr_view_t<vertex_t, edge_t> consume_raw = raw;
+  void* consume_args[] = {&consume_raw,
+                          &distances,
+                          &dense_words,
+                          &dense_dirty,
+                          &masks_a,
+                          &masks_b,
+                          &gamma_a,
+                          &gamma_b,
+                          &deferred_begins,
+                          &deferred_ends,
+                          &deferred_capacity,
+                          &state};
+  RAFT_CUDA_TRY(add_kernel_node(
+    body_graph,
+    &consume_node,
+    &reset_node,
+    1,
+    reinterpret_cast<void*>(consume_frontier_kernel<vertex_t, edge_t>),
+    dim3(consume_blocks),
+    dim3(block_size),
+    0,
+    consume_args));
+
+  cudaGraphNode_t deferred_node = nullptr;
+  raw_csr_view_t<vertex_t, edge_t> deferred_raw = raw;
+  void* deferred_args[] = {&deferred_raw,
+                           &distances,
+                           &dense_words,
+                           &dense_dirty,
+                           &deferred_begins,
+                           &deferred_ends,
+                           &deferred_capacity,
+                           &state};
+  RAFT_CUDA_TRY(add_kernel_node(
+    body_graph,
+    &deferred_node,
+    &consume_node,
+    1,
+    reinterpret_cast<void*>(consume_deferred_edges_kernel<vertex_t, edge_t>),
+    dim3(deferred_edge_chunk_blocks),
+    dim3(block_size),
+    0,
+    deferred_args));
+
+  cudaGraphNode_t compact_node = nullptr;
+  auto compact_blocks = std::max(
+    1,
+    static_cast<int>((dirty_count + compact_dirty_words_per_block - 1) /
+                     compact_dirty_words_per_block));
+  auto compact_block_size = 32 * compact_dirty_words_per_block;
+  vertex_t beta_count_index = static_cast<vertex_t>(state_beta_word_count);
+  void* compact_args[] = {&word_count,
+                          &dense_words,
+                          &dense_dirty,
+                          &masks_a,
+                          &masks_b,
+                          &gamma_a,
+                          &gamma_b,
+                          &state,
+                          &beta_count_index};
+  RAFT_CUDA_TRY(add_kernel_node(
+    body_graph,
+    &compact_node,
+    &deferred_node,
+    1,
+    reinterpret_cast<void*>(compact_dense_frontier_kernel<vertex_t>),
+    dim3(compact_blocks),
+    dim3(compact_block_size),
+    0,
+    compact_args));
+
+  cudaGraphNode_t finalize_node = nullptr;
+  cudaGraphConditionalHandle finalize_handle = conditional_handle;
+  void* finalize_args[] = {&finalize_handle, &state, &depth_limit};
+  RAFT_CUDA_TRY(add_kernel_node(
+    body_graph,
+    &finalize_node,
+    &compact_node,
+    1,
+    reinterpret_cast<void*>(finalize_iteration_kernel<vertex_t>),
+    dim3(1),
+    dim3(1),
+    0,
+    finalize_args));
+
+  RAFT_CUDA_TRY(cudaGraphInstantiate(graph_exec, *graph, 0));
+}
+
+template <typename vertex_t, typename edge_t>
+inline void run_initialized_frontier(raw_csr_view_t<vertex_t, edge_t> raw,
+                                     vertex_t* distances,
+                                     uint32_t* dense_words,
+                                     uint32_t* dense_dirty,
+                                     uint32_t* dense_dirty_super,
+                                     vertex_t* active_super_list,
+                                     uint32_t* masks_a,
+                                     uint32_t* masks_b,
+                                     vertex_t* gamma_a,
+                                     vertex_t* gamma_b,
+                                     vertex_t* state,
+                                     edge_t* deferred_begins,
+                                     edge_t* deferred_ends,
+                                     vertex_t word_count,
+                                     vertex_t dirty_count,
+                                     vertex_t dirty_super_count,
+                                     vertex_t deferred_capacity,
+                                     vertex_t depth_limit,
+                                     rmm::cuda_stream_view stream,
+                                     cudaGraph_t* graph,
+                                     cudaGraphExec_t* graph_exec)
+{
+  create_initialized_frontier_graph(raw,
+                                    distances,
+                                    dense_words,
+                                    dense_dirty,
+                                    dense_dirty_super,
+                                    active_super_list,
+                                    masks_a,
+                                    masks_b,
+                                    gamma_a,
+                                    gamma_b,
+                                    state,
+                                    deferred_begins,
+                                    deferred_ends,
+                                    word_count,
+                                    dirty_count,
+                                    dirty_super_count,
+                                    deferred_capacity,
+                                    depth_limit,
+                                    graph,
+                                    graph_exec);
+  RAFT_CUDA_TRY(cudaGraphLaunch(*graph_exec, stream.value()));
+  stream.synchronize();
+}
+
+template <typename vertex_t, typename edge_t>
+inline void run_single_source(raw_csr_view_t<vertex_t, edge_t> raw,
+                              vertex_t* distances,
+                              vertex_t source,
+                              vertex_t depth_limit,
+                              rmm::cuda_stream_view stream)
+{
+  CUGRAPH_EXPECTS((source >= 0) && (source < raw.num_vertices),
+                  "Invalid input argument: source is out of range.");
+
+  rmm::device_uvector<uint32_t> dense_words((static_cast<size_t>(raw.num_vertices) + 31) / 32,
+                                            stream);
+  auto word_count = static_cast<vertex_t>(dense_words.size());
+  auto dirty_count = static_cast<vertex_t>((word_count + words_per_dirty - 1) / words_per_dirty);
+  auto dirty_super_count =
+    static_cast<vertex_t>((dirty_count + dirty_words_per_super - 1) / dirty_words_per_super);
+
+  rmm::device_uvector<uint32_t> dense_dirty(dirty_count, stream);
+  rmm::device_uvector<uint32_t> dense_dirty_super(dirty_super_count, stream);
+  rmm::device_uvector<vertex_t> active_super_list(dirty_super_count, stream);
+  rmm::device_uvector<uint32_t> masks_a(word_count, stream);
+  rmm::device_uvector<uint32_t> masks_b(word_count, stream);
+  rmm::device_uvector<vertex_t> gamma_a(word_count, stream);
+  rmm::device_uvector<vertex_t> gamma_b(word_count, stream);
+  rmm::device_uvector<vertex_t> state(state_count, stream);
+  rmm::device_uvector<edge_t> deferred_begins(
+    (static_cast<size_t>(raw.num_edges) + deferred_edge_chunk_size - 1) / deferred_edge_chunk_size +
+      word_count,
+    stream);
+  rmm::device_uvector<edge_t> deferred_ends(deferred_begins.size(), stream);
+
+  auto init_blocks = static_cast<int>(
+    (std::max(static_cast<size_t>(raw.num_vertices), static_cast<size_t>(word_count)) +
+     block_size - 1) /
+    block_size);
+  init_blocks = std::max(1, std::min(init_blocks, 1024));
+  init_kernel<<<init_blocks, block_size, 0, stream.value()>>>(raw,
+                                                              source,
+                                                              distances,
+                                                              dense_words.data(),
+                                                              dense_dirty.data(),
+                                                              dense_dirty_super.data(),
+                                                              active_super_list.data(),
+                                                              masks_a.data(),
+                                                              masks_b.data(),
+                                                              gamma_a.data(),
+                                                              gamma_b.data(),
+                                                              state.data(),
+                                                              word_count,
+                                                              dirty_count,
+                                                              dirty_super_count);
+  RAFT_CUDA_TRY(cudaPeekAtLastError());
+
+  cudaGraph_t graph = nullptr;
+  cudaGraphExec_t graph_exec = nullptr;
+  run_initialized_frontier(raw,
+                           distances,
+                           dense_words.data(),
+                           dense_dirty.data(),
+                           dense_dirty_super.data(),
+                           active_super_list.data(),
+                           masks_a.data(),
+                           masks_b.data(),
+                           gamma_a.data(),
+                           gamma_b.data(),
+                           state.data(),
+                           deferred_begins.data(),
+                           deferred_ends.data(),
+                           word_count,
+                           dirty_count,
+                           dirty_super_count,
+                           static_cast<vertex_t>(deferred_begins.size()),
+                           depth_limit,
+                           stream,
+                           &graph,
+                           &graph_exec);
+  if (graph_exec != nullptr) { cudaGraphExecDestroy(graph_exec); }
+  if (graph != nullptr) { cudaGraphDestroy(graph); }
+}
+
+template <typename vertex_t, typename edge_t>
+inline void run_multi_source(raw_csr_view_t<vertex_t, edge_t> raw,
+                             vertex_t* distances,
+                             vertex_t const* sources,
+                             size_t n_sources,
+                             vertex_t depth_limit,
+                             rmm::cuda_stream_view stream,
+                             workspace_t<vertex_t, edge_t>& workspace)
+{
+  CUGRAPH_EXPECTS(n_sources > 0, "Invalid input argument: sources cannot be empty.");
+
+  auto word_count = static_cast<vertex_t>(workspace.dense_words.size());
+  auto dirty_count = static_cast<vertex_t>((word_count + words_per_dirty - 1) / words_per_dirty);
+  auto dirty_super_count =
+    static_cast<vertex_t>((dirty_count + dirty_words_per_super - 1) / dirty_words_per_super);
+  CUGRAPH_EXPECTS(static_cast<vertex_t>(workspace.dense_dirty.size()) == dirty_count,
+                  "Invalid DAWN workspace: dense_dirty has the wrong size.");
+  CUGRAPH_EXPECTS(static_cast<vertex_t>(workspace.dense_dirty_super.size()) == dirty_super_count,
+                  "Invalid DAWN workspace: dense_dirty_super has the wrong size.");
+
+  auto init_items = std::max(
+    std::max(static_cast<size_t>(raw.num_vertices), static_cast<size_t>(word_count)),
+    std::max(static_cast<size_t>(dirty_count), static_cast<size_t>(dirty_super_count)));
+  auto init_blocks =
+    std::max(1, std::min(static_cast<int>((init_items + block_size - 1) / block_size), 1024));
+  init_multi_source_workspace_kernel<<<init_blocks, block_size, 0, stream.value()>>>(
+    distances,
+    workspace.dense_words.data(),
+    workspace.dense_dirty.data(),
+    workspace.dense_dirty_super.data(),
+    workspace.active_super_list.data(),
+    workspace.masks_a.data(),
+    workspace.masks_b.data(),
+    workspace.gamma_a.data(),
+    workspace.gamma_b.data(),
+    workspace.state.data(),
+    raw.num_vertices,
+    word_count,
+    dirty_count,
+    dirty_super_count);
+  RAFT_CUDA_TRY(cudaPeekAtLastError());
+
+  auto seed_blocks =
+    std::max(1, std::min(static_cast<int>((n_sources + block_size - 1) / block_size), 1024));
+  seed_source_distances_kernel<<<seed_blocks, block_size, 0, stream.value()>>>(
+    sources, static_cast<vertex_t>(n_sources), distances);
+  RAFT_CUDA_TRY(cudaPeekAtLastError());
+
+  auto compact_block_size = 32 * compact_dirty_words_per_block;
+  auto compact_blocks = std::max(
+    1,
+    static_cast<int>((dirty_count + compact_dirty_words_per_block - 1) /
+                     compact_dirty_words_per_block));
+  if (depth_limit > 0) {
+    auto neighbor_seed_blocks = std::max(1, std::min(static_cast<int>(n_sources), 65535));
+    seed_multi_source_neighbors_kernel<<<neighbor_seed_blocks, block_size, 0, stream.value()>>>(
+      raw,
+      sources,
+      static_cast<vertex_t>(n_sources),
+      distances,
+      workspace.dense_words.data(),
+      workspace.dense_dirty.data(),
+      workspace.state.data());
+    RAFT_CUDA_TRY(cudaPeekAtLastError());
+
+    compact_dense_frontier_kernel<<<compact_blocks, compact_block_size, 0, stream.value()>>>(
+      word_count,
+      workspace.dense_words.data(),
+      workspace.dense_dirty.data(),
+      workspace.masks_a.data(),
+      workspace.masks_b.data(),
+      workspace.gamma_a.data(),
+      workspace.gamma_b.data(),
+      workspace.state.data(),
+      static_cast<vertex_t>(state_alpha_word_count));
+    RAFT_CUDA_TRY(cudaPeekAtLastError());
+  }
+
+  run_initialized_frontier(raw,
+                           distances,
+                           workspace.dense_words.data(),
+                           workspace.dense_dirty.data(),
+                           workspace.dense_dirty_super.data(),
+                           workspace.active_super_list.data(),
+                           workspace.masks_a.data(),
+                           workspace.masks_b.data(),
+                           workspace.gamma_a.data(),
+                           workspace.gamma_b.data(),
+                           workspace.state.data(),
+                           workspace.deferred_begins.data(),
+                           workspace.deferred_ends.data(),
+                           word_count,
+                           dirty_count,
+                           dirty_super_count,
+                           static_cast<vertex_t>(workspace.deferred_begins.size()),
+                           depth_limit,
+                           stream,
+                           &workspace.graph,
+                           &workspace.graph_exec);
+}
+
+template <typename vertex_t, typename edge_t>
+inline void run_multi_source(raw_csr_view_t<vertex_t, edge_t> raw,
+                             vertex_t* distances,
+                             vertex_t const* sources,
+                             size_t n_sources,
+                             vertex_t depth_limit,
+                             rmm::cuda_stream_view stream)
+{
+  workspace_t<vertex_t, edge_t> workspace(raw, stream);
+  run_multi_source(raw, distances, sources, n_sources, depth_limit, stream, workspace);
+}
+
+}  // namespace dawn
+}  // namespace detail
+
+template <typename vertex_t, typename edge_t, bool multi_gpu>
+void dawn_bfs(raft::handle_t const& handle,
+              graph_view_t<vertex_t, edge_t, false, multi_gpu> const& graph_view,
+              vertex_t* distances,
+              vertex_t const* sources,
+              size_t n_sources,
+              vertex_t depth_limit,
+              bool do_expensive_check)
+{
+  static_assert(!multi_gpu);
+
+  CUGRAPH_EXPECTS(sources != nullptr, "Invalid input argument: source cannot be null.");
+  CUGRAPH_EXPECTS(distances != nullptr, "Invalid input argument: distances cannot be null.");
+  auto num_vertices = graph_view.number_of_vertices();
+  if (num_vertices == 0) { return; }
+
+  auto stream = handle.get_stream();
+  if (do_expensive_check) {
+    std::vector<vertex_t> h_sources(n_sources);
+    raft::update_host(h_sources.data(), sources, n_sources, stream);
+    stream.synchronize();
+    for (auto source : h_sources) {
+      CUGRAPH_EXPECTS((source >= 0) && (source < num_vertices),
+                      "Invalid input argument: source is out of range.");
+    }
+  }
+
+  auto edge_partition = graph_view.local_edge_partition_view();
+  auto offsets = edge_partition.offsets();
+  auto indices = edge_partition.indices();
+
+  detail::dawn::raw_csr_view_t<vertex_t, edge_t> raw{
+    offsets.data(),
+    indices.data(),
+    static_cast<vertex_t>(num_vertices),
+    static_cast<edge_t>(indices.size())};
+
+  detail::dawn::run_multi_source(raw, distances, sources, n_sources, depth_limit, stream);
+
+}
+
+template <typename vertex_t, typename edge_t, bool multi_gpu>
+void dawn_bfs(raft::handle_t const& handle,
+              graph_view_t<vertex_t, edge_t, false, multi_gpu> const& graph_view,
+              vertex_t* distances,
+              vertex_t const* sources,
+              size_t n_sources,
+              vertex_t depth_limit,
+              bool do_expensive_check,
+              detail::dawn::workspace_t<vertex_t, edge_t>& workspace)
+{
+  static_assert(!multi_gpu);
+
+  CUGRAPH_EXPECTS(sources != nullptr, "Invalid input argument: source cannot be null.");
+  CUGRAPH_EXPECTS(distances != nullptr, "Invalid input argument: distances cannot be null.");
+  auto num_vertices = graph_view.number_of_vertices();
+  if (num_vertices == 0) { return; }
+
+  auto stream = handle.get_stream();
+  if (do_expensive_check) {
+    std::vector<vertex_t> h_sources(n_sources);
+    raft::update_host(h_sources.data(), sources, n_sources, stream);
+    stream.synchronize();
+    for (auto source : h_sources) {
+      CUGRAPH_EXPECTS((source >= 0) && (source < num_vertices),
+                      "Invalid input argument: source is out of range.");
+    }
+  }
+
+  auto edge_partition = graph_view.local_edge_partition_view();
+  auto offsets = edge_partition.offsets();
+  auto indices = edge_partition.indices();
+
+  detail::dawn::raw_csr_view_t<vertex_t, edge_t> raw{
+    offsets.data(),
+    indices.data(),
+    static_cast<vertex_t>(num_vertices),
+    static_cast<edge_t>(indices.size())};
+
+  detail::dawn::run_multi_source(
+    raw, distances, sources, n_sources, depth_limit, stream, workspace);
+}
+
+}  // namespace cugraph

--- a/cpp/src/traversal/dawn_bfs_sg_v32_e32.cu
+++ b/cpp/src/traversal/dawn_bfs_sg_v32_e32.cu
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "traversal/dawn_bfs_impl.cuh"
+
+namespace cugraph {
+
+template void dawn_bfs(raft::handle_t const& handle,
+                       graph_view_t<int32_t, int32_t, false, false> const& graph_view,
+                       int32_t* distances,
+                       int32_t const* sources,
+                       size_t n_sources,
+                       int32_t depth_limit,
+                       bool do_expensive_check);
+
+}  // namespace cugraph

--- a/cpp/src/traversal/dawn_bfs_sg_v64_e64.cu
+++ b/cpp/src/traversal/dawn_bfs_sg_v64_e64.cu
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "traversal/dawn_bfs_impl.cuh"
+
+namespace cugraph {
+
+template void dawn_bfs(raft::handle_t const& handle,
+                       graph_view_t<int64_t, int64_t, false, false> const& graph_view,
+                       int64_t* distances,
+                       int64_t const* sources,
+                       size_t n_sources,
+                       int64_t depth_limit,
+                       bool do_expensive_check);
+
+}  // namespace cugraph

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -278,6 +278,46 @@ function(ConfigureCTest CMAKE_TEST_NAME)
 
 endfunction()
 
+function(ConfigureCOnlyCTest CMAKE_TEST_NAME)
+    set(options)
+    set(one_value GPUS PERCENT)
+    set(multi_value)
+    cmake_parse_arguments(_CUGRAPH_TEST "${options}" "${one_value}" "${multi_value}" ${ARGN})
+    if(NOT DEFINED _CUGRAPH_TEST_GPUS AND NOT DEFINED _CUGRAPH_TEST_PERCENT)
+        set(_CUGRAPH_TEST_GPUS 1)
+        set(_CUGRAPH_TEST_PERCENT 25)
+    endif()
+    if(NOT DEFINED _CUGRAPH_TEST_GPUS)
+        set(_CUGRAPH_TEST_GPUS 1)
+    endif()
+    if(NOT DEFINED _CUGRAPH_TEST_PERCENT)
+        set(_CUGRAPH_TEST_PERCENT 100)
+    endif()
+
+    add_executable(${CMAKE_TEST_NAME} ${_CUGRAPH_TEST_UNPARSED_ARGUMENTS})
+
+    target_link_libraries(${CMAKE_TEST_NAME}
+        PRIVATE
+            cugraph::cugraph_c
+    )
+    set_target_properties(
+        ${CMAKE_TEST_NAME}
+            PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUGRAPH_BINARY_DIR}/gtests>"
+                       INSTALL_RPATH "\$ORIGIN/../../../lib"
+                       LINK_FLAGS "-Wl,--allow-shlib-undefined")
+
+    rapids_test_add(
+        NAME ${CMAKE_TEST_NAME}
+        COMMAND ${CMAKE_TEST_NAME}
+        GPUS ${_CUGRAPH_TEST_GPUS}
+        PERCENT ${_CUGRAPH_TEST_PERCENT}
+        INSTALL_COMPONENT_SET testing_c
+        INSTALL_TARGET ${CMAKE_TEST_NAME}
+    )
+    set_tests_properties(${CMAKE_TEST_NAME} PROPERTIES LABELS "CUGRAPH_C")
+
+endfunction()
+
 function(ConfigureCTestMG CMAKE_TEST_NAME)
     add_executable(${CMAKE_TEST_NAME} ${ARGN})
 
@@ -919,6 +959,8 @@ ConfigureCTest(CAPI_BETWEENNESS_CENTRALITY_TEST c_api/betweenness_centrality_tes
 ConfigureCTest(CAPI_EDGE_BETWEENNESS_CENTRALITY_TEST c_api/edge_betweenness_centrality_test.c)
 ConfigureCTest(CAPI_HITS_TEST c_api/hits_test.c)
 ConfigureCTest(CAPI_BFS_TEST c_api/bfs_test.c)
+ConfigureCOnlyCTest(CAPI_DAWN_BFS_TEST c_api/dawn_bfs_test.c)
+
 ConfigureCTest(CAPI_SSSP_TEST c_api/sssp_test.c)
 ConfigureCTest(CAPI_EXTRACT_PATHS_TEST c_api/extract_paths_test.c)
 ConfigureCTest(CAPI_WEAKLY_CONNECTED_COMPONENTS_TEST c_api/weakly_connected_components_test.c)

--- a/cpp/tests/c_api/dawn_bfs_test.c
+++ b/cpp/tests/c_api/dawn_bfs_test.c
@@ -1,0 +1,655 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cugraph_c/algorithms.h>
+#include <cugraph_c/array.h>
+#include <cugraph_c/error.h>
+#include <cugraph_c/graph.h>
+#include <cugraph_c/resource_handle.h>
+#include <cugraph_c/traversal_algorithms.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static const int32_t INF = INT32_MAX;
+static const int64_t INF64 = INT64_MAX;
+
+static int fail_with_error(const char* what, cugraph_error_t* error)
+{
+  fprintf(stderr, "%s failed", what);
+  if (error != NULL) { fprintf(stderr, ": %s", cugraph_error_message(error)); }
+  fprintf(stderr, "\n");
+  return 1;
+}
+
+static int expect_success(cugraph_error_code_t code, cugraph_error_t* error, const char* what)
+{
+  if (code != CUGRAPH_SUCCESS) { return fail_with_error(what, error); }
+  return 0;
+}
+
+static int expect_error(cugraph_error_code_t code,
+                        cugraph_error_code_t expected,
+                        cugraph_error_t* error,
+                        const char* what)
+{
+  if (code != expected) {
+    fprintf(stderr, "%s returned %d, expected %d", what, (int)code, (int)expected);
+    if (error != NULL) { fprintf(stderr, ": %s", cugraph_error_message(error)); }
+    fprintf(stderr, "\n");
+    return 1;
+  }
+  cugraph_error_free(error);
+  return 0;
+}
+
+static cugraph_type_erased_device_array_t* make_device_i32(const cugraph_resource_handle_t* handle,
+                                                           const int32_t* host,
+                                                           size_t count,
+                                                           const char* name)
+{
+  cugraph_error_t* error = NULL;
+  cugraph_type_erased_device_array_t* array = NULL;
+  if (expect_success(cugraph_type_erased_device_array_create(handle, count, INT32, &array, &error),
+                     error,
+                     name)) {
+    exit(1);
+  }
+  cugraph_type_erased_device_array_view_t* view = cugraph_type_erased_device_array_view(array);
+  if (expect_success(cugraph_type_erased_device_array_view_copy_from_host(
+                       handle, view, (const byte_t*)host, &error),
+                     error,
+                     name)) {
+    exit(1);
+  }
+  cugraph_type_erased_device_array_view_free(view);
+  return array;
+}
+
+static cugraph_type_erased_device_array_t* make_device_i64(const cugraph_resource_handle_t* handle,
+                                                           const int64_t* host,
+                                                           size_t count,
+                                                           const char* name)
+{
+  cugraph_error_t* error = NULL;
+  cugraph_type_erased_device_array_t* array = NULL;
+  if (expect_success(cugraph_type_erased_device_array_create(handle, count, INT64, &array, &error),
+                     error,
+                     name)) {
+    exit(1);
+  }
+  cugraph_type_erased_device_array_view_t* view = cugraph_type_erased_device_array_view(array);
+  if (expect_success(cugraph_type_erased_device_array_view_copy_from_host(
+                       handle, view, (const byte_t*)host, &error),
+                     error,
+                     name)) {
+    exit(1);
+  }
+  cugraph_type_erased_device_array_view_free(view);
+  return array;
+}
+
+static int fetch_distances_by_vertex(const cugraph_resource_handle_t* handle,
+                                     cugraph_paths_result_t* result,
+                                     int32_t* out,
+                                     size_t n,
+                                     const char* name)
+{
+  cugraph_error_t* error                         = NULL;
+  cugraph_type_erased_device_array_view_t* verts = cugraph_paths_result_get_vertices(result);
+  cugraph_type_erased_device_array_view_t* dists = cugraph_paths_result_get_distances(result);
+  if (cugraph_type_erased_device_array_view_size(dists) != n) {
+    fprintf(stderr, "%s returned wrong distance size\n", name);
+    return 1;
+  }
+  size_t vertex_count = cugraph_type_erased_device_array_view_size(verts);
+  if (vertex_count == 0) {
+    if (expect_success(cugraph_type_erased_device_array_view_copy_to_host(
+                         handle, (byte_t*)out, dists, &error),
+                       error,
+                       name)) {
+      return 1;
+    }
+    return 0;
+  }
+  if (vertex_count != n) {
+    fprintf(stderr, "%s returned wrong vertex size\n", name);
+    return 1;
+  }
+
+  int32_t* tmp_vertices  = (int32_t*)malloc(n * sizeof(int32_t));
+  int32_t* tmp_distances = (int32_t*)malloc(n * sizeof(int32_t));
+  if (tmp_vertices == NULL || tmp_distances == NULL) {
+    fprintf(stderr, "%s allocation failed\n", name);
+    free(tmp_vertices);
+    free(tmp_distances);
+    return 1;
+  }
+
+  if (expect_success(cugraph_type_erased_device_array_view_copy_to_host(
+                       handle, (byte_t*)tmp_vertices, verts, &error),
+                     error,
+                     name)) {
+    free(tmp_vertices);
+    free(tmp_distances);
+    return 1;
+  }
+  if (expect_success(cugraph_type_erased_device_array_view_copy_to_host(
+                       handle, (byte_t*)tmp_distances, dists, &error),
+                     error,
+                     name)) {
+    free(tmp_vertices);
+    free(tmp_distances);
+    return 1;
+  }
+
+  for (size_t i = 0; i < n; ++i) { out[i] = INT32_MIN; }
+  for (size_t i = 0; i < n; ++i) {
+    if (tmp_vertices[i] < 0 || tmp_vertices[i] >= (int32_t)n) {
+      fprintf(stderr, "%s returned out-of-range vertex id %d\n", name, tmp_vertices[i]);
+      free(tmp_vertices);
+      free(tmp_distances);
+      return 1;
+    }
+    out[tmp_vertices[i]] = tmp_distances[i];
+  }
+
+  free(tmp_vertices);
+  free(tmp_distances);
+  return 0;
+}
+
+static int fetch_distances_by_vertex64(const cugraph_resource_handle_t* handle,
+                                       cugraph_paths_result_t* result,
+                                       int64_t* out,
+                                       size_t n,
+                                       const char* name)
+{
+  cugraph_error_t* error                         = NULL;
+  cugraph_type_erased_device_array_view_t* verts = cugraph_paths_result_get_vertices(result);
+  cugraph_type_erased_device_array_view_t* dists = cugraph_paths_result_get_distances(result);
+  if (cugraph_type_erased_device_array_view_size(dists) != n) {
+    fprintf(stderr, "%s returned wrong distance size\n", name);
+    return 1;
+  }
+  size_t vertex_count = cugraph_type_erased_device_array_view_size(verts);
+  if (vertex_count == 0) {
+    if (expect_success(cugraph_type_erased_device_array_view_copy_to_host(
+                         handle, (byte_t*)out, dists, &error),
+                       error,
+                       name)) {
+      return 1;
+    }
+    return 0;
+  }
+  if (vertex_count != n) {
+    fprintf(stderr, "%s returned wrong vertex size\n", name);
+    return 1;
+  }
+
+  int64_t* tmp_vertices  = (int64_t*)malloc(n * sizeof(int64_t));
+  int64_t* tmp_distances = (int64_t*)malloc(n * sizeof(int64_t));
+  if (tmp_vertices == NULL || tmp_distances == NULL) {
+    fprintf(stderr, "%s allocation failed\n", name);
+    free(tmp_vertices);
+    free(tmp_distances);
+    return 1;
+  }
+
+  if (expect_success(cugraph_type_erased_device_array_view_copy_to_host(
+                       handle, (byte_t*)tmp_vertices, verts, &error),
+                     error,
+                     name)) {
+    free(tmp_vertices);
+    free(tmp_distances);
+    return 1;
+  }
+  if (expect_success(cugraph_type_erased_device_array_view_copy_to_host(
+                       handle, (byte_t*)tmp_distances, dists, &error),
+                     error,
+                     name)) {
+    free(tmp_vertices);
+    free(tmp_distances);
+    return 1;
+  }
+
+  for (size_t i = 0; i < n; ++i) { out[i] = INT64_MIN; }
+  for (size_t i = 0; i < n; ++i) {
+    if (tmp_vertices[i] < 0 || tmp_vertices[i] >= (int64_t)n) {
+      fprintf(stderr, "%s returned out-of-range vertex id %ld\n", name, (long)tmp_vertices[i]);
+      free(tmp_vertices);
+      free(tmp_distances);
+      return 1;
+    }
+    out[tmp_vertices[i]] = tmp_distances[i];
+  }
+
+  free(tmp_vertices);
+  free(tmp_distances);
+  return 0;
+}
+
+static int fetch_distances_view(const cugraph_resource_handle_t* handle,
+                                cugraph_type_erased_device_array_view_t* dists,
+                                int32_t* out,
+                                size_t n,
+                                const char* name)
+{
+  cugraph_error_t* error = NULL;
+  if (cugraph_type_erased_device_array_view_size(dists) != n) {
+    fprintf(stderr, "%s returned wrong distance size\n", name);
+    return 1;
+  }
+  return expect_success(
+    cugraph_type_erased_device_array_view_copy_to_host(handle, (byte_t*)out, dists, &error),
+    error,
+    name);
+}
+
+static int check_distances(const int32_t* got,
+                           const int32_t* expected,
+                           size_t n,
+                           const char* label)
+{
+  for (size_t i = 0; i < n; ++i) {
+    if (got[i] != expected[i]) {
+      fprintf(stderr,
+              "%s mismatch at %zu: got %d expected %d\n",
+              label,
+              i,
+              got[i],
+              expected[i]);
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static int check_distances64(const int64_t* got,
+                             const int64_t* expected,
+                             size_t n,
+                             const char* label)
+{
+  for (size_t i = 0; i < n; ++i) {
+    if (got[i] != expected[i]) {
+      fprintf(stderr,
+              "%s mismatch at %zu: got %ld expected %ld\n",
+              label,
+              i,
+              (long)got[i],
+              (long)expected[i]);
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static int create_i32_graph(const cugraph_resource_handle_t* handle,
+                            bool_t store_transposed,
+                            bool_t renumber,
+                            cugraph_graph_t** graph)
+{
+  const size_t num_vertices = 6;
+  const size_t num_edges    = 8;
+  int32_t vertices[]        = {0, 1, 2, 3, 4, 5};
+  int32_t src[]             = {0, 1, 1, 2, 2, 2, 3, 4};
+  int32_t dst[]             = {1, 3, 4, 0, 1, 3, 5, 5};
+
+  cugraph_error_t* error = NULL;
+  cugraph_type_erased_device_array_t* vertices_array =
+    make_device_i32(handle, vertices, num_vertices, "vertices");
+  cugraph_type_erased_device_array_t* src_array = make_device_i32(handle, src, num_edges, "src");
+  cugraph_type_erased_device_array_t* dst_array = make_device_i32(handle, dst, num_edges, "dst");
+  cugraph_type_erased_device_array_view_t* vertices_view =
+    cugraph_type_erased_device_array_view(vertices_array);
+  cugraph_type_erased_device_array_view_t* src_view =
+    cugraph_type_erased_device_array_view(src_array);
+  cugraph_type_erased_device_array_view_t* dst_view =
+    cugraph_type_erased_device_array_view(dst_array);
+
+  cugraph_graph_properties_t properties;
+  properties.is_symmetric  = FALSE;
+  properties.is_multigraph = FALSE;
+
+  int result = expect_success(cugraph_graph_create_sg(handle,
+                                                      &properties,
+                                                      vertices_view,
+                                                      src_view,
+                                                      dst_view,
+                                                      NULL,
+                                                      NULL,
+                                                      NULL,
+                                                      store_transposed,
+                                                      renumber,
+                                                      FALSE,
+                                                      FALSE,
+                                                      FALSE,
+                                                      FALSE,
+                                                      graph,
+                                                      &error),
+                              error,
+                              "graph create");
+
+  cugraph_type_erased_device_array_view_free(dst_view);
+  cugraph_type_erased_device_array_view_free(src_view);
+  cugraph_type_erased_device_array_view_free(vertices_view);
+  cugraph_type_erased_device_array_free(dst_array);
+  cugraph_type_erased_device_array_free(src_array);
+  cugraph_type_erased_device_array_free(vertices_array);
+  cugraph_error_free(error);
+  return result;
+}
+
+static int run_dawn_bfs_case(bool_t renumber, size_t depth_limit, const int32_t* expected)
+{
+  const size_t num_vertices = 6;
+  int32_t source[]          = {0};
+  int32_t distances[6];
+  int result = 0;
+
+  cugraph_resource_handle_t* handle = cugraph_create_resource_handle(NULL);
+  if (handle == NULL) { return 1; }
+
+  cugraph_graph_t* graph = NULL;
+  result |= create_i32_graph(handle, FALSE, renumber, &graph);
+
+  cugraph_type_erased_device_array_t* source_array = make_device_i32(handle, source, 1, "source");
+  cugraph_type_erased_device_array_view_t* source_view =
+    cugraph_type_erased_device_array_view(source_array);
+
+  cugraph_error_t* error       = NULL;
+  cugraph_paths_result_t* path = NULL;
+  result |= expect_success(
+    cugraph_dawn_bfs(handle, graph, source_view, depth_limit, FALSE, &path, &error),
+    error,
+    "cugraph_dawn_bfs");
+  if (result == 0) {
+    result |= fetch_distances_by_vertex(handle, path, distances, num_vertices, "dawn distances");
+    result |= check_distances(distances, expected, num_vertices, "dawn distances");
+  }
+
+  if (path != NULL) { cugraph_paths_result_free(path); }
+  cugraph_type_erased_device_array_view_free(source_view);
+  cugraph_type_erased_device_array_free(source_array);
+  cugraph_graph_free(graph);
+  cugraph_free_resource_handle(handle);
+  cugraph_error_free(error);
+  return result;
+}
+
+static int test_dawn_bfs_non_renumbered(void)
+{
+  int32_t expected[] = {0, 1, INF, 2, 2, 3};
+  return run_dawn_bfs_case(FALSE, SIZE_MAX, expected);
+}
+
+static int test_dawn_bfs_depth_limit(void)
+{
+  int32_t expected[] = {0, 1, INF, INF, INF, INF};
+  return run_dawn_bfs_case(FALSE, 1, expected);
+}
+
+static int test_dawn_bfs_distances_api(void)
+{
+  const size_t num_vertices = 6;
+  int32_t sources[]         = {0, 1};
+  int32_t distances[6];
+  int32_t expected[] = {0, 0, INF, 1, 1, 2};
+  int result = 0;
+
+  cugraph_resource_handle_t* handle = cugraph_create_resource_handle(NULL);
+  if (handle == NULL) { return 1; }
+
+  cugraph_graph_t* graph = NULL;
+  result |= create_i32_graph(handle, FALSE, FALSE, &graph);
+
+  cugraph_type_erased_device_array_t* source_array = make_device_i32(handle, sources, 2, "sources");
+  cugraph_type_erased_device_array_view_t* source_view =
+    cugraph_type_erased_device_array_view(source_array);
+
+  cugraph_error_t* error = NULL;
+  cugraph_type_erased_device_array_t* distance_array = NULL;
+  result |= expect_success(cugraph_type_erased_device_array_create(
+                             handle, num_vertices, INT32, &distance_array, &error),
+                           error,
+                           "distance array");
+  cugraph_type_erased_device_array_view_t* distance_view =
+    cugraph_type_erased_device_array_view(distance_array);
+
+  result |= expect_success(cugraph_dawn_bfs_distances(
+                             handle, graph, source_view, SIZE_MAX, FALSE, distance_view, &error),
+                           error,
+                           "cugraph_dawn_bfs_distances");
+  if (result == 0) {
+    result |= fetch_distances_view(handle, distance_view, distances, num_vertices, "distances api");
+    result |= check_distances(distances, expected, num_vertices, "distances api");
+  }
+
+  cugraph_type_erased_device_array_view_free(distance_view);
+  cugraph_type_erased_device_array_free(distance_array);
+  cugraph_type_erased_device_array_view_free(source_view);
+  cugraph_type_erased_device_array_free(source_array);
+  cugraph_graph_free(graph);
+  cugraph_free_resource_handle(handle);
+  cugraph_error_free(error);
+  return result;
+}
+
+static int test_dawn_bfs_renumbered_rejected(void)
+{
+  const size_t num_vertices = 6;
+  int32_t source[]          = {0};
+  int result = 0;
+
+  cugraph_resource_handle_t* handle = cugraph_create_resource_handle(NULL);
+  if (handle == NULL) { return 1; }
+
+  cugraph_graph_t* graph = NULL;
+  result |= create_i32_graph(handle, FALSE, TRUE, &graph);
+
+  cugraph_type_erased_device_array_t* source_array = make_device_i32(handle, source, 1, "source");
+  cugraph_type_erased_device_array_view_t* source_view =
+    cugraph_type_erased_device_array_view(source_array);
+
+  cugraph_error_t* error       = NULL;
+  cugraph_paths_result_t* path = NULL;
+  result |= expect_error(
+    cugraph_dawn_bfs(handle, graph, source_view, SIZE_MAX, FALSE, &path, &error),
+    CUGRAPH_UNSUPPORTED_TYPE_COMBINATION,
+    error,
+    "renumbered cugraph_dawn_bfs");
+
+  cugraph_type_erased_device_array_t* distance_array = NULL;
+  result |= expect_success(cugraph_type_erased_device_array_create(
+                             handle, num_vertices, INT32, &distance_array, &error),
+                           error,
+                           "distance array");
+  cugraph_type_erased_device_array_view_t* distance_view =
+    cugraph_type_erased_device_array_view(distance_array);
+  result |= expect_error(cugraph_dawn_bfs_distances(
+                           handle, graph, source_view, SIZE_MAX, FALSE, distance_view, &error),
+                         CUGRAPH_UNSUPPORTED_TYPE_COMBINATION,
+                         error,
+                         "renumbered cugraph_dawn_bfs_distances");
+
+  if (path != NULL) { cugraph_paths_result_free(path); }
+  cugraph_type_erased_device_array_view_free(distance_view);
+  cugraph_type_erased_device_array_free(distance_array);
+  cugraph_type_erased_device_array_view_free(source_view);
+  cugraph_type_erased_device_array_free(source_array);
+  cugraph_graph_free(graph);
+  cugraph_free_resource_handle(handle);
+  cugraph_error_free(error);
+  return result;
+}
+
+static int test_dawn_bfs_store_transposed_rejected(void)
+{
+  int32_t source[] = {0};
+  int result       = 0;
+
+  cugraph_resource_handle_t* handle = cugraph_create_resource_handle(NULL);
+  if (handle == NULL) { return 1; }
+
+  cugraph_graph_t* graph = NULL;
+  result |= create_i32_graph(handle, TRUE, FALSE, &graph);
+
+  cugraph_type_erased_device_array_t* source_array = make_device_i32(handle, source, 1, "source");
+  cugraph_type_erased_device_array_view_t* source_view =
+    cugraph_type_erased_device_array_view(source_array);
+
+  cugraph_error_t* error       = NULL;
+  cugraph_paths_result_t* path = NULL;
+  result |= expect_error(
+    cugraph_dawn_bfs(handle, graph, source_view, SIZE_MAX, FALSE, &path, &error),
+    CUGRAPH_UNSUPPORTED_TYPE_COMBINATION,
+    error,
+    "store_transposed cugraph_dawn_bfs");
+
+  if (path != NULL) { cugraph_paths_result_free(path); }
+  cugraph_type_erased_device_array_view_free(source_view);
+  cugraph_type_erased_device_array_free(source_array);
+  cugraph_graph_free(graph);
+  cugraph_free_resource_handle(handle);
+  return result;
+}
+
+static int test_dawn_bfs_multi_source(void)
+{
+  int32_t sources[] = {0, 1};
+  int32_t distances[6];
+  int result = 0;
+
+  cugraph_resource_handle_t* handle = cugraph_create_resource_handle(NULL);
+  if (handle == NULL) { return 1; }
+
+  cugraph_graph_t* graph = NULL;
+  result |= create_i32_graph(handle, FALSE, FALSE, &graph);
+
+  cugraph_type_erased_device_array_t* source_array = make_device_i32(handle, sources, 2, "sources");
+  cugraph_type_erased_device_array_view_t* source_view =
+    cugraph_type_erased_device_array_view(source_array);
+
+  cugraph_error_t* error       = NULL;
+  cugraph_paths_result_t* path = NULL;
+  result |= expect_success(
+    cugraph_dawn_bfs(handle, graph, source_view, SIZE_MAX, FALSE, &path, &error),
+    error,
+    "multi-source cugraph_dawn_bfs");
+  if (result == 0) {
+    int32_t expected[] = {0, 0, INF, 1, 1, 2};
+    result |= fetch_distances_by_vertex(handle, path, distances, 6, "multi-source distances");
+    result |= check_distances(distances, expected, 6, "multi-source distances");
+  }
+
+  if (path != NULL) { cugraph_paths_result_free(path); }
+  cugraph_type_erased_device_array_view_free(source_view);
+  cugraph_type_erased_device_array_free(source_array);
+  cugraph_graph_free(graph);
+  cugraph_free_resource_handle(handle);
+  return result;
+}
+
+static int test_dawn_bfs_v64_e64(void)
+{
+  const size_t num_vertices = 6;
+  const size_t num_edges    = 8;
+  int64_t vertices[]        = {0, 1, 2, 3, 4, 5};
+  int64_t src[]             = {0, 1, 1, 2, 2, 2, 3, 4};
+  int64_t dst[]             = {1, 3, 4, 0, 1, 3, 5, 5};
+  int64_t source[]          = {0};
+  int64_t distances[6];
+  int result                = 0;
+
+  cugraph_resource_handle_t* handle = cugraph_create_resource_handle(NULL);
+  if (handle == NULL) { return 1; }
+
+  cugraph_type_erased_device_array_t* vertices_array =
+    make_device_i64(handle, vertices, num_vertices, "vertices64");
+  cugraph_type_erased_device_array_t* src_array = make_device_i64(handle, src, num_edges, "src64");
+  cugraph_type_erased_device_array_t* dst_array = make_device_i64(handle, dst, num_edges, "dst64");
+  cugraph_type_erased_device_array_t* source_array = make_device_i64(handle, source, 1, "source64");
+  cugraph_type_erased_device_array_view_t* vertices_view =
+    cugraph_type_erased_device_array_view(vertices_array);
+  cugraph_type_erased_device_array_view_t* src_view =
+    cugraph_type_erased_device_array_view(src_array);
+  cugraph_type_erased_device_array_view_t* dst_view =
+    cugraph_type_erased_device_array_view(dst_array);
+  cugraph_type_erased_device_array_view_t* source_view =
+    cugraph_type_erased_device_array_view(source_array);
+
+  cugraph_graph_properties_t properties;
+  properties.is_symmetric  = FALSE;
+  properties.is_multigraph = FALSE;
+
+  cugraph_error_t* error = NULL;
+  cugraph_graph_t* graph = NULL;
+  result |= expect_success(cugraph_graph_create_sg(handle,
+                                                   &properties,
+                                                   vertices_view,
+                                                   src_view,
+                                                   dst_view,
+                                                   NULL,
+                                                   NULL,
+                                                   NULL,
+                                                   FALSE,
+                                                   FALSE,
+                                                   FALSE,
+                                                   FALSE,
+                                                   FALSE,
+                                                   FALSE,
+                                                   &graph,
+                                                   &error),
+                           error,
+                           "graph64 create");
+
+  cugraph_paths_result_t* path = NULL;
+  result |= expect_success(cugraph_dawn_bfs(handle, graph, source_view, SIZE_MAX, FALSE, &path, &error),
+                           error,
+                           "v64/e64 cugraph_dawn_bfs");
+  if (result == 0) {
+    int64_t expected[] = {0, 1, INF64, 2, 2, 3};
+    result |= fetch_distances_by_vertex64(handle, path, distances, num_vertices, "v64/e64 distances");
+    result |= check_distances64(distances, expected, num_vertices, "v64/e64 distances");
+  }
+
+  if (path != NULL) { cugraph_paths_result_free(path); }
+  cugraph_graph_free(graph);
+  cugraph_type_erased_device_array_view_free(source_view);
+  cugraph_type_erased_device_array_view_free(dst_view);
+  cugraph_type_erased_device_array_view_free(src_view);
+  cugraph_type_erased_device_array_view_free(vertices_view);
+  cugraph_type_erased_device_array_free(source_array);
+  cugraph_type_erased_device_array_free(dst_array);
+  cugraph_type_erased_device_array_free(src_array);
+  cugraph_type_erased_device_array_free(vertices_array);
+  cugraph_free_resource_handle(handle);
+  cugraph_error_free(error);
+  return result;
+}
+
+static int run_test(int (*test)(void), const char* name)
+{
+  int result = test();
+  printf("%s %s\n", result == 0 ? "PASS" : "FAIL", name);
+  return result;
+}
+
+int main(int argc, char** argv)
+{
+  (void)argc;
+  (void)argv;
+  int result = 0;
+  result |= run_test(test_dawn_bfs_non_renumbered, "test_dawn_bfs_non_renumbered");
+  result |= run_test(test_dawn_bfs_depth_limit, "test_dawn_bfs_depth_limit");
+  result |= run_test(test_dawn_bfs_distances_api, "test_dawn_bfs_distances_api");
+  result |= run_test(test_dawn_bfs_renumbered_rejected, "test_dawn_bfs_renumbered_rejected");
+  result |= run_test(test_dawn_bfs_store_transposed_rejected,
+                     "test_dawn_bfs_store_transposed_rejected");
+  result |= run_test(test_dawn_bfs_multi_source, "test_dawn_bfs_multi_source");
+  result |= run_test(test_dawn_bfs_v64_e64, "test_dawn_bfs_v64_e64");
+  return result;
+}


### PR DESCRIPTION
[REVIEW] Add experimental DAWN BFS C API

## Summary

Related to #5537.

This PR adds an experimental single-GPU DAWN BFS backend and exposes it through C++ and C API entry points for unrenumbered BFS distance computation.

DAWN is a matrix-operation-optimized shortest-path method originally presented at ICS 2024, where the paper was included in the Best Paper Nominees session. The goal of this PR is to start a concrete technical collaboration on bringing that research path into cuGraph: first as an experimental, constrained BFS path with focused tests, and then iteratively toward the API shape, implementation boundaries, and performance validation that the RAPIDS team would consider production-ready.

## What changed

- Add `cugraph::dawn_bfs(...)` for SG BFS distance computation.
- Add C API entry points:
  - `cugraph_dawn_bfs(...)`: compatibility wrapper returning `cugraph_paths_result_t`.
  - `cugraph_dawn_bfs_distances(...)`: distances-only API using a caller-owned output buffer.
- Add DAWN BFS instantiations for:
  - `int32_t` vertices / `int32_t` edges
  - `int64_t` vertices / `int64_t` edges
- Add focused C API tests covering:
  - unrenumbered graph execution
  - depth limit
  - multi-source inputs
  - direct distances output
  - int64 graph support
  - expected rejection of renumbered, store-transposed, and MG inputs
- Track graph renumbering state in the C API graph wrapper so unsupported DAWN inputs can be rejected explicitly.

## Current scope and constraints

This is intentionally limited to the narrow mode where the first implementation is meaningful and comparable:

- single-GPU only
- unrenumbered graphs only (`renumber=false`)
- non-transposed storage only (`store_transposed=false`)
- distances only; predecessors are not computed
- vertex/edge type pairs currently limited to `int32/int32` and `int64/int64`

The compatibility wrapper returns an empty `vertex_ids` array. Distances are laid out by contiguous unrenumbered vertex id. The lower-overhead path is `cugraph_dawn_bfs_distances(...)`, where the caller provides the graph-sized output distance buffer.

## Integration philosophy

The main goal of this contribution is to preserve DAWN's performance characteristics while fitting the implementation into cuGraph's existing abstractions, APIs, and engineering conventions wherever possible.

I would appreciate reviewer guidance on the additional functionality, API adjustments, graph-mode support, benchmark coverage, and implementation refactoring needed for this to move from an experimental backend toward a production-quality cuGraph component. I expect this to require multiple rounds of review and iteration, and I am happy to collaborate closely with the RAPIDS/cuGraph team on that process.

## Validation

Correctness:

```text
cd /home/lxr/code/cugraph/cpp/build-dawn
ninja gtests/CAPI_DAWN_BFS_TEST -j4
./gtests/CAPI_DAWN_BFS_TEST
ctest -R CAPI_DAWN_BFS_TEST --output-on-failure
```

Result:

```text
2/2 tests passed
```

Benchmark methodology used for the current local comparison:

- RTX 5070 Laptop GPU
- SG execution
- `renumber=false`
- `store_transposed=false`
- `predecessor=false`
- single-source mode for both DAWN and cuGraph BFS
- 147 MatrixMarket graphs
- 10 sources per graph
- 10 repeats per source
- raw rows retained for both algorithms

Current aligned result summary:

```text
147/147 graphs passed correctness checks
geomean speedup: 6.70x
median speedup:  6.52x
p25 / p75:       4.79x / 8.48x
min / max:       1.60x / 23.66x
```

## Discussion points for maintainers

I expect this PR to need review and iteration with the cuGraph team. In particular, I would appreciate guidance on:

- Whether this should remain an experimental C/C++ API or be wired into an existing BFS dispatch path.
- Whether the distances-only API is acceptable, or whether the result object should be refactored differently.
- How the team would prefer to represent unsupported graph modes (`renumber=true`, MG, transposed storage).
- What benchmark suite and reporting format would be most useful before considering this beyond experimental status.
- Whether the CUDA Graph conditional-loop structure is acceptable for this backend or should be integrated differently with existing traversal primitives.

## References

- ICS 2024 accepted papers: https://ics2024.github.io/paper.html
- DAWN publication entry: https://researchr.org/publication/FengWZLLL24
- DAWN arXiv preprint: https://arxiv.org/abs/2208.04514
