### PR TITLE
Improve Louvain determinism

### DIFF
--- a/cpp/include/cugraph/algorithms.hpp
+++ b/cpp/include/cugraph/algorithms.hpp
@@ -528,7 +528,11 @@ weight_t hungarian(raft::handle_t const& handle,
  *                               are assumed to be 1.0.
   @param[out] clustering         Pointer to device array where the clustering should be stored
  * @param[in]  max_level         (optional) maximum number of levels to run (default 100)
- * @param[in]  threshold         (optional) threshold for convergence at each level (default 1e-7)
+ * @param[in]  threshold         (optional) Minimum modularity gain threshold for each level.
+ *                               A vertex move is accepted only if its delta modularity exceeds
+ *                               @p threshold, and an iteration is committed / the level loop
+ *                               continues only if the global modularity gain exceeds @p threshold.
+ *                               (default 1e-7)
  * @param[in]  resolution        (optional) The value of the resolution parameter to use.
  *                               Called gamma in the modularity formula, this changes the size
  *                               of the communities.  Higher resolutions lead to more smaller
@@ -577,7 +581,11 @@ std::pair<size_t, weight_t> louvain(
  *                               If @pedge_weight_view.has_value() == false, edge weights
  *                               are assumed to be 1.0.
  * @param[in]  max_level         (optional) maximum number of levels to run (default 100)
- * @param[in]  threshold         (optional) threshold for convergence at each level (default 1e-7)
+ * @param[in]  threshold         (optional) Minimum modularity gain threshold for each level.
+ *                               A vertex move is accepted only if its delta modularity exceeds
+ *                               @p threshold, and an iteration is committed / the level loop
+ *                               continues only if the global modularity gain exceeds @p threshold.
+ *                               (default 1e-7)
  * @param[in]  resolution        (optional) The value of the resolution parameter to use.
  *                               Called gamma in the modularity formula, this changes the size
  *                               of the communities.  Higher resolutions lead to more smaller
@@ -755,7 +763,11 @@ std::pair<size_t, weight_t> leiden(
  *                               algorithm if an edge does not appear in any of the ensemble runs.
  * @param[in]  ensemble_size     The ensemble size parameter
  * @param[in]  max_level         (optional) maximum number of levels to run (default 100)
- * @param[in]  threshold         (optional) threshold for convergence at each level (default 1e-7)
+ * @param[in]  threshold         (optional) Minimum modularity gain threshold for each level.
+ *                               A vertex move is accepted only if its delta modularity exceeds
+ *                               @p threshold, and an iteration is committed / the level loop
+ *                               continues only if the global modularity gain exceeds @p threshold.
+ *                               (default 1e-7)
  * @param[in]  resolution        (optional) The value of the resolution parameter to use.
  *                               Called gamma in the modularity formula, this changes the size
  *                               of the communities.  Higher resolutions lead to more smaller

--- a/cpp/src/community/detail/common_methods.cuh
+++ b/cpp/src/community/detail/common_methods.cuh
@@ -93,6 +93,7 @@ struct reduce_op_t {
 template <typename vertex_t, typename weight_t>
 struct count_updown_moves_op_t {
   bool up_down{};
+  weight_t min_gain{};
   __device__ auto operator()(
     cuda::std::tuple<vertex_t, cuda::std::tuple<vertex_t, weight_t>> p) const
   {
@@ -102,25 +103,25 @@ struct count_updown_moves_op_t {
     weight_t delta_modularity  = cuda::std::get<1>(new_cluster_gain_pair);
 
     auto result_assignment =
-      (delta_modularity > weight_t{0})
+      (delta_modularity > min_gain)
         ? (((new_cluster > old_cluster) != up_down) ? old_cluster : new_cluster)
         : old_cluster;
 
-    return (delta_modularity > weight_t{0})
-             ? (((new_cluster > old_cluster) != up_down) ? false : true)
-             : false;
+    return (delta_modularity > min_gain) ? (((new_cluster > old_cluster) != up_down) ? false : true)
+                                         : false;
   }
 };
 // FIXME: a workaround for cudaErrorInvalidDeviceFunction error when device lambda is used
 template <typename vertex_t, typename weight_t>
 struct cluster_update_op_t {
   bool up_down{};
+  weight_t min_gain{};
   __device__ auto operator()(vertex_t old_cluster, cuda::std::tuple<vertex_t, weight_t> p) const
   {
     vertex_t new_cluster      = cuda::std::get<0>(p);
     weight_t delta_modularity = cuda::std::get<1>(p);
 
-    return (delta_modularity > weight_t{0})
+    return (delta_modularity > min_gain)
              ? (((new_cluster > old_cluster) != up_down) ? old_cluster : new_cluster)
              : old_cluster;
   }
@@ -246,7 +247,8 @@ rmm::device_uvector<vertex_t> update_clustering_by_delta_modularity(
   edge_src_property_t<vertex_t, weight_t> const& src_vertex_weights_cache,
   edge_src_property_t<vertex_t, vertex_t> const& src_clusters_cache,
   edge_dst_property_t<vertex_t, vertex_t> const& dst_clusters_cache,
-  bool up_down)
+  bool up_down,
+  weight_t threshold)
 {
   CUGRAPH_EXPECTS(edge_weight_view.has_value(), "Graph must be weighted.");
 
@@ -398,7 +400,7 @@ rmm::device_uvector<vertex_t> update_clustering_by_delta_modularity(
                                                cugraph::get_dataframe_buffer_begin(output_buffer)),
                      thrust::make_zip_iterator(next_clusters_v.end(),
                                                cugraph::get_dataframe_buffer_end(output_buffer)),
-                     detail::count_updown_moves_op_t<vertex_t, weight_t>{up_down});
+                     detail::count_updown_moves_op_t<vertex_t, weight_t>{up_down, threshold});
 
   if constexpr (multi_gpu) {
     nr_moves = host_scalar_allreduce(
@@ -412,7 +414,7 @@ rmm::device_uvector<vertex_t> update_clustering_by_delta_modularity(
                     next_clusters_v.end(),
                     cugraph::get_dataframe_buffer_begin(output_buffer),
                     next_clusters_v.begin(),
-                    detail::cluster_update_op_t<vertex_t, weight_t>{up_down});
+                    detail::cluster_update_op_t<vertex_t, weight_t>{up_down, threshold});
 
   return std::move(next_clusters_v);
 }

--- a/cpp/src/community/detail/common_methods.hpp
+++ b/cpp/src/community/detail/common_methods.hpp
@@ -93,7 +93,8 @@ rmm::device_uvector<vertex_t> update_clustering_by_delta_modularity(
   edge_src_property_t<vertex_t, weight_t> const& src_vertex_weights_cache,
   edge_src_property_t<vertex_t, vertex_t> const& src_clusters_cache,
   edge_dst_property_t<vertex_t, vertex_t> const& dst_clusters_cache,
-  bool up_down);
+  bool up_down,
+  weight_t threshold);
 
 template <typename vertex_t, typename edge_t, typename weight_t, bool multi_gpu>
 std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<weight_t>>

--- a/cpp/src/community/detail/common_methods_mg_v32_e32.cu
+++ b/cpp/src/community/detail/common_methods_mg_v32_e32.cu
@@ -58,7 +58,8 @@ template CUGRAPH_EXPORT rmm::device_uvector<int32_t> update_clustering_by_delta_
   edge_src_property_t<int32_t, float> const& src_vertex_weights_cache,
   edge_src_property_t<int32_t, int32_t> const& src_clusters_cache,
   edge_dst_property_t<int32_t, int32_t> const& dst_clusters_cache,
-  bool up_down);
+  bool up_down,
+  float threshold);
 
 template CUGRAPH_EXPORT rmm::device_uvector<int32_t> update_clustering_by_delta_modularity(
   raft::handle_t const& handle,
@@ -73,7 +74,8 @@ template CUGRAPH_EXPORT rmm::device_uvector<int32_t> update_clustering_by_delta_
   edge_src_property_t<int32_t, double> const& src_vertex_weights_cache,
   edge_src_property_t<int32_t, int32_t> const& src_clusters_cache,
   edge_dst_property_t<int32_t, int32_t> const& dst_clusters_cache,
-  bool up_down);
+  bool up_down,
+  double threshold);
 
 template CUGRAPH_EXPORT std::tuple<rmm::device_uvector<int32_t>, rmm::device_uvector<float>>
 compute_cluster_keys_and_values(

--- a/cpp/src/community/detail/common_methods_mg_v64_e64.cu
+++ b/cpp/src/community/detail/common_methods_mg_v64_e64.cu
@@ -58,7 +58,8 @@ template CUGRAPH_EXPORT rmm::device_uvector<int64_t> update_clustering_by_delta_
   edge_src_property_t<int64_t, float> const& src_vertex_weights_cache,
   edge_src_property_t<int64_t, int64_t> const& src_clusters_cache,
   edge_dst_property_t<int64_t, int64_t> const& dst_clusters_cache,
-  bool up_down);
+  bool up_down,
+  float threshold);
 
 template CUGRAPH_EXPORT rmm::device_uvector<int64_t> update_clustering_by_delta_modularity(
   raft::handle_t const& handle,
@@ -73,7 +74,8 @@ template CUGRAPH_EXPORT rmm::device_uvector<int64_t> update_clustering_by_delta_
   edge_src_property_t<int64_t, double> const& src_vertex_weights_cache,
   edge_src_property_t<int64_t, int64_t> const& src_clusters_cache,
   edge_dst_property_t<int64_t, int64_t> const& dst_clusters_cache,
-  bool up_down);
+  bool up_down,
+  double threshold);
 
 template CUGRAPH_EXPORT std::tuple<rmm::device_uvector<int64_t>, rmm::device_uvector<float>>
 compute_cluster_keys_and_values(

--- a/cpp/src/community/detail/common_methods_sg_v32_e32.cu
+++ b/cpp/src/community/detail/common_methods_sg_v32_e32.cu
@@ -58,7 +58,8 @@ template CUGRAPH_EXPORT rmm::device_uvector<int32_t> update_clustering_by_delta_
   edge_src_property_t<int32_t, float> const& src_vertex_weights_cache,
   edge_src_property_t<int32_t, int32_t> const& src_clusters_cache,
   edge_dst_property_t<int32_t, int32_t> const& dst_clusters_cache,
-  bool up_down);
+  bool up_down,
+  float threshold);
 
 template CUGRAPH_EXPORT rmm::device_uvector<int32_t> update_clustering_by_delta_modularity(
   raft::handle_t const& handle,
@@ -73,7 +74,8 @@ template CUGRAPH_EXPORT rmm::device_uvector<int32_t> update_clustering_by_delta_
   edge_src_property_t<int32_t, double> const& src_vertex_weights_cache,
   edge_src_property_t<int32_t, int32_t> const& src_clusters_cache,
   edge_dst_property_t<int32_t, int32_t> const& dst_clusters_cache,
-  bool up_down);
+  bool up_down,
+  double threshold);
 
 template CUGRAPH_EXPORT std::tuple<rmm::device_uvector<int32_t>, rmm::device_uvector<float>>
 compute_cluster_keys_and_values(

--- a/cpp/src/community/detail/common_methods_sg_v64_e64.cu
+++ b/cpp/src/community/detail/common_methods_sg_v64_e64.cu
@@ -58,7 +58,8 @@ template CUGRAPH_EXPORT rmm::device_uvector<int64_t> update_clustering_by_delta_
   edge_src_property_t<int64_t, float> const& src_vertex_weights_cache,
   edge_src_property_t<int64_t, int64_t> const& src_clusters_cache,
   edge_dst_property_t<int64_t, int64_t> const& dst_clusters_cache,
-  bool up_down);
+  bool up_down,
+  float threshold);
 
 template CUGRAPH_EXPORT rmm::device_uvector<int64_t> update_clustering_by_delta_modularity(
   raft::handle_t const& handle,
@@ -73,7 +74,8 @@ template CUGRAPH_EXPORT rmm::device_uvector<int64_t> update_clustering_by_delta_
   edge_src_property_t<int64_t, double> const& src_vertex_weights_cache,
   edge_src_property_t<int64_t, int64_t> const& src_clusters_cache,
   edge_dst_property_t<int64_t, int64_t> const& dst_clusters_cache,
-  bool up_down);
+  bool up_down,
+  double threshold);
 
 template CUGRAPH_EXPORT std::tuple<rmm::device_uvector<int64_t>, rmm::device_uvector<float>>
 compute_cluster_keys_and_values(

--- a/cpp/src/community/leiden_impl.cuh
+++ b/cpp/src/community/leiden_impl.cuh
@@ -322,7 +322,8 @@ std::pair<std::unique_ptr<Dendrogram<vertex_t>>, weight_t> leiden(
                                                       src_vertex_weights_cache,
                                                       src_louvain_assignment_cache,
                                                       dst_louvain_assignment_cache,
-                                                      up_down);
+                                                      up_down,
+                                                      weight_t{0});
 
       if constexpr (graph_view_t::is_multi_gpu) {
         update_edge_src_property(handle,

--- a/cpp/src/community/louvain_impl.cuh
+++ b/cpp/src/community/louvain_impl.cuh
@@ -201,7 +201,8 @@ std::pair<std::unique_ptr<Dendrogram<vertex_t>>, weight_t> louvain(
                                                                       src_vertex_weights_cache,
                                                                       src_clusters_cache,
                                                                       dst_clusters_cache,
-                                                                      up_down);
+                                                                      up_down,
+                                                                      threshold);
 
       if constexpr (graph_view_t::is_multi_gpu) {
         update_edge_src_property(
@@ -225,7 +226,7 @@ std::pair<std::unique_ptr<Dendrogram<vertex_t>>, weight_t> louvain(
                                          total_edge_weight,
                                          resolution);
 
-      if (new_Q > cur_Q) {
+      if (new_Q > (cur_Q + threshold)) {
         raft::copy(dendrogram->current_level_begin(),
                    next_clusters_v.begin(),
                    next_clusters_v.size(),

--- a/cpp/tests/community/louvain_test.cpp
+++ b/cpp/tests/community/louvain_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.  All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.  All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "utilities/base_fixture.hpp"
@@ -232,8 +232,8 @@ INSTANTIATE_TEST_SUITE_P(
   ::testing::Combine(::testing::Values(
                        Louvain_Usecase{
                          std::nullopt, std::nullopt, std::nullopt, true, 3, 0.39907956},
-                       Louvain_Usecase{20, double{1e-3}, std::nullopt, true, 3, 0.39907956},
-                       Louvain_Usecase{100, double{1e-3}, double{0.8}, true, 3, 0.47547662}),
+                       Louvain_Usecase{20, double{1e-3}, std::nullopt, true, 3, 0.41978961},
+                       Louvain_Usecase{100, double{1e-3}, double{0.8}, true, 3, 0.48573306}),
                      ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Update the threshold parameter to also use it for comparing to decide if a delta modularity is worth moving to a new cluster.

We occasionally see non-deterministic results across runs with the same graph due to numerical instability.  The fundamental issue arises when the delta modularity gets small, and when that happens we occasionally move vertices between clusters when the change in modularity is in fact not significant.

This PR uses the existing threshold parameter, which was previously used solely to decide whether we had converged or not, to decide whether a delta modularity is worth moving a vertex as well.  The consequence of this change is that the user has the ability to adjust the threshold to increase the determinism (a larger threshold causes movement of vertices between clusters to stop earlier in each level of the hierarchical clustering).

Closes #5516 