### PR TITLE
Define a wrapper for thrust::sort to reduce binary size

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -157,6 +157,7 @@ set(CUGRAPH_COMMON_UTILITY_SOURCES
     src/detail/permute_range_common_v32.cu
     src/detail/permute_range_common_v64.cu
     src/utilities/invert_flags_common.cu
+    src/utilities/thrust_wrappers.cu
 )
 
 set(CUGRAPH_COMMON_DISTRIBUTED_SOURCES

--- a/cpp/include/cugraph/detail/utility_wrappers.hpp
+++ b/cpp/include/cugraph/detail/utility_wrappers.hpp
@@ -64,20 +64,6 @@ void scalar_fill(raft::handle_t const& handle, value_t* d_value, size_t size, va
 
 /**
  * @ingroup utility_wrappers_cpp
- * @brief    Sort a device span
- *
- * @tparam      value_t      type of the value to operate on. Must be either int32_t or int64_t.
- *
- * @param [in]  handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator,
- * and handles to various CUDA libraries) to run graph algorithms.
- * @param[out]  values      device span to sort
- *
- */
-template <typename value_t>
-void sort_ints(raft::handle_t const& handle, raft::device_span<value_t> values);
-
-/**
- * @ingroup utility_wrappers_cpp
  * @brief    Keep unique element from a device span
  *
  * @tparam      value_t      type of the value to operate on. Must be either int32_t or int64_t.

--- a/cpp/include/cugraph/prims/detail/extract_transform_if_v_frontier_e.cuh
+++ b/cpp/include/cugraph/prims/detail/extract_transform_if_v_frontier_e.cuh
@@ -22,6 +22,7 @@
 #include <cugraph/utilities/device_comm.hpp>
 #include <cugraph/utilities/device_functors.cuh>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
@@ -842,9 +843,9 @@ extract_transform_if_v_frontier_e(raft::handle_t const& handle,
                  frontier_key_first,
                  frontier_key_last,
                  get_dataframe_buffer_begin(frontier_keys));
-    thrust::sort(handle.get_thrust_policy(),
-                 get_dataframe_buffer_begin(frontier_keys),
-                 get_dataframe_buffer_end(frontier_keys));
+    cugraph::sort_wrapper(handle.get_thrust_policy(),
+                          get_dataframe_buffer_begin(frontier_keys),
+                          get_dataframe_buffer_end(frontier_keys));
     frontier_key_first = get_dataframe_buffer_begin(frontier_keys);
     frontier_key_last  = get_dataframe_buffer_end(frontier_keys);
   }

--- a/cpp/include/cugraph/prims/detail/nbr_intersection.cuh
+++ b/cpp/include/cugraph/prims/detail/nbr_intersection.cuh
@@ -19,6 +19,7 @@
 #include <cugraph/utilities/mask_utils.cuh>
 #include <cugraph/utilities/shuffle_comm.cuh>
 #include <cugraph/utilities/thrust_tuple_utils.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/device_span.hpp>
 #include <raft/core/handle.hpp>
@@ -760,7 +761,8 @@ nbr_intersection(raft::handle_t const& handle,
                      second_element_first + input_size,
                      unique_majors.begin());
 
-        thrust::sort(handle.get_thrust_policy(), unique_majors.begin(), unique_majors.end());
+        cugraph::sort_wrapper(
+          handle.get_thrust_policy(), unique_majors.begin(), unique_majors.end());
         unique_majors.resize(
           cuda::std::distance(
             unique_majors.begin(),
@@ -789,7 +791,8 @@ nbr_intersection(raft::handle_t const& handle,
             handle.get_stream());
           unique_majors = std::move(rx_unique_majors);
 
-          thrust::sort(handle.get_thrust_policy(), unique_majors.begin(), unique_majors.end());
+          cugraph::sort_wrapper(
+            handle.get_thrust_policy(), unique_majors.begin(), unique_majors.end());
           unique_majors.resize(cuda::std::distance(unique_majors.begin(),
                                                    thrust::unique(handle.get_thrust_policy(),
                                                                   unique_majors.begin(),

--- a/cpp/include/cugraph/prims/detail/sample_and_compute_local_nbr_indices.cuh
+++ b/cpp/include/cugraph/prims/detail/sample_and_compute_local_nbr_indices.cuh
@@ -20,6 +20,7 @@
 #include <cugraph/utilities/mask_utils.cuh>
 #include <cugraph/utilities/misc_utils.cuh>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <raft/random/rng.cuh>
@@ -400,9 +401,9 @@ compute_unique_keys(raft::handle_t const& handle,
                  aggregate_local_frontier_key_first + local_frontier_offsets[i],
                  aggregate_local_frontier_key_first + local_frontier_offsets[i + 1],
                  get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i]);
-    thrust::sort(handle.get_thrust_policy(),
-                 get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i],
-                 get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i + 1]);
+    cugraph::sort_wrapper(handle.get_thrust_policy(),
+                          get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i],
+                          get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i + 1]);
     local_frontier_unique_key_sizes[i] = cuda::std::distance(
       get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i],
       thrust::unique(handle.get_thrust_policy(),

--- a/cpp/include/cugraph/prims/key_store.cuh
+++ b/cpp/include/cugraph/prims/key_store.cuh
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cugraph/export.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
@@ -190,7 +191,7 @@ class key_binary_search_store_t {
   {
     thrust::copy(rmm::exec_policy(stream), key_first, key_last, store_keys_.begin());
     if (!key_sorted) {
-      thrust::sort(rmm::exec_policy(stream), store_keys_.begin(), store_keys_.end());
+      cugraph::sort_wrapper(rmm::exec_policy(stream), store_keys_.begin(), store_keys_.end());
     }
   }
 
@@ -203,7 +204,7 @@ class key_binary_search_store_t {
     : store_keys_(std::move(keys))
   {
     if (!key_sorted) {
-      thrust::sort(rmm::exec_policy(stream), store_keys_.begin(), store_keys_.end());
+      cugraph::sort_wrapper(rmm::exec_policy(stream), store_keys_.begin(), store_keys_.end());
     }
   }
 

--- a/cpp/include/cugraph/prims/kv_store.cuh
+++ b/cpp/include/cugraph/prims/kv_store.cuh
@@ -9,6 +9,7 @@
 #include <cugraph/prims/detail/optional_dataframe_buffer.hpp>
 #include <cugraph/utilities/dataframe_buffer.hpp>
 #include <cugraph/utilities/device_functors.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
@@ -707,12 +708,12 @@ class kv_cuco_store_t {
       store_value_offsets.resize(0, stream);
       store_value_offsets.shrink_to_fit(stream);
 
-      thrust::sort(rmm::exec_policy(stream),
-                   kv_indices.begin(),
-                   kv_indices.end(),
-                   [key_first] __device__(auto lhs, auto rhs) {
-                     return *(key_first + lhs) < *(key_first + rhs);
-                   });
+      cugraph::sort_wrapper(rmm::exec_policy(stream),
+                            kv_indices.begin(),
+                            kv_indices.end(),
+                            [key_first] __device__(auto lhs, auto rhs) {
+                              return *(key_first + lhs) < *(key_first + rhs);
+                            });
       kv_indices.resize(
         cuda::std::distance(kv_indices.begin(),
                             thrust::unique(rmm::exec_policy(stream),

--- a/cpp/include/cugraph/prims/per_v_pair_transform_src_dst_nbr_intersection.cuh
+++ b/cpp/include/cugraph/prims/per_v_pair_transform_src_dst_nbr_intersection.cuh
@@ -16,6 +16,7 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/error_check_utils.cuh>
 #include <cugraph/utilities/graph_partition_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -226,9 +227,9 @@ void per_v_pair_transform_minor_nbr_intersection(
                  elem1_first,
                  elem1_first + num_input_pairs,
                  (*sorted_unique_vertices).begin() + num_input_pairs);
-    thrust::sort(handle.get_thrust_policy(),
-                 (*sorted_unique_vertices).begin(),
-                 (*sorted_unique_vertices).end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(),
+                          (*sorted_unique_vertices).begin(),
+                          (*sorted_unique_vertices).end());
     (*sorted_unique_vertices)
       .resize(cuda::std::distance((*sorted_unique_vertices).begin(),
                                   thrust::unique(handle.get_thrust_policy(),
@@ -326,12 +327,12 @@ void per_v_pair_transform_minor_nbr_intersection(
     for (size_t j = 0; j < h_chunk_sizes.size(); ++j) {
       auto this_chunk_size = h_chunk_sizes[j];
 
-      thrust::sort(handle.get_thrust_policy(),
-                   chunk_vertex_pair_index_first,
-                   chunk_vertex_pair_index_first + this_chunk_size,
-                   detail::indirection_compare_less_t<VertexPairIterator>{
-                     vertex_pair_first});  // detail::nbr_intersection() requires the input vertex
-                                           // pairs to be sorted.
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            chunk_vertex_pair_index_first,
+                            chunk_vertex_pair_index_first + this_chunk_size,
+                            detail::indirection_compare_less_t<VertexPairIterator>{
+                              vertex_pair_first});  // detail::nbr_intersection() requires the input
+                                                    // vertex pairs to be sorted.
 
       // FIXME: better restrict detail::nbr_intersection input vertex pairs to a single edge
       // partition? This may provide additional performance improvement opportunities???

--- a/cpp/include/cugraph/prims/per_v_transform_reduce_dst_key_aggregated_outgoing_e.cuh
+++ b/cpp/include/cugraph/prims/per_v_transform_reduce_dst_key_aggregated_outgoing_e.cuh
@@ -21,6 +21,7 @@
 #include <cugraph/utilities/misc_utils.cuh>
 #include <cugraph/utilities/shuffle_comm.cuh>
 #include <cugraph/utilities/thrust_tuple_utils.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <raft/core/handle.hpp>
@@ -675,7 +676,7 @@ void per_v_transform_reduce_dst_key_aggregated_outgoing_e(
             handle.get_thrust_policy(), tmp_majors.begin(), tmp_majors.end(), majors.begin());
 
           auto pair_first = thrust::make_zip_iterator(minor_comm_ranks.begin(), majors.begin());
-          thrust::sort(
+          cugraph::sort_wrapper(
             handle.get_thrust_policy(), pair_first, pair_first + minor_comm_ranks.size());
           auto unique_pair_last = thrust::unique(
             handle.get_thrust_policy(), pair_first, pair_first + minor_comm_ranks.size());
@@ -883,11 +884,12 @@ void per_v_transform_reduce_dst_key_aggregated_outgoing_e(
                                          int{1},
                                          handle.get_stream());
 
-          thrust::sort(handle.get_thrust_policy(), key_pair_first, second_first);
+          cugraph::sort_wrapper(handle.get_thrust_policy(), key_pair_first, second_first);
 
-          thrust::sort(handle.get_thrust_policy(), second_first, key_pair_first + rx_majors.size());
+          cugraph::sort_wrapper(
+            handle.get_thrust_policy(), second_first, key_pair_first + rx_majors.size());
         } else {
-          thrust::sort(
+          cugraph::sort_wrapper(
             handle.get_thrust_policy(), key_pair_first, key_pair_first + rx_majors.size());
         }
 
@@ -919,7 +921,8 @@ void per_v_transform_reduce_dst_key_aggregated_outgoing_e(
                    tmp_minor_keys.begin(),
                    tmp_minor_keys.end(),
                    unique_minor_keys.begin());
-      thrust::sort(handle.get_thrust_policy(), unique_minor_keys.begin(), unique_minor_keys.end());
+      cugraph::sort_wrapper(
+        handle.get_thrust_policy(), unique_minor_keys.begin(), unique_minor_keys.end());
       unique_minor_keys.resize(cuda::std::distance(unique_minor_keys.begin(),
                                                    thrust::unique(handle.get_thrust_policy(),
                                                                   unique_minor_keys.begin(),

--- a/cpp/include/cugraph/prims/transform_gather_e.cuh
+++ b/cpp/include/cugraph/prims/transform_gather_e.cuh
@@ -16,6 +16,7 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/mask_utils.cuh>
 #include <cugraph/utilities/packed_bool_utils.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -232,12 +233,12 @@ void transform_gather_e(raft::handle_t const& handle,
   if constexpr (!EdgeBucketType::is_sorted_unique) {
     thrust::sequence(
       handle.get_thrust_policy(), output_indices.begin(), output_indices.end(), size_t{0});
-    thrust::sort(handle.get_thrust_policy(),
-                 output_indices.begin(),
-                 output_indices.end(),
-                 cuda::proclaim_return_type<bool>([edge_first] __device__(auto l, auto r) {
-                   return *(edge_first + l) < *(edge_first + r);
-                 }));
+    cugraph::sort_wrapper(handle.get_thrust_policy(),
+                          output_indices.begin(),
+                          output_indices.end(),
+                          cuda::proclaim_return_type<bool>([edge_first] __device__(auto l, auto r) {
+                            return *(edge_first + l) < *(edge_first + r);
+                          }));
   }
 
   std::vector<size_t> edge_partition_offsets(graph_view.number_of_local_edge_partitions() + 1, 0);

--- a/cpp/include/cugraph/prims/transform_reduce_if_v_frontier_outgoing_e_by_dst.cuh
+++ b/cpp/include/cugraph/prims/transform_reduce_if_v_frontier_outgoing_e_by_dst.cuh
@@ -24,6 +24,7 @@
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <raft/core/handle.hpp>
@@ -264,9 +265,9 @@ sort_and_reduce_buffer_elements(
                 if (invalid_key && key == *invalid_key) { return false; }
                 return key < threshold;
               }))));
-        thrust::sort(handle.get_thrust_policy(),
-                     get_dataframe_buffer_begin(key_buffer),
-                     get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements);
+        cugraph::sort_wrapper(handle.get_thrust_policy(),
+                              get_dataframe_buffer_begin(key_buffer),
+                              get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements);
 
       } else {
         auto pair_first = thrust::make_zip_iterator(get_dataframe_buffer_begin(key_buffer),
@@ -395,9 +396,9 @@ sort_and_reduce_buffer_elements(
                         get_dataframe_buffer_begin(tmp_key_buffer) + num_unique_prefix_elements,
                         is_equal_t<bool>{true});
         key_buffer = std::move(tmp_key_buffer);
-        thrust::sort(handle.get_thrust_policy(),
-                     get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements,
-                     get_dataframe_buffer_end(key_buffer));
+        cugraph::sort_wrapper(handle.get_thrust_policy(),
+                              get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements,
+                              get_dataframe_buffer_end(key_buffer));
       } else {
         static_assert(std::is_same_v<ReduceOp, reduce_op::any<typename ReduceOp::value_type>>);
         auto tmp_key_buffer = allocate_dataframe_buffer<input_key_t>(
@@ -448,9 +449,9 @@ sort_and_reduce_buffer_elements(
   }
 
   if constexpr (std::is_same_v<payload_t, void>) {
-    thrust::sort(handle.get_thrust_policy(),
-                 get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements,
-                 get_dataframe_buffer_end(key_buffer));
+    cugraph::sort_wrapper(handle.get_thrust_policy(),
+                          get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements,
+                          get_dataframe_buffer_end(key_buffer));
   } else {
     thrust::sort_by_key(handle.get_thrust_policy(),
                         get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements,

--- a/cpp/include/cugraph/prims/transform_reduce_src_dst_nbr_intersection_of_e_endpoints_by_v.cuh
+++ b/cpp/include/cugraph/prims/transform_reduce_src_dst_nbr_intersection_of_e_endpoints_by_v.cuh
@@ -16,6 +16,7 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/mask_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -299,7 +300,7 @@ void transform_reduce_minor_nbr_intersection_of_e_endpoints_by_v(
     for (size_t j = 0; j < h_chunk_sizes.size(); ++j) {
       auto this_chunk_size = h_chunk_sizes[j];
 
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(),
         chunk_vertex_pair_first,
         chunk_vertex_pair_first + this_chunk_size);  // detail::nbr_intersection() requires the

--- a/cpp/include/cugraph/utilities/collect_comm.cuh
+++ b/cpp/include/cugraph/utilities/collect_comm.cuh
@@ -12,6 +12,7 @@
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -29,7 +30,6 @@
 #include <thrust/find.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/sort.h>
 #include <thrust/transform.h>
 #include <thrust/unique.h>
 
@@ -160,9 +160,9 @@ dataframe_buffer_type_t<typename KVStoreViewType::value_type> collect_values_for
                collect_key_first,
                collect_key_last,
                get_dataframe_buffer_begin(unique_keys));
-  thrust::sort(rmm::exec_policy_nosync(stream_view),
-               get_dataframe_buffer_begin(unique_keys),
-               get_dataframe_buffer_end(unique_keys));
+  cugraph::sort_wrapper(rmm::exec_policy_nosync(stream_view),
+                        get_dataframe_buffer_begin(unique_keys),
+                        get_dataframe_buffer_end(unique_keys));
   unique_keys.resize(cuda::std::distance(get_dataframe_buffer_begin(unique_keys),
                                          thrust::unique(rmm::exec_policy(stream_view),
                                                         get_dataframe_buffer_begin(unique_keys),
@@ -246,9 +246,9 @@ collect_values_for_unique_keys(
                  get_dataframe_buffer_begin(rx_keys),
                  get_dataframe_buffer_end(rx_keys),
                  get_dataframe_buffer_begin(rx_unique_keys));
-    thrust::sort(handle.get_thrust_policy(),
-                 get_dataframe_buffer_begin(rx_unique_keys),
-                 get_dataframe_buffer_end(rx_unique_keys));
+    cugraph::sort_wrapper(handle.get_thrust_policy(),
+                          get_dataframe_buffer_begin(rx_unique_keys),
+                          get_dataframe_buffer_end(rx_unique_keys));
     rx_unique_keys.resize(
       cuda::std::distance(get_dataframe_buffer_begin(rx_unique_keys),
                           thrust::unique(handle.get_thrust_policy(),
@@ -324,7 +324,7 @@ dataframe_buffer_type_t<typename KVStoreViewType::value_type> collect_values_for
                                          handle.get_stream());
   thrust::copy(
     handle.get_thrust_policy(), collect_key_first, collect_key_last, unique_keys.begin());
-  thrust::sort(handle.get_thrust_policy(), unique_keys.begin(), unique_keys.end());
+  cugraph::sort_wrapper(handle.get_thrust_policy(), unique_keys.begin(), unique_keys.end());
   unique_keys.resize(
     cuda::std::distance(
       unique_keys.begin(),
@@ -570,9 +570,9 @@ collect_values_for_int_vertices(
                collect_vertex_first,
                collect_vertex_last,
                sorted_unique_int_vertices.begin());
-  thrust::sort(handle.get_thrust_policy(),
-               sorted_unique_int_vertices.begin(),
-               sorted_unique_int_vertices.end());
+  cugraph::sort_wrapper(handle.get_thrust_policy(),
+                        sorted_unique_int_vertices.begin(),
+                        sorted_unique_int_vertices.end());
   auto last = thrust::unique(handle.get_thrust_policy(),
                              sorted_unique_int_vertices.begin(),
                              sorted_unique_int_vertices.end());

--- a/cpp/include/cugraph/utilities/thrust_wrappers.hpp
+++ b/cpp/include/cugraph/utilities/thrust_wrappers.hpp
@@ -1,0 +1,155 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <cugraph/export.hpp>
+#include <cugraph/utilities/thrust_wrappers_zip_types.hpp>
+
+#include <rmm/exec_policy.hpp>
+
+#include <cuda/std/iterator>
+#include <thrust/sort.h>
+
+#include <cstdint>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace CUGRAPH_EXPORT cugraph {
+namespace detail {
+
+/** @brief True for value types dispatched to @ref sort_impl without Thrust in headers. */
+template <typename T>
+inline constexpr bool sort_scalar_value_v =
+  std::disjunction_v<std::is_same<std::remove_cv_t<T>, std::int32_t>,
+                     std::is_same<std::remove_cv_t<T>, std::uint32_t>,
+                     std::is_same<std::remove_cv_t<T>, std::int64_t>>;
+
+/** @brief Whether iterator type @p T has an out-of-line @ref sort_impl lexicographic sort.
+ *
+ *  Supported @c thrust::make_zip_iterator(...) iterator types are listed in
+ *  thrust_wrappers_zip_types.hpp and instantiated in thrust_wrappers.cu. Scalar element sorts use
+ *  @ref sort_scalar_value_v and @ref sort_impl for @c rmm::exec_policy and
+ *  @c rmm::exec_policy_nosync.
+ *
+ *  Keep this in lockstep with those explicit instantiations: add a disjunct only when you add the
+ *  matching explicit instantiation (otherwise a call through @ref cugraph::sort_wrapper can fail at
+ *  link
+ *  time).
+ */
+template <typename T>
+inline constexpr bool sort_supported_v =
+  std::disjunction_v<std::is_same<std::remove_cv_t<T>, zip_i32_i32>,
+                     std::is_same<std::remove_cv_t<T>, zip_i64_i64>,
+                     std::is_same<std::remove_cv_t<T>, zip_i64_i32>,
+                     std::is_same<std::remove_cv_t<T>, zip_i32_i64>,
+                     std::is_same<std::remove_cv_t<T>, zip_sz_i32>,
+                     std::is_same<std::remove_cv_t<T>, zip_sz_i64>,
+                     std::is_same<std::remove_cv_t<T>, zip_f_sz>,
+                     std::is_same<std::remove_cv_t<T>, zip_d_sz>,
+                     std::is_same<std::remove_cv_t<T>, zip_i32_i32_f>,
+                     std::is_same<std::remove_cv_t<T>, zip_i32_i32_d>,
+                     std::is_same<std::remove_cv_t<T>, zip_i64_i64_f>,
+                     std::is_same<std::remove_cv_t<T>, zip_i64_i64_d>,
+                     std::is_same<std::remove_cv_t<T>, zip_sz_i32_i32>,
+                     std::is_same<std::remove_cv_t<T>, zip_sz_i64_i64>,
+                     std::is_same<std::remove_cv_t<T>, zip_i32_i32_sz>,
+                     std::is_same<std::remove_cv_t<T>, zip_i64_i64_sz>,
+                     std::is_same<std::remove_cv_t<T>, zip_i32_i32_i32>,
+                     std::is_same<std::remove_cv_t<T>, zip_i32_i64_i32>,
+                     std::is_same<std::remove_cv_t<T>, zip_i64_i32_i32>,
+                     std::is_same<std::remove_cv_t<T>, zip_i64_i64_i32>,
+                     std::is_same<std::remove_cv_t<T>, zip_i32_i32_sz_i>,
+                     std::is_same<std::remove_cv_t<T>, zip_i64_i64_sz_i>,
+                     std::is_same<std::remove_cv_t<T>, zip_i32_i32_i32_sz>,
+                     std::is_same<std::remove_cv_t<T>, zip_i64_i64_i64_sz>>;
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Sort elements in [first, last) on the given CUDA stream (out-of-line implementation).
+ *
+ * @tparam      RandomAccessIterator  iterator type; must match an explicit instantiation in
+ *                                     @c thrust_wrappers.cu.
+ *
+ * @param[in]   policy       @c rmm::exec_policy or @c rmm::exec_policy_nosync (e.g.
+ *                           @c handle.get_thrust_policy())
+ * @param[in]   first        beginning of the range to sort
+ * @param[in]   last         end of the range to sort
+ *
+ */
+template <typename RandomAccessIterator>
+void sort_impl(rmm::exec_policy const& policy,
+               RandomAccessIterator first,
+               RandomAccessIterator last);
+
+template <typename RandomAccessIterator>
+void sort_impl(rmm::exec_policy_nosync const& policy,
+               RandomAccessIterator first,
+               RandomAccessIterator last);
+
+/** Value type of @p Iterator for @ref cugraph::sort_wrapper constraints (C++17-friendly). */
+template <typename Iterator>
+using sort_iterator_value_t =
+  std::remove_cv_t<typename std::iterator_traits<std::remove_cv_t<Iterator>>::value_type>;
+
+}  // namespace detail
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Sort elements in [first, last)
+ *
+ * Similar to @c thrust::sort; dispatches to an explicitly instantiated backend for supported
+ * scalar and zip-iterator ranges.
+ *
+ * @tparam      RandomAccessIterator  random-access iterator
+ *
+ * @param[in]   policy       Thrust execution policy
+ * @param[in]   first        beginning of the range to sort
+ * @param[in]   last         end of the range to sort
+ *
+ */
+// FIXME: Would like to call this sort, but there's an issue
+// with CCCL and nvcc which results in a runtime error.
+template <typename ExecutionPolicy, typename RandomAccessIterator>
+void sort_wrapper(ExecutionPolicy const& policy,
+                  RandomAccessIterator first,
+                  RandomAccessIterator last)
+{
+  using value_t = detail::sort_iterator_value_t<RandomAccessIterator>;
+  if constexpr (detail::sort_scalar_value_v<value_t> ||
+                detail::sort_supported_v<std::remove_cv_t<RandomAccessIterator>>) {
+    detail::sort_impl(policy, first, last);
+  } else {
+    thrust::sort(policy, first, last);
+  }
+}
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Sort elements in [first, last) with a custom comparison
+ *
+ * Similar to @c thrust::sort.
+ *
+ * @tparam      RandomAccessIterator  random-access iterator
+ * @tparam      Compare               comparison functor
+ *
+ * @param[in]   policy       Thrust execution policy
+ * @param[in]   first        beginning of the range to sort
+ * @param[in]   last         end of the range to sort
+ * @param[in]   compare      comparison functor
+ *
+ */
+// FIXME: Would like to call this sort, but there's an issue
+// with CCCL and nvcc which results in a runtime error.
+template <typename ExecutionPolicy, typename RandomAccessIterator, typename Compare>
+void sort_wrapper(ExecutionPolicy const& policy,
+                  RandomAccessIterator first,
+                  RandomAccessIterator last,
+                  Compare compare)
+{
+  thrust::sort(policy, first, last, compare);
+}
+
+}  // namespace CUGRAPH_EXPORT cugraph

