### PR TITLE
Fix pagerank typo

### DIFF
--- a/cpp/tests/link_analysis/pagerank_test.cpp
+++ b/cpp/tests/link_analysis/pagerank_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/link_analysis/pagerank_test.cpp
+++ b/cpp/tests/link_analysis/pagerank_test.cpp
@@ -327,7 +327,7 @@ class Tests_PageRank
 
       auto threshold_ratio = 1e-3;
       auto threshold_magnitude =
-        1e-6;  // skip comparison for low PageRank verties (lowly ranked vertices)
+        1e-6;  // skip comparison for low PageRank vertices (lowly ranked vertices)
       auto nearly_equal = [threshold_ratio, threshold_magnitude](auto lhs, auto rhs) {
         return std::abs(lhs - rhs) <
                std::max(std::max(lhs, rhs) * threshold_ratio, threshold_magnitude);


### PR DESCRIPTION
This is a tiny PR to fix a typo ("verties"  $\to$ "vertices") in the comments of the pagerank tests.