--- a/cpp/include/cugraph/utilities/thrust_wrappers.hpp
+++ b/cpp/include/cugraph/utilities/thrust_wrappers.hpp
@@ -20,9 +20,9 @@
 namespace CUGRAPH_EXPORT cugraph {
 namespace detail {
 
-/** @brief True for value types dispatched to @ref sort_impl without Thrust in headers. */
+/** @brief Whether iterator type @p T has an out-of-line @ref sort_impl lexicographic sort. */
 template <typename T>
-inline constexpr bool sort_scalar_value_v =
+inline constexpr bool sort_supported_arithmetic_scalar_v =
   std::disjunction_v<std::is_same<std::remove_cv_t<T>, std::int32_t>,
                      std::is_same<std::remove_cv_t<T>, std::uint32_t>,
                      std::is_same<std::remove_cv_t<T>, std::int64_t>>;
@@ -31,7 +31,7 @@ inline constexpr bool sort_scalar_value_v =
  *
  *  Supported @c thrust::make_zip_iterator(...) iterator types are listed in
  *  thrust_wrappers_zip_types.hpp and instantiated in thrust_wrappers.cu. Scalar element sorts use
- *  @ref sort_scalar_value_v and @ref sort_impl for @c rmm::exec_policy and
+ *  @ref sort_supported_arithmetic_scalar_v and @ref sort_impl for @c rmm::exec_policy and
  *  @c rmm::exec_policy_nosync.
  *
  *  Keep this in lockstep with those explicit instantiations: add a disjunct only when you add the
@@ -40,7 +40,7 @@ inline constexpr bool sort_scalar_value_v =
  *  time).
  */
 template <typename T>
-inline constexpr bool sort_supported_v =
+inline constexpr bool sort_supported_zip_v =
   std::disjunction_v<std::is_same<std::remove_cv_t<T>, zip_i32_i32>,
                      std::is_same<std::remove_cv_t<T>, zip_i64_i64>,
                      std::is_same<std::remove_cv_t<T>, zip_i64_i32>,
@@ -118,8 +118,8 @@ void sort_wrapper(ExecutionPolicy const& policy,
                   RandomAccessIterator last)
 {
   using value_t = detail::sort_iterator_value_t<RandomAccessIterator>;
-  if constexpr (detail::sort_scalar_value_v<value_t> ||
-                detail::sort_supported_v<std::remove_cv_t<RandomAccessIterator>>) {
+  if constexpr (detail::sort_supported_arithmetic_scalar_v<value_t> ||
+                detail::sort_supported_zip_v<std::remove_cv_t<RandomAccessIterator>>) {
     detail::sort_impl(policy, first, last);
   } else {
     thrust::sort(policy, first, last);

--- a/cpp/include/cugraph/utilities/thrust_wrappers_zip_types.hpp
+++ b/cpp/include/cugraph/utilities/thrust_wrappers_zip_types.hpp
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <cuda/std/tuple>
+#include <thrust/iterator/zip_iterator.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace cugraph {
+namespace detail {
+
+/** Thrust zip_iterator types matching @c thrust_wrappers.cu explicit @c sort_impl instantiations.
+ */
+template <typename... Ts>
+using zip_iterator_t = thrust::zip_iterator<cuda::std::tuple<Ts*...>>;
+
+using zip_i32_i32 = zip_iterator_t<std::int32_t, std::int32_t>;
+using zip_i64_i64 = zip_iterator_t<std::int64_t, std::int64_t>;
+using zip_i64_i32 = zip_iterator_t<std::int64_t, std::int32_t>;
+using zip_i32_i64 = zip_iterator_t<std::int32_t, std::int64_t>;
+using zip_sz_i32  = zip_iterator_t<std::size_t, std::int32_t>;
+using zip_sz_i64  = zip_iterator_t<std::size_t, std::int64_t>;
+using zip_f_sz    = zip_iterator_t<float, std::size_t>;
+using zip_d_sz    = zip_iterator_t<double, std::size_t>;
+
+using zip_i32_i32_f   = zip_iterator_t<std::int32_t, std::int32_t, float>;
+using zip_i32_i32_d   = zip_iterator_t<std::int32_t, std::int32_t, double>;
+using zip_i64_i64_f   = zip_iterator_t<std::int64_t, std::int64_t, float>;
+using zip_i64_i64_d   = zip_iterator_t<std::int64_t, std::int64_t, double>;
+using zip_sz_i32_i32  = zip_iterator_t<std::size_t, std::int32_t, std::int32_t>;
+using zip_sz_i64_i64  = zip_iterator_t<std::size_t, std::int64_t, std::int64_t>;
+using zip_i32_i32_sz  = zip_iterator_t<std::int32_t, std::int32_t, std::size_t>;
+using zip_i64_i64_sz  = zip_iterator_t<std::int64_t, std::int64_t, std::size_t>;
+using zip_i32_i32_i32 = zip_iterator_t<std::int32_t, std::int32_t, std::int32_t>;
+using zip_i32_i64_i32 = zip_iterator_t<std::int32_t, std::int64_t, std::int32_t>;
+using zip_i64_i32_i32 = zip_iterator_t<std::int64_t, std::int32_t, std::int32_t>;
+using zip_i64_i64_i32 = zip_iterator_t<std::int64_t, std::int64_t, std::int32_t>;
+
+using zip_i32_i32_sz_i   = zip_iterator_t<std::int32_t, std::int32_t, std::size_t, int>;
+using zip_i64_i64_sz_i   = zip_iterator_t<std::int64_t, std::int64_t, std::size_t, int>;
+using zip_i32_i32_i32_sz = zip_iterator_t<std::int32_t, std::int32_t, std::int32_t, std::size_t>;
+using zip_i64_i64_i64_sz = zip_iterator_t<std::int64_t, std::int64_t, std::int64_t, std::size_t>;
+
+}  // namespace detail
+}  // namespace cugraph

--- a/cpp/src/c_api/capi_helper.cu
+++ b/cpp/src/c_api/capi_helper.cu
@@ -9,12 +9,12 @@
 #include <cugraph/export.hpp>
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/misc_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/std/iterator>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/sort.h>
 
 namespace cugraph {
 namespace c_api {
@@ -34,9 +34,9 @@ shuffle_vertex_ids_and_offsets(raft::handle_t const& handle,
     cugraph::shuffle_ext_vertices(handle, std::move(vertices), std::move(vertex_properties));
   ids = std::move(std::get<rmm::device_uvector<vertex_t>>(vertex_properties[0]));
 
-  thrust::sort(handle.get_thrust_policy(),
-               thrust::make_zip_iterator(ids.begin(), vertices.begin()),
-               thrust::make_zip_iterator(ids.end(), vertices.end()));
+  cugraph::sort_wrapper(handle.get_thrust_policy(),
+                        thrust::make_zip_iterator(ids.begin(), vertices.begin()),
+                        thrust::make_zip_iterator(ids.end(), vertices.end()));
 
   auto return_offsets = cugraph::detail::compute_sparse_offsets<size_t>(
     handle, ids.begin(), ids.end(), size_t{0}, size_t{offsets.size() - 1}, true);
@@ -151,7 +151,8 @@ reorder_extracted_egonets(raft::handle_t const& handle,
                         triplet_first + sort_indices.size(),
                         (*edge_weights).begin());
   } else {
-    thrust::sort(handle.get_thrust_policy(), triplet_first, triplet_first + sort_indices.size());
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(), triplet_first, triplet_first + sort_indices.size());
   }
 
   thrust::tabulate(

--- a/cpp/src/c_api/neighbor_sampling.cpp
+++ b/cpp/src/c_api/neighbor_sampling.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -21,6 +21,7 @@
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/sampling_functions.hpp>
 #include <cugraph/shuffle_functions.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -173,9 +174,8 @@ struct neighbor_sampling_functor : public cugraph::c_api::abstract_functor {
 
           // Get unique labels
           // sort the start_vertex_labels
-          cugraph::detail::sort_ints(
-            handle_.get_stream(),
-            raft::device_span<label_t>{unique_labels.data(), unique_labels.size()});
+          cugraph::sort_wrapper(
+            handle_.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
 
           auto num_unique_labels = cugraph::detail::unique_ints(
             handle_.get_stream(),

--- a/cpp/src/c_api/renumber_arbitrary_edgelist.cu
+++ b/cpp/src/c_api/renumber_arbitrary_edgelist.cu
@@ -12,6 +12,7 @@
 #include <cugraph/export.hpp>
 #include <cugraph/graph.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <cuda/std/iterator>
 #include <thrust/binary_search.h>
@@ -35,7 +36,7 @@ cugraph_error_code_t renumber_arbitrary_edgelist(
                  dsts->size_,
                  vertices.data() + srcs->size_);
 
-  thrust::sort(handle.get_thrust_policy(), vertices.begin(), vertices.end());
+  cugraph::sort_wrapper(handle.get_thrust_policy(), vertices.begin(), vertices.end());
   vertices.resize(cuda::std::distance(
                     vertices.begin(),
                     thrust::unique(handle.get_thrust_policy(), vertices.begin(), vertices.end())),

--- a/cpp/src/c_api/temporal_neighbor_sampling.cpp
+++ b/cpp/src/c_api/temporal_neighbor_sampling.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -21,6 +21,7 @@
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/sampling_functions.hpp>
 #include <cugraph/shuffle_functions.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -204,9 +205,8 @@ struct temporal_neighbor_sampling_functor : public cugraph::c_api::abstract_func
 
           // Get unique labels
           // sort the start_vertex_labels
-          cugraph::detail::sort_ints(
-            handle_.get_stream(),
-            raft::device_span<label_t>{unique_labels.data(), unique_labels.size()});
+          cugraph::sort_wrapper(
+            handle_.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
 
           auto num_unique_labels = cugraph::detail::unique_ints(
             handle_.get_stream(),

--- a/cpp/src/centrality/betweenness_centrality_impl.cuh
+++ b/cpp/src/centrality/betweenness_centrality_impl.cuh
@@ -22,6 +22,7 @@
 #include <cugraph/prims/update_v_frontier.cuh>
 #include <cugraph/prims/vertex_frontier.cuh>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <raft/core/handle.hpp>
@@ -457,7 +458,7 @@ void accumulate_edge_results(
                                                              do_expensive_check);
 
       auto triplet_first = thrust::make_zip_iterator(srcs.begin(), dsts.begin(), indices->begin());
-      thrust::sort(handle.get_thrust_policy(), triplet_first, triplet_first + srcs.size());
+      cugraph::sort_wrapper(handle.get_thrust_policy(), triplet_first, triplet_first + srcs.size());
     } else {
       std::tie(srcs, dsts) = extract_transform_if_e(handle,
                                                     graph_view,
@@ -468,7 +469,7 @@ void accumulate_edge_results(
                                                     extract_edge_pred_op_t<vertex_t>{d},
                                                     do_expensive_check);
       auto pair_first      = thrust::make_zip_iterator(srcs.begin(), dsts.begin());
-      thrust::sort(handle.get_thrust_policy(), pair_first, pair_first + srcs.size());
+      cugraph::sort_wrapper(handle.get_thrust_policy(), pair_first, pair_first + srcs.size());
     }
     edge_list.insert(srcs.begin(),
                      srcs.end(),
@@ -592,7 +593,7 @@ batch_partition_frontier(raft::handle_t const& handle,
 
   std::vector<size_t> batch_offsets{0, frontier.size()};
   if (source_lasts) {
-    thrust::sort(
+    cugraph::sort_wrapper(
       handle.get_thrust_policy(),
       frontier.begin(),
       frontier.end(),

--- a/cpp/src/community/detail/refine_impl.cuh
+++ b/cpp/src/community/detail/refine_impl.cuh
@@ -20,6 +20,7 @@
 #include <cugraph/utilities/collect_comm.cuh>
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/mask_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/random/rng_device.cuh>
 
@@ -38,7 +39,6 @@
 #include <thrust/scatter.h>
 #include <thrust/sequence.h>
 #include <thrust/shuffle.h>
-#include <thrust/sort.h>
 #include <thrust/tabulate.h>
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
@@ -646,7 +646,7 @@ refine_clustering(raft::handle_t const& handle,
     vertices_in_mis.resize(0, handle.get_stream());
     vertices_in_mis.shrink_to_fit(handle.get_stream());
 
-    thrust::sort(handle.get_thrust_policy(), dst_vertices.begin(), dst_vertices.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), dst_vertices.begin(), dst_vertices.end());
 
     dst_vertices.resize(
       static_cast<size_t>(cuda::std::distance(
@@ -662,7 +662,7 @@ refine_clustering(raft::handle_t const& handle,
                                       std::vector<cugraph::arithmetic_device_uvector_t>{},
                                       graph_view.vertex_partition_range_lasts());
 
-      thrust::sort(handle.get_thrust_policy(), dst_vertices.begin(), dst_vertices.end());
+      cugraph::sort_wrapper(handle.get_thrust_policy(), dst_vertices.begin(), dst_vertices.end());
 
       dst_vertices.resize(
         static_cast<size_t>(cuda::std::distance(
@@ -707,9 +707,9 @@ refine_clustering(raft::handle_t const& handle,
                leiden_assignment.end(),
                leiden_keys_to_read_louvain.begin());
 
-  thrust::sort(handle.get_thrust_policy(),
-               leiden_keys_to_read_louvain.begin(),
-               leiden_keys_to_read_louvain.end());
+  cugraph::sort_wrapper(handle.get_thrust_policy(),
+                        leiden_keys_to_read_louvain.begin(),
+                        leiden_keys_to_read_louvain.end());
 
   auto nr_unique_leiden_clusters =
     static_cast<size_t>(cuda::std::distance(leiden_keys_to_read_louvain.begin(),
@@ -728,9 +728,9 @@ refine_clustering(raft::handle_t const& handle,
                                     std::vector<cugraph::arithmetic_device_uvector_t>{},
                                     graph_view.vertex_partition_range_lasts());
 
-    thrust::sort(handle.get_thrust_policy(),
-                 leiden_keys_to_read_louvain.begin(),
-                 leiden_keys_to_read_louvain.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(),
+                          leiden_keys_to_read_louvain.begin(),
+                          leiden_keys_to_read_louvain.end());
 
     nr_unique_leiden_clusters =
       static_cast<size_t>(cuda::std::distance(leiden_keys_to_read_louvain.begin(),

--- a/cpp/src/community/edge_triangle_count_impl.cuh
+++ b/cpp/src/community/edge_triangle_count_impl.cuh
@@ -15,6 +15,7 @@
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/graph_partition_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/util/integer_utils.hpp>
 
@@ -25,7 +26,6 @@
 #include <cuda/std/tuple>
 #include <thrust/adjacent_difference.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/sort.h>
 
 namespace cugraph {
 
@@ -228,9 +228,9 @@ edge_property_t<edge_t, edge_t> edge_triangle_count_impl(
                                             intersection_indices.size()),
           edge_first});
 
-      thrust::sort(handle.get_thrust_policy(),
-                   get_dataframe_buffer_begin(vertex_pair_buffer_tmp),
-                   get_dataframe_buffer_end(vertex_pair_buffer_tmp));
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            get_dataframe_buffer_begin(vertex_pair_buffer_tmp),
+                            get_dataframe_buffer_end(vertex_pair_buffer_tmp));
 
       rmm::device_uvector<edge_t> increase_count_tmp(2 * intersection_indices.size(),
                                                      handle.get_stream());

--- a/cpp/src/community/k_truss_impl.cuh
+++ b/cpp/src/community/k_truss_impl.cuh
@@ -16,6 +16,7 @@
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/util/integer_utils.hpp>
 
@@ -326,7 +327,7 @@ k_truss(raft::handle_t const& handle,
       auto weak_edgelist_last =
         thrust::make_zip_iterator(weak_edgelist_srcs.end(), weak_edgelist_dsts.end());
 
-      thrust::sort(handle.get_thrust_policy(), weak_edgelist_first, weak_edgelist_last);
+      cugraph::sort_wrapper(handle.get_thrust_policy(), weak_edgelist_first, weak_edgelist_last);
 
       // Perform nbr_intersection of the weak edges from the undirected
       // graph view
@@ -357,9 +358,9 @@ k_truss(raft::handle_t const& handle,
           raft::device_span<vertex_t const>(weak_edgelist_srcs.data(), weak_edgelist_srcs.size()),
           raft::device_span<vertex_t const>(weak_edgelist_dsts.data(), weak_edgelist_dsts.size())});
 
-      thrust::sort(handle.get_thrust_policy(),
-                   get_dataframe_buffer_begin(triangles_endpoints),
-                   get_dataframe_buffer_end(triangles_endpoints));
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            get_dataframe_buffer_begin(triangles_endpoints),
+                            get_dataframe_buffer_end(triangles_endpoints));
 
       auto unique_triangle_end = thrust::unique(handle.get_thrust_policy(),
                                                 get_dataframe_buffer_begin(triangles_endpoints),
@@ -397,9 +398,9 @@ k_truss(raft::handle_t const& handle,
             std::move(std::get<rmm::device_uvector<vertex_t>>(edge_properties[0]));
         }
 
-        thrust::sort(handle.get_thrust_policy(),
-                     get_dataframe_buffer_begin(triangles_endpoints),
-                     get_dataframe_buffer_end(triangles_endpoints));
+        cugraph::sort_wrapper(handle.get_thrust_policy(),
+                              get_dataframe_buffer_begin(triangles_endpoints),
+                              get_dataframe_buffer_end(triangles_endpoints));
 
         unique_triangle_end = thrust::unique(handle.get_thrust_policy(),
                                              get_dataframe_buffer_begin(triangles_endpoints),
@@ -462,9 +463,9 @@ k_truss(raft::handle_t const& handle,
                                                   cur_graph_view.vertex_partition_range_lasts());
       }
 
-      thrust::sort(handle.get_thrust_policy(),
-                   get_dataframe_buffer_begin(edgelist_to_update_count),
-                   get_dataframe_buffer_end(edgelist_to_update_count));
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            get_dataframe_buffer_begin(edgelist_to_update_count),
+                            get_dataframe_buffer_end(edgelist_to_update_count));
 
       auto unique_pair_count =
         thrust::unique_count(handle.get_thrust_policy(),
@@ -590,7 +591,7 @@ k_truss(raft::handle_t const& handle,
 
       edgelist_weak.clear();
 
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(),
         thrust::make_zip_iterator(weak_edgelist_srcs.begin(), weak_edgelist_dsts.begin()),
         thrust::make_zip_iterator(weak_edgelist_srcs.end(), weak_edgelist_dsts.end()));
@@ -636,7 +637,7 @@ k_truss(raft::handle_t const& handle,
                             cur_graph_view.vertex_partition_range_lasts());
       }
 
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(),
         thrust::make_zip_iterator(weak_edgelist_dsts.begin(), weak_edgelist_srcs.begin()),
         thrust::make_zip_iterator(weak_edgelist_dsts.end(), weak_edgelist_srcs.end()));

--- a/cpp/src/community/leiden_impl.cuh
+++ b/cpp/src/community/leiden_impl.cuh
@@ -13,6 +13,7 @@
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <rmm/device_uvector.hpp>
 
@@ -36,7 +37,7 @@ void check_clustering(graph_view_t<vertex_t, edge_t, false, multi_gpu> const& gr
 template <typename vertex_t, bool multi_gpu>
 vertex_t remove_duplicates(raft::handle_t const& handle, rmm::device_uvector<vertex_t>& input_array)
 {
-  thrust::sort(handle.get_thrust_policy(), input_array.begin(), input_array.end());
+  cugraph::sort_wrapper(handle.get_thrust_policy(), input_array.begin(), input_array.end());
 
   auto nr_unique_elements = static_cast<vertex_t>(cuda::std::distance(
     input_array.begin(),
@@ -48,7 +49,7 @@ vertex_t remove_duplicates(raft::handle_t const& handle, rmm::device_uvector<ver
     std::tie(input_array, std::ignore) = shuffle_ext_vertices(
       handle, std::move(input_array), std::vector<cugraph::arithmetic_device_uvector_t>{});
 
-    thrust::sort(handle.get_thrust_policy(), input_array.begin(), input_array.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), input_array.begin(), input_array.end());
 
     nr_unique_elements = static_cast<vertex_t>(cuda::std::distance(
       input_array.begin(),
@@ -525,9 +526,10 @@ std::pair<std::unique_ptr<Dendrogram<vertex_t>>, weight_t> leiden(
                    louvain_of_refined_graph.size(),
                    handle.get_stream());
 
-        thrust::sort(handle.get_thrust_policy(),
-                     thrust::make_zip_iterator(numbering_map->begin(), numeric_sequence.begin()),
-                     thrust::make_zip_iterator(numbering_map->end(), numeric_sequence.end()));
+        cugraph::sort_wrapper(
+          handle.get_thrust_policy(),
+          thrust::make_zip_iterator(numbering_map->begin(), numeric_sequence.begin()),
+          thrust::make_zip_iterator(numbering_map->end(), numeric_sequence.end()));
 
         size_t new_size = cuda::std::distance(numbering_map->begin(),
                                               thrust::unique_by_key(handle.get_thrust_policy(),
@@ -549,9 +551,10 @@ std::pair<std::unique_ptr<Dendrogram<vertex_t>>, weight_t> leiden(
               std::move(std::get<rmm::device_uvector<vertex_t>>(vertex_properties[0]));
           }
 
-          thrust::sort(handle.get_thrust_policy(),
-                       thrust::make_zip_iterator(numbering_map->begin(), numeric_sequence.begin()),
-                       thrust::make_zip_iterator(numbering_map->end(), numeric_sequence.end()));
+          cugraph::sort_wrapper(
+            handle.get_thrust_policy(),
+            thrust::make_zip_iterator(numbering_map->begin(), numeric_sequence.begin()),
+            thrust::make_zip_iterator(numbering_map->end(), numeric_sequence.end()));
 
           size_t new_size = cuda::std::distance(numbering_map->begin(),
                                                 thrust::unique_by_key(handle.get_thrust_policy(),

--- a/cpp/src/community/triangle_count_impl.cuh
+++ b/cpp/src/community/triangle_count_impl.cuh
@@ -17,6 +17,7 @@
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/host_scalar_comm.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <cuda/functional>
 #include <cuda/iterator>
@@ -195,7 +196,8 @@ void triangle_count(raft::handle_t const& handle,
     rmm::device_uvector<vertex_t> unique_vertices((*vertices).size(), handle.get_stream());
     thrust::copy(
       handle.get_thrust_policy(), (*vertices).begin(), (*vertices).end(), unique_vertices.begin());
-    thrust::sort(handle.get_thrust_policy(), unique_vertices.begin(), unique_vertices.end());
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(), unique_vertices.begin(), unique_vertices.end());
     unique_vertices.resize(
       cuda::std::distance(
         unique_vertices.begin(),
@@ -216,7 +218,7 @@ void triangle_count(raft::handle_t const& handle,
                  unique_one_hop_nbrs.begin());
     one_hop_nbrs.resize(0, handle.get_stream());
     one_hop_nbrs.shrink_to_fit(handle.get_stream());
-    thrust::sort(
+    cugraph::sort_wrapper(
       handle.get_thrust_policy(), unique_one_hop_nbrs.begin(), unique_one_hop_nbrs.end());
     unique_one_hop_nbrs.resize(cuda::std::distance(unique_one_hop_nbrs.begin(),
                                                    thrust::unique(handle.get_thrust_policy(),
@@ -230,7 +232,7 @@ void triangle_count(raft::handle_t const& handle,
                              std::move(unique_one_hop_nbrs),
                              std::vector<cugraph::arithmetic_device_uvector_t>{},
                              cur_graph_view.vertex_partition_range_lasts());
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(), unique_one_hop_nbrs.begin(), unique_one_hop_nbrs.end());
       unique_one_hop_nbrs.resize(cuda::std::distance(unique_one_hop_nbrs.begin(),
                                                      thrust::unique(handle.get_thrust_policy(),
@@ -253,7 +255,7 @@ void triangle_count(raft::handle_t const& handle,
                  unique_two_hop_nbrs.begin());
     two_hop_nbrs.resize(0, handle.get_stream());
     two_hop_nbrs.shrink_to_fit(handle.get_stream());
-    thrust::sort(
+    cugraph::sort_wrapper(
       handle.get_thrust_policy(), unique_two_hop_nbrs.begin(), unique_two_hop_nbrs.end());
     unique_two_hop_nbrs.resize(cuda::std::distance(unique_two_hop_nbrs.begin(),
                                                    thrust::unique(handle.get_thrust_policy(),
@@ -267,7 +269,7 @@ void triangle_count(raft::handle_t const& handle,
                              std::move(unique_two_hop_nbrs),
                              std::vector<cugraph::arithmetic_device_uvector_t>{},
                              cur_graph_view.vertex_partition_range_lasts());
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(), unique_two_hop_nbrs.begin(), unique_two_hop_nbrs.end());
       unique_two_hop_nbrs.resize(cuda::std::distance(unique_two_hop_nbrs.begin(),
                                                      thrust::unique(handle.get_thrust_policy(),

--- a/cpp/src/components/strongly_connected_components_impl.cuh
+++ b/cpp/src/components/strongly_connected_components_impl.cuh
@@ -25,6 +25,7 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/packed_bool_utils.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -127,7 +128,8 @@ rmm::device_uvector<typename GraphViewType::vertex_type> find_trivial_singleton_
             return (cur_in_degrees[v_offset] == 0) || (cur_out_degrees[v_offset] == 0);
           }))),
     handle.get_stream());
-  thrust::sort(handle.get_thrust_policy(), frontier_vertices.begin(), frontier_vertices.end());
+  cugraph::sort_wrapper(
+    handle.get_thrust_policy(), frontier_vertices.begin(), frontier_vertices.end());
 
   rmm::device_uvector<vertex_t> peeled_vertices(0, handle.get_stream());
   peeled_vertices.reserve(candidate_vertices.size(), handle.get_stream());
@@ -223,7 +225,7 @@ rmm::device_uvector<typename GraphViewType::vertex_type> find_trivial_singleton_
                                  repetitively rebuilding a kv_store_t object for the entire local
                                  vertex partition range */
 
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(), inv_frontier_vertices.begin(), inv_frontier_vertices.end());
 
       key_bucket_t<vertex_t, void, multi_gpu, true> inv_frontier(handle,
@@ -308,7 +310,8 @@ rmm::device_uvector<typename GraphViewType::vertex_type> find_trivial_singleton_
                            is_newly_peeled);
     frontier_vertices.resize(cuda::std::distance(frontier_vertices.begin(), last),
                              handle.get_stream());
-    thrust::sort(handle.get_thrust_policy(), frontier_vertices.begin(), frontier_vertices.end());
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(), frontier_vertices.begin(), frontier_vertices.end());
     frontier_vertices.resize(cuda::std::distance(frontier_vertices.begin(),
                                                  thrust::unique(handle.get_thrust_policy(),
                                                                 frontier_vertices.begin(),
@@ -316,7 +319,7 @@ rmm::device_uvector<typename GraphViewType::vertex_type> find_trivial_singleton_
                              handle.get_stream());
     ++iter;
   }
-  thrust::sort(handle.get_thrust_policy(), peeled_vertices.begin(), peeled_vertices.end());
+  cugraph::sort_wrapper(handle.get_thrust_policy(), peeled_vertices.begin(), peeled_vertices.end());
 
   if (aggregate_frontier_size > 0) {  // check for chains from or to peeled vertices
     // find in-degree 1 and out-degree 1 vertices and their predecessors and successors
@@ -346,8 +349,9 @@ rmm::device_uvector<typename GraphViewType::vertex_type> find_trivial_singleton_
 
     rmm::device_uvector<vertex_t> descendants(one_vertices.size(), handle.get_stream());
     {
-      thrust::sort(handle.get_thrust_policy(), peeled_vertices.begin(), peeled_vertices.end());
-      thrust::sort(handle.get_thrust_policy(), one_vertices.begin(), one_vertices.end());
+      cugraph::sort_wrapper(
+        handle.get_thrust_policy(), peeled_vertices.begin(), peeled_vertices.end());
+      cugraph::sort_wrapper(handle.get_thrust_policy(), one_vertices.begin(), one_vertices.end());
       auto edge_dst_peeled_flags = make_initialized_edge_dst_property(handle, graph_view, false);
       fill_edge_dst_property(
         handle,
@@ -409,9 +413,10 @@ rmm::device_uvector<typename GraphViewType::vertex_type> find_trivial_singleton_
         handle.get_stream()); /* functionally identical to renumber_local_ext_vertices but to avoid
                                  repetitively rebuilding a kv_store_t object for the entire local
                                  vertex partition range */
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(), inv_peeled_vertices.begin(), inv_peeled_vertices.end());
-      thrust::sort(handle.get_thrust_policy(), inv_one_vertices.begin(), inv_one_vertices.end());
+      cugraph::sort_wrapper(
+        handle.get_thrust_policy(), inv_one_vertices.begin(), inv_one_vertices.end());
       auto edge_dst_peeled_flags =
         make_initialized_edge_dst_property(handle, inverse_graph_view, false);
       fill_edge_dst_property(
@@ -723,7 +728,8 @@ rmm::device_uvector<typename GraphViewType::vertex_type> find_trivial_singleton_
       }
     }
 
-    thrust::sort(handle.get_thrust_policy(), peeled_vertices.begin(), peeled_vertices.end());
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(), peeled_vertices.begin(), peeled_vertices.end());
   }
 
   peeled_vertices.shrink_to_fit(handle.get_stream());
@@ -1048,7 +1054,7 @@ reachable_sets(
 
   {
     auto pair_first = thrust::make_zip_iterator(idxs.begin(), vertices.begin());
-    thrust::sort(handle.get_thrust_policy(), pair_first, pair_first + idxs.size());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), pair_first, pair_first + idxs.size());
   }
 
   // starting_vertices => component indices
@@ -1934,7 +1940,7 @@ forward_backward_intersect(
         std::move(std::get<rmm::device_uvector<vertex_t>>(vertex_properties[0]));
       auto pair_first = thrust::make_zip_iterator(tmp_unresolved_component_idxs.begin(),
                                                   backward_set_vertices.begin());
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(), pair_first, pair_first + tmp_unresolved_component_idxs.size());
       backward_set_offsets.set_element_to_zero_async(0, handle.get_stream());
       thrust::upper_bound(
@@ -1947,7 +1953,7 @@ forward_backward_intersect(
     } else {
       auto pair_first = thrust::make_zip_iterator(tmp_unresolved_component_idxs.begin(),
                                                   backward_set_vertices.begin());
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(), pair_first, pair_first + tmp_unresolved_component_idxs.size());
     }
   } else {
@@ -2217,7 +2223,7 @@ void strongly_connected_components_impl(
                    scc_component_vertices.begin(),
                    scc_component_vertices.end(),
                    tmp_vertices.begin() + unresolved_component_vertices.size());
-      thrust::sort(handle.get_thrust_policy(), tmp_vertices.begin(), tmp_vertices.end());
+      cugraph::sort_wrapper(handle.get_thrust_policy(), tmp_vertices.begin(), tmp_vertices.end());
       rmm::device_uvector<vertex_t> tmp_components(tmp_vertices.size(), handle.get_stream());
       auto map_first = cuda::make_transform_iterator(
         tmp_vertices.begin(),

--- a/cpp/src/components/weakly_connected_components_impl.cuh
+++ b/cpp/src/components/weakly_connected_components_impl.cuh
@@ -22,6 +22,7 @@
 #include <cugraph/utilities/device_functors.cuh>
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -44,7 +45,6 @@
 #include <thrust/scan.h>
 #include <thrust/sequence.h>
 #include <thrust/shuffle.h>
-#include <thrust/sort.h>
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
 #include <thrust/unique.h>
@@ -500,9 +500,9 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
                                                        GraphViewType::is_multi_gpu>(
           handle, tmp_graph_view, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
       }
-      thrust::sort(handle.get_thrust_policy(),
-                   get_dataframe_buffer_begin(edge_buffer),
-                   get_dataframe_buffer_end(edge_buffer));
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            get_dataframe_buffer_begin(edge_buffer),
+                            get_dataframe_buffer_end(edge_buffer));
       resize_dataframe_buffer(
         edge_buffer,
         cuda::std::distance(get_dataframe_buffer_begin(edge_buffer),
@@ -710,7 +710,7 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
           next_candidate_offset += num_scanned;
           edge_count += degree_sum;
 
-          thrust::sort(handle.get_thrust_policy(), new_roots.begin(), new_roots.end());
+          cugraph::sort_wrapper(handle.get_thrust_policy(), new_roots.begin(), new_roots.end());
 
           thrust::for_each(
             handle.get_thrust_policy(),
@@ -828,9 +828,9 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
         auto new_num_edge_inserts = num_edge_inserts.value(handle.get_stream());
         if (new_num_edge_inserts > old_num_edge_inserts) {
           auto edge_first = get_dataframe_buffer_begin(edge_buffer);
-          thrust::sort(handle.get_thrust_policy(),
-                       edge_first + old_num_edge_inserts,
-                       edge_first + new_num_edge_inserts);
+          cugraph::sort_wrapper(handle.get_thrust_policy(),
+                                edge_first + old_num_edge_inserts,
+                                edge_first + new_num_edge_inserts);
           if (old_num_edge_inserts > 0) {
             auto tmp_edge_buffer = allocate_dataframe_buffer<cuda::std::tuple<vertex_t, vertex_t>>(
               new_num_edge_inserts, handle.get_stream());
@@ -910,7 +910,7 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
                             GraphViewType::is_storage_transposed);
         auto edge_first = get_dataframe_buffer_begin(edge_buffer);
         auto edge_last  = get_dataframe_buffer_end(edge_buffer);
-        thrust::sort(handle.get_thrust_policy(), edge_first, edge_last);
+        cugraph::sort_wrapper(handle.get_thrust_policy(), edge_first, edge_last);
         auto unique_edge_last = thrust::unique(handle.get_thrust_policy(), edge_first, edge_last);
         resize_dataframe_buffer(
           edge_buffer,
@@ -982,7 +982,7 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
                    current_level_components,
                    current_level_components + current_level_local_vertex_partition_range_size,
                    sorted_unique_keys.begin());
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(), sorted_unique_keys.begin(), sorted_unique_keys.end());
       sorted_unique_keys.resize(cuda::std::distance(sorted_unique_keys.begin(),
                                                     thrust::unique(handle.get_thrust_policy(),

--- a/cpp/src/dag/topological_sort_impl.cuh
+++ b/cpp/src/dag/topological_sort_impl.cuh
@@ -15,6 +15,7 @@
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/host_scalar_comm.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -30,7 +31,6 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/reduce.h>
-#include <thrust/sort.h>
 
 namespace cugraph {
 
@@ -51,7 +51,7 @@ rmm::device_uvector<vertex_t> topological_sort(
 
     auto components = strongly_connected_components(handle, graph_view, true);
 
-    thrust::sort(handle.get_thrust_policy(), components.begin(), components.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), components.begin(), components.end());
     CUGRAPH_EXPECTS(
       static_cast<size_t>(thrust::unique_count(
         handle.get_thrust_policy(), components.begin(), components.end())) == components.size(),
@@ -61,7 +61,7 @@ rmm::device_uvector<vertex_t> topological_sort(
       std::tie(components, std::ignore) = shuffle_ext_vertices(
         handle, std::move(components), std::vector<arithmetic_device_uvector_t>{});
 
-      thrust::sort(handle.get_thrust_policy(), components.begin(), components.end());
+      cugraph::sort_wrapper(handle.get_thrust_policy(), components.begin(), components.end());
       CUGRAPH_EXPECTS(
         static_cast<size_t>(thrust::unique_count(
           handle.get_thrust_policy(), components.begin(), components.end())) == components.size(),

--- a/cpp/src/detail/utility_wrappers_32_common.cu
+++ b/cpp/src/detail/utility_wrappers_32_common.cu
@@ -58,9 +58,6 @@ template CUGRAPH_EXPORT void scalar_fill(raft::handle_t const& handle,
                                          size_t size,
                                          float value);
 
-template CUGRAPH_EXPORT void sort_ints(raft::handle_t const& handle,
-                                       raft::device_span<int32_t> values);
-
 template CUGRAPH_EXPORT size_t unique_ints(raft::handle_t const& handle,
                                            raft::device_span<int32_t> values);
 

--- a/cpp/src/detail/utility_wrappers_64_common.cu
+++ b/cpp/src/detail/utility_wrappers_64_common.cu
@@ -53,9 +53,6 @@ template CUGRAPH_EXPORT void scalar_fill(raft::handle_t const& handle,
                                          size_t size,
                                          double value);
 
-template CUGRAPH_EXPORT void sort_ints(raft::handle_t const& handle,
-                                       raft::device_span<int64_t> values);
-
 template CUGRAPH_EXPORT size_t unique_ints(raft::handle_t const& handle,
                                            raft::device_span<int64_t> values);
 

--- a/cpp/src/detail/utility_wrappers_impl.cuh
+++ b/cpp/src/detail/utility_wrappers_impl.cuh
@@ -54,12 +54,6 @@ void scalar_fill(raft::handle_t const& handle, value_t* d_value, size_t size, va
 }
 
 template <typename value_t>
-void sort_ints(raft::handle_t const& handle, raft::device_span<value_t> values)
-{
-  thrust::sort(handle.get_thrust_policy(), values.begin(), values.end());
-}
-
-template <typename value_t>
 size_t unique_ints(raft::handle_t const& handle, raft::device_span<value_t> values)
 {
   auto unique_element_last =

--- a/cpp/src/generators/generator_tools.cuh
+++ b/cpp/src/generators/generator_tools.cuh
@@ -9,6 +9,7 @@
 
 #include <cugraph/graph_generators.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/util/cuda_utils.cuh>
 
@@ -22,7 +23,6 @@
 #include <thrust/for_each.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/partition.h>
-#include <thrust/sort.h>
 #include <thrust/transform.h>
 #include <thrust/unique.h>
 
@@ -123,9 +123,10 @@ combine_edgelists(raft::handle_t const& handle,
     size_t number_of_edges{srcs_v.size()};
 
     if (optional_d_weights) {
-      thrust::sort(handle.get_thrust_policy(),
-                   thrust::make_zip_iterator(srcs_v.begin(), dsts_v.begin(), weights_v.begin()),
-                   thrust::make_zip_iterator(srcs_v.end(), dsts_v.end(), weights_v.end()));
+      cugraph::sort_wrapper(
+        handle.get_thrust_policy(),
+        thrust::make_zip_iterator(srcs_v.begin(), dsts_v.begin(), weights_v.begin()),
+        thrust::make_zip_iterator(srcs_v.end(), dsts_v.end(), weights_v.end()));
 
       auto pair_first = thrust::make_zip_iterator(srcs_v.begin(), dsts_v.begin());
       auto end_iter   = thrust::unique_by_key(
@@ -133,9 +134,9 @@ combine_edgelists(raft::handle_t const& handle,
 
       number_of_edges = cuda::std::distance(pair_first, cuda::std::get<0>(end_iter));
     } else {
-      thrust::sort(handle.get_thrust_policy(),
-                   thrust::make_zip_iterator(srcs_v.begin(), dsts_v.begin()),
-                   thrust::make_zip_iterator(srcs_v.end(), dsts_v.end()));
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            thrust::make_zip_iterator(srcs_v.begin(), dsts_v.begin()),
+                            thrust::make_zip_iterator(srcs_v.end(), dsts_v.end()));
 
       auto pair_first = thrust::make_zip_iterator(srcs_v.begin(), dsts_v.begin());
 

--- a/cpp/src/link_analysis/pagerank_impl.cuh
+++ b/cpp/src/link_analysis/pagerank_impl.cuh
@@ -17,6 +17,7 @@
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
 #include <cugraph/utilities/device_functors.cuh>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -158,7 +159,7 @@ centrality_algorithm_metadata_t pagerank(
                    std::get<0>(*personalization).end(),
                    check_for_duplicates.begin());
 
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(), check_for_duplicates.begin(), check_for_duplicates.end());
 
       auto num_uniques =

--- a/cpp/src/lookup/lookup_src_dst_impl.cuh
+++ b/cpp/src/lookup/lookup_src_dst_impl.cuh
@@ -17,6 +17,7 @@
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/mask_utils.cuh>
 #include <cugraph/utilities/misc_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -232,7 +233,7 @@ struct lookup_container_t<edge_id_t, edge_type_t, vertex_t, value_t>::lookup_con
         handle.get_stream());
       unique_types = std::move(rx_unique_types);
 
-      thrust::sort(handle.get_thrust_policy(), unique_types.begin(), unique_types.end());
+      cugraph::sort_wrapper(handle.get_thrust_policy(), unique_types.begin(), unique_types.end());
 
       unique_types.resize(
         cuda::std::distance(
@@ -425,9 +426,9 @@ EdgeTypeAndIdToSrcDstLookupContainerType build_edge_id_and_type_to_src_dst_looku
     auto type_and_gpu_id_pair_begin =
       thrust::make_zip_iterator(edge_types.begin(), gpu_ids.begin());
 
-    thrust::sort(handle.get_thrust_policy(),
-                 type_and_gpu_id_pair_begin,
-                 type_and_gpu_id_pair_begin + edge_types.size());
+    cugraph::sort_wrapper(handle.get_thrust_policy(),
+                          type_and_gpu_id_pair_begin,
+                          type_and_gpu_id_pair_begin + edge_types.size());
 
     auto nr_unique_pairs = thrust::count_if(
       handle.get_thrust_policy(),
@@ -516,7 +517,7 @@ EdgeTypeAndIdToSrcDstLookupContainerType build_edge_id_and_type_to_src_dst_looku
           return et;
         }));
 
-    thrust::sort(handle.get_thrust_policy(), edge_types.begin(), edge_types.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), edge_types.begin(), edge_types.end());
 
     auto nr_unique_types =
       thrust::count_if(handle.get_thrust_policy(),

--- a/cpp/src/sampling/detail/deduplicate_edges_by_minor_impl.cuh
+++ b/cpp/src/sampling/detail/deduplicate_edges_by_minor_impl.cuh
@@ -13,6 +13,7 @@
 #include <cugraph/utilities/collect_comm.cuh>
 #include <cugraph/utilities/mask_utils.cuh>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/copy.hpp>
 
@@ -109,19 +110,19 @@ deduplicate_edges_by_minor(raft::handle_t const& handle,
     if (has_types) {
       auto& types = std::get<rmm::device_uvector<int32_t>>(result_types);
       if (has_labels) {
-        thrust::sort(handle.get_thrust_policy(),
-                     thrust::make_zip_iterator(result_labels->begin(),
-                                               result_minors.begin(),
-                                               result_majors.begin(),
-                                               property.begin(),
-                                               types.begin()),
-                     thrust::make_zip_iterator(result_labels->end(),
-                                               result_minors.end(),
-                                               result_majors.end(),
-                                               property.end(),
-                                               types.end()));
+        cugraph::sort_wrapper(handle.get_thrust_policy(),
+                              thrust::make_zip_iterator(result_labels->begin(),
+                                                        result_minors.begin(),
+                                                        result_majors.begin(),
+                                                        property.begin(),
+                                                        types.begin()),
+                              thrust::make_zip_iterator(result_labels->end(),
+                                                        result_minors.end(),
+                                                        result_majors.end(),
+                                                        property.end(),
+                                                        types.end()));
       } else {
-        thrust::sort(
+        cugraph::sort_wrapper(
           handle.get_thrust_policy(),
           thrust::make_zip_iterator(
             result_minors.begin(), result_majors.begin(), property.begin(), types.begin()),
@@ -129,14 +130,14 @@ deduplicate_edges_by_minor(raft::handle_t const& handle,
             result_minors.end(), result_majors.end(), property.end(), types.end()));
       }
     } else if (has_labels) {
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(),
         thrust::make_zip_iterator(
           result_labels->begin(), result_minors.begin(), result_majors.begin(), property.begin()),
         thrust::make_zip_iterator(
           result_labels->end(), result_minors.end(), result_majors.end(), property.end()));
     } else {
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(),
         thrust::make_zip_iterator(result_minors.begin(), result_majors.begin(), property.begin()),
         thrust::make_zip_iterator(result_minors.end(), result_majors.end(), property.end()));
@@ -145,28 +146,28 @@ deduplicate_edges_by_minor(raft::handle_t const& handle,
     if (has_types) {
       auto& types = std::get<rmm::device_uvector<int32_t>>(result_types);
       if (has_labels) {
-        thrust::sort(
+        cugraph::sort_wrapper(
           handle.get_thrust_policy(),
           thrust::make_zip_iterator(
             result_labels->begin(), result_minors.begin(), result_majors.begin(), types.begin()),
           thrust::make_zip_iterator(
             result_labels->end(), result_minors.end(), result_majors.end(), types.end()));
       } else {
-        thrust::sort(
+        cugraph::sort_wrapper(
           handle.get_thrust_policy(),
           thrust::make_zip_iterator(result_minors.begin(), result_majors.begin(), types.begin()),
           thrust::make_zip_iterator(result_minors.end(), result_majors.end(), types.end()));
       }
     } else if (has_labels) {
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(),
         thrust::make_zip_iterator(
           result_labels->begin(), result_minors.begin(), result_majors.begin()),
         thrust::make_zip_iterator(result_labels->end(), result_minors.end(), result_majors.end()));
     } else {
-      thrust::sort(handle.get_thrust_policy(),
-                   thrust::make_zip_iterator(result_minors.begin(), result_majors.begin()),
-                   thrust::make_zip_iterator(result_minors.end(), result_majors.end()));
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            thrust::make_zip_iterator(result_minors.begin(), result_majors.begin()),
+                            thrust::make_zip_iterator(result_minors.end(), result_majors.end()));
     }
   }
 

--- a/cpp/src/sampling/detail/prepare_next_frontier_impl.cuh
+++ b/cpp/src/sampling/detail/prepare_next_frontier_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,6 +13,7 @@
 #include <cugraph/sampling_functions.hpp>
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/thrust_tuple_utils.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
@@ -198,7 +199,8 @@ prepare_next_frontier(
                           frontier_vertex_times->begin());
 
     } else {
-      thrust::sort(handle.get_thrust_policy(), begin_iter, begin_iter + frontier_vertices.size());
+      cugraph::sort_wrapper(
+        handle.get_thrust_policy(), begin_iter, begin_iter + frontier_vertices.size());
     }
   } else {
     if (frontier_vertex_times) {
@@ -208,7 +210,8 @@ prepare_next_frontier(
                           frontier_vertex_times->begin());
 
     } else {
-      thrust::sort(handle.get_thrust_policy(), frontier_vertices.begin(), frontier_vertices.end());
+      cugraph::sort_wrapper(
+        handle.get_thrust_policy(), frontier_vertices.begin(), frontier_vertices.end());
     }
   }
 
@@ -249,7 +252,7 @@ prepare_next_frontier(
       if (sampled_src_vertex_times) {
         auto begin_iter = thrust::make_zip_iterator(verts.begin(), labels->begin(), times->begin());
 
-        thrust::sort(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
+        cugraph::sort_wrapper(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
 
         auto end_iter =
           thrust::unique(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
@@ -260,7 +263,7 @@ prepare_next_frontier(
       } else {
         auto begin_iter = thrust::make_zip_iterator(verts.begin(), labels->begin());
 
-        thrust::sort(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
+        cugraph::sort_wrapper(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
 
         auto end_iter =
           thrust::unique(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
@@ -272,7 +275,7 @@ prepare_next_frontier(
       if (sampled_src_vertex_times) {
         auto begin_iter = thrust::make_zip_iterator(verts.begin(), times->begin());
 
-        thrust::sort(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
+        cugraph::sort_wrapper(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
 
         auto end_iter =
           thrust::unique(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
@@ -281,7 +284,7 @@ prepare_next_frontier(
         times->resize(cuda::std::distance(begin_iter, end_iter), handle.get_stream());
 
       } else {
-        thrust::sort(handle.get_thrust_policy(), verts.begin(), verts.end());
+        cugraph::sort_wrapper(handle.get_thrust_policy(), verts.begin(), verts.end());
 
         auto end_iter = thrust::unique(handle.get_thrust_policy(), verts.begin(), verts.end());
 

--- a/cpp/src/sampling/detail/remove_visited_vertices_from_frontier.cuh
+++ b/cpp/src/sampling/detail/remove_visited_vertices_from_frontier.cuh
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cugraph/utilities/thrust_wrappers.hpp>
+
 #include <raft/core/device_span.hpp>
 #include <raft/core/handle.hpp>
 
@@ -37,7 +39,8 @@ remove_visited_vertices_from_frontier(
     if (frontier_vertex_labels) {
       auto sort_iter = thrust::make_zip_iterator(
         frontier_vertex_labels->begin(), frontier_vertices.begin(), frontier_vertex_times->begin());
-      thrust::sort(handle.get_thrust_policy(), sort_iter, sort_iter + frontier_vertices.size());
+      cugraph::sort_wrapper(
+        handle.get_thrust_policy(), sort_iter, sort_iter + frontier_vertices.size());
 
       auto begin_iter =
         thrust::make_zip_iterator(frontier_vertex_labels->begin(), frontier_vertices.begin());
@@ -59,7 +62,8 @@ remove_visited_vertices_from_frontier(
     } else {
       auto sort_iter =
         thrust::make_zip_iterator(frontier_vertices.begin(), frontier_vertex_times->begin());
-      thrust::sort(handle.get_thrust_policy(), sort_iter, sort_iter + frontier_vertices.size());
+      cugraph::sort_wrapper(
+        handle.get_thrust_policy(), sort_iter, sort_iter + frontier_vertices.size());
 
       auto new_end = thrust::reduce_by_key(handle.get_thrust_policy(),
                                            frontier_vertices.begin(),

--- a/cpp/src/sampling/detail/sample_edges.cuh
+++ b/cpp/src/sampling/detail/sample_edges.cuh
@@ -24,6 +24,7 @@
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/mask_utils.cuh>
 #include <cugraph/utilities/thrust_tuple_utils.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
@@ -1075,12 +1076,11 @@ sample_unvisited_with_one_property(
 
       if (num_types == size_t{1}) {
         if (agg_labels) {
-          thrust::sort(handle.get_thrust_policy(),
-                       thrust::make_zip_iterator(agg_labels->begin(), agg_majors.begin()),
-                       thrust::make_zip_iterator(agg_labels->end(), agg_majors.end()));
+          cugraph::sort_wrapper(handle.get_thrust_policy(),
+                                thrust::make_zip_iterator(agg_labels->begin(), agg_majors.begin()),
+                                thrust::make_zip_iterator(agg_labels->end(), agg_majors.end()));
         } else {
-          cugraph::detail::sort_ints(
-            handle, raft::device_span<vertex_t>{agg_majors.data(), agg_majors.size()});
+          cugraph::sort_wrapper(handle.get_thrust_policy(), agg_majors.begin(), agg_majors.end());
         }
 
         rmm::device_uvector<size_t> agg_counts(agg_majors.size(), handle.get_stream());
@@ -1120,14 +1120,14 @@ sample_unvisited_with_one_property(
           std::get<rmm::device_uvector<edge_type_t>>(std::move(discarded_types));
 
         if (agg_labels) {
-          thrust::sort(
+          cugraph::sort_wrapper(
             handle.get_thrust_policy(),
             thrust::make_zip_iterator(agg_labels->begin(), agg_majors.begin(), types.begin()),
             thrust::make_zip_iterator(agg_labels->end(), agg_majors.end(), types.end()));
         } else {
-          thrust::sort(handle.get_thrust_policy(),
-                       thrust::make_zip_iterator(agg_majors.begin(), types.begin()),
-                       thrust::make_zip_iterator(agg_majors.end(), types.end()));
+          cugraph::sort_wrapper(handle.get_thrust_policy(),
+                                thrust::make_zip_iterator(agg_majors.begin(), types.begin()),
+                                thrust::make_zip_iterator(agg_majors.end(), types.end()));
         }
 
         rmm::device_uvector<size_t> kr_cnt(agg_majors.size(), handle.get_stream());

--- a/cpp/src/sampling/detail/shuffle_and_organize_output_common.cu
+++ b/cpp/src/sampling/detail/shuffle_and_organize_output_common.cu
@@ -9,6 +9,7 @@
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/device_functors.cuh>
 #include <cugraph/utilities/graph_partition_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -136,7 +137,7 @@ shuffle_and_organize_output(
     // Need to generate offsets for each unique label (not each seed) on each GPU
     rmm::device_uvector<int32_t> unique_labels(labels->size(), handle.get_stream());
     raft::copy(unique_labels.data(), labels->data(), labels->size(), handle.get_stream());
-    thrust::sort(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
     auto unique_end =
       thrust::unique(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
     size_t num_unique_labels =

--- a/cpp/src/sampling/detail/temporal_partition_vertices_impl.cuh
+++ b/cpp/src/sampling/detail/temporal_partition_vertices_impl.cuh
@@ -9,6 +9,7 @@
 
 #include <cugraph/utilities/device_functors.cuh>
 #include <cugraph/utilities/mask_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/core/resource/thrust_policy.hpp>
@@ -57,15 +58,15 @@ temporal_partition_vertices(raft::handle_t const& handle,
                  vertex_labels->end(),
                  vertex_labels_p1->begin());
 
-    thrust::sort(
+    cugraph::sort_wrapper(
       handle.get_thrust_policy(),
       thrust::make_zip_iterator(
         vertices_p1.begin(), vertex_times_p1.begin(), vertex_labels_p1->begin()),
       thrust::make_zip_iterator(vertices_p1.end(), vertex_times_p1.end(), vertex_labels_p1->end()));
   } else {
-    thrust::sort(handle.get_thrust_policy(),
-                 thrust::make_zip_iterator(vertices_p1.begin(), vertex_times_p1.begin()),
-                 thrust::make_zip_iterator(vertices_p1.end(), vertex_times_p1.end()));
+    cugraph::sort_wrapper(handle.get_thrust_policy(),
+                          thrust::make_zip_iterator(vertices_p1.begin(), vertex_times_p1.begin()),
+                          thrust::make_zip_iterator(vertices_p1.end(), vertex_times_p1.end()));
   }
 
   rmm::device_uvector<uint32_t> vertex_partition_mask(cugraph::packed_bool_size(vertices_p1.size()),

--- a/cpp/src/sampling/detail/update_visited_utils_impl.cuh
+++ b/cpp/src/sampling/detail/update_visited_utils_impl.cuh
@@ -12,6 +12,7 @@
 #include <cugraph/utilities/collect_comm.cuh>
 #include <cugraph/utilities/device_comm.hpp>
 #include <cugraph/utilities/host_scalar_comm.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <rmm/exec_policy.hpp>
@@ -70,9 +71,10 @@ update_dst_visited_vertices_and_labels(
 
   // 2) Sort and dedupe the new sampled items (reduce comm and storage)
   if (new_sample_labels) {
-    thrust::sort(handle.get_thrust_policy(),
-                 thrust::make_zip_iterator(new_samples.begin(), new_sample_labels->begin()),
-                 thrust::make_zip_iterator(new_samples.end(), new_sample_labels->end()));
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(),
+      thrust::make_zip_iterator(new_samples.begin(), new_sample_labels->begin()),
+      thrust::make_zip_iterator(new_samples.end(), new_sample_labels->end()));
     auto new_zip_end =
       thrust::unique(handle.get_thrust_policy(),
                      thrust::make_zip_iterator(new_samples.begin(), new_sample_labels->begin()),
@@ -82,7 +84,7 @@ update_dst_visited_vertices_and_labels(
     new_samples.resize(new_size, handle.get_stream());
     new_sample_labels->resize(new_size, handle.get_stream());
   } else {
-    thrust::sort(handle.get_thrust_policy(), new_samples.begin(), new_samples.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), new_samples.begin(), new_samples.end());
     auto new_end =
       thrust::unique(handle.get_thrust_policy(), new_samples.begin(), new_samples.end());
     size_t n_keep = static_cast<size_t>(new_end - new_samples.begin());
@@ -120,11 +122,12 @@ update_dst_visited_vertices_and_labels(
                  new_sample_labels->end(),
                  visited_minor_labels->begin() + orig_size);
 
-    thrust::sort(handle.get_thrust_policy(),
-                 thrust::make_zip_iterator(visited_minors.begin(), visited_minor_labels->begin()),
-                 thrust::make_zip_iterator(visited_minors.end(), visited_minor_labels->end()));
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(),
+      thrust::make_zip_iterator(visited_minors.begin(), visited_minor_labels->begin()),
+      thrust::make_zip_iterator(visited_minors.end(), visited_minor_labels->end()));
   } else {
-    thrust::sort(handle.get_thrust_policy(), visited_minors.begin(), visited_minors.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), visited_minors.begin(), visited_minors.end());
   }
 
   return std::make_tuple(std::move(visited_minors), std::move(visited_minor_labels));

--- a/cpp/src/sampling/negative_sampling_impl.cuh
+++ b/cpp/src/sampling/negative_sampling_impl.cuh
@@ -15,6 +15,7 @@
 #include <cugraph/utilities/device_comm.hpp>
 #include <cugraph/utilities/device_functors.cuh>
 #include <cugraph/utilities/host_scalar_comm.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/device_span.hpp>
 #include <raft/core/handle.hpp>
@@ -157,9 +158,9 @@ rmm::device_uvector<vertex_t> create_local_samples(
                                   weight_t{1},
                                   rng_state);
 
-      thrust::sort(handle.get_thrust_policy(),
-                   thrust::make_zip_iterator(random_values.begin(), position.begin()),
-                   thrust::make_zip_iterator(random_values.end(), position.end()));
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            thrust::make_zip_iterator(random_values.begin(), position.begin()),
+                            thrust::make_zip_iterator(random_values.end(), position.end()));
 
       thrust::upper_bound(handle.get_thrust_policy(),
                           random_values.begin(),
@@ -236,9 +237,9 @@ rmm::device_uvector<vertex_t> create_local_samples(
                                                      sample_count_from_each_gpu.size()),
                        handle.get_stream());
 
-      thrust::sort(handle.get_thrust_policy(),
-                   thrust::make_zip_iterator(position.begin(), samples.begin()),
-                   thrust::make_zip_iterator(position.end(), samples.begin()));
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            thrust::make_zip_iterator(position.begin(), samples.begin()),
+                            thrust::make_zip_iterator(position.end(), samples.begin()));
     }
   } else {
     samples.resize(samples_in_this_batch, handle.get_stream());
@@ -352,9 +353,9 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> negativ
     }
 
     if (remove_duplicates) {
-      thrust::sort(handle.get_thrust_policy(),
-                   thrust::make_zip_iterator(batch_srcs.begin(), batch_dsts.begin()),
-                   thrust::make_zip_iterator(batch_srcs.end(), batch_dsts.end()));
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            thrust::make_zip_iterator(batch_srcs.begin(), batch_dsts.begin()),
+                            thrust::make_zip_iterator(batch_srcs.end(), batch_dsts.end()));
 
       auto new_end =
         thrust::unique(handle.get_thrust_policy(),

--- a/cpp/src/sampling/neighbor_sampling_impl.hpp
+++ b/cpp/src/sampling/neighbor_sampling_impl.hpp
@@ -160,6 +160,10 @@ neighbor_sample_impl(raft::handle_t const& handle,
     edge_property_views.data(), edge_property_views.size()};
   size_t const n_edge_props = edge_property_views.size();
 
+  // Edge types are only a filter key for heterogeneous sampling. Homogeneous sampling may still
+  // carry edge types as an output property, so keep edge_type_view in edge_property_views above.
+  auto const edge_type_filter_view = num_edge_types ? edge_type_view : std::nullopt;
+
   std::optional<rmm::device_uvector<vertex_t>> visited_minors{std::nullopt};
   std::optional<rmm::device_uvector<label_t>> visited_minor_labels{std::nullopt};
 
@@ -359,7 +363,7 @@ neighbor_sample_impl(raft::handle_t const& handle,
             handle,
             graph_view,
             n_edge_props,
-            edge_type_view,
+            edge_type_filter_view,
             hop == 0 ? starting_vertices
                      : raft::device_span<vertex_t const>(frontier_vertices.data(),
                                                          frontier_vertices.size()),
@@ -388,7 +392,7 @@ neighbor_sample_impl(raft::handle_t const& handle,
           handle,
           graph_view,
           n_edge_props,
-          edge_type_view,
+          edge_type_filter_view,
           hop == 0
             ? starting_vertices
             : raft::device_span<vertex_t const>(frontier_vertices.data(), frontier_vertices.size()),

--- a/cpp/src/sampling/random_walks_impl.cuh
+++ b/cpp/src/sampling/random_walks_impl.cuh
@@ -23,6 +23,7 @@
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/random/rng.cuh>
@@ -642,17 +643,17 @@ random_walk_impl(raft::handle_t const& handle,
     //  Sort for nbr_intersection, must sort all together
     if (previous_vertices) {
       if constexpr (multi_gpu) {
-        thrust::sort(handle.get_thrust_policy(),
-                     thrust::make_zip_iterator(current_vertices.begin(),
-                                               (*previous_vertices).begin(),
-                                               current_position.begin(),
-                                               current_gpu.begin()),
-                     thrust::make_zip_iterator(current_vertices.end(),
-                                               (*previous_vertices).end(),
-                                               current_position.end(),
-                                               current_gpu.end()));
+        cugraph::sort_wrapper(handle.get_thrust_policy(),
+                              thrust::make_zip_iterator(current_vertices.begin(),
+                                                        (*previous_vertices).begin(),
+                                                        current_position.begin(),
+                                                        current_gpu.begin()),
+                              thrust::make_zip_iterator(current_vertices.end(),
+                                                        (*previous_vertices).end(),
+                                                        current_position.end(),
+                                                        current_gpu.end()));
       } else {
-        thrust::sort(
+        cugraph::sort_wrapper(
           handle.get_thrust_policy(),
           thrust::make_zip_iterator(
             current_vertices.begin(), (*previous_vertices).begin(), current_position.begin()),

--- a/cpp/src/sampling/sampling_post_processing_impl.cuh
+++ b/cpp/src/sampling/sampling_post_processing_impl.cuh
@@ -11,6 +11,7 @@
 #include <cugraph/utilities/device_functors.cuh>
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/misc_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -347,7 +348,8 @@ void check_input_edges(raft::handle_t const& handle,
           handle.get_thrust_policy(), edge_types.begin(), edge_types.end(), tmp_edge_types.begin());
         auto triplet_first =
           thrust::make_zip_iterator(tmp_edge_types.begin(), tmp_majors.begin(), tmp_minors.begin());
-        thrust::sort(handle.get_thrust_policy(), triplet_first, triplet_first + tmp_majors.size());
+        cugraph::sort_wrapper(
+          handle.get_thrust_policy(), triplet_first, triplet_first + tmp_majors.size());
         CUGRAPH_EXPECTS(
           thrust::count_if(
             handle.get_thrust_policy(),
@@ -394,7 +396,8 @@ void check_input_edges(raft::handle_t const& handle,
           "have an identical vertex type.");
       } else {
         auto pair_first = thrust::make_zip_iterator(tmp_majors.begin(), tmp_minors.begin());
-        thrust::sort(handle.get_thrust_policy(), pair_first, pair_first + tmp_majors.size());
+        cugraph::sort_wrapper(
+          handle.get_thrust_policy(), pair_first, pair_first + tmp_majors.size());
         CUGRAPH_EXPECTS(
           thrust::count_if(
             handle.get_thrust_policy(),
@@ -458,9 +461,9 @@ void check_input_edges(raft::handle_t const& handle,
                        (*seed_vertices).begin() + start_offset,
                        (*seed_vertices).begin() + end_offset,
                        this_label_seed_vertices.begin());
-          thrust::sort(handle.get_thrust_policy(),
-                       this_label_seed_vertices.begin(),
-                       this_label_seed_vertices.end());
+          cugraph::sort_wrapper(handle.get_thrust_policy(),
+                                this_label_seed_vertices.begin(),
+                                this_label_seed_vertices.end());
           this_label_seed_vertices.resize(
             cuda::std::distance(this_label_seed_vertices.begin(),
                                 thrust::unique(handle.get_thrust_policy(),
@@ -497,9 +500,9 @@ void check_input_edges(raft::handle_t const& handle,
                          edgelist_majors.begin() + end_offset,
                          this_label_zero_hop_majors.begin());
           }
-          thrust::sort(handle.get_thrust_policy(),
-                       this_label_zero_hop_majors.begin(),
-                       this_label_zero_hop_majors.end());
+          cugraph::sort_wrapper(handle.get_thrust_policy(),
+                                this_label_zero_hop_majors.begin(),
+                                this_label_zero_hop_majors.end());
           this_label_zero_hop_majors.resize(
             cuda::std::distance(this_label_zero_hop_majors.begin(),
                                 thrust::unique(handle.get_thrust_policy(),
@@ -563,7 +566,7 @@ compute_min_hop_for_unique_label_vertex_pairs(
       // cub::DeviceSegmentedSort currently does not suuport cuda::std::tuple type keys, sorting in
       // chunks still helps in limiting the binary search range and improving memory locality
       for (size_t i = 0; i < num_chunks; ++i) {
-        thrust::sort(
+        cugraph::sort_wrapper(
           handle.get_thrust_policy(),
           tmp_indices.begin() + h_edge_offsets[i],
           tmp_indices.begin() + h_edge_offsets[i + 1],
@@ -917,7 +920,8 @@ compute_min_hop_for_unique_label_vertex_pairs(
       auto pair_first = thrust::make_zip_iterator(
         tmp_vertices.begin(),
         (*tmp_hops).begin());  // vertex is a primary key, hop is a secondary key
-      thrust::sort(handle.get_thrust_policy(), pair_first, pair_first + tmp_vertices.size());
+      cugraph::sort_wrapper(
+        handle.get_thrust_policy(), pair_first, pair_first + tmp_vertices.size());
       tmp_vertices.resize(
         cuda::std::distance(tmp_vertices.begin(),
                             cuda::std::get<0>(thrust::unique_by_key(handle.get_thrust_policy(),
@@ -929,7 +933,7 @@ compute_min_hop_for_unique_label_vertex_pairs(
       tmp_vertices.shrink_to_fit(handle.get_stream());
       (*tmp_hops).shrink_to_fit(handle.get_stream());
     } else {
-      thrust::sort(handle.get_thrust_policy(), tmp_vertices.begin(), tmp_vertices.end());
+      cugraph::sort_wrapper(handle.get_thrust_policy(), tmp_vertices.begin(), tmp_vertices.end());
       tmp_vertices.resize(
         cuda::std::distance(
           tmp_vertices.begin(),
@@ -947,7 +951,7 @@ compute_min_hop_for_unique_label_vertex_pairs(
                    (*seed_vertices).begin(),
                    (*seed_vertices).end(),
                    unique_seed_vertices.begin());
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(), unique_seed_vertices.begin(), unique_seed_vertices.end());
       unique_seed_vertices.resize(cuda::std::distance(unique_seed_vertices.begin(),
                                                       thrust::unique(handle.get_thrust_policy(),
@@ -1157,7 +1161,7 @@ compute_vertex_renumber_map(
                                                             merged_vertices.begin(),
                                                             merged_hops.begin(),
                                                             merged_flags.begin());
-          thrust::sort(
+          cugraph::sort_wrapper(
             handle.get_thrust_policy(),
             quadraplet_first,
             quadraplet_first + merged_vertices.size(),
@@ -1220,7 +1224,7 @@ compute_vertex_renumber_map(
         if (vertex_type_offsets) {
           auto triplet_first = thrust::make_zip_iterator(
             merged_label_indices.begin(), merged_vertices.begin(), merged_flags.begin());
-          thrust::sort(
+          cugraph::sort_wrapper(
             handle.get_thrust_policy(),
             triplet_first,
             triplet_first + merged_vertices.size(),
@@ -1344,7 +1348,7 @@ compute_vertex_renumber_map(
       if (vertex_type_offsets) {
         auto triplet_first = thrust::make_zip_iterator(
           merged_vertices.begin(), merged_hops.begin(), merged_flags.begin());
-        thrust::sort(
+        cugraph::sort_wrapper(
           handle.get_thrust_policy(),
           triplet_first,
           triplet_first + merged_vertices.size(),
@@ -1467,7 +1471,7 @@ compute_edge_id_renumber_map(
     for (size_t i = 0; i < num_chunks; ++i) {
       // sort by (label, (type), id, (hop))
 
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(),
         tmp_indices.begin() + h_edge_offsets[i],
         tmp_indices.begin() + h_edge_offsets[i + 1],
@@ -1532,7 +1536,7 @@ compute_edge_id_renumber_map(
       // sort by (label, (type), (min_hop), id)
 
       if (edgelist_hops) {
-        thrust::sort(
+        cugraph::sort_wrapper(
           handle.get_thrust_policy(),
           tmp_indices.begin() + h_edge_offsets[i],
           last,
@@ -1671,17 +1675,18 @@ compute_edge_id_renumber_map(
       if (tmp_hops) {
         auto triplet_first =
           thrust::make_zip_iterator((*tmp_types).begin(), tmp_ids.begin(), (*tmp_hops).begin());
-        thrust::sort(handle.get_thrust_policy(), triplet_first, triplet_first + tmp_ids.size());
+        cugraph::sort_wrapper(
+          handle.get_thrust_policy(), triplet_first, triplet_first + tmp_ids.size());
       } else {
         auto pair_first = thrust::make_zip_iterator((*tmp_types).begin(), tmp_ids.begin());
-        thrust::sort(handle.get_thrust_policy(), pair_first, pair_first + tmp_ids.size());
+        cugraph::sort_wrapper(handle.get_thrust_policy(), pair_first, pair_first + tmp_ids.size());
       }
     } else {
       if (tmp_hops) {
         auto pair_first = thrust::make_zip_iterator(tmp_ids.begin(), (*tmp_hops).begin());
-        thrust::sort(handle.get_thrust_policy(), pair_first, pair_first + tmp_ids.size());
+        cugraph::sort_wrapper(handle.get_thrust_policy(), pair_first, pair_first + tmp_ids.size());
       } else {
-        thrust::sort(handle.get_thrust_policy(), tmp_ids.begin(), tmp_ids.end());
+        cugraph::sort_wrapper(handle.get_thrust_policy(), tmp_ids.begin(), tmp_ids.end());
       }
     }
 
@@ -1730,10 +1735,11 @@ compute_edge_id_renumber_map(
       if (tmp_types) {
         auto triplet_first =
           thrust::make_zip_iterator((*tmp_types).begin(), (*tmp_hops).begin(), tmp_ids.begin());
-        thrust::sort(handle.get_thrust_policy(), triplet_first, triplet_first + tmp_ids.size());
+        cugraph::sort_wrapper(
+          handle.get_thrust_policy(), triplet_first, triplet_first + tmp_ids.size());
       } else {
         auto pair_first = thrust::make_zip_iterator((*tmp_hops).begin(), tmp_ids.begin());
-        thrust::sort(handle.get_thrust_policy(), pair_first, pair_first + tmp_ids.size());
+        cugraph::sort_wrapper(handle.get_thrust_policy(), pair_first, pair_first + tmp_ids.size());
       }
     }
 
@@ -2528,7 +2534,8 @@ sort_sampled_edge_tuples(raft::handle_t const& handle,
       raft::device_span<vertex_t const>(edgelist_majors.data() + h_edge_offsets[i], indices.size()),
       raft::device_span<vertex_t const>(edgelist_minors.data() + h_edge_offsets[i],
                                         indices.size())};
-    thrust::sort(handle.get_thrust_policy(), indices.begin(), indices.end(), edge_order_comp);
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(), indices.begin(), indices.end(), edge_order_comp);
 
     permute_array(handle,
                   indices.begin(),
@@ -2697,11 +2704,12 @@ renumber_and_compress_sampled_edgelist(
         *seed_vertex_label_offsets, label_index_t{0}, handle.get_stream());
       auto pair_first =
         thrust::make_zip_iterator(label_indices.begin(), (*renumbered_seed_vertices).begin());
-      thrust::sort(handle.get_thrust_policy(), pair_first, pair_first + label_indices.size());
+      cugraph::sort_wrapper(
+        handle.get_thrust_policy(), pair_first, pair_first + label_indices.size());
     } else {
-      thrust::sort(handle.get_thrust_policy(),
-                   (*renumbered_seed_vertices).begin(),
-                   (*renumbered_seed_vertices).end());
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            (*renumbered_seed_vertices).begin(),
+                            (*renumbered_seed_vertices).end());
     }
   }
 

--- a/cpp/src/sampling/temporal_sampling_impl.hpp
+++ b/cpp/src/sampling/temporal_sampling_impl.hpp
@@ -209,6 +209,10 @@ temporal_neighbor_sample_impl(
     edge_property_views.data(), edge_property_views.size()};
   size_t const n_edge_props = edge_property_views.size();
 
+  // Edge types are only a filter key for heterogeneous sampling. Homogeneous temporal sampling may
+  // still carry edge types as an output property, so keep edge_type_view in edge_property_views.
+  auto const edge_type_filter_view = num_edge_types ? edge_type_view : std::nullopt;
+
   graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu> temporal_graph_view{graph_view};
 
   cugraph::edge_property_t<edge_t, bool> edge_time_mask(handle, graph_view);
@@ -514,7 +518,7 @@ temporal_neighbor_sample_impl(
           handle,
           temporal_graph_view,
           n_edge_props,
-          edge_type_view,
+          edge_type_filter_view,
           raft::device_span<vertex_t const>{frontier_vertices_no_duplicates.data(),
                                             frontier_vertices_no_duplicates.size()},
           frontier_vertex_labels_no_duplicates
@@ -584,7 +588,7 @@ temporal_neighbor_sample_impl(
           graph_view,
           edge_prop_span,
           edge_start_time_view,
-          edge_type_view,
+          edge_type_filter_view,
           raft::device_span<vertex_t const>{frontier_vertices_has_duplicates.data(),
                                             frontier_vertices_has_duplicates.size()},
 

--- a/cpp/src/structure/coarsen_graph_impl.cuh
+++ b/cpp/src/structure/coarsen_graph_impl.cuh
@@ -16,6 +16,7 @@
 #include <cugraph/utilities/device_functors.cuh>
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/graph_partition_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -109,7 +110,8 @@ groupby_e_and_coarsen_edgelist(rmm::device_uvector<vertex_t>&& edgelist_majors,
                            std::move(tmp_edgelist_minors),
                            std::move(tmp_edgelist_weights));
   } else {
-    thrust::sort(rmm::exec_policy(stream_view), pair_first, pair_first + edgelist_majors.size());
+    cugraph::sort_wrapper(
+      rmm::exec_policy(stream_view), pair_first, pair_first + edgelist_majors.size());
     auto num_uniques = static_cast<size_t>(cuda::std::distance(
       pair_first,
       thrust::unique(
@@ -505,7 +507,7 @@ coarsen_graph(raft::handle_t const& handle,
                                               handle.get_stream());
   thrust::copy(
     handle.get_thrust_policy(), labels, labels + unique_labels.size(), unique_labels.begin());
-  thrust::sort(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
+  cugraph::sort_wrapper(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
   unique_labels.resize(
     cuda::std::distance(
       unique_labels.begin(),
@@ -515,7 +517,7 @@ coarsen_graph(raft::handle_t const& handle,
   std::tie(unique_labels, std::ignore) = cugraph::shuffle_ext_vertices(
     handle, std::move(unique_labels), std::vector<cugraph::arithmetic_device_uvector_t>{});
 
-  thrust::sort(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
+  cugraph::sort_wrapper(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
   unique_labels.resize(
     cuda::std::distance(
       unique_labels.begin(),
@@ -666,7 +668,7 @@ coarsen_graph(raft::handle_t const& handle,
   rmm::device_uvector<vertex_t> vertices(graph_view.number_of_vertices(), handle.get_stream());
   if (renumber) {
     thrust::copy(handle.get_thrust_policy(), labels, labels + vertices.size(), vertices.begin());
-    thrust::sort(handle.get_thrust_policy(), vertices.begin(), vertices.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), vertices.begin(), vertices.end());
     vertices.resize(cuda::std::distance(
                       vertices.begin(),
                       thrust::unique(handle.get_thrust_policy(), vertices.begin(), vertices.end())),

--- a/cpp/src/structure/create_graph_from_edgelist_impl.cuh
+++ b/cpp/src/structure/create_graph_from_edgelist_impl.cuh
@@ -19,6 +19,7 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/host_scalar_comm.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -73,7 +74,8 @@ void expensive_check_edgelist(raft::handle_t const& handle,
     rmm::device_uvector<vertex_t> sorted_vertices((*vertices).size(), handle.get_stream());
     thrust::copy(
       handle.get_thrust_policy(), (*vertices).begin(), (*vertices).end(), sorted_vertices.begin());
-    thrust::sort(handle.get_thrust_policy(), sorted_vertices.begin(), sorted_vertices.end());
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(), sorted_vertices.begin(), sorted_vertices.end());
     CUGRAPH_EXPECTS(static_cast<size_t>(cuda::std::distance(
                       sorted_vertices.begin(),
                       thrust::unique(handle.get_thrust_policy(),
@@ -190,7 +192,8 @@ void expensive_check_edgelist(raft::handle_t const& handle,
                           raft::host_span<size_t const>(recvcounts.data(), recvcounts.size()),
                           raft::host_span<size_t const>(displacements.data(), displacements.size()),
                           handle.get_stream());
-        thrust::sort(handle.get_thrust_policy(), sorted_majors.begin(), sorted_majors.end());
+        cugraph::sort_wrapper(
+          handle.get_thrust_policy(), sorted_majors.begin(), sorted_majors.end());
       }
 
       rmm::device_uvector<vertex_t> sorted_minors(0, handle.get_stream());
@@ -211,7 +214,8 @@ void expensive_check_edgelist(raft::handle_t const& handle,
                           raft::host_span<size_t const>(recvcounts.data(), recvcounts.size()),
                           raft::host_span<size_t const>(displacements.data(), displacements.size()),
                           handle.get_stream());
-        thrust::sort(handle.get_thrust_policy(), sorted_minors.begin(), sorted_minors.end());
+        cugraph::sort_wrapper(
+          handle.get_thrust_policy(), sorted_minors.begin(), sorted_minors.end());
       }
 
       auto edge_first = thrust::make_zip_iterator(edgelist_majors.begin(), edgelist_minors.begin());
@@ -233,7 +237,8 @@ void expensive_check_edgelist(raft::handle_t const& handle,
                    (*vertices).begin(),
                    (*vertices).end(),
                    sorted_vertices.begin());
-      thrust::sort(handle.get_thrust_policy(), sorted_vertices.begin(), sorted_vertices.end());
+      cugraph::sort_wrapper(
+        handle.get_thrust_policy(), sorted_vertices.begin(), sorted_vertices.end());
       auto edge_first = thrust::make_zip_iterator(edgelist_majors.begin(), edgelist_minors.begin());
       CUGRAPH_EXPECTS(
         thrust::count_if(handle.get_thrust_policy(),
@@ -293,12 +298,13 @@ bool check_symmetric(raft::handle_t const& handle,
   if (org_srcs.size() != symmetrized_srcs.size()) { return false; }
 
   auto org_edge_first = thrust::make_zip_iterator(org_srcs.begin(), org_dsts.begin());
-  thrust::sort(handle.get_thrust_policy(), org_edge_first, org_edge_first + org_srcs.size());
+  cugraph::sort_wrapper(
+    handle.get_thrust_policy(), org_edge_first, org_edge_first + org_srcs.size());
   auto symmetrized_edge_first =
     thrust::make_zip_iterator(symmetrized_srcs.begin(), symmetrized_dsts.begin());
-  thrust::sort(handle.get_thrust_policy(),
-               symmetrized_edge_first,
-               symmetrized_edge_first + symmetrized_srcs.size());
+  cugraph::sort_wrapper(handle.get_thrust_policy(),
+                        symmetrized_edge_first,
+                        symmetrized_edge_first + symmetrized_srcs.size());
 
   return thrust::equal(handle.get_thrust_policy(),
                        org_edge_first,
@@ -319,7 +325,8 @@ bool check_no_parallel_edge(raft::handle_t const& handle,
     handle.get_thrust_policy(), edgelist_dsts.begin(), edgelist_dsts.end(), org_dsts.begin());
 
   auto org_edge_first = thrust::make_zip_iterator(org_srcs.begin(), org_dsts.begin());
-  thrust::sort(handle.get_thrust_policy(), org_edge_first, org_edge_first + org_srcs.size());
+  cugraph::sort_wrapper(
+    handle.get_thrust_policy(), org_edge_first, org_edge_first + org_srcs.size());
   return thrust::unique(
            handle.get_thrust_policy(), org_edge_first, org_edge_first + edgelist_srcs.size()) ==
          (org_edge_first + edgelist_srcs.size());

--- a/cpp/src/structure/detail/structure_utils.cuh
+++ b/cpp/src/structure/detail/structure_utils.cuh
@@ -12,6 +12,7 @@
 #include <cugraph/utilities/mask_utils.cuh>
 #include <cugraph/utilities/misc_utils.cuh>
 #include <cugraph/utilities/packed_bool_utils.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/util/device_atomics.cuh>
@@ -95,7 +96,7 @@ rmm::device_uvector<edge_t> compute_sparse_offsets(
           indices.begin(),
           cuda::proclaim_return_type<vertex_t>(
             [major_range_first] __device__(auto major) { return major - major_range_first; }));
-        thrust::sort(
+        cugraph::sort_wrapper(
           handle.get_thrust_policy(), indices.begin(), indices.begin() + num_edges_to_process);
         auto it          = thrust::reduce_by_key(handle.get_thrust_policy(),
                                         indices.begin(),
@@ -371,10 +372,10 @@ sort_and_compress_edgelist(
                                      pivots[2],
                                      handle.get_stream(),
                                      large_edge_buffer_type);
-      thrust::sort(handle.get_thrust_policy(), pair_first, second_quarter_first);
-      thrust::sort(handle.get_thrust_policy(), second_quarter_first, second_half_first);
-      thrust::sort(handle.get_thrust_policy(), second_half_first, last_quarter_first);
-      thrust::sort(
+      cugraph::sort_wrapper(handle.get_thrust_policy(), pair_first, second_quarter_first);
+      cugraph::sort_wrapper(handle.get_thrust_policy(), second_quarter_first, second_half_first);
+      cugraph::sort_wrapper(handle.get_thrust_policy(), second_half_first, last_quarter_first);
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(), last_quarter_first, pair_first + edgelist_major_offsets.size());
     } else {
       offsets = compute_sparse_offsets<edge_t>(handle,
@@ -417,10 +418,10 @@ sort_and_compress_edgelist(
                                      pivots[2],
                                      handle.get_stream(),
                                      large_edge_buffer_type);
-      thrust::sort(handle.get_thrust_policy(), edge_first, second_quarter_first);
-      thrust::sort(handle.get_thrust_policy(), second_quarter_first, second_half_first);
-      thrust::sort(handle.get_thrust_policy(), second_half_first, last_quarter_first);
-      thrust::sort(
+      cugraph::sort_wrapper(handle.get_thrust_policy(), edge_first, second_quarter_first);
+      cugraph::sort_wrapper(handle.get_thrust_policy(), second_quarter_first, second_half_first);
+      cugraph::sort_wrapper(handle.get_thrust_policy(), second_half_first, last_quarter_first);
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(), last_quarter_first, edge_first + edgelist_majors.size());
       edgelist_majors.resize(0, handle.get_stream());
       edgelist_majors.shrink_to_fit(handle.get_stream());
@@ -431,7 +432,7 @@ sort_and_compress_edgelist(
       large_edge_buffer_type
         ? rmm::exec_policy_nosync(handle.get_stream(), large_buffer_manager::memory_buffer_mr())
         : handle.get_thrust_policy();
-    thrust::sort(exec_policy, edge_first, edge_first + edgelist_minors.size());
+    cugraph::sort_wrapper(exec_policy, edge_first, edge_first + edgelist_minors.size());
     offsets = compute_sparse_offsets<edge_t>(handle,
                                              edgelist_majors.begin(),
                                              edgelist_majors.end(),

--- a/cpp/src/structure/graph_view_impl.cuh
+++ b/cpp/src/structure/graph_view_impl.cuh
@@ -17,6 +17,7 @@
 #include <cugraph/utilities/error_check_utils.cuh>
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/mask_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
@@ -428,12 +429,12 @@ compute_edge_indices_and_edge_partition_offsets(
 
   rmm::device_uvector<size_t> edge_indices(edge_majors.size(), handle.get_stream());
   thrust::sequence(handle.get_thrust_policy(), edge_indices.begin(), edge_indices.end(), size_t{0});
-  thrust::sort(handle.get_thrust_policy(),
-               edge_indices.begin(),
-               edge_indices.end(),
-               [edge_first] __device__(size_t lhs, size_t rhs) {
-                 return *(edge_first + lhs) < *(edge_first + rhs);
-               });
+  cugraph::sort_wrapper(handle.get_thrust_policy(),
+                        edge_indices.begin(),
+                        edge_indices.end(),
+                        [edge_first] __device__(size_t lhs, size_t rhs) {
+                          return *(edge_first + lhs) < *(edge_first + rhs);
+                        });
 
   std::vector<size_t> h_major_range_lasts(graph_view.number_of_local_edge_partitions());
   for (size_t i = 0; i < h_major_range_lasts.size(); ++i) {

--- a/cpp/src/structure/induced_subgraph_impl.cuh
+++ b/cpp/src/structure/induced_subgraph_impl.cuh
@@ -18,6 +18,7 @@
 #include <cugraph/utilities/collect_comm.cuh>
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/misc_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <raft/core/handle.hpp>
@@ -181,9 +182,10 @@ extract_induced_subgraphs(
     graph_ids_v = cugraph::detail::device_allgatherv(
       handle, major_comm, raft::device_span<size_t const>(graph_ids_v.data(), graph_ids_v.size()));
 
-    thrust::sort(handle.get_thrust_policy(),
-                 thrust::make_zip_iterator(graph_ids_v.begin(), dst_subgraph_vertices_v.begin()),
-                 thrust::make_zip_iterator(graph_ids_v.end(), dst_subgraph_vertices_v.end()));
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(),
+      thrust::make_zip_iterator(graph_ids_v.begin(), dst_subgraph_vertices_v.begin()),
+      thrust::make_zip_iterator(graph_ids_v.end(), dst_subgraph_vertices_v.end()));
 
     dst_subgraph_offsets_v =
       detail::compute_sparse_offsets<size_t>(handle,
@@ -201,9 +203,10 @@ extract_induced_subgraphs(
                subgraph_vertices.data(),
                subgraph_vertices.size(),
                handle.get_stream());
-    thrust::sort(handle.get_thrust_policy(),
-                 thrust::make_zip_iterator(graph_ids_v.begin(), dst_subgraph_vertices_v.begin()),
-                 thrust::make_zip_iterator(graph_ids_v.end(), dst_subgraph_vertices_v.end()));
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(),
+      thrust::make_zip_iterator(graph_ids_v.begin(), dst_subgraph_vertices_v.begin()),
+      thrust::make_zip_iterator(graph_ids_v.end(), dst_subgraph_vertices_v.end()));
   }
 
   graph_ids_v.resize(0, handle.get_stream());
@@ -268,11 +271,12 @@ extract_induced_subgraphs(
           dst_subgraph_offsets, dst_subgraph_vertices},
         do_expensive_check);
 
-    thrust::sort(handle.get_thrust_policy(),
-                 thrust::make_zip_iterator(
-                   subgraph_edge_graph_ids.begin(), edge_majors.begin(), edge_minors.begin()),
-                 thrust::make_zip_iterator(
-                   subgraph_edge_graph_ids.end(), edge_majors.end(), edge_minors.end()));
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(),
+      thrust::make_zip_iterator(
+        subgraph_edge_graph_ids.begin(), edge_majors.begin(), edge_minors.begin()),
+      thrust::make_zip_iterator(
+        subgraph_edge_graph_ids.end(), edge_majors.end(), edge_minors.end()));
   }
 
   auto subgraph_edge_offsets =

--- a/cpp/src/structure/relabel_impl.cuh
+++ b/cpp/src/structure/relabel_impl.cuh
@@ -11,6 +11,7 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -62,7 +63,8 @@ void relabel(raft::handle_t const& handle,
 
     rmm::device_uvector<vertex_t> unique_old_labels(num_labels, handle.get_stream());
     thrust::copy(handle.get_thrust_policy(), labels, labels + num_labels, unique_old_labels.data());
-    thrust::sort(handle.get_thrust_policy(), unique_old_labels.begin(), unique_old_labels.end());
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(), unique_old_labels.begin(), unique_old_labels.end());
     unique_old_labels.resize(cuda::std::distance(unique_old_labels.begin(),
                                                  thrust::unique(handle.get_thrust_policy(),
                                                                 unique_old_labels.begin(),

--- a/cpp/src/structure/remove_multi_edges_impl.cuh
+++ b/cpp/src/structure/remove_multi_edges_impl.cuh
@@ -12,6 +12,7 @@
 // FIXME: mem_frugal_partition should probably not be in shuffle_comm.hpp
 //        It's used here without any notion of shuffling
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/device_span.hpp>
 #include <raft/core/handle.hpp>
@@ -189,7 +190,7 @@ std::vector<rmm::device_uvector<bool>> compute_multi_edge_flags(
   size_t num_possibly_multi_edges{0};
   {
     if (tot_edges < mem_frugal_threshold) {
-      thrust::sort(handle.get_thrust_policy(), hashes.begin(), hashes.end());
+      cugraph::sort_wrapper(handle.get_thrust_policy(), hashes.begin(), hashes.end());
     } else {
       auto second_first =
         mem_frugal_partition(hashes.begin(),
@@ -198,8 +199,8 @@ std::vector<rmm::device_uvector<bool>> compute_multi_edge_flags(
                                [] __device__(auto hash) { return static_cast<int>(hash % 2); }),
                              int{1},
                              handle.get_stream());
-      thrust::sort(handle.get_thrust_policy(), hashes.begin(), second_first);
-      thrust::sort(handle.get_thrust_policy(), second_first, hashes.end());
+      cugraph::sort_wrapper(handle.get_thrust_policy(), hashes.begin(), second_first);
+      cugraph::sort_wrapper(handle.get_thrust_policy(), second_first, hashes.end());
     }
     auto is_definitely_not_multi_edge_hashes =
       large_buffer_type
@@ -237,9 +238,9 @@ std::vector<rmm::device_uvector<bool>> compute_multi_edge_flags(
     is_definitely_not_multi_edge_hashes.resize(0, handle.get_stream());
     is_definitely_not_multi_edge_hashes.shrink_to_fit(handle.get_stream());
 
-    thrust::sort(handle.get_thrust_policy(),
-                 unique_possibly_multi_edge_hashes.begin(),
-                 unique_possibly_multi_edge_hashes.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(),
+                          unique_possibly_multi_edge_hashes.begin(),
+                          unique_possibly_multi_edge_hashes.end());
     unique_possibly_multi_edge_hashes.resize(
       cuda::std::distance(unique_possibly_multi_edge_hashes.begin(),
                           thrust::unique(handle.get_thrust_policy(),
@@ -279,9 +280,9 @@ std::vector<rmm::device_uvector<bool>> compute_multi_edge_flags(
       offset += cuda::std::distance(output_pair_first + offset, output_pair_last);
     }
 
-    thrust::sort(handle.get_thrust_policy(),
-                 output_pair_first,
-                 output_pair_first + unique_multi_edge_srcs.size());
+    cugraph::sort_wrapper(handle.get_thrust_policy(),
+                          output_pair_first,
+                          output_pair_first + unique_multi_edge_srcs.size());
     unique_multi_edge_srcs.resize(
       cuda::std::distance(output_pair_first,
                           thrust::unique(handle.get_thrust_policy(),
@@ -332,7 +333,8 @@ void sort_multi_edges(raft::handle_t const& handle,
     if (keep_min_value_edge) {
       auto edge_first = thrust::make_zip_iterator(
         edgelist_srcs.begin(), edgelist_dsts.begin(), edgelist_values->begin());
-      thrust::sort(handle.get_thrust_policy(), edge_first, edge_first + edgelist_srcs.size());
+      cugraph::sort_wrapper(
+        handle.get_thrust_policy(), edge_first, edge_first + edgelist_srcs.size());
     } else {
       thrust::sort_by_key(handle.get_thrust_policy(),
                           pair_first,
@@ -340,7 +342,8 @@ void sort_multi_edges(raft::handle_t const& handle,
                           edgelist_values->begin());
     }
   } else {
-    thrust::sort(handle.get_thrust_policy(), pair_first, pair_first + edgelist_srcs.size());
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(), pair_first, pair_first + edgelist_srcs.size());
   }
 
   return;
@@ -374,7 +377,7 @@ void sort_multi_edges(
     };
     auto edge_first = thrust::make_zip_iterator(
       edgelist_srcs.begin(), edgelist_dsts.begin(), edgelist_indices.begin());
-    thrust::sort(
+    cugraph::sort_wrapper(
       handle.get_thrust_policy(), edge_first, edge_first + edgelist_srcs.size(), edge_compare);
   } else {
     thrust::sort_by_key(handle.get_thrust_policy(),

--- a/cpp/src/structure/renumber_edgelist_impl.cuh
+++ b/cpp/src/structure/renumber_edgelist_impl.cuh
@@ -13,6 +13,7 @@
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -123,7 +124,8 @@ rmm::device_uvector<vertex_t> find_uniques(raft::handle_t const& handle,
                  vertices.begin(),
                  vertices.begin() + first_half_size,
                  first_half_uniques.begin());
-    thrust::sort(handle.get_thrust_policy(), first_half_uniques.begin(), first_half_uniques.end());
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(), first_half_uniques.begin(), first_half_uniques.end());
     first_half_uniques.resize(cuda::std::distance(first_half_uniques.begin(),
                                                   thrust::unique(handle.get_thrust_policy(),
                                                                  first_half_uniques.begin(),
@@ -142,7 +144,7 @@ rmm::device_uvector<vertex_t> find_uniques(raft::handle_t const& handle,
                  vertices.begin() + first_half_size,
                  vertices.end(),
                  second_half_uniques.begin());
-    thrust::sort(
+    cugraph::sort_wrapper(
       handle.get_thrust_policy(), second_half_uniques.begin(), second_half_uniques.end());
     second_half_uniques.resize(cuda::std::distance(second_half_uniques.begin(),
                                                    thrust::unique(handle.get_thrust_policy(),
@@ -178,7 +180,7 @@ rmm::device_uvector<vertex_t> find_uniques(raft::handle_t const& handle,
                                                                               handle.get_stream())
                      : rmm::device_uvector<vertex_t>(vertices.size(), handle.get_stream());
     thrust::copy(handle.get_thrust_policy(), vertices.begin(), vertices.end(), uniques.begin());
-    thrust::sort(handle.get_thrust_policy(), uniques.begin(), uniques.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), uniques.begin(), uniques.end());
     uniques.resize(cuda::std::distance(
                      uniques.begin(),
                      thrust::unique(handle.get_thrust_policy(), uniques.begin(), uniques.end())),
@@ -390,7 +392,7 @@ void compute_sorted_local_major_degrees_without_atomics(
           return static_cast<vertex_t>(cuda::std::distance(
             sorted_local_majors.begin(), thrust::lower_bound(thrust::seq, first, last, major)));
         }));
-    thrust::sort(
+    cugraph::sort_wrapper(
       handle.get_thrust_policy(), indices.begin(), indices.begin() + num_edges_to_process);
     auto it          = thrust::reduce_by_key(handle.get_thrust_policy(),
                                     indices.begin(),
@@ -605,7 +607,7 @@ compute_renumber_map(raft::handle_t const& handle,
     sorted_local_vertices.shrink_to_fit(handle.get_stream());
   } else {
     sorted_local_vertices = std::move(*local_vertices);
-    thrust::sort(
+    cugraph::sort_wrapper(
       handle.get_thrust_policy(), sorted_local_vertices.begin(), sorted_local_vertices.end());
   }
 
@@ -840,7 +842,7 @@ void expensive_check_edgelist(
                  (*local_vertices).begin(),
                  (*local_vertices).end(),
                  (*sorted_local_vertices).begin());
-    thrust::sort(
+    cugraph::sort_wrapper(
       handle.get_thrust_policy(), (*sorted_local_vertices).begin(), (*sorted_local_vertices).end());
     CUGRAPH_EXPECTS(
       static_cast<size_t>(cuda::std::distance((*sorted_local_vertices).begin(),
@@ -948,7 +950,7 @@ void expensive_check_edgelist(
                         raft::host_span<size_t const>(recvcounts.data(), recvcounts.size()),
                         raft::host_span<size_t const>(displacements.data(), displacements.size()),
                         handle.get_stream());
-      thrust::sort(handle.get_thrust_policy(), sorted_minors.begin(), sorted_minors.end());
+      cugraph::sort_wrapper(handle.get_thrust_policy(), sorted_minors.begin(), sorted_minors.end());
 
       auto major_range_sizes =
         host_scalar_allgather(minor_comm, (*sorted_local_vertices).size(), handle.get_stream());

--- a/cpp/src/structure/renumber_utils_impl.cuh
+++ b/cpp/src/structure/renumber_utils_impl.cuh
@@ -12,6 +12,7 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
@@ -343,7 +344,7 @@ void renumber_ext_vertices(raft::handle_t const& handle,
                  renumber_map_labels,
                  renumber_map_labels + labels.size(),
                  labels.begin());
-    thrust::sort(handle.get_thrust_policy(), labels.begin(), labels.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), labels.begin(), labels.end());
     CUGRAPH_EXPECTS(
       thrust::unique(handle.get_thrust_policy(), labels.begin(), labels.end()) == labels.end(),
       "Invalid input arguments: renumber_map_labels have duplicate elements.");
@@ -368,9 +369,9 @@ void renumber_ext_vertices(raft::handle_t const& handle,
                         sorted_unique_ext_vertices.begin(),
                         [] __device__(auto v) { return v != invalid_vertex_id<vertex_t>::value; })),
       handle.get_stream());
-    thrust::sort(handle.get_thrust_policy(),
-                 sorted_unique_ext_vertices.begin(),
-                 sorted_unique_ext_vertices.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(),
+                          sorted_unique_ext_vertices.begin(),
+                          sorted_unique_ext_vertices.end());
     sorted_unique_ext_vertices.resize(
       cuda::std::distance(sorted_unique_ext_vertices.begin(),
                           thrust::unique(handle.get_thrust_policy(),
@@ -451,7 +452,7 @@ void renumber_local_ext_vertices(raft::handle_t const& handle,
                  renumber_map_labels,
                  renumber_map_labels + labels.size(),
                  labels.begin());
-    thrust::sort(handle.get_thrust_policy(), labels.begin(), labels.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), labels.begin(), labels.end());
     CUGRAPH_EXPECTS(
       thrust::unique(handle.get_thrust_policy(), labels.begin(), labels.end()) == labels.end(),
       "Invalid input arguments: renumber_map_labels have duplicate elements.");
@@ -571,9 +572,9 @@ void unrenumber_int_vertices(raft::handle_t const& handle,
                         sorted_unique_int_vertices.begin(),
                         [] __device__(auto v) { return v != invalid_vertex_id<vertex_t>::value; })),
       handle.get_stream());
-    thrust::sort(handle.get_thrust_policy(),
-                 sorted_unique_int_vertices.begin(),
-                 sorted_unique_int_vertices.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(),
+                          sorted_unique_int_vertices.begin(),
+                          sorted_unique_int_vertices.end());
     sorted_unique_int_vertices.resize(
       cuda::std::distance(sorted_unique_int_vertices.begin(),
                           thrust::unique(handle.get_thrust_policy(),

--- a/cpp/src/structure/select_random_vertices_impl.hpp
+++ b/cpp/src/structure/select_random_vertices_impl.hpp
@@ -13,6 +13,7 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -247,7 +248,8 @@ rmm::device_uvector<vertex_t> select_random_vertices(
   }
 
   if (sort_vertices) {
-    thrust::sort(handle.get_thrust_policy(), mg_sample_buffer.begin(), mg_sample_buffer.end());
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(), mg_sample_buffer.begin(), mg_sample_buffer.end());
   }
 
   return mg_sample_buffer;

--- a/cpp/src/structure/symmetrize_edgelist_impl.cuh
+++ b/cpp/src/structure/symmetrize_edgelist_impl.cuh
@@ -7,6 +7,7 @@
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -207,18 +208,19 @@ merge_lower_triangular(raft::handle_t const& handle,
   auto lower_triangular_edge_first = thrust::make_zip_iterator(lower_triangular_majors.begin(),
                                                                lower_triangular_minors.begin(),
                                                                lower_triangular_properties.begin());
-  thrust::sort(handle.get_thrust_policy(),
-               lower_triangular_edge_first,
-               lower_triangular_edge_first + lower_triangular_majors.size());
+  cugraph::sort_wrapper(handle.get_thrust_policy(),
+                        lower_triangular_edge_first,
+                        lower_triangular_edge_first + lower_triangular_majors.size());
   auto upper_triangular_edge_first = thrust::make_zip_iterator(
     upper_triangular_majors.begin(),
     upper_triangular_minors.begin(),
     upper_triangular_properties
       .begin());  // do not flip here to use "lower_triangular = major > minor"
-  thrust::sort(handle.get_thrust_policy(),
-               upper_triangular_edge_first,
-               upper_triangular_edge_first + upper_triangular_majors.size(),
-               compare_upper_triangular_edges_as_lower_triangular_t<vertex_t, property_t>{});
+  cugraph::sort_wrapper(
+    handle.get_thrust_policy(),
+    upper_triangular_edge_first,
+    upper_triangular_edge_first + upper_triangular_majors.size(),
+    compare_upper_triangular_edges_as_lower_triangular_t<vertex_t, property_t>{});
 
   merged_majors.resize(lower_triangular_majors.size() + upper_triangular_majors.size(),
                        handle.get_stream());
@@ -298,14 +300,14 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> merge_l
 
   auto lower_triangular_edge_first =
     thrust::make_zip_iterator(lower_triangular_majors.begin(), lower_triangular_minors.begin());
-  thrust::sort(handle.get_thrust_policy(),
-               lower_triangular_edge_first,
-               lower_triangular_edge_first + lower_triangular_majors.size());
+  cugraph::sort_wrapper(handle.get_thrust_policy(),
+                        lower_triangular_edge_first,
+                        lower_triangular_edge_first + lower_triangular_majors.size());
   auto upper_triangular_edge_first = thrust::make_zip_iterator(
     upper_triangular_minors.begin(), upper_triangular_majors.begin());  // flip
-  thrust::sort(handle.get_thrust_policy(),
-               upper_triangular_edge_first,
-               upper_triangular_edge_first + upper_triangular_majors.size());
+  cugraph::sort_wrapper(handle.get_thrust_policy(),
+                        upper_triangular_edge_first,
+                        upper_triangular_edge_first + upper_triangular_majors.size());
 
   merged_majors.resize(reciprocal
                          ? std::min(num_lower_triangular_edges, upper_triangular_majors.size())

--- a/cpp/src/traversal/od_shortest_distances_impl.cuh
+++ b/cpp/src/traversal/od_shortest_distances_impl.cuh
@@ -19,6 +19,7 @@
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
 #include <cugraph/prims/vertex_frontier.cuh>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <raft/util/cudart_utils.hpp>
@@ -494,7 +495,7 @@ rmm::device_uvector<weight_t> od_shortest_distances(
 
     rmm::device_uvector<vertex_t> tmp_origins(origins.size(), handle.get_stream());
     thrust::copy(handle.get_thrust_policy(), origins.begin(), origins.end(), tmp_origins.begin());
-    thrust::sort(handle.get_thrust_policy(), tmp_origins.begin(), tmp_origins.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), tmp_origins.begin(), tmp_origins.end());
     CUGRAPH_EXPECTS(
       thrust::unique(handle.get_thrust_policy(), tmp_origins.begin(), tmp_origins.end()) ==
         tmp_origins.end(),
@@ -505,7 +506,8 @@ rmm::device_uvector<weight_t> od_shortest_distances(
                  destinations.begin(),
                  destinations.end(),
                  tmp_destinations.begin());
-    thrust::sort(handle.get_thrust_policy(), tmp_destinations.begin(), tmp_destinations.end());
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(), tmp_destinations.begin(), tmp_destinations.end());
     CUGRAPH_EXPECTS(thrust::unique(handle.get_thrust_policy(),
                                    tmp_destinations.begin(),
                                    tmp_destinations.end()) == tmp_destinations.end(),
@@ -839,7 +841,8 @@ rmm::device_uvector<weight_t> od_shortest_distances(
         num_copied += this_loop_size;
       }
 
-      thrust::sort(handle.get_thrust_policy(), tmp_near_q_keys.begin(), tmp_near_q_keys.end());
+      cugraph::sort_wrapper(
+        handle.get_thrust_policy(), tmp_near_q_keys.begin(), tmp_near_q_keys.end());
       tmp_near_q_keys.resize(cuda::std::distance(tmp_near_q_keys.begin(),
                                                  thrust::unique(handle.get_thrust_policy(),
                                                                 tmp_near_q_keys.begin(),
@@ -1002,7 +1005,8 @@ rmm::device_uvector<weight_t> od_shortest_distances(
             }
           }
 
-          thrust::sort(handle.get_thrust_policy(), new_near_q_keys.begin(), new_near_q_keys.end());
+          cugraph::sort_wrapper(
+            handle.get_thrust_policy(), new_near_q_keys.begin(), new_near_q_keys.end());
           new_near_q_keys.resize(cuda::std::distance(new_near_q_keys.begin(),
                                                      thrust::unique(handle.get_thrust_policy(),
                                                                     new_near_q_keys.begin(),

--- a/cpp/src/utilities/shuffle_local_edge_srcs_dsts.cuh
+++ b/cpp/src/utilities/shuffle_local_edge_srcs_dsts.cuh
@@ -9,6 +9,7 @@
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <thrust/binary_search.h>
 #include <thrust/gather.h>
@@ -127,7 +128,7 @@ shuffle_local_edge_majors_to_local_gpu_by_vertex_partitioning(
   auto& minor_comm = handle.get_subcomm(cugraph::partition_manager::minor_comm_name());
 
   if (edge_major_properties.size() == 0) {
-    thrust::sort(handle.get_thrust_policy(), edge_majors.begin(), edge_majors.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), edge_majors.begin(), edge_majors.end());
   } else if (edge_major_properties.size() == 1) {
     cugraph::variant_type_dispatch(edge_major_properties[0], [&handle, &edge_majors](auto& prop) {
       thrust::sort_by_key(
@@ -197,7 +198,7 @@ shuffle_local_edge_minors_to_local_gpu_by_vertex_partitioning(
   auto& major_comm = handle.get_subcomm(cugraph::partition_manager::major_comm_name());
 
   if (edge_minor_properties.size() == 0) {
-    thrust::sort(handle.get_thrust_policy(), edge_minors.begin(), edge_minors.end());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), edge_minors.begin(), edge_minors.end());
   } else if (edge_minor_properties.size() == 1) {
     cugraph::variant_type_dispatch(edge_minor_properties[0], [&handle, &edge_minors](auto& prop) {
       thrust::sort_by_key(

--- a/cpp/src/utilities/thrust_wrappers.cu
+++ b/cpp/src/utilities/thrust_wrappers.cu
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Explicit instantiations for cugraph/utilities/thrust_wrappers.hpp.
+ */
+
+#include <cugraph/export.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
+
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/sort.h>
+
+#include <cstdint>
+
+namespace cugraph {
+namespace detail {
+
+template <typename RandomAccessIterator>
+void sort_impl(rmm::exec_policy const& policy,
+               RandomAccessIterator first,
+               RandomAccessIterator last)
+{
+  thrust::sort(policy, first, last);
+}
+
+template <typename RandomAccessIterator>
+void sort_impl(rmm::exec_policy_nosync const& policy,
+               RandomAccessIterator first,
+               RandomAccessIterator last)
+{
+  thrust::sort(policy, first, last);
+}
+
+template CUGRAPH_EXPORT void sort_impl<int32_t*>(rmm::exec_policy const& policy,
+                                                 int32_t* first,
+                                                 int32_t* last);
+template CUGRAPH_EXPORT void sort_impl<int32_t*>(rmm::exec_policy_nosync const& policy,
+                                                 int32_t* first,
+                                                 int32_t* last);
+
+template CUGRAPH_EXPORT void sort_impl<uint32_t*>(rmm::exec_policy const& policy,
+                                                  uint32_t* first,
+                                                  uint32_t* last);
+template CUGRAPH_EXPORT void sort_impl<uint32_t*>(rmm::exec_policy_nosync const& policy,
+                                                  uint32_t* first,
+                                                  uint32_t* last);
+
+template CUGRAPH_EXPORT void sort_impl<int64_t*>(rmm::exec_policy const& policy,
+                                                 int64_t* first,
+                                                 int64_t* last);
+template CUGRAPH_EXPORT void sort_impl<int64_t*>(rmm::exec_policy_nosync const& policy,
+                                                 int64_t* first,
+                                                 int64_t* last);
+
+#define CUGRAPH_SORT_ZIP_INST(ZipType)                            \
+  template CUGRAPH_EXPORT void sort_impl<ZipType>(                \
+    rmm::exec_policy const& policy, ZipType first, ZipType last); \
+  template CUGRAPH_EXPORT void sort_impl<ZipType>(                \
+    rmm::exec_policy_nosync const& policy, ZipType first, ZipType last)
+
+CUGRAPH_SORT_ZIP_INST(zip_i32_i32);
+CUGRAPH_SORT_ZIP_INST(zip_i64_i64);
+CUGRAPH_SORT_ZIP_INST(zip_i64_i32);
+CUGRAPH_SORT_ZIP_INST(zip_i32_i64);
+CUGRAPH_SORT_ZIP_INST(zip_sz_i32);
+CUGRAPH_SORT_ZIP_INST(zip_sz_i64);
+CUGRAPH_SORT_ZIP_INST(zip_f_sz);
+CUGRAPH_SORT_ZIP_INST(zip_d_sz);
+
+CUGRAPH_SORT_ZIP_INST(zip_i32_i32_f);
+CUGRAPH_SORT_ZIP_INST(zip_i32_i32_d);
+CUGRAPH_SORT_ZIP_INST(zip_i64_i64_f);
+CUGRAPH_SORT_ZIP_INST(zip_i64_i64_d);
+CUGRAPH_SORT_ZIP_INST(zip_sz_i32_i32);
+CUGRAPH_SORT_ZIP_INST(zip_sz_i64_i64);
+CUGRAPH_SORT_ZIP_INST(zip_i32_i32_sz);
+CUGRAPH_SORT_ZIP_INST(zip_i64_i64_sz);
+CUGRAPH_SORT_ZIP_INST(zip_i32_i32_i32);
+CUGRAPH_SORT_ZIP_INST(zip_i32_i64_i32);
+CUGRAPH_SORT_ZIP_INST(zip_i64_i32_i32);
+CUGRAPH_SORT_ZIP_INST(zip_i64_i64_i32);
+
+CUGRAPH_SORT_ZIP_INST(zip_i32_i32_sz_i);
+CUGRAPH_SORT_ZIP_INST(zip_i64_i64_sz_i);
+CUGRAPH_SORT_ZIP_INST(zip_i32_i32_i32_sz);
+CUGRAPH_SORT_ZIP_INST(zip_i64_i64_i64_sz);
+
+#undef CUGRAPH_SORT_ZIP_INST
+
+}  // namespace detail
+}  // namespace cugraph

--- a/cpp/tests/community/egonet_validate.cu
+++ b/cpp/tests/community/egonet_validate.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,6 +7,7 @@
 #include "utilities/conversion_utilities.hpp"
 
 #include <cugraph/algorithms.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <cuda/std/iterator>
 #include <cuda/std/tuple>
@@ -141,7 +142,7 @@ egonet_reference(
           return !thrust::binary_search(thrust::seq, visited_begin, visited_end, v);
         });
       frontier.resize(cuda::std::distance(frontier.begin(), new_end), handle.get_stream());
-      thrust::sort(handle.get_thrust_policy(), frontier.begin(), frontier.end());
+      cugraph::sort_wrapper(handle.get_thrust_policy(), frontier.begin(), frontier.end());
       new_end = thrust::unique(handle.get_thrust_policy(), frontier.begin(), frontier.end());
       frontier.resize(cuda::std::distance(frontier.begin(), new_end), handle.get_stream());
 
@@ -151,7 +152,7 @@ egonet_reference(
                    frontier.begin(),
                    frontier.end(),
                    visited.begin() + old_visited_size);
-      thrust::sort(handle.get_thrust_policy(), visited.begin(), visited.end());
+      cugraph::sort_wrapper(handle.get_thrust_policy(), visited.begin(), visited.end());
 
       offset += new_entries;
     }
@@ -256,24 +257,24 @@ void egonet_validate(raft::handle_t const& handle,
 
   for (size_t i = 0; i < (h_offsets.size() - 1); ++i) {
     if (d_reference_egonet_wgt) {
-      thrust::sort(handle.get_thrust_policy(),
-                   thrust::make_zip_iterator(d_reference_egonet_src.begin(),
-                                             d_reference_egonet_dst.begin(),
-                                             d_reference_egonet_wgt->begin()) +
-                     h_offsets[i],
-                   thrust::make_zip_iterator(d_reference_egonet_src.begin(),
-                                             d_reference_egonet_dst.begin(),
-                                             d_reference_egonet_wgt->begin()) +
-                     h_offsets[i + 1]);
-      thrust::sort(handle.get_thrust_policy(),
-                   thrust::make_zip_iterator(d_cugraph_egonet_src.begin(),
-                                             d_cugraph_egonet_dst.begin(),
-                                             d_cugraph_egonet_wgt->begin()) +
-                     h_offsets[i],
-                   thrust::make_zip_iterator(d_cugraph_egonet_src.begin(),
-                                             d_cugraph_egonet_dst.begin(),
-                                             d_cugraph_egonet_wgt->begin()) +
-                     h_offsets[i + 1]);
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            thrust::make_zip_iterator(d_reference_egonet_src.begin(),
+                                                      d_reference_egonet_dst.begin(),
+                                                      d_reference_egonet_wgt->begin()) +
+                              h_offsets[i],
+                            thrust::make_zip_iterator(d_reference_egonet_src.begin(),
+                                                      d_reference_egonet_dst.begin(),
+                                                      d_reference_egonet_wgt->begin()) +
+                              h_offsets[i + 1]);
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            thrust::make_zip_iterator(d_cugraph_egonet_src.begin(),
+                                                      d_cugraph_egonet_dst.begin(),
+                                                      d_cugraph_egonet_wgt->begin()) +
+                              h_offsets[i],
+                            thrust::make_zip_iterator(d_cugraph_egonet_src.begin(),
+                                                      d_cugraph_egonet_dst.begin(),
+                                                      d_cugraph_egonet_wgt->begin()) +
+                              h_offsets[i + 1]);
 
       ASSERT_TRUE(thrust::equal(handle.get_thrust_policy(),
                                 thrust::make_zip_iterator(d_reference_egonet_src.begin(),
@@ -308,13 +309,13 @@ void egonet_validate(raft::handle_t const& handle,
         << "Extracted egonet edges do not match with the edges extracted by the reference "
            "implementation.";
     } else {
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(),
         thrust::make_zip_iterator(d_reference_egonet_src.begin(), d_reference_egonet_dst.begin()) +
           h_offsets[i],
         thrust::make_zip_iterator(d_reference_egonet_src.begin(), d_reference_egonet_dst.begin()) +
           h_offsets[i + 1]);
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(),
         thrust::make_zip_iterator(d_cugraph_egonet_src.begin(), d_cugraph_egonet_dst.begin()) +
           h_offsets[i],

--- a/cpp/tests/community/mg_egonet_test.cu
+++ b/cpp/tests/community/mg_egonet_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,6 +15,7 @@
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
 #include <cugraph/utilities/misc_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -185,9 +186,9 @@ class Tests_MGEgonet
                             triplet_first + d_mg_aggregate_edgelist_src.size(),
                             d_mg_aggregate_edgelist_wgt->begin());
       } else {
-        thrust::sort(handle_->get_thrust_policy(),
-                     triplet_first,
-                     triplet_first + d_mg_aggregate_edgelist_src.size());
+        cugraph::sort_wrapper(handle_->get_thrust_policy(),
+                              triplet_first,
+                              triplet_first + d_mg_aggregate_edgelist_src.size());
       }
 
       cugraph::graph_t<vertex_t, edge_t, false, false> sg_graph(*handle_);

--- a/cpp/tests/mtmg/threaded_test.cpp
+++ b/cpp/tests/mtmg/threaded_test.cpp
@@ -18,6 +18,7 @@
 #include <cugraph/mtmg/renumber_map.hpp>
 #include <cugraph/mtmg/resource_manager.hpp>
 #include <cugraph/mtmg/vertex_result.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/util/cudart_utils.hpp>
 
@@ -175,8 +176,8 @@ class Tests_Multithreaded
                d_dst_v.begin(),
                d_dst_v.size(),
                handle.get_stream());
-    cugraph::detail::sort_ints(
-      handle, raft::device_span<vertex_t>{d_unique_vertices.data(), d_unique_vertices.size()});
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(), d_unique_vertices.begin(), d_unique_vertices.end());
     d_unique_vertices.resize(
       cugraph::detail::unique_ints(
         handle, raft::device_span<vertex_t>{d_unique_vertices.data(), d_unique_vertices.size()}),

--- a/cpp/tests/mtmg/threaded_test_jaccard.cpp
+++ b/cpp/tests/mtmg/threaded_test_jaccard.cpp
@@ -18,6 +18,7 @@
 #include <cugraph/mtmg/renumber_map.hpp>
 #include <cugraph/mtmg/resource_manager.hpp>
 #include <cugraph/mtmg/vertex_pair_result.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/util/cudart_utils.hpp>
 
@@ -159,8 +160,8 @@ class Tests_Multithreaded
                d_dst_v.begin(),
                d_dst_v.size(),
                handle.get_stream());
-    cugraph::detail::sort_ints(
-      handle, raft::device_span<vertex_t>{d_unique_vertices.data(), d_unique_vertices.size()});
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(), d_unique_vertices.begin(), d_unique_vertices.end());
     d_unique_vertices.resize(
       cugraph::detail::unique_ints(
         handle, raft::device_span<vertex_t>{d_unique_vertices.data(), d_unique_vertices.size()}),

--- a/cpp/tests/mtmg/threaded_test_louvain.cpp
+++ b/cpp/tests/mtmg/threaded_test_louvain.cpp
@@ -17,6 +17,7 @@
 #include <cugraph/mtmg/renumber_map.hpp>
 #include <cugraph/mtmg/resource_manager.hpp>
 #include <cugraph/mtmg/vertex_result.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/util/cudart_utils.hpp>
 
@@ -172,8 +173,8 @@ class Tests_Multithreaded
                d_dst_v.begin(),
                d_dst_v.size(),
                handle.get_stream());
-    cugraph::detail::sort_ints(
-      handle, raft::device_span<vertex_t>{d_unique_vertices.data(), d_unique_vertices.size()});
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(), d_unique_vertices.begin(), d_unique_vertices.end());
     d_unique_vertices.resize(
       cugraph::detail::unique_ints(
         handle, raft::device_span<vertex_t>{d_unique_vertices.data(), d_unique_vertices.size()}),

--- a/cpp/tests/prims/mg_extract_transform_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_e.cu
@@ -21,6 +21,7 @@
 #include <cugraph/prims/vertex_frontier.cuh>
 #include <cugraph/utilities/dataframe_buffer.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -200,7 +201,7 @@ class Tests_MGExtractTransformE
           false);
 
       if (handle_->get_comms().get_rank() == int{0}) {
-        thrust::sort(
+        cugraph::sort_wrapper(
           handle_->get_thrust_policy(),
           cugraph::get_dataframe_buffer_begin(mg_aggregate_extract_transform_output_buffer),
           cugraph::get_dataframe_buffer_end(mg_aggregate_extract_transform_output_buffer));
@@ -215,9 +216,10 @@ class Tests_MGExtractTransformE
                                        cugraph::edge_dummy_property_t{}.view(),
                                        e_op_t<vertex_t, output_payload_t>{});
 
-        thrust::sort(handle_->get_thrust_policy(),
-                     cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
-                     cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
+        cugraph::sort_wrapper(
+          handle_->get_thrust_policy(),
+          cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
+          cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
 
         bool e_op_result_passed = thrust::equal(
           handle_->get_thrust_policy(),

--- a/cpp/tests/prims/mg_extract_transform_if_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_if_e.cu
@@ -21,6 +21,7 @@
 #include <cugraph/prims/vertex_frontier.cuh>
 #include <cugraph/utilities/dataframe_buffer.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -228,7 +229,7 @@ class Tests_MGExtractTransformIfE
           raft::device_span<result_t const>(mg_vertex_prop.data(), mg_vertex_prop.size()));
 
       if (handle_->get_comms().get_rank() == int{0}) {
-        thrust::sort(
+        cugraph::sort_wrapper(
           handle_->get_thrust_policy(),
           cugraph::get_dataframe_buffer_begin(mg_aggregate_extract_transform_output_buffer),
           cugraph::get_dataframe_buffer_end(mg_aggregate_extract_transform_output_buffer));
@@ -249,9 +250,10 @@ class Tests_MGExtractTransformIfE
                                           e_op_t<vertex_t, result_t, output_payload_t>{},
                                           pred_op_t<vertex_t, result_t>{});
 
-        thrust::sort(handle_->get_thrust_policy(),
-                     cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
-                     cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
+        cugraph::sort_wrapper(
+          handle_->get_thrust_policy(),
+          cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
+          cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
 
         bool e_op_result_passed = thrust::equal(
           handle_->get_thrust_policy(),

--- a/cpp/tests/prims/mg_extract_transform_if_v_frontier_incoming_outgoing_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_if_v_frontier_incoming_outgoing_e.cu
@@ -20,6 +20,7 @@
 #include <cugraph/prims/vertex_frontier.cuh>
 #include <cugraph/utilities/dataframe_buffer.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -361,7 +362,7 @@ class Tests_MGExtractTransformIfVFrontierIncomingOutgoingE
           raft::device_span<result_t const>(mg_vertex_prop.data(), mg_vertex_prop.size()));
 
       if (handle_->get_comms().get_rank() == int{0}) {
-        thrust::sort(
+        cugraph::sort_wrapper(
           handle_->get_thrust_policy(),
           cugraph::get_dataframe_buffer_begin(mg_aggregate_extract_transform_output_buffer),
           cugraph::get_dataframe_buffer_end(mg_aggregate_extract_transform_output_buffer));
@@ -422,9 +423,10 @@ class Tests_MGExtractTransformIfVFrontierIncomingOutgoingE
             pred_op_t<key_t, vertex_t, result_t, store_transposed>{});
         }
 
-        thrust::sort(handle_->get_thrust_policy(),
-                     cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
-                     cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
+        cugraph::sort_wrapper(
+          handle_->get_thrust_policy(),
+          cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
+          cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
 
         bool e_op_result_passed = thrust::equal(
           handle_->get_thrust_policy(),

--- a/cpp/tests/prims/mg_extract_transform_v_frontier_incoming_outgoing_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_v_frontier_incoming_outgoing_e.cu
@@ -20,6 +20,7 @@
 #include <cugraph/prims/vertex_frontier.cuh>
 #include <cugraph/utilities/dataframe_buffer.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -312,7 +313,7 @@ class Tests_MGExtractTransformVFrontierIncomingOutgoingE
           false);
 
       if (handle_->get_comms().get_rank() == int{0}) {
-        thrust::sort(
+        cugraph::sort_wrapper(
           handle_->get_thrust_policy(),
           cugraph::get_dataframe_buffer_begin(mg_aggregate_extract_transform_output_buffer),
           cugraph::get_dataframe_buffer_end(mg_aggregate_extract_transform_output_buffer));
@@ -366,9 +367,10 @@ class Tests_MGExtractTransformVFrontierIncomingOutgoingE
             e_op_t<key_t, vertex_t, output_payload_t, store_transposed>{});
         }
 
-        thrust::sort(handle_->get_thrust_policy(),
-                     cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
-                     cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
+        cugraph::sort_wrapper(
+          handle_->get_thrust_policy(),
+          cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
+          cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
 
         bool e_op_result_passed = thrust::equal(
           handle_->get_thrust_policy(),

--- a/cpp/tests/prims/mg_transform_e.cu
+++ b/cpp/tests/prims/mg_transform_e.cu
@@ -20,6 +20,7 @@
 #include <cugraph/prims/fill_edge_property.cuh>
 #include <cugraph/prims/transform_e.cuh>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -144,7 +145,8 @@ class Tests_MGTransformE
           thrust::make_zip_iterator(store_transposed ? dsts.begin() : srcs.begin(),
                                     store_transposed ? srcs.begin() : dsts.begin(),
                                     multi_edge_indices->begin());
-        thrust::sort(handle_->get_thrust_policy(), triplet_first, triplet_first + srcs.size());
+        cugraph::sort_wrapper(
+          handle_->get_thrust_policy(), triplet_first, triplet_first + srcs.size());
       } else {
         auto ret = cugraph::extract_transform_if_e(
           *handle_,
@@ -163,7 +165,7 @@ class Tests_MGTransformE
         dsts            = std::move(std::get<1>(ret));
         auto pair_first = thrust::make_zip_iterator(store_transposed ? dsts.begin() : srcs.begin(),
                                                     store_transposed ? srcs.begin() : dsts.begin());
-        thrust::sort(handle_->get_thrust_policy(), pair_first, pair_first + srcs.size());
+        cugraph::sort_wrapper(handle_->get_thrust_policy(), pair_first, pair_first + srcs.size());
       }
 
       edge_list.insert(

--- a/cpp/tests/prims/mg_transform_gather_e.cu
+++ b/cpp/tests/prims/mg_transform_gather_e.cu
@@ -18,6 +18,7 @@
 #include <cugraph/prims/extract_transform_if_e.cuh>
 #include <cugraph/prims/transform_gather_e.cuh>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -158,7 +159,8 @@ class Tests_MGTransformGatherE
                                     multi_edge_indices->begin(),
                                     cugraph::get_dataframe_buffer_begin(should_be_gathered_values));
         if (prims_usecase.use_sorted_unique_edgelist) {
-          thrust::sort(handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
+          cugraph::sort_wrapper(
+            handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
         } else {
           thrust::shuffle(handle_->get_thrust_policy(),
                           tuple_first,
@@ -201,7 +203,8 @@ class Tests_MGTransformGatherE
                                     store_transposed ? srcs.begin() : dsts.begin(),
                                     cugraph::get_dataframe_buffer_begin(should_be_gathered_values));
         if (prims_usecase.use_sorted_unique_edgelist) {
-          thrust::sort(handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
+          cugraph::sort_wrapper(
+            handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
         } else {
           thrust::shuffle(handle_->get_thrust_policy(),
                           tuple_first,

--- a/cpp/tests/prims/mg_transform_gather_e_edge_ids.cu
+++ b/cpp/tests/prims/mg_transform_gather_e_edge_ids.cu
@@ -19,6 +19,7 @@
 #include <cugraph/prims/extract_transform_if_e.cuh>
 #include <cugraph/prims/transform_gather_e.cuh>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -201,7 +202,7 @@ class Tests_MGTransformGatherE
                                                    multi_edge_indices->begin(),
                                                    should_be_gathered_ids.begin());
       if (prims_usecase.use_sorted_unique_edgelist) {
-        thrust::sort(handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
+        cugraph::sort_wrapper(handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
       } else {
         thrust::shuffle(handle_->get_thrust_policy(),
                         tuple_first,
@@ -213,7 +214,7 @@ class Tests_MGTransformGatherE
                                                    store_transposed ? srcs.begin() : dsts.begin(),
                                                    should_be_gathered_ids.begin());
       if (prims_usecase.use_sorted_unique_edgelist) {
-        thrust::sort(handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
+        cugraph::sort_wrapper(handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
       } else {
         thrust::shuffle(handle_->get_thrust_policy(),
                         tuple_first,

--- a/cpp/tests/prims/mg_transform_reduce_if_v_frontier_outgoing_e_by_dst.cu
+++ b/cpp/tests/prims/mg_transform_reduce_if_v_frontier_outgoing_e_by_dst.cu
@@ -19,6 +19,7 @@
 #include <cugraph/prims/vertex_frontier.cuh>
 #include <cugraph/utilities/dataframe_buffer.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -308,7 +309,7 @@ class Tests_MGTransformReduceIfVFrontierOutgoingEBySrcDst
 
       if (handle_->get_comms().get_rank() == int{0}) {
         if constexpr (std::is_same_v<payload_t, void>) {
-          thrust::sort(
+          cugraph::sort_wrapper(
             handle_->get_thrust_policy(),
             cugraph::get_dataframe_buffer_begin(mg_reduce_by_dst_aggregate_new_frontier_key_buffer),
             cugraph::get_dataframe_buffer_end(mg_reduce_by_dst_aggregate_new_frontier_key_buffer));
@@ -390,7 +391,7 @@ class Tests_MGTransformReduceIfVFrontierOutgoingEBySrcDst
         }
 
         if constexpr (std::is_same_v<payload_t, void>) {
-          thrust::sort(
+          cugraph::sort_wrapper(
             handle_->get_thrust_policy(),
             cugraph::get_dataframe_buffer_begin(sg_reduce_by_dst_new_frontier_key_buffer),
             cugraph::get_dataframe_buffer_end(sg_reduce_by_dst_new_frontier_key_buffer));

--- a/cpp/tests/prims/mg_transform_reduce_v_frontier_outgoing_e_by_dst.cu
+++ b/cpp/tests/prims/mg_transform_reduce_v_frontier_outgoing_e_by_dst.cu
@@ -19,6 +19,7 @@
 #include <cugraph/prims/vertex_frontier.cuh>
 #include <cugraph/utilities/dataframe_buffer.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -286,7 +287,7 @@ class Tests_MGTransformReduceVFrontierOutgoingEBySrcDst
 
       if (handle_->get_comms().get_rank() == int{0}) {
         if constexpr (std::is_same_v<payload_t, void>) {
-          thrust::sort(
+          cugraph::sort_wrapper(
             handle_->get_thrust_policy(),
             cugraph::get_dataframe_buffer_begin(mg_reduce_by_dst_aggregate_new_frontier_key_buffer),
             cugraph::get_dataframe_buffer_end(mg_reduce_by_dst_aggregate_new_frontier_key_buffer));
@@ -353,7 +354,7 @@ class Tests_MGTransformReduceVFrontierOutgoingEBySrcDst
         }
 
         if constexpr (std::is_same_v<payload_t, void>) {
-          thrust::sort(
+          cugraph::sort_wrapper(
             handle_->get_thrust_policy(),
             cugraph::get_dataframe_buffer_begin(sg_reduce_by_dst_new_frontier_key_buffer),
             cugraph::get_dataframe_buffer_end(sg_reduce_by_dst_new_frontier_key_buffer));

--- a/cpp/tests/sampling/detail/nbr_sampling_validate.cu
+++ b/cpp/tests/sampling/detail/nbr_sampling_validate.cu
@@ -9,6 +9,7 @@
 #include <cugraph/graph_view.hpp>
 #include <cugraph/sampling_functions.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/device_span.hpp>
 #include <raft/core/handle.hpp>
@@ -118,7 +119,7 @@ bool validate_extracted_graph_is_subgraph(
     raft::copy(wgt_v.data(), wgt->data(), wgt->size(), handle.get_stream());
 
     auto graph_iter = thrust::make_zip_iterator(src_v.begin(), dst_v.begin(), wgt_v.begin());
-    thrust::sort(
+    cugraph::sort_wrapper(
       handle.get_thrust_policy(), graph_iter, graph_iter + src_v.size(), ArithmeticZipLess{});
     auto graph_iter_end = thrust::unique(
       handle.get_thrust_policy(), graph_iter, graph_iter + src_v.size(), ArithmeticZipEqual{});
@@ -140,7 +141,7 @@ bool validate_extracted_graph_is_subgraph(
                        });
   } else {
     auto graph_iter = thrust::make_zip_iterator(src_v.begin(), dst_v.begin());
-    thrust::sort(
+    cugraph::sort_wrapper(
       handle.get_thrust_policy(), graph_iter, graph_iter + src_v.size(), ArithmeticZipLess{});
     auto graph_iter_end = thrust::unique(
       handle.get_thrust_policy(), graph_iter, graph_iter + src_v.size(), ArithmeticZipEqual{});
@@ -313,9 +314,9 @@ bool validate_temporal_integrity(
   raft::copy(sorted_dsts.begin(), dsts.begin(), dsts.size(), handle.get_stream());
   raft::copy(sorted_dst_times.begin(), edge_times.begin(), edge_times.size(), handle.get_stream());
 
-  thrust::sort(handle.get_thrust_policy(),
-               thrust::make_zip_iterator(sorted_dsts.begin(), sorted_dst_times.begin()),
-               thrust::make_zip_iterator(sorted_dsts.end(), sorted_dst_times.end()));
+  cugraph::sort_wrapper(handle.get_thrust_policy(),
+                        thrust::make_zip_iterator(sorted_dsts.begin(), sorted_dst_times.begin()),
+                        thrust::make_zip_iterator(sorted_dsts.end(), sorted_dst_times.end()));
 
   if ((temporal_sampling_comparison ==
        cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING) ||

--- a/cpp/tests/sampling/detail/sampling_post_processing_validate.cu
+++ b/cpp/tests/sampling/detail/sampling_post_processing_validate.cu
@@ -6,6 +6,7 @@
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/utilities/device_functors.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
@@ -136,15 +137,15 @@ bool compare_edgelist(raft::handle_t const& handle,
         thrust::make_zip_iterator(this_label_sorted_org_edgelist_srcs.begin(),
                                   this_label_sorted_org_edgelist_dsts.begin(),
                                   (*this_label_sorted_org_edgelist_weights).begin());
-      thrust::sort(handle.get_thrust_policy(),
-                   sorted_org_edge_first,
-                   sorted_org_edge_first + this_label_sorted_org_edgelist_srcs.size());
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            sorted_org_edge_first,
+                            sorted_org_edge_first + this_label_sorted_org_edgelist_srcs.size());
     } else {
       auto sorted_org_edge_first = thrust::make_zip_iterator(
         this_label_sorted_org_edgelist_srcs.begin(), this_label_sorted_org_edgelist_dsts.begin());
-      thrust::sort(handle.get_thrust_policy(),
-                   sorted_org_edge_first,
-                   sorted_org_edge_first + this_label_sorted_org_edgelist_srcs.size());
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            sorted_org_edge_first,
+                            sorted_org_edge_first + this_label_sorted_org_edgelist_srcs.size());
     }
 
     rmm::device_uvector<vertex_t> this_label_sorted_unrenumbered_edgelist_srcs(
@@ -205,7 +206,7 @@ bool compare_edgelist(raft::handle_t const& handle,
         thrust::make_zip_iterator(this_label_sorted_unrenumbered_edgelist_srcs.begin(),
                                   this_label_sorted_unrenumbered_edgelist_dsts.begin(),
                                   (*this_label_sorted_unrenumbered_edgelist_weights).begin());
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(),
         sorted_unrenumbered_edge_first,
         sorted_unrenumbered_edge_first + this_label_sorted_unrenumbered_edgelist_srcs.size());
@@ -224,7 +225,7 @@ bool compare_edgelist(raft::handle_t const& handle,
       auto sorted_unrenumbered_edge_first =
         thrust::make_zip_iterator(this_label_sorted_unrenumbered_edgelist_srcs.begin(),
                                   this_label_sorted_unrenumbered_edgelist_dsts.begin());
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(),
         sorted_unrenumbered_edge_first,
         sorted_unrenumbered_edge_first + this_label_sorted_unrenumbered_edgelist_srcs.size());
@@ -368,7 +369,7 @@ bool compare_heterogeneous_edgelist(
                      this_label_org_sorted_indices.end(),
                      size_t{0});
 
-    thrust::sort(
+    cugraph::sort_wrapper(
       handle.get_thrust_policy(),
       this_label_org_sorted_indices.begin(),
       this_label_org_sorted_indices.end(),
@@ -653,7 +654,7 @@ bool compare_heterogeneous_edgelist(
 
         if (hop_start_offset == hop_end_offset) { continue; }
 
-        thrust::sort(
+        cugraph::sort_wrapper(
           handle.get_thrust_policy(),
           this_edge_type_unrenumbered_sorted_indices.begin() +
             (hop_start_offset - edge_type_start_offset),
@@ -1015,7 +1016,7 @@ bool check_vertex_renumber_map_invariants(
 
       auto pair_first = thrust::make_zip_iterator(this_label_unique_majors.begin(),
                                                   (*this_label_unique_major_hops).begin());
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(), pair_first, pair_first + this_label_unique_majors.size());
       this_label_unique_majors.resize(
         cuda::std::distance(
@@ -1027,9 +1028,9 @@ bool check_vertex_renumber_map_invariants(
         handle.get_stream());
       (*this_label_unique_major_hops).resize(this_label_unique_majors.size(), handle.get_stream());
     } else {
-      thrust::sort(handle.get_thrust_policy(),
-                   this_label_unique_majors.begin(),
-                   this_label_unique_majors.end());
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            this_label_unique_majors.begin(),
+                            this_label_unique_majors.end());
       this_label_unique_majors.resize(
         cuda::std::distance(this_label_unique_majors.begin(),
                             thrust::unique(handle.get_thrust_policy(),
@@ -1058,7 +1059,7 @@ bool check_vertex_renumber_map_invariants(
 
       auto pair_first = thrust::make_zip_iterator(this_label_unique_minors.begin(),
                                                   (*this_label_unique_minor_hops).begin());
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(), pair_first, pair_first + this_label_unique_minors.size());
       this_label_unique_minors.resize(
         cuda::std::distance(
@@ -1073,9 +1074,9 @@ bool check_vertex_renumber_map_invariants(
           .resize(this_label_unique_minors.size(), handle.get_stream());
       }
     } else {
-      thrust::sort(handle.get_thrust_policy(),
-                   this_label_unique_minors.begin(),
-                   this_label_unique_minors.end());
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            this_label_unique_minors.begin(),
+                            this_label_unique_minors.end());
       this_label_unique_minors.resize(
         cuda::std::distance(this_label_unique_minors.begin(),
                             thrust::unique(handle.get_thrust_policy(),
@@ -1535,9 +1536,9 @@ bool check_edge_id_renumber_map_invariants(
         auto triplet_first = thrust::make_zip_iterator((*this_label_unique_key_edge_types).begin(),
                                                        this_label_unique_key_edge_ids.begin(),
                                                        (*this_label_unique_key_hops).begin());
-        thrust::sort(handle.get_thrust_policy(),
-                     triplet_first,
-                     triplet_first + this_label_unique_key_edge_ids.size());
+        cugraph::sort_wrapper(handle.get_thrust_policy(),
+                              triplet_first,
+                              triplet_first + this_label_unique_key_edge_ids.size());
         auto key_first = thrust::make_zip_iterator((*this_label_unique_key_edge_types).begin(),
                                                    this_label_unique_key_edge_ids.begin());
         this_label_unique_key_edge_ids.resize(
@@ -1555,9 +1556,9 @@ bool check_edge_id_renumber_map_invariants(
       } else {
         auto pair_first = thrust::make_zip_iterator((*this_label_unique_key_edge_types).begin(),
                                                     this_label_unique_key_edge_ids.begin());
-        thrust::sort(handle.get_thrust_policy(),
-                     pair_first,
-                     pair_first + this_label_unique_key_edge_ids.size());
+        cugraph::sort_wrapper(handle.get_thrust_policy(),
+                              pair_first,
+                              pair_first + this_label_unique_key_edge_ids.size());
         this_label_unique_key_edge_ids.resize(
           cuda::std::distance(pair_first,
                               thrust::unique(handle.get_thrust_policy(),
@@ -1571,9 +1572,9 @@ bool check_edge_id_renumber_map_invariants(
       if (org_edgelist_hops) {
         auto pair_first = thrust::make_zip_iterator(this_label_unique_key_edge_ids.begin(),
                                                     (*this_label_unique_key_hops).begin());
-        thrust::sort(handle.get_thrust_policy(),
-                     pair_first,
-                     pair_first + this_label_unique_key_edge_ids.size());
+        cugraph::sort_wrapper(handle.get_thrust_policy(),
+                              pair_first,
+                              pair_first + this_label_unique_key_edge_ids.size());
         this_label_unique_key_edge_ids.resize(
           cuda::std::distance(
             this_label_unique_key_edge_ids.begin(),
@@ -1585,9 +1586,9 @@ bool check_edge_id_renumber_map_invariants(
         (*this_label_unique_key_hops)
           .resize(this_label_unique_key_edge_ids.size(), handle.get_stream());
       } else {
-        thrust::sort(handle.get_thrust_policy(),
-                     this_label_unique_key_edge_ids.begin(),
-                     this_label_unique_key_edge_ids.end());
+        cugraph::sort_wrapper(handle.get_thrust_policy(),
+                              this_label_unique_key_edge_ids.begin(),
+                              this_label_unique_key_edge_ids.end());
         this_label_unique_key_edge_ids.resize(
           cuda::std::distance(this_label_unique_key_edge_ids.begin(),
                               thrust::unique(handle.get_thrust_policy(),

--- a/cpp/tests/sampling/random_walks_check.cuh
+++ b/cpp/tests/sampling/random_walks_check.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "sampling/random_walks_check.hpp"
@@ -7,6 +7,7 @@
 
 #include <cugraph/graph.hpp>
 #include <cugraph/graph_functions.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <cuda/std/iterator>
 #include <cuda/std/tuple>
@@ -62,9 +63,9 @@ void random_walks_validate(
     rmm::device_uvector<int> failures(d_start.size() * max_length, handle.get_stream());
 
     if (d_wgt) {
-      thrust::sort(handle.get_thrust_policy(),
-                   thrust::make_zip_iterator(d_src.begin(), d_dst.begin(), d_wgt->begin()),
-                   thrust::make_zip_iterator(d_src.end(), d_dst.end(), d_wgt->end()));
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            thrust::make_zip_iterator(d_src.begin(), d_dst.begin(), d_wgt->begin()),
+                            thrust::make_zip_iterator(d_src.end(), d_dst.end(), d_wgt->end()));
 
       thrust::transform(
         handle.get_thrust_policy(),
@@ -109,9 +110,9 @@ void random_walks_validate(
           return 0;
         });
     } else {
-      thrust::sort(handle.get_thrust_policy(),
-                   thrust::make_zip_iterator(d_src.begin(), d_dst.begin()),
-                   thrust::make_zip_iterator(d_src.end(), d_dst.end()));
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            thrust::make_zip_iterator(d_src.begin(), d_dst.begin()),
+                            thrust::make_zip_iterator(d_src.end(), d_dst.end()));
 
       thrust::transform(
         handle.get_thrust_policy(),

--- a/cpp/tests/structure/induced_subgraph_validate.cu
+++ b/cpp/tests/structure/induced_subgraph_validate.cu
@@ -4,6 +4,8 @@
  */
 #include "structure/induced_subgraph_validate.hpp"
 
+#include <cugraph/utilities/thrust_wrappers.hpp>
+
 #include <raft/core/handle.hpp>
 
 #include <rmm/device_uvector.hpp>
@@ -96,20 +98,20 @@ void induced_subgraph_validate(
       << "Extracted subgraph edges do not match with the edges extracted by the reference "
          "implementation.";
   } else {
-    thrust::sort(handle.get_thrust_policy(),
-                 thrust::make_zip_iterator(d_subgraph_index.begin(),
-                                           d_reference_subgraph_edgelist_majors.begin(),
-                                           d_reference_subgraph_edgelist_minors.begin()),
-                 thrust::make_zip_iterator(d_subgraph_index.end(),
-                                           d_reference_subgraph_edgelist_majors.end(),
-                                           d_reference_subgraph_edgelist_minors.end()));
-    thrust::sort(handle.get_thrust_policy(),
-                 thrust::make_zip_iterator(d_subgraph_index.begin(),
-                                           d_cugraph_subgraph_edgelist_majors.begin(),
-                                           d_cugraph_subgraph_edgelist_minors.begin()),
-                 thrust::make_zip_iterator(d_subgraph_index.end(),
-                                           d_cugraph_subgraph_edgelist_majors.end(),
-                                           d_cugraph_subgraph_edgelist_minors.end()));
+    cugraph::sort_wrapper(handle.get_thrust_policy(),
+                          thrust::make_zip_iterator(d_subgraph_index.begin(),
+                                                    d_reference_subgraph_edgelist_majors.begin(),
+                                                    d_reference_subgraph_edgelist_minors.begin()),
+                          thrust::make_zip_iterator(d_subgraph_index.end(),
+                                                    d_reference_subgraph_edgelist_majors.end(),
+                                                    d_reference_subgraph_edgelist_minors.end()));
+    cugraph::sort_wrapper(handle.get_thrust_policy(),
+                          thrust::make_zip_iterator(d_subgraph_index.begin(),
+                                                    d_cugraph_subgraph_edgelist_majors.begin(),
+                                                    d_cugraph_subgraph_edgelist_minors.begin()),
+                          thrust::make_zip_iterator(d_subgraph_index.end(),
+                                                    d_cugraph_subgraph_edgelist_majors.end(),
+                                                    d_cugraph_subgraph_edgelist_minors.end()));
 
     ASSERT_TRUE(
       thrust::equal(handle.get_thrust_policy(),

--- a/cpp/tests/structure/mg_induced_subgraph_test.cu
+++ b/cpp/tests/structure/mg_induced_subgraph_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "structure/detail/structure_utils.cuh"
@@ -16,6 +16,7 @@
 #include <cugraph/graph_view.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
 #include <cugraph/utilities/misc_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -203,7 +204,7 @@ class Tests_MGInducedSubgraph
                             triplet_first + graph_ids_v.size(),
                             d_subgraph_edgelist_weights->begin());
       } else {
-        thrust::sort(
+        cugraph::sort_wrapper(
           handle_->get_thrust_policy(), triplet_first, triplet_first + graph_ids_v.size());
       }
 

--- a/cpp/tests/traversal/detail/graph500_forest_pruning_utils.cuh
+++ b/cpp/tests/traversal/detail/graph500_forest_pruning_utils.cuh
@@ -21,6 +21,7 @@
 #include <cugraph/utilities/collect_comm.cuh>
 #include <cugraph/utilities/device_functors.cuh>
 #include <cugraph/utilities/host_scalar_comm.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/comms.hpp>
 #include <raft/core/handle.hpp>
@@ -246,7 +247,7 @@ find_trees_from_2cores(
       weights = std::nullopt;
 
       auto new_reachable_vertices = std::move(srcs);
-      thrust::sort(
+      cugraph::sort_wrapper(
         handle.get_thrust_policy(), new_reachable_vertices.begin(), new_reachable_vertices.end());
       fill_edge_src_property(handle,
                              tmp_graph_view,

--- a/cpp/tests/traversal/detail/graph500_nbr_unrenumber_cache.cuh
+++ b/cpp/tests/traversal/detail/graph500_nbr_unrenumber_cache.cuh
@@ -13,6 +13,7 @@
 #include <cugraph/prims/vertex_frontier.cuh>
 #include <cugraph/utilities/collect_comm.cuh>
 #include <cugraph/utilities/packed_bool_utils.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/device_span.hpp>
 #include <raft/core/handle.hpp>
@@ -702,7 +703,8 @@ nbr_unrenumber_cache_t<vertex_t> build_nbr_unrenumber_cache(
                              handle.get_stream());
       this_round_nbrs.shrink_to_fit(handle.get_stream());
     }
-    thrust::sort(handle.get_thrust_policy(), this_round_nbrs.begin(), this_round_nbrs.end());
+    cugraph::sort_wrapper(
+      handle.get_thrust_policy(), this_round_nbrs.begin(), this_round_nbrs.end());
     this_round_nbrs.resize(
       cuda::std::distance(
         this_round_nbrs.begin(),

--- a/cpp/tests/traversal/detail/graph500_validation_utils.cuh
+++ b/cpp/tests/traversal/detail/graph500_validation_utils.cuh
@@ -23,6 +23,7 @@
 #include <cugraph/utilities/collect_comm.cuh>
 #include <cugraph/utilities/device_functors.cuh>
 #include <cugraph/utilities/host_scalar_comm.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/comms.hpp>
 #include <raft/core/handle.hpp>
@@ -521,7 +522,8 @@ bool check_edge_endpoint_distances(
         cuda::proclaim_return_type<vertex_t>(
           [v_first = mg_subgraph_view.local_vertex_partition_range_first()] __device__(
             auto v_offset) { return v_first + v_offset; }));
-      thrust::sort(handle.get_thrust_policy(), subgraph_level_vs.begin(), subgraph_level_vs.end());
+      cugraph::sort_wrapper(
+        handle.get_thrust_policy(), subgraph_level_vs.begin(), subgraph_level_vs.end());
       cugraph::fill_edge_src_property(
         handle, mg_subgraph_view, edge_src_flags.mutable_view(), false);
       cugraph::fill_edge_src_property(handle,
@@ -539,9 +541,9 @@ bool check_edge_endpoint_distances(
         cuda::proclaim_return_type<vertex_t>(
           [v_first = mg_subgraph_view.local_vertex_partition_range_first()] __device__(
             auto v_offset) { return v_first + v_offset; }));
-      thrust::sort(handle.get_thrust_policy(),
-                   subgraph_adjacent_level_vs.begin(),
-                   subgraph_adjacent_level_vs.end());
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            subgraph_adjacent_level_vs.begin(),
+                            subgraph_adjacent_level_vs.end());
       cugraph::fill_edge_dst_property(
         handle, mg_subgraph_view, edge_dst_flags.mutable_view(), false);
       cugraph::fill_edge_dst_property(handle,
@@ -905,9 +907,9 @@ bool check_has_edge_from_parents(
       }
       auto forest_edge_first =
         thrust::make_zip_iterator(forest_edge_vertices.begin(), forest_edge_parents.begin());
-      thrust::sort(handle.get_thrust_policy(),
-                   forest_edge_first,
-                   forest_edge_first + forest_edge_vertices.size());
+      cugraph::sort_wrapper(handle.get_thrust_policy(),
+                            forest_edge_first,
+                            forest_edge_first + forest_edge_vertices.size());
       query_edge_first = thrust::make_zip_iterator(query_preds.begin(), query_vertices.begin());
       query_preds.resize(
         cuda::std::distance(

--- a/cpp/tests/traversal/mg_graph500_sssp_test.cu
+++ b/cpp/tests/traversal/mg_graph500_sssp_test.cu
@@ -32,6 +32,7 @@
 #include <cugraph/utilities/high_res_timer.hpp>
 #include <cugraph/utilities/misc_utils.cuh>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -903,7 +904,7 @@ class Tests_GRAPH500_MGSSSP
             cugraph::edge_bucket_t<vertex_t, edge_t, !store_transposed, multi_gpu, true> edge_list(
               *handle_, false);
             auto edge_pair_first = thrust::make_zip_iterator(tree_srcs.begin(), tree_dsts.begin());
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle_->get_thrust_policy(), edge_pair_first, edge_pair_first + tree_srcs.size());
             edge_list.insert(tree_srcs.begin(),
                              tree_srcs.end(),

--- a/cpp/tests/utilities/csv_file_utilities_impl.cuh
+++ b/cpp/tests/utilities/csv_file_utilities_impl.cuh
@@ -10,6 +10,7 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/graph_partition_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -112,20 +113,20 @@ bool check_symmetric(raft::handle_t const& handle,
   if (edgelist_weights) {
     auto org_first = thrust::make_zip_iterator(
       cuda::std::make_tuple(org_srcs.begin(), org_dsts.begin(), (*org_weights).begin()));
-    thrust::sort(handle.get_thrust_policy(), org_first, org_first + org_srcs.size());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), org_first, org_first + org_srcs.size());
     auto symmetrized_first = thrust::make_zip_iterator(cuda::std::make_tuple(
       symmetrized_srcs.begin(), symmetrized_dsts.begin(), (*symmetrized_weights).begin()));
-    thrust::sort(
+    cugraph::sort_wrapper(
       handle.get_thrust_policy(), symmetrized_first, symmetrized_first + symmetrized_srcs.size());
     return thrust::equal(
       handle.get_thrust_policy(), org_first, org_first + org_srcs.size(), symmetrized_first);
   } else {
     auto org_first =
       thrust::make_zip_iterator(cuda::std::make_tuple(org_srcs.begin(), org_dsts.begin()));
-    thrust::sort(handle.get_thrust_policy(), org_first, org_first + org_srcs.size());
+    cugraph::sort_wrapper(handle.get_thrust_policy(), org_first, org_first + org_srcs.size());
     auto symmetrized_first = thrust::make_zip_iterator(
       cuda::std::make_tuple(symmetrized_srcs.begin(), symmetrized_dsts.begin()));
-    thrust::sort(
+    cugraph::sort_wrapper(
       handle.get_thrust_policy(), symmetrized_first, symmetrized_first + symmetrized_srcs.size());
     return thrust::equal(
       handle.get_thrust_policy(), org_first, org_first + org_srcs.size(), symmetrized_first);

--- a/cpp/tests/utilities/thrust_wrapper.cu
+++ b/cpp/tests/utilities/thrust_wrapper.cu
@@ -7,6 +7,7 @@
 
 #include <cugraph/utilities/device_functors.cuh>
 #include <cugraph/utilities/misc_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <rmm/exec_policy.hpp>
 
@@ -44,9 +45,9 @@ cugraph::dataframe_buffer_type_t<value_t> sort(
                cugraph::get_dataframe_buffer_end(values),
                cugraph::get_dataframe_buffer_begin(sorted_values));
 
-  thrust::sort(handle.get_thrust_policy(),
-               cugraph::get_dataframe_buffer_begin(sorted_values),
-               cugraph::get_dataframe_buffer_end(sorted_values));
+  cugraph::sort_wrapper(handle.get_thrust_policy(),
+                        cugraph::get_dataframe_buffer_begin(sorted_values),
+                        cugraph::get_dataframe_buffer_end(sorted_values));
 
   return sorted_values;
 }
@@ -63,9 +64,9 @@ cugraph::dataframe_buffer_type_t<value_t> sort(raft::handle_t const& handle,
 {
   auto sorted_values = std::move(values);
 
-  thrust::sort(handle.get_thrust_policy(),
-               cugraph::get_dataframe_buffer_begin(sorted_values),
-               cugraph::get_dataframe_buffer_end(sorted_values));
+  cugraph::sort_wrapper(handle.get_thrust_policy(),
+                        cugraph::get_dataframe_buffer_begin(sorted_values),
+                        cugraph::get_dataframe_buffer_end(sorted_values));
 
   return sorted_values;
 }
@@ -95,7 +96,7 @@ sort(raft::handle_t const& handle,
                input_first,
                input_first + size_dataframe_buffer(first),
                output_first);
-  thrust::sort(
+  cugraph::sort_wrapper(
     handle.get_thrust_policy(), output_first, output_first + size_dataframe_buffer(sorted_first));
 
   return std::make_tuple(std::move(sorted_first), std::move(sorted_second));

--- a/cpp/tests/utilities/validation_utilities.cu
+++ b/cpp/tests/utilities/validation_utilities.cu
@@ -6,6 +6,7 @@
 #include "utilities/validation_utilities.hpp"
 
 #include <cugraph/utilities/graph_partition_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <cuda/std/iterator>
@@ -53,9 +54,9 @@ void sort(raft::handle_t const& handle,
           raft::device_span<vertex_t> srcs,
           raft::device_span<vertex_t> dsts)
 {
-  thrust::sort(handle.get_thrust_policy(),
-               thrust::make_zip_iterator(srcs.begin(), dsts.begin()),
-               thrust::make_zip_iterator(srcs.end(), dsts.end()));
+  cugraph::sort_wrapper(handle.get_thrust_policy(),
+                        thrust::make_zip_iterator(srcs.begin(), dsts.begin()),
+                        thrust::make_zip_iterator(srcs.end(), dsts.end()));
 }
 
 template <typename vertex_t,
@@ -77,23 +78,23 @@ void sort(raft::handle_t const& handle,
       if (types) {
         if (start_times) {
           if (end_times) {
-            thrust::sort(handle.get_thrust_policy(),
-                         thrust::make_zip_iterator(srcs.begin(),
-                                                   dsts.begin(),
-                                                   wgts->begin(),
-                                                   ids->begin(),
-                                                   types->begin(),
-                                                   start_times->begin(),
-                                                   end_times->begin()),
-                         thrust::make_zip_iterator(srcs.end(),
-                                                   dsts.end(),
-                                                   wgts->end(),
-                                                   ids->end(),
-                                                   types->end(),
-                                                   start_times->end(),
-                                                   end_times->end()));
+            cugraph::sort_wrapper(handle.get_thrust_policy(),
+                                  thrust::make_zip_iterator(srcs.begin(),
+                                                            dsts.begin(),
+                                                            wgts->begin(),
+                                                            ids->begin(),
+                                                            types->begin(),
+                                                            start_times->begin(),
+                                                            end_times->begin()),
+                                  thrust::make_zip_iterator(srcs.end(),
+                                                            dsts.end(),
+                                                            wgts->end(),
+                                                            ids->end(),
+                                                            types->end(),
+                                                            start_times->end(),
+                                                            end_times->end()));
           } else {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(),
                                         dsts.begin(),
@@ -106,7 +107,7 @@ void sort(raft::handle_t const& handle,
           }
         } else {
           if (end_times) {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(),
                                         dsts.begin(),
@@ -117,31 +118,32 @@ void sort(raft::handle_t const& handle,
               thrust::make_zip_iterator(
                 srcs.end(), dsts.end(), wgts->end(), ids->end(), types->end(), end_times->end()));
           } else {
-            thrust::sort(handle.get_thrust_policy(),
-                         thrust::make_zip_iterator(
-                           srcs.begin(), dsts.begin(), wgts->begin(), ids->begin(), types->begin()),
-                         thrust::make_zip_iterator(
-                           srcs.end(), dsts.end(), wgts->end(), ids->end(), types->end()));
+            cugraph::sort_wrapper(
+              handle.get_thrust_policy(),
+              thrust::make_zip_iterator(
+                srcs.begin(), dsts.begin(), wgts->begin(), ids->begin(), types->begin()),
+              thrust::make_zip_iterator(
+                srcs.end(), dsts.end(), wgts->end(), ids->end(), types->end()));
           }
         }
       } else {
         if (start_times) {
           if (end_times) {
-            thrust::sort(handle.get_thrust_policy(),
-                         thrust::make_zip_iterator(srcs.begin(),
-                                                   dsts.begin(),
-                                                   wgts->begin(),
-                                                   ids->begin(),
-                                                   start_times->begin(),
-                                                   end_times->begin()),
-                         thrust::make_zip_iterator(srcs.end(),
-                                                   dsts.end(),
-                                                   wgts->end(),
-                                                   ids->end(),
-                                                   start_times->end(),
-                                                   end_times->end()));
+            cugraph::sort_wrapper(handle.get_thrust_policy(),
+                                  thrust::make_zip_iterator(srcs.begin(),
+                                                            dsts.begin(),
+                                                            wgts->begin(),
+                                                            ids->begin(),
+                                                            start_times->begin(),
+                                                            end_times->begin()),
+                                  thrust::make_zip_iterator(srcs.end(),
+                                                            dsts.end(),
+                                                            wgts->end(),
+                                                            ids->end(),
+                                                            start_times->end(),
+                                                            end_times->end()));
           } else {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), wgts->begin(), ids->begin(), start_times->begin()),
@@ -150,14 +152,14 @@ void sort(raft::handle_t const& handle,
           }
         } else {
           if (end_times) {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), wgts->begin(), ids->begin(), end_times->begin()),
               thrust::make_zip_iterator(
                 srcs.end(), dsts.end(), wgts->end(), ids->end(), end_times->end()));
           } else {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(), dsts.begin(), wgts->begin(), ids->begin()),
               thrust::make_zip_iterator(srcs.end(), dsts.end(), wgts->end(), ids->end()));
@@ -168,21 +170,21 @@ void sort(raft::handle_t const& handle,
       if (types) {
         if (start_times) {
           if (end_times) {
-            thrust::sort(handle.get_thrust_policy(),
-                         thrust::make_zip_iterator(srcs.begin(),
-                                                   dsts.begin(),
-                                                   wgts->begin(),
-                                                   types->begin(),
-                                                   start_times->begin(),
-                                                   end_times->begin()),
-                         thrust::make_zip_iterator(srcs.end(),
-                                                   dsts.end(),
-                                                   wgts->end(),
-                                                   types->end(),
-                                                   start_times->end(),
-                                                   end_times->end()));
+            cugraph::sort_wrapper(handle.get_thrust_policy(),
+                                  thrust::make_zip_iterator(srcs.begin(),
+                                                            dsts.begin(),
+                                                            wgts->begin(),
+                                                            types->begin(),
+                                                            start_times->begin(),
+                                                            end_times->begin()),
+                                  thrust::make_zip_iterator(srcs.end(),
+                                                            dsts.end(),
+                                                            wgts->end(),
+                                                            types->end(),
+                                                            start_times->end(),
+                                                            end_times->end()));
           } else {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), wgts->begin(), types->begin(), start_times->begin()),
@@ -191,14 +193,14 @@ void sort(raft::handle_t const& handle,
           }
         } else {
           if (end_times) {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), wgts->begin(), types->begin(), end_times->begin()),
               thrust::make_zip_iterator(
                 srcs.end(), dsts.end(), wgts->end(), types->end(), end_times->end()));
           } else {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(), dsts.begin(), wgts->begin(), types->begin()),
               thrust::make_zip_iterator(srcs.end(), dsts.end(), wgts->end(), types->end()));
@@ -207,7 +209,7 @@ void sort(raft::handle_t const& handle,
       } else {
         if (start_times) {
           if (end_times) {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(),
                                         dsts.begin(),
@@ -217,7 +219,7 @@ void sort(raft::handle_t const& handle,
               thrust::make_zip_iterator(
                 srcs.end(), dsts.end(), wgts->end(), start_times->end(), end_times->end()));
           } else {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), wgts->begin(), start_times->begin()),
@@ -225,15 +227,16 @@ void sort(raft::handle_t const& handle,
           }
         } else {
           if (end_times) {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), wgts->begin(), end_times->begin()),
               thrust::make_zip_iterator(srcs.end(), dsts.end(), wgts->end(), end_times->end()));
           } else {
-            thrust::sort(handle.get_thrust_policy(),
-                         thrust::make_zip_iterator(srcs.begin(), dsts.begin(), wgts->begin()),
-                         thrust::make_zip_iterator(srcs.end(), dsts.end(), wgts->end()));
+            cugraph::sort_wrapper(
+              handle.get_thrust_policy(),
+              thrust::make_zip_iterator(srcs.begin(), dsts.begin(), wgts->begin()),
+              thrust::make_zip_iterator(srcs.end(), dsts.end(), wgts->end()));
           }
         }
       }
@@ -243,21 +246,21 @@ void sort(raft::handle_t const& handle,
       if (types) {
         if (start_times) {
           if (end_times) {
-            thrust::sort(handle.get_thrust_policy(),
-                         thrust::make_zip_iterator(srcs.begin(),
-                                                   dsts.begin(),
-                                                   ids->begin(),
-                                                   types->begin(),
-                                                   start_times->begin(),
-                                                   end_times->begin()),
-                         thrust::make_zip_iterator(srcs.end(),
-                                                   dsts.end(),
-                                                   ids->end(),
-                                                   types->end(),
-                                                   start_times->end(),
-                                                   end_times->end()));
+            cugraph::sort_wrapper(handle.get_thrust_policy(),
+                                  thrust::make_zip_iterator(srcs.begin(),
+                                                            dsts.begin(),
+                                                            ids->begin(),
+                                                            types->begin(),
+                                                            start_times->begin(),
+                                                            end_times->begin()),
+                                  thrust::make_zip_iterator(srcs.end(),
+                                                            dsts.end(),
+                                                            ids->end(),
+                                                            types->end(),
+                                                            start_times->end(),
+                                                            end_times->end()));
           } else {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), ids->begin(), types->begin(), start_times->begin()),
@@ -266,14 +269,14 @@ void sort(raft::handle_t const& handle,
           }
         } else {
           if (end_times) {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), ids->begin(), types->begin(), end_times->begin()),
               thrust::make_zip_iterator(
                 srcs.end(), dsts.end(), ids->end(), types->end(), end_times->end()));
           } else {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(), dsts.begin(), ids->begin(), types->begin()),
               thrust::make_zip_iterator(srcs.end(), dsts.end(), ids->end(), types->end()));
@@ -282,14 +285,14 @@ void sort(raft::handle_t const& handle,
       } else {
         if (start_times) {
           if (end_times) {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), ids->begin(), start_times->begin(), end_times->begin()),
               thrust::make_zip_iterator(
                 srcs.end(), dsts.end(), ids->end(), start_times->end(), end_times->end()));
           } else {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), ids->begin(), start_times->begin()),
@@ -297,15 +300,16 @@ void sort(raft::handle_t const& handle,
           }
         } else {
           if (end_times) {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), ids->begin(), end_times->begin()),
               thrust::make_zip_iterator(srcs.end(), dsts.end(), ids->end(), end_times->end()));
           } else {
-            thrust::sort(handle.get_thrust_policy(),
-                         thrust::make_zip_iterator(srcs.begin(), dsts.begin(), ids->begin()),
-                         thrust::make_zip_iterator(srcs.end(), dsts.end(), ids->end()));
+            cugraph::sort_wrapper(
+              handle.get_thrust_policy(),
+              thrust::make_zip_iterator(srcs.begin(), dsts.begin(), ids->begin()),
+              thrust::make_zip_iterator(srcs.end(), dsts.end(), ids->end()));
           }
         }
       }
@@ -313,7 +317,7 @@ void sort(raft::handle_t const& handle,
       if (types) {
         if (start_times) {
           if (end_times) {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(),
                                         dsts.begin(),
@@ -323,7 +327,7 @@ void sort(raft::handle_t const& handle,
               thrust::make_zip_iterator(
                 srcs.end(), dsts.end(), types->end(), start_times->end(), end_times->end()));
           } else {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), types->begin(), start_times->begin()),
@@ -331,40 +335,43 @@ void sort(raft::handle_t const& handle,
           }
         } else {
           if (end_times) {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), types->begin(), end_times->begin()),
               thrust::make_zip_iterator(srcs.end(), dsts.end(), types->end(), end_times->end()));
           } else {
-            thrust::sort(handle.get_thrust_policy(),
-                         thrust::make_zip_iterator(srcs.begin(), dsts.begin(), types->begin()),
-                         thrust::make_zip_iterator(srcs.end(), dsts.end(), types->end()));
+            cugraph::sort_wrapper(
+              handle.get_thrust_policy(),
+              thrust::make_zip_iterator(srcs.begin(), dsts.begin(), types->begin()),
+              thrust::make_zip_iterator(srcs.end(), dsts.end(), types->end()));
           }
         }
       } else {
         if (start_times) {
           if (end_times) {
-            thrust::sort(handle.get_thrust_policy(),
-                         thrust::make_zip_iterator(
-                           srcs.begin(), dsts.begin(), start_times->begin(), end_times->begin()),
-                         thrust::make_zip_iterator(
-                           srcs.end(), dsts.end(), start_times->end(), end_times->end()));
+            cugraph::sort_wrapper(
+              handle.get_thrust_policy(),
+              thrust::make_zip_iterator(
+                srcs.begin(), dsts.begin(), start_times->begin(), end_times->begin()),
+              thrust::make_zip_iterator(
+                srcs.end(), dsts.end(), start_times->end(), end_times->end()));
           } else {
-            thrust::sort(
+            cugraph::sort_wrapper(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(), dsts.begin(), start_times->begin()),
               thrust::make_zip_iterator(srcs.end(), dsts.end(), start_times->end()));
           }
         } else {
           if (end_times) {
-            thrust::sort(handle.get_thrust_policy(),
-                         thrust::make_zip_iterator(srcs.begin(), dsts.begin(), end_times->begin()),
-                         thrust::make_zip_iterator(srcs.end(), dsts.end(), end_times->end()));
+            cugraph::sort_wrapper(
+              handle.get_thrust_policy(),
+              thrust::make_zip_iterator(srcs.begin(), dsts.begin(), end_times->begin()),
+              thrust::make_zip_iterator(srcs.end(), dsts.end(), end_times->end()));
           } else {
-            thrust::sort(handle.get_thrust_policy(),
-                         thrust::make_zip_iterator(srcs.begin(), dsts.begin()),
-                         thrust::make_zip_iterator(srcs.end(), dsts.end()));
+            cugraph::sort_wrapper(handle.get_thrust_policy(),
+                                  thrust::make_zip_iterator(srcs.begin(), dsts.begin()),
+                                  thrust::make_zip_iterator(srcs.end(), dsts.end()));
           }
         }
       }


### PR DESCRIPTION
Continuing the work to reduce the binary size.

This PR wraps thrust::sort so it can be compiled in libcugraph_common.so for most cases, added new function cugraph::sort_wrapper which either calls thrust::sort inline or calls one of the pre-compiled variants.  Note that we'd like to name the function cugraph::sort, however there's a problem getting that to work, so we're using cugraph::sort_wrapper for the time being.

## Size reduction breakdown

| Stage | `libcugraph_common.so` | `libcugraph.so` | `libcugraph_mg.so` | Combined |
|---|---|---|---|---|
| CUDA 12 Before | 97 MB | 783 MB | 967 MB | 1847 MB |
| CUDA 12 After |  98 MB (+1, +1.1%) | 756 MB (-27, -3.4%) | 940 MB (-27, -2.8%) | 1794 MB (-53, -2.87%) |
|---|---|---|---|---|
| CUDA 13 Before | 49 MB | 383 MB | 466 MB | 898 MB |
| CUDA 13 After |  49 MB (+0, +0%)| 370 MB (-13, -3.4%)| 452  MB (-14, -3.0%) | 871 MB (-27, -3.0%)|
