### PR TITLE
Reduce binary size scan

### DIFF
--- a/cpp/include/cugraph/prims/detail/extract_transform_if_v_frontier_e.cuh
+++ b/cpp/include/cugraph/prims/detail/extract_transform_if_v_frontier_e.cuh
@@ -1572,10 +1572,10 @@ extract_transform_if_v_frontier_e(raft::handle_t const& handle,
                     auto major_offset = edge_partition.major_offset_from_major_nocheck(major);
                     return static_cast<size_t>(edge_partition.local_degree(major_offset));
                   }));
-              thrust::inclusive_scan(rmm::exec_policy_nosync(loop_stream),
-                                     key_local_degree_first,
-                                     key_local_degree_first + key_segment_offsets[1],
-                                     high_segment_key_local_degree_offsets.begin() + 1);
+              cugraph::inclusive_scan_wrapper(rmm::exec_policy_nosync(loop_stream),
+                                              key_local_degree_first,
+                                              key_local_degree_first + key_segment_offsets[1],
+                                              high_segment_key_local_degree_offsets.begin() + 1);
               computed = true;
             }
           }
@@ -1596,10 +1596,10 @@ extract_transform_if_v_frontier_e(raft::handle_t const& handle,
                 auto major_offset = edge_partition.major_offset_from_major_nocheck(major);
                 return static_cast<size_t>(edge_partition.local_degree(major_offset));
               }));
-            thrust::inclusive_scan(rmm::exec_policy_nosync(loop_stream),
-                                   key_local_degree_first,
-                                   key_local_degree_first + key_segment_offsets[1],
-                                   high_segment_key_local_degree_offsets.begin() + 1);
+            cugraph::inclusive_scan_wrapper(rmm::exec_policy_nosync(loop_stream),
+                                            key_local_degree_first,
+                                            key_local_degree_first + key_segment_offsets[1],
+                                            high_segment_key_local_degree_offsets.begin() + 1);
           }
           thrust::copy(rmm::exec_policy_nosync(loop_stream),
                        high_segment_key_local_degree_offsets.begin() + key_segment_offsets[1],

--- a/cpp/include/cugraph/prims/detail/extract_transform_if_v_frontier_e.cuh
+++ b/cpp/include/cugraph/prims/detail/extract_transform_if_v_frontier_e.cuh
@@ -1572,10 +1572,10 @@ extract_transform_if_v_frontier_e(raft::handle_t const& handle,
                     auto major_offset = edge_partition.major_offset_from_major_nocheck(major);
                     return static_cast<size_t>(edge_partition.local_degree(major_offset));
                   }));
-              cugraph::inclusive_scan_wrapper(rmm::exec_policy_nosync(loop_stream),
-                                              key_local_degree_first,
-                                              key_local_degree_first + key_segment_offsets[1],
-                                              high_segment_key_local_degree_offsets.begin() + 1);
+              cugraph::inclusive_scan(rmm::exec_policy_nosync(loop_stream),
+                                      key_local_degree_first,
+                                      key_local_degree_first + key_segment_offsets[1],
+                                      high_segment_key_local_degree_offsets.begin() + 1);
               computed = true;
             }
           }
@@ -1596,10 +1596,10 @@ extract_transform_if_v_frontier_e(raft::handle_t const& handle,
                 auto major_offset = edge_partition.major_offset_from_major_nocheck(major);
                 return static_cast<size_t>(edge_partition.local_degree(major_offset));
               }));
-            cugraph::inclusive_scan_wrapper(rmm::exec_policy_nosync(loop_stream),
-                                            key_local_degree_first,
-                                            key_local_degree_first + key_segment_offsets[1],
-                                            high_segment_key_local_degree_offsets.begin() + 1);
+            cugraph::inclusive_scan(rmm::exec_policy_nosync(loop_stream),
+                                    key_local_degree_first,
+                                    key_local_degree_first + key_segment_offsets[1],
+                                    high_segment_key_local_degree_offsets.begin() + 1);
           }
           thrust::copy(rmm::exec_policy_nosync(loop_stream),
                        high_segment_key_local_degree_offsets.begin() + key_segment_offsets[1],

--- a/cpp/include/cugraph/prims/detail/nbr_intersection.cuh
+++ b/cpp/include/cugraph/prims/detail/nbr_intersection.cuh
@@ -881,10 +881,10 @@ nbr_intersection(raft::handle_t const& handle,
 
         rmm::device_uvector<size_t> d_rx_reordered_group_lasts(rx_reordered_group_counts.size(),
                                                                handle.get_stream());
-        cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                        rx_reordered_group_counts.begin(),
-                                        rx_reordered_group_counts.end(),
-                                        d_rx_reordered_group_lasts.begin());
+        cugraph::inclusive_scan(handle.get_thrust_policy(),
+                                rx_reordered_group_counts.begin(),
+                                rx_reordered_group_counts.end(),
+                                d_rx_reordered_group_lasts.begin());
         std::vector<size_t> h_rx_reordered_group_lasts(d_rx_reordered_group_lasts.size());
         raft::update_host(h_rx_reordered_group_lasts.data(),
                           d_rx_reordered_group_lasts.data(),
@@ -938,10 +938,10 @@ nbr_intersection(raft::handle_t const& handle,
         local_nbr_offsets_for_rx_majors.set_element_to_zero_async(size_t{0}, handle.get_stream());
         auto degree_first = cuda::make_transform_iterator(local_degrees_for_rx_majors.begin(),
                                                           detail::typecast_t<edge_t, size_t>{});
-        cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                        degree_first,
-                                        degree_first + local_degrees_for_rx_majors.size(),
-                                        local_nbr_offsets_for_rx_majors.begin() + 1);
+        cugraph::inclusive_scan(handle.get_thrust_policy(),
+                                degree_first,
+                                degree_first + local_degrees_for_rx_majors.size(),
+                                local_nbr_offsets_for_rx_majors.begin() + 1);
 
         local_nbrs_for_rx_majors.resize(
           local_nbr_offsets_for_rx_majors.back_element(handle.get_stream()), handle.get_stream());
@@ -1037,10 +1037,10 @@ nbr_intersection(raft::handle_t const& handle,
         (*major_nbr_offsets).set_element_to_zero_async(size_t{0}, handle.get_stream());
         auto degree_first = cuda::make_transform_iterator(local_degrees_for_unique_majors.begin(),
                                                           detail::typecast_t<edge_t, size_t>{});
-        cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                        degree_first,
-                                        degree_first + local_degrees_for_unique_majors.size(),
-                                        (*major_nbr_offsets).begin() + 1);
+        cugraph::inclusive_scan(handle.get_thrust_policy(),
+                                degree_first,
+                                degree_first + local_degrees_for_unique_majors.size(),
+                                (*major_nbr_offsets).begin() + 1);
       }
 
       std::tie(major_nbr_indices, std::ignore) = shuffle_values(
@@ -1240,10 +1240,10 @@ nbr_intersection(raft::handle_t const& handle,
                                                                      handle.get_stream());
         auto size_first = cuda::make_transform_iterator(
           rx_v_pair_nbr_intersection_sizes.begin(), cugraph::detail::typecast_t<edge_t, size_t>{});
-        cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                        size_first,
-                                        size_first + rx_v_pair_nbr_intersection_sizes.size(),
-                                        rx_v_pair_nbr_intersection_offsets.begin() + 1);
+        cugraph::inclusive_scan(handle.get_thrust_policy(),
+                                size_first,
+                                size_first + rx_v_pair_nbr_intersection_sizes.size(),
+                                rx_v_pair_nbr_intersection_offsets.begin() + 1);
 
         rx_v_pair_nbr_intersection_indices.resize(
           rx_v_pair_nbr_intersection_offsets.back_element(handle.get_stream()),
@@ -1351,10 +1351,10 @@ nbr_intersection(raft::handle_t const& handle,
           rx_v_pair_nbr_intersection_e_property_values1.shrink_to_fit(handle.get_stream());
         }
 
-        cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                        size_first,
-                                        size_first + rx_v_pair_nbr_intersection_sizes.size(),
-                                        rx_v_pair_nbr_intersection_offsets.begin() + 1);
+        cugraph::inclusive_scan(handle.get_thrust_policy(),
+                                size_first,
+                                size_first + rx_v_pair_nbr_intersection_sizes.size(),
+                                rx_v_pair_nbr_intersection_offsets.begin() + 1);
 
         std::vector<size_t> h_rx_v_pair_lasts(rx_v_pair_counts.size());
         std::inclusive_scan(
@@ -1434,22 +1434,20 @@ nbr_intersection(raft::handle_t const& handle,
         combined_nbr_intersection_offsets.set_element_to_zero_async(size_t{0}, handle.get_stream());
         auto combined_size_first = cuda::make_transform_iterator(
           combined_nbr_intersection_sizes.begin(), detail::typecast_t<edge_t, size_t>{});
-        cugraph::inclusive_scan_wrapper(
-          handle.get_thrust_policy(),
-          combined_size_first,
-          combined_size_first + combined_nbr_intersection_sizes.size(),
-          combined_nbr_intersection_offsets.begin() + 1);
+        cugraph::inclusive_scan(handle.get_thrust_policy(),
+                                combined_size_first,
+                                combined_size_first + combined_nbr_intersection_sizes.size(),
+                                combined_nbr_intersection_offsets.begin() + 1);
 
         gathered_nbr_intersection_offsets.resize(gathered_nbr_intersection_sizes.size() + 1,
                                                  handle.get_stream());
         gathered_nbr_intersection_offsets.set_element_to_zero_async(size_t{0}, handle.get_stream());
         auto gathered_size_first = cuda::make_transform_iterator(
           gathered_nbr_intersection_sizes.begin(), detail::typecast_t<edge_t, size_t>{});
-        cugraph::inclusive_scan_wrapper(
-          handle.get_thrust_policy(),
-          gathered_size_first,
-          gathered_size_first + gathered_nbr_intersection_sizes.size(),
-          gathered_nbr_intersection_offsets.begin() + 1);
+        cugraph::inclusive_scan(handle.get_thrust_policy(),
+                                gathered_size_first,
+                                gathered_size_first + gathered_nbr_intersection_sizes.size(),
+                                gathered_nbr_intersection_offsets.begin() + 1);
 
         auto map_first = cuda::make_transform_iterator(
           thrust::make_counting_iterator(size_t{1}),
@@ -1667,10 +1665,10 @@ nbr_intersection(raft::handle_t const& handle,
     nbr_intersection_offsets.set_element_to_zero_async(size_t{0}, handle.get_stream());
     auto size_first = cuda::make_transform_iterator(nbr_intersection_sizes.begin(),
                                                     detail::typecast_t<edge_t, size_t>{});
-    cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                    size_first,
-                                    size_first + nbr_intersection_sizes.size(),
-                                    nbr_intersection_offsets.begin() + 1);
+    cugraph::inclusive_scan(handle.get_thrust_policy(),
+                            size_first,
+                            size_first + nbr_intersection_sizes.size(),
+                            nbr_intersection_offsets.begin() + 1);
   } else {
     auto edge_partition =
       edge_partition_device_view_t<vertex_t, edge_t, GraphViewType::is_multi_gpu>(
@@ -1706,10 +1704,10 @@ nbr_intersection(raft::handle_t const& handle,
     nbr_intersection_offsets.set_element_to_zero_async(size_t{0}, handle.get_stream());
     auto size_first = cuda::make_transform_iterator(nbr_intersection_sizes.begin(),
                                                     detail::typecast_t<edge_t, size_t>{});
-    cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                    size_first,
-                                    size_first + nbr_intersection_sizes.size(),
-                                    nbr_intersection_offsets.begin() + 1);
+    cugraph::inclusive_scan(handle.get_thrust_policy(),
+                            size_first,
+                            size_first + nbr_intersection_sizes.size(),
+                            nbr_intersection_offsets.begin() + 1);
 
     nbr_intersection_indices.resize(nbr_intersection_offsets.back_element(handle.get_stream()),
                                     handle.get_stream());
@@ -1855,10 +1853,10 @@ nbr_intersection(raft::handle_t const& handle,
     }
 #endif
 
-    cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                    size_first,
-                                    size_first + nbr_intersection_sizes.size(),
-                                    nbr_intersection_offsets.begin() + 1);
+    cugraph::inclusive_scan(handle.get_thrust_policy(),
+                            size_first,
+                            size_first + nbr_intersection_sizes.size(),
+                            nbr_intersection_offsets.begin() + 1);
   }
 
   // 5. Return

--- a/cpp/include/cugraph/prims/detail/nbr_intersection.cuh
+++ b/cpp/include/cugraph/prims/detail/nbr_intersection.cuh
@@ -881,10 +881,10 @@ nbr_intersection(raft::handle_t const& handle,
 
         rmm::device_uvector<size_t> d_rx_reordered_group_lasts(rx_reordered_group_counts.size(),
                                                                handle.get_stream());
-        thrust::inclusive_scan(handle.get_thrust_policy(),
-                               rx_reordered_group_counts.begin(),
-                               rx_reordered_group_counts.end(),
-                               d_rx_reordered_group_lasts.begin());
+        cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                        rx_reordered_group_counts.begin(),
+                                        rx_reordered_group_counts.end(),
+                                        d_rx_reordered_group_lasts.begin());
         std::vector<size_t> h_rx_reordered_group_lasts(d_rx_reordered_group_lasts.size());
         raft::update_host(h_rx_reordered_group_lasts.data(),
                           d_rx_reordered_group_lasts.data(),
@@ -893,10 +893,10 @@ nbr_intersection(raft::handle_t const& handle,
         handle.sync_stream();
 
         rmm::device_uvector<size_t> rx_group_firsts(rx_group_counts.size(), handle.get_stream());
-        thrust::exclusive_scan(handle.get_thrust_policy(),
-                               rx_group_counts.begin(),
-                               rx_group_counts.end(),
-                               rx_group_firsts.begin());
+        cugraph::exclusive_scan(handle.get_thrust_policy(),
+                                rx_group_counts.begin(),
+                                rx_group_counts.end(),
+                                rx_group_firsts.begin());
 
         local_degrees_for_rx_majors.resize(rx_majors.size(), handle.get_stream());
         for (size_t i = 0; i < graph_view.number_of_local_edge_partitions(); ++i) {
@@ -938,10 +938,10 @@ nbr_intersection(raft::handle_t const& handle,
         local_nbr_offsets_for_rx_majors.set_element_to_zero_async(size_t{0}, handle.get_stream());
         auto degree_first = cuda::make_transform_iterator(local_degrees_for_rx_majors.begin(),
                                                           detail::typecast_t<edge_t, size_t>{});
-        thrust::inclusive_scan(handle.get_thrust_policy(),
-                               degree_first,
-                               degree_first + local_degrees_for_rx_majors.size(),
-                               local_nbr_offsets_for_rx_majors.begin() + 1);
+        cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                        degree_first,
+                                        degree_first + local_degrees_for_rx_majors.size(),
+                                        local_nbr_offsets_for_rx_majors.begin() + 1);
 
         local_nbrs_for_rx_majors.resize(
           local_nbr_offsets_for_rx_majors.back_element(handle.get_stream()), handle.get_stream());
@@ -1037,10 +1037,10 @@ nbr_intersection(raft::handle_t const& handle,
         (*major_nbr_offsets).set_element_to_zero_async(size_t{0}, handle.get_stream());
         auto degree_first = cuda::make_transform_iterator(local_degrees_for_unique_majors.begin(),
                                                           detail::typecast_t<edge_t, size_t>{});
-        thrust::inclusive_scan(handle.get_thrust_policy(),
-                               degree_first,
-                               degree_first + local_degrees_for_unique_majors.size(),
-                               (*major_nbr_offsets).begin() + 1);
+        cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                        degree_first,
+                                        degree_first + local_degrees_for_unique_majors.size(),
+                                        (*major_nbr_offsets).begin() + 1);
       }
 
       std::tie(major_nbr_indices, std::ignore) = shuffle_values(
@@ -1240,10 +1240,10 @@ nbr_intersection(raft::handle_t const& handle,
                                                                      handle.get_stream());
         auto size_first = cuda::make_transform_iterator(
           rx_v_pair_nbr_intersection_sizes.begin(), cugraph::detail::typecast_t<edge_t, size_t>{});
-        thrust::inclusive_scan(handle.get_thrust_policy(),
-                               size_first,
-                               size_first + rx_v_pair_nbr_intersection_sizes.size(),
-                               rx_v_pair_nbr_intersection_offsets.begin() + 1);
+        cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                        size_first,
+                                        size_first + rx_v_pair_nbr_intersection_sizes.size(),
+                                        rx_v_pair_nbr_intersection_offsets.begin() + 1);
 
         rx_v_pair_nbr_intersection_indices.resize(
           rx_v_pair_nbr_intersection_offsets.back_element(handle.get_stream()),
@@ -1351,10 +1351,10 @@ nbr_intersection(raft::handle_t const& handle,
           rx_v_pair_nbr_intersection_e_property_values1.shrink_to_fit(handle.get_stream());
         }
 
-        thrust::inclusive_scan(handle.get_thrust_policy(),
-                               size_first,
-                               size_first + rx_v_pair_nbr_intersection_sizes.size(),
-                               rx_v_pair_nbr_intersection_offsets.begin() + 1);
+        cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                        size_first,
+                                        size_first + rx_v_pair_nbr_intersection_sizes.size(),
+                                        rx_v_pair_nbr_intersection_offsets.begin() + 1);
 
         std::vector<size_t> h_rx_v_pair_lasts(rx_v_pair_counts.size());
         std::inclusive_scan(
@@ -1434,20 +1434,22 @@ nbr_intersection(raft::handle_t const& handle,
         combined_nbr_intersection_offsets.set_element_to_zero_async(size_t{0}, handle.get_stream());
         auto combined_size_first = cuda::make_transform_iterator(
           combined_nbr_intersection_sizes.begin(), detail::typecast_t<edge_t, size_t>{});
-        thrust::inclusive_scan(handle.get_thrust_policy(),
-                               combined_size_first,
-                               combined_size_first + combined_nbr_intersection_sizes.size(),
-                               combined_nbr_intersection_offsets.begin() + 1);
+        cugraph::inclusive_scan_wrapper(
+          handle.get_thrust_policy(),
+          combined_size_first,
+          combined_size_first + combined_nbr_intersection_sizes.size(),
+          combined_nbr_intersection_offsets.begin() + 1);
 
         gathered_nbr_intersection_offsets.resize(gathered_nbr_intersection_sizes.size() + 1,
                                                  handle.get_stream());
         gathered_nbr_intersection_offsets.set_element_to_zero_async(size_t{0}, handle.get_stream());
         auto gathered_size_first = cuda::make_transform_iterator(
           gathered_nbr_intersection_sizes.begin(), detail::typecast_t<edge_t, size_t>{});
-        thrust::inclusive_scan(handle.get_thrust_policy(),
-                               gathered_size_first,
-                               gathered_size_first + gathered_nbr_intersection_sizes.size(),
-                               gathered_nbr_intersection_offsets.begin() + 1);
+        cugraph::inclusive_scan_wrapper(
+          handle.get_thrust_policy(),
+          gathered_size_first,
+          gathered_size_first + gathered_nbr_intersection_sizes.size(),
+          gathered_nbr_intersection_offsets.begin() + 1);
 
         auto map_first = cuda::make_transform_iterator(
           thrust::make_counting_iterator(size_t{1}),
@@ -1665,10 +1667,10 @@ nbr_intersection(raft::handle_t const& handle,
     nbr_intersection_offsets.set_element_to_zero_async(size_t{0}, handle.get_stream());
     auto size_first = cuda::make_transform_iterator(nbr_intersection_sizes.begin(),
                                                     detail::typecast_t<edge_t, size_t>{});
-    thrust::inclusive_scan(handle.get_thrust_policy(),
-                           size_first,
-                           size_first + nbr_intersection_sizes.size(),
-                           nbr_intersection_offsets.begin() + 1);
+    cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                    size_first,
+                                    size_first + nbr_intersection_sizes.size(),
+                                    nbr_intersection_offsets.begin() + 1);
   } else {
     auto edge_partition =
       edge_partition_device_view_t<vertex_t, edge_t, GraphViewType::is_multi_gpu>(
@@ -1704,10 +1706,10 @@ nbr_intersection(raft::handle_t const& handle,
     nbr_intersection_offsets.set_element_to_zero_async(size_t{0}, handle.get_stream());
     auto size_first = cuda::make_transform_iterator(nbr_intersection_sizes.begin(),
                                                     detail::typecast_t<edge_t, size_t>{});
-    thrust::inclusive_scan(handle.get_thrust_policy(),
-                           size_first,
-                           size_first + nbr_intersection_sizes.size(),
-                           nbr_intersection_offsets.begin() + 1);
+    cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                    size_first,
+                                    size_first + nbr_intersection_sizes.size(),
+                                    nbr_intersection_offsets.begin() + 1);
 
     nbr_intersection_indices.resize(nbr_intersection_offsets.back_element(handle.get_stream()),
                                     handle.get_stream());
@@ -1853,10 +1855,10 @@ nbr_intersection(raft::handle_t const& handle,
     }
 #endif
 
-    thrust::inclusive_scan(handle.get_thrust_policy(),
-                           size_first,
-                           size_first + nbr_intersection_sizes.size(),
-                           nbr_intersection_offsets.begin() + 1);
+    cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                    size_first,
+                                    size_first + nbr_intersection_sizes.size(),
+                                    nbr_intersection_offsets.begin() + 1);
   }
 
   // 5. Return

--- a/cpp/include/cugraph/prims/detail/per_v_transform_reduce_e.cuh
+++ b/cpp/include/cugraph/prims/detail/per_v_transform_reduce_e.cuh
@@ -2251,7 +2251,7 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
                     input_count_offsets.resize(
                       (rx_bitmap.size() - packed_bool_offset(range_offset_first)) + 1, loop_stream);
                     input_count_offsets.set_element_to_zero_async(0, loop_stream);
-                    cugraph::inclusive_scan_wrapper(
+                    cugraph::inclusive_scan(
                       rmm::exec_policy_nosync(loop_stream),
                       input_count_first,
                       input_count_first +
@@ -2349,10 +2349,10 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
                       }));
                     output_count_offsets.resize(filtered_bitmap.size() + 1, loop_stream);
                     output_count_offsets.set_element_to_zero_async(0, loop_stream);
-                    cugraph::inclusive_scan_wrapper(rmm::exec_policy_nosync(loop_stream),
-                                                    output_count_first,
-                                                    output_count_first + filtered_bitmap.size(),
-                                                    output_count_offsets.begin() + 1);
+                    cugraph::inclusive_scan(rmm::exec_policy_nosync(loop_stream),
+                                            output_count_first,
+                                            output_count_first + filtered_bitmap.size(),
+                                            output_count_offsets.begin() + 1);
                   }
                 }
                 filtered_bitmap_vectors.push_back(std::move(filtered_bitmap));

--- a/cpp/include/cugraph/prims/detail/per_v_transform_reduce_e.cuh
+++ b/cpp/include/cugraph/prims/detail/per_v_transform_reduce_e.cuh
@@ -2251,7 +2251,7 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
                     input_count_offsets.resize(
                       (rx_bitmap.size() - packed_bool_offset(range_offset_first)) + 1, loop_stream);
                     input_count_offsets.set_element_to_zero_async(0, loop_stream);
-                    thrust::inclusive_scan(
+                    cugraph::inclusive_scan_wrapper(
                       rmm::exec_policy_nosync(loop_stream),
                       input_count_first,
                       input_count_first +
@@ -2349,10 +2349,10 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
                       }));
                     output_count_offsets.resize(filtered_bitmap.size() + 1, loop_stream);
                     output_count_offsets.set_element_to_zero_async(0, loop_stream);
-                    thrust::inclusive_scan(rmm::exec_policy_nosync(loop_stream),
-                                           output_count_first,
-                                           output_count_first + filtered_bitmap.size(),
-                                           output_count_offsets.begin() + 1);
+                    cugraph::inclusive_scan_wrapper(rmm::exec_policy_nosync(loop_stream),
+                                                    output_count_first,
+                                                    output_count_first + filtered_bitmap.size(),
+                                                    output_count_offsets.begin() + 1);
                   }
                 }
                 filtered_bitmap_vectors.push_back(std::move(filtered_bitmap));

--- a/cpp/include/cugraph/prims/detail/sample_and_compute_local_nbr_indices.cuh
+++ b/cpp/include/cugraph/prims/detail/sample_and_compute_local_nbr_indices.cuh
@@ -549,10 +549,10 @@ compute_valid_local_nbr_count_inclusive_sums(raft::handle_t const& handle,
         return static_cast<size_t>((local_degree + packed_bools_per_word() - 1) /
                                    packed_bools_per_word());
       }));
-    thrust::inclusive_scan(handle.get_thrust_policy(),
-                           size_first,
-                           size_first + edge_partition_local_degrees.size(),
-                           inclusive_sum_offsets.begin() + 1);
+    cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                    size_first,
+                                    size_first + edge_partition_local_degrees.size(),
+                                    inclusive_sum_offsets.begin() + 1);
 
     auto [edge_partition_frontier_indices, frontier_partition_offsets] = partition_v_frontier(
       handle,
@@ -711,7 +711,7 @@ void sample_nbr_index_with_replacement(
       std::get<1>(*frontier_index_type_pairs).begin(),
       cuda::proclaim_return_type<size_t>(
         [K_offsets] __device__(auto type) { return K_offsets[type + 1] - K_offsets[type]; }));
-    thrust::inclusive_scan(
+    cugraph::inclusive_scan_wrapper(
       handle.get_thrust_policy(), k_first, k_first + num_keys, (*input_r_offsets).begin() + 1);
   }
 
@@ -836,10 +836,10 @@ void sample_nbr_index_without_replacement(
           auto d = static_cast<size_t>(frontier_degrees[i]);
           return d > K ? (d - K) : size_t{0};
         }));
-      thrust::inclusive_scan(handle.get_thrust_policy(),
-                             count_first,
-                             count_first + num_keys,
-                             input_r_offsets.begin() + 1);
+      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                      count_first,
+                                      count_first + num_keys,
+                                      input_r_offsets.begin() + 1);
 
     } else {
       auto count_first = cuda::make_transform_iterator(
@@ -847,10 +847,10 @@ void sample_nbr_index_without_replacement(
           auto d = static_cast<size_t>(degree);
           return d > K ? (d - K) : size_t{0};
         }));
-      thrust::inclusive_scan(handle.get_thrust_policy(),
-                             count_first,
-                             count_first + num_keys,
-                             input_r_offsets.begin() + 1);
+      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                      count_first,
+                                      count_first + num_keys,
+                                      input_r_offsets.begin() + 1);
     }
 
     rmm::device_uvector<bias_t> sample_random_numbers(
@@ -921,7 +921,7 @@ void sample_nbr_index_without_replacement(
       std::get<1>(*frontier_index_type_pairs).begin(),
       cuda::proclaim_return_type<size_t>(
         [K_offsets] __device__(auto type) { return K_offsets[type + 1] - K_offsets[type]; }));
-    thrust::inclusive_scan(
+    cugraph::inclusive_scan_wrapper(
       handle.get_thrust_policy(), k_first, k_first + num_keys, sample_size_offsets.begin() + 1);
 
     thrust::for_each(
@@ -988,10 +988,10 @@ void sample_nbr_index_without_replacement(
             auto K = K_offsets[type + 1] - K_offsets[type];
             return d > K ? (d - K) : size_t{0};
           }));
-      thrust::inclusive_scan(handle.get_thrust_policy(),
-                             count_first,
-                             count_first + num_keys,
-                             input_r_offsets.begin() + 1);
+      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                      count_first,
+                                      count_first + num_keys,
+                                      input_r_offsets.begin() + 1);
     } else {
       auto count_first = cuda::make_transform_iterator(
         thrust::make_counting_iterator(size_t{0}),
@@ -1003,10 +1003,10 @@ void sample_nbr_index_without_replacement(
             auto K              = K_offsets[type + 1] - K_offsets[type];
             return d > K ? (d - K) : size_t{0};
           }));
-      thrust::inclusive_scan(handle.get_thrust_policy(),
-                             count_first,
-                             count_first + num_keys,
-                             input_r_offsets.begin() + 1);
+      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                      count_first,
+                                      count_first + num_keys,
+                                      input_r_offsets.begin() + 1);
     }
 
     rmm::device_uvector<bias_t> sample_random_numbers(
@@ -1869,10 +1869,10 @@ rmm::device_uvector<edge_t> compute_heterogeneous_uniform_sampling_index_without
         segment_frontier_type_first,
         cuda::proclaim_return_type<size_t>(
           [K_offsets] __device__(auto type) { return K_offsets[type + 1] - K_offsets[type]; }));
-      thrust::inclusive_scan(handle.get_thrust_policy(),
-                             k_first,
-                             k_first + num_segments,
-                             output_count_offsets.begin() + 1);
+      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                      k_first,
+                                      k_first + num_segments,
+                                      output_count_offsets.begin() + 1);
       thrust::for_each(
         handle.get_thrust_policy(),
         thrust::make_counting_iterator(size_t{0}),
@@ -1937,10 +1937,10 @@ void compute_homogeneous_biased_sampling_index_without_replacement(
         cuda::proclaim_return_type<size_t>([input_degree_offsets] __device__(size_t i) {
           return input_degree_offsets[i + 1] - input_degree_offsets[i];
         }));
-      thrust::inclusive_scan(handle.get_thrust_policy(),
-                             degree_first,
-                             degree_first + (*input_frontier_indices).size(),
-                             (*packed_input_degree_offsets).begin() + 1);
+      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                      degree_first,
+                                      degree_first + (*input_frontier_indices).size(),
+                                      (*packed_input_degree_offsets).begin() + 1);
     }
 
     // generate (key, nbr_index) pairs
@@ -2198,10 +2198,10 @@ void compute_heterogeneous_biased_sampling_index_without_replacement(
             return input_per_type_degree_offsets[idx * num_edge_types + type + 1] -
                    input_per_type_degree_offsets[idx * num_edge_types + type];
           }));
-      thrust::inclusive_scan(handle.get_thrust_policy(),
-                             per_type_degree_first,
-                             per_type_degree_first + (*input_frontier_indices).size(),
-                             (*packed_input_per_type_degree_offsets).begin() + 1);
+      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                      per_type_degree_first,
+                                      per_type_degree_first + (*input_frontier_indices).size(),
+                                      (*packed_input_per_type_degree_offsets).begin() + 1);
     }
 
     // generate (key, nbr_index) pairs
@@ -2651,10 +2651,10 @@ compute_aggregate_local_frontier_biases(raft::handle_t const& handle,
     aggregate_local_frontier_biases = std::move(nz_biases);
   }
 
-  thrust::inclusive_scan(handle.get_thrust_policy(),
-                         aggregate_local_frontier_local_degrees.begin(),
-                         aggregate_local_frontier_local_degrees.end(),
-                         aggregate_local_frontier_local_degree_offsets.begin() + 1);
+  cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                  aggregate_local_frontier_local_degrees.begin(),
+                                  aggregate_local_frontier_local_degrees.end(),
+                                  aggregate_local_frontier_local_degree_offsets.begin() + 1);
 
   return std::make_tuple(std::move(aggregate_local_frontier_biases),
                          std::move(aggregate_local_frontier_nz_bias_indices),
@@ -2822,10 +2822,10 @@ compute_aggregate_local_frontier_bias_type_pairs(
                      });
   }
 
-  thrust::inclusive_scan(handle.get_thrust_policy(),
-                         aggregate_local_frontier_local_degrees.begin(),
-                         aggregate_local_frontier_local_degrees.end(),
-                         aggregate_local_frontier_local_degree_offsets.begin() + 1);
+  cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                  aggregate_local_frontier_local_degrees.begin(),
+                                  aggregate_local_frontier_local_degrees.end(),
+                                  aggregate_local_frontier_local_degree_offsets.begin() + 1);
 
   {
     auto triplet_first =
@@ -2932,7 +2932,7 @@ shuffle_and_compute_local_nbr_values(
       minor_comm_size,
       invalid_value});
   rmm::device_uvector<size_t> tx_displacements(minor_comm_size, handle.get_stream());
-  thrust::exclusive_scan(
+  cugraph::exclusive_scan(
     handle.get_thrust_policy(), d_tx_counts.begin(), d_tx_counts.end(), tx_displacements.begin());
   auto tmp_sample_local_nbr_values =
     rmm::device_uvector<value_t>(tx_displacements.back_element(handle.get_stream()) +
@@ -3044,7 +3044,7 @@ shuffle_and_compute_per_type_local_nbr_values(
                      minor_comm_size,
                      invalid_value});
   rmm::device_uvector<size_t> tx_displacements(minor_comm_size, handle.get_stream());
-  thrust::exclusive_scan(
+  cugraph::exclusive_scan(
     handle.get_thrust_policy(), d_tx_counts.begin(), d_tx_counts.end(), tx_displacements.begin());
   auto tmp_sample_per_type_local_nbr_values =
     rmm::device_uvector<value_t>(tx_displacements.back_element(handle.get_stream()) +
@@ -3658,12 +3658,13 @@ homogeneous_biased_sample_without_replacement(
           aggregate_mid_local_frontier_local_degrees.size() + 1, handle.get_stream());
         aggregate_mid_local_frontier_local_degree_offsets.set_element_to_zero_async(
           0, handle.get_stream());
-        thrust::inclusive_scan(handle.get_thrust_policy(),
-                               aggregate_mid_local_frontier_local_degrees.begin(),
-                               aggregate_mid_local_frontier_local_degrees.end(),
-                               aggregate_mid_local_frontier_local_degree_offsets.begin() + 1,
-                               size_t{0},
-                               converting_plus_t<edge_t, size_t>{});
+        cugraph::inclusive_scan_wrapper(
+          handle.get_thrust_policy(),
+          aggregate_mid_local_frontier_local_degrees.begin(),
+          aggregate_mid_local_frontier_local_degrees.end(),
+          aggregate_mid_local_frontier_local_degree_offsets.begin() + 1,
+          size_t{0},
+          converting_plus_t<edge_t, size_t>{});
         aggregate_mid_local_frontier_biases.resize(
           aggregate_mid_local_frontier_local_degree_offsets.back_element(handle.get_stream()),
           handle.get_stream());
@@ -3752,12 +3753,12 @@ homogeneous_biased_sample_without_replacement(
           mid_frontier_gathered_local_degrees.size() + 1, handle.get_stream());
         mid_frontier_gathered_local_degree_offsets.set_element_to_zero_async(0,
                                                                              handle.get_stream());
-        thrust::inclusive_scan(handle.get_thrust_policy(),
-                               mid_frontier_gathered_local_degrees.begin(),
-                               mid_frontier_gathered_local_degrees.end(),
-                               mid_frontier_gathered_local_degree_offsets.begin() + 1,
-                               size_t{0},
-                               converting_plus_t<edge_t, size_t>{});
+        cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                        mid_frontier_gathered_local_degrees.begin(),
+                                        mid_frontier_gathered_local_degrees.end(),
+                                        mid_frontier_gathered_local_degree_offsets.begin() + 1,
+                                        size_t{0},
+                                        converting_plus_t<edge_t, size_t>{});
       }
 
       rmm::device_uvector<bias_t> mid_frontier_gathered_biases(0, handle.get_stream());
@@ -3779,12 +3780,12 @@ homogeneous_biased_sample_without_replacement(
       rmm::device_uvector<size_t> mid_frontier_degree_offsets(mid_frontier_size + 1,
                                                               handle.get_stream());
       mid_frontier_degree_offsets.set_element_to_zero_async(0, handle.get_stream());
-      thrust::inclusive_scan(handle.get_thrust_policy(),
-                             mid_frontier_degree_first,
-                             mid_frontier_degree_first + mid_frontier_size,
-                             mid_frontier_degree_offsets.begin() + 1,
-                             size_t{0},
-                             converting_plus_t<edge_t, size_t>{});
+      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                      mid_frontier_degree_first,
+                                      mid_frontier_degree_first + mid_frontier_size,
+                                      mid_frontier_degree_offsets.begin() + 1,
+                                      size_t{0},
+                                      converting_plus_t<edge_t, size_t>{});
       rmm::device_uvector<bias_t> mid_frontier_biases(mid_frontier_gathered_biases.size(),
                                                       handle.get_stream());
       thrust::for_each(
@@ -4305,7 +4306,7 @@ heterogeneous_biased_sample_without_replacement(
           aggregate_mid_local_frontier_per_type_local_degrees.size() + 1, handle.get_stream());
         aggregate_mid_local_frontier_per_type_local_degree_offsets.set_element_to_zero_async(
           0, handle.get_stream());
-        thrust::inclusive_scan(
+        cugraph::inclusive_scan_wrapper(
           handle.get_thrust_policy(),
           aggregate_mid_local_frontier_per_type_local_degrees.begin(),
           aggregate_mid_local_frontier_per_type_local_degrees.end(),
@@ -4408,12 +4409,13 @@ heterogeneous_biased_sample_without_replacement(
           mid_frontier_gathered_per_type_local_degrees.size() + 1, handle.get_stream());
         mid_frontier_gathered_per_type_local_degree_offsets.set_element_to_zero_async(
           0, handle.get_stream());
-        thrust::inclusive_scan(handle.get_thrust_policy(),
-                               mid_frontier_gathered_per_type_local_degrees.begin(),
-                               mid_frontier_gathered_per_type_local_degrees.end(),
-                               mid_frontier_gathered_per_type_local_degree_offsets.begin() + 1,
-                               size_t{0},
-                               converting_plus_t<edge_t, size_t>{});
+        cugraph::inclusive_scan_wrapper(
+          handle.get_thrust_policy(),
+          mid_frontier_gathered_per_type_local_degrees.begin(),
+          mid_frontier_gathered_per_type_local_degrees.end(),
+          mid_frontier_gathered_per_type_local_degree_offsets.begin() + 1,
+          size_t{0},
+          converting_plus_t<edge_t, size_t>{});
       }
 
       rmm::device_uvector<bias_t> mid_frontier_gathered_biases(0, handle.get_stream());
@@ -4438,12 +4440,12 @@ heterogeneous_biased_sample_without_replacement(
       rmm::device_uvector<size_t> mid_frontier_per_type_degree_offsets(mid_frontier_size + 1,
                                                                        handle.get_stream());
       mid_frontier_per_type_degree_offsets.set_element_to_zero_async(0, handle.get_stream());
-      thrust::inclusive_scan(handle.get_thrust_policy(),
-                             mid_frontier_per_type_degree_first,
-                             mid_frontier_per_type_degree_first + mid_frontier_size,
-                             mid_frontier_per_type_degree_offsets.begin() + 1,
-                             size_t{0},
-                             converting_plus_t<edge_t, size_t>{});
+      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                      mid_frontier_per_type_degree_first,
+                                      mid_frontier_per_type_degree_first + mid_frontier_size,
+                                      mid_frontier_per_type_degree_offsets.begin() + 1,
+                                      size_t{0},
+                                      converting_plus_t<edge_t, size_t>{});
       rmm::device_uvector<bias_t> mid_frontier_biases(mid_frontier_gathered_biases.size(),
                                                       handle.get_stream());
       thrust::for_each(
@@ -4555,7 +4557,7 @@ heterogeneous_biased_sample_without_replacement(
             }));
         aggregate_high_local_frontier_output_offsets.set_element_to_zero_async(0,
                                                                                handle.get_stream());
-        thrust::inclusive_scan(
+        cugraph::inclusive_scan_wrapper(
           handle.get_thrust_policy(),
           K_first,
           K_first + std::get<1>(aggregate_high_local_frontier_index_type_pairs).size(),
@@ -4661,10 +4663,10 @@ heterogeneous_biased_sample_without_replacement(
               return K_offsets[type + 1] - K_offsets[type];
             }));
         high_frontier_output_offsets.set_element_to_zero_async(0, handle.get_stream());
-        thrust::inclusive_scan(handle.get_thrust_policy(),
-                               K_first,
-                               K_first + high_frontier_size,
-                               high_frontier_output_offsets.begin() + 1);
+        cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                        K_first,
+                                        K_first + high_frontier_size,
+                                        high_frontier_output_offsets.begin() + 1);
       }
 
       rmm::device_uvector<edge_t> high_frontier_per_type_nbr_indices(
@@ -5474,7 +5476,7 @@ heterogeneous_uniform_sample_and_compute_local_nbr_indices(
 
       aggregate_local_frontier_unique_key_per_type_local_degree_offsets.set_element_to_zero_async(
         0, handle.get_stream());
-      thrust::inclusive_scan(
+      cugraph::inclusive_scan_wrapper(
         handle.get_thrust_policy(),
         aggregate_local_frontier_unique_key_per_type_local_degrees.begin(),
         aggregate_local_frontier_unique_key_per_type_local_degrees.end(),
@@ -5941,7 +5943,7 @@ heterogeneous_biased_sample_and_compute_local_nbr_indices(
         aggregate_local_frontier_unique_key_per_type_local_degrees.size() + 1, handle.get_stream());
       aggregate_local_frontier_unique_key_per_type_local_degree_offsets.set_element_to_zero_async(
         0, handle.get_stream());
-      thrust::inclusive_scan(
+      cugraph::inclusive_scan_wrapper(
         handle.get_thrust_policy(),
         aggregate_local_frontier_unique_key_per_type_local_degrees.begin(),
         aggregate_local_frontier_unique_key_per_type_local_degrees.end(),

--- a/cpp/include/cugraph/prims/detail/sample_and_compute_local_nbr_indices.cuh
+++ b/cpp/include/cugraph/prims/detail/sample_and_compute_local_nbr_indices.cuh
@@ -549,10 +549,10 @@ compute_valid_local_nbr_count_inclusive_sums(raft::handle_t const& handle,
         return static_cast<size_t>((local_degree + packed_bools_per_word() - 1) /
                                    packed_bools_per_word());
       }));
-    cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                    size_first,
-                                    size_first + edge_partition_local_degrees.size(),
-                                    inclusive_sum_offsets.begin() + 1);
+    cugraph::inclusive_scan(handle.get_thrust_policy(),
+                            size_first,
+                            size_first + edge_partition_local_degrees.size(),
+                            inclusive_sum_offsets.begin() + 1);
 
     auto [edge_partition_frontier_indices, frontier_partition_offsets] = partition_v_frontier(
       handle,
@@ -711,7 +711,7 @@ void sample_nbr_index_with_replacement(
       std::get<1>(*frontier_index_type_pairs).begin(),
       cuda::proclaim_return_type<size_t>(
         [K_offsets] __device__(auto type) { return K_offsets[type + 1] - K_offsets[type]; }));
-    cugraph::inclusive_scan_wrapper(
+    cugraph::inclusive_scan(
       handle.get_thrust_policy(), k_first, k_first + num_keys, (*input_r_offsets).begin() + 1);
   }
 
@@ -836,10 +836,10 @@ void sample_nbr_index_without_replacement(
           auto d = static_cast<size_t>(frontier_degrees[i]);
           return d > K ? (d - K) : size_t{0};
         }));
-      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                      count_first,
-                                      count_first + num_keys,
-                                      input_r_offsets.begin() + 1);
+      cugraph::inclusive_scan(handle.get_thrust_policy(),
+                              count_first,
+                              count_first + num_keys,
+                              input_r_offsets.begin() + 1);
 
     } else {
       auto count_first = cuda::make_transform_iterator(
@@ -847,10 +847,10 @@ void sample_nbr_index_without_replacement(
           auto d = static_cast<size_t>(degree);
           return d > K ? (d - K) : size_t{0};
         }));
-      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                      count_first,
-                                      count_first + num_keys,
-                                      input_r_offsets.begin() + 1);
+      cugraph::inclusive_scan(handle.get_thrust_policy(),
+                              count_first,
+                              count_first + num_keys,
+                              input_r_offsets.begin() + 1);
     }
 
     rmm::device_uvector<bias_t> sample_random_numbers(
@@ -921,7 +921,7 @@ void sample_nbr_index_without_replacement(
       std::get<1>(*frontier_index_type_pairs).begin(),
       cuda::proclaim_return_type<size_t>(
         [K_offsets] __device__(auto type) { return K_offsets[type + 1] - K_offsets[type]; }));
-    cugraph::inclusive_scan_wrapper(
+    cugraph::inclusive_scan(
       handle.get_thrust_policy(), k_first, k_first + num_keys, sample_size_offsets.begin() + 1);
 
     thrust::for_each(
@@ -988,10 +988,10 @@ void sample_nbr_index_without_replacement(
             auto K = K_offsets[type + 1] - K_offsets[type];
             return d > K ? (d - K) : size_t{0};
           }));
-      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                      count_first,
-                                      count_first + num_keys,
-                                      input_r_offsets.begin() + 1);
+      cugraph::inclusive_scan(handle.get_thrust_policy(),
+                              count_first,
+                              count_first + num_keys,
+                              input_r_offsets.begin() + 1);
     } else {
       auto count_first = cuda::make_transform_iterator(
         thrust::make_counting_iterator(size_t{0}),
@@ -1003,10 +1003,10 @@ void sample_nbr_index_without_replacement(
             auto K              = K_offsets[type + 1] - K_offsets[type];
             return d > K ? (d - K) : size_t{0};
           }));
-      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                      count_first,
-                                      count_first + num_keys,
-                                      input_r_offsets.begin() + 1);
+      cugraph::inclusive_scan(handle.get_thrust_policy(),
+                              count_first,
+                              count_first + num_keys,
+                              input_r_offsets.begin() + 1);
     }
 
     rmm::device_uvector<bias_t> sample_random_numbers(
@@ -1869,10 +1869,10 @@ rmm::device_uvector<edge_t> compute_heterogeneous_uniform_sampling_index_without
         segment_frontier_type_first,
         cuda::proclaim_return_type<size_t>(
           [K_offsets] __device__(auto type) { return K_offsets[type + 1] - K_offsets[type]; }));
-      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                      k_first,
-                                      k_first + num_segments,
-                                      output_count_offsets.begin() + 1);
+      cugraph::inclusive_scan(handle.get_thrust_policy(),
+                              k_first,
+                              k_first + num_segments,
+                              output_count_offsets.begin() + 1);
       thrust::for_each(
         handle.get_thrust_policy(),
         thrust::make_counting_iterator(size_t{0}),
@@ -1937,10 +1937,10 @@ void compute_homogeneous_biased_sampling_index_without_replacement(
         cuda::proclaim_return_type<size_t>([input_degree_offsets] __device__(size_t i) {
           return input_degree_offsets[i + 1] - input_degree_offsets[i];
         }));
-      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                      degree_first,
-                                      degree_first + (*input_frontier_indices).size(),
-                                      (*packed_input_degree_offsets).begin() + 1);
+      cugraph::inclusive_scan(handle.get_thrust_policy(),
+                              degree_first,
+                              degree_first + (*input_frontier_indices).size(),
+                              (*packed_input_degree_offsets).begin() + 1);
     }
 
     // generate (key, nbr_index) pairs
@@ -2198,10 +2198,10 @@ void compute_heterogeneous_biased_sampling_index_without_replacement(
             return input_per_type_degree_offsets[idx * num_edge_types + type + 1] -
                    input_per_type_degree_offsets[idx * num_edge_types + type];
           }));
-      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                      per_type_degree_first,
-                                      per_type_degree_first + (*input_frontier_indices).size(),
-                                      (*packed_input_per_type_degree_offsets).begin() + 1);
+      cugraph::inclusive_scan(handle.get_thrust_policy(),
+                              per_type_degree_first,
+                              per_type_degree_first + (*input_frontier_indices).size(),
+                              (*packed_input_per_type_degree_offsets).begin() + 1);
     }
 
     // generate (key, nbr_index) pairs
@@ -2651,10 +2651,10 @@ compute_aggregate_local_frontier_biases(raft::handle_t const& handle,
     aggregate_local_frontier_biases = std::move(nz_biases);
   }
 
-  cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                  aggregate_local_frontier_local_degrees.begin(),
-                                  aggregate_local_frontier_local_degrees.end(),
-                                  aggregate_local_frontier_local_degree_offsets.begin() + 1);
+  cugraph::inclusive_scan(handle.get_thrust_policy(),
+                          aggregate_local_frontier_local_degrees.begin(),
+                          aggregate_local_frontier_local_degrees.end(),
+                          aggregate_local_frontier_local_degree_offsets.begin() + 1);
 
   return std::make_tuple(std::move(aggregate_local_frontier_biases),
                          std::move(aggregate_local_frontier_nz_bias_indices),
@@ -2822,10 +2822,10 @@ compute_aggregate_local_frontier_bias_type_pairs(
                      });
   }
 
-  cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                  aggregate_local_frontier_local_degrees.begin(),
-                                  aggregate_local_frontier_local_degrees.end(),
-                                  aggregate_local_frontier_local_degree_offsets.begin() + 1);
+  cugraph::inclusive_scan(handle.get_thrust_policy(),
+                          aggregate_local_frontier_local_degrees.begin(),
+                          aggregate_local_frontier_local_degrees.end(),
+                          aggregate_local_frontier_local_degree_offsets.begin() + 1);
 
   {
     auto triplet_first =
@@ -3658,13 +3658,12 @@ homogeneous_biased_sample_without_replacement(
           aggregate_mid_local_frontier_local_degrees.size() + 1, handle.get_stream());
         aggregate_mid_local_frontier_local_degree_offsets.set_element_to_zero_async(
           0, handle.get_stream());
-        cugraph::inclusive_scan_wrapper(
-          handle.get_thrust_policy(),
-          aggregate_mid_local_frontier_local_degrees.begin(),
-          aggregate_mid_local_frontier_local_degrees.end(),
-          aggregate_mid_local_frontier_local_degree_offsets.begin() + 1,
-          size_t{0},
-          converting_plus_t<edge_t, size_t>{});
+        cugraph::inclusive_scan(handle.get_thrust_policy(),
+                                aggregate_mid_local_frontier_local_degrees.begin(),
+                                aggregate_mid_local_frontier_local_degrees.end(),
+                                aggregate_mid_local_frontier_local_degree_offsets.begin() + 1,
+                                size_t{0},
+                                converting_plus_t<edge_t, size_t>{});
         aggregate_mid_local_frontier_biases.resize(
           aggregate_mid_local_frontier_local_degree_offsets.back_element(handle.get_stream()),
           handle.get_stream());
@@ -3753,12 +3752,12 @@ homogeneous_biased_sample_without_replacement(
           mid_frontier_gathered_local_degrees.size() + 1, handle.get_stream());
         mid_frontier_gathered_local_degree_offsets.set_element_to_zero_async(0,
                                                                              handle.get_stream());
-        cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                        mid_frontier_gathered_local_degrees.begin(),
-                                        mid_frontier_gathered_local_degrees.end(),
-                                        mid_frontier_gathered_local_degree_offsets.begin() + 1,
-                                        size_t{0},
-                                        converting_plus_t<edge_t, size_t>{});
+        cugraph::inclusive_scan(handle.get_thrust_policy(),
+                                mid_frontier_gathered_local_degrees.begin(),
+                                mid_frontier_gathered_local_degrees.end(),
+                                mid_frontier_gathered_local_degree_offsets.begin() + 1,
+                                size_t{0},
+                                converting_plus_t<edge_t, size_t>{});
       }
 
       rmm::device_uvector<bias_t> mid_frontier_gathered_biases(0, handle.get_stream());
@@ -3780,12 +3779,12 @@ homogeneous_biased_sample_without_replacement(
       rmm::device_uvector<size_t> mid_frontier_degree_offsets(mid_frontier_size + 1,
                                                               handle.get_stream());
       mid_frontier_degree_offsets.set_element_to_zero_async(0, handle.get_stream());
-      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                      mid_frontier_degree_first,
-                                      mid_frontier_degree_first + mid_frontier_size,
-                                      mid_frontier_degree_offsets.begin() + 1,
-                                      size_t{0},
-                                      converting_plus_t<edge_t, size_t>{});
+      cugraph::inclusive_scan(handle.get_thrust_policy(),
+                              mid_frontier_degree_first,
+                              mid_frontier_degree_first + mid_frontier_size,
+                              mid_frontier_degree_offsets.begin() + 1,
+                              size_t{0},
+                              converting_plus_t<edge_t, size_t>{});
       rmm::device_uvector<bias_t> mid_frontier_biases(mid_frontier_gathered_biases.size(),
                                                       handle.get_stream());
       thrust::for_each(
@@ -4306,7 +4305,7 @@ heterogeneous_biased_sample_without_replacement(
           aggregate_mid_local_frontier_per_type_local_degrees.size() + 1, handle.get_stream());
         aggregate_mid_local_frontier_per_type_local_degree_offsets.set_element_to_zero_async(
           0, handle.get_stream());
-        cugraph::inclusive_scan_wrapper(
+        cugraph::inclusive_scan(
           handle.get_thrust_policy(),
           aggregate_mid_local_frontier_per_type_local_degrees.begin(),
           aggregate_mid_local_frontier_per_type_local_degrees.end(),
@@ -4409,13 +4408,12 @@ heterogeneous_biased_sample_without_replacement(
           mid_frontier_gathered_per_type_local_degrees.size() + 1, handle.get_stream());
         mid_frontier_gathered_per_type_local_degree_offsets.set_element_to_zero_async(
           0, handle.get_stream());
-        cugraph::inclusive_scan_wrapper(
-          handle.get_thrust_policy(),
-          mid_frontier_gathered_per_type_local_degrees.begin(),
-          mid_frontier_gathered_per_type_local_degrees.end(),
-          mid_frontier_gathered_per_type_local_degree_offsets.begin() + 1,
-          size_t{0},
-          converting_plus_t<edge_t, size_t>{});
+        cugraph::inclusive_scan(handle.get_thrust_policy(),
+                                mid_frontier_gathered_per_type_local_degrees.begin(),
+                                mid_frontier_gathered_per_type_local_degrees.end(),
+                                mid_frontier_gathered_per_type_local_degree_offsets.begin() + 1,
+                                size_t{0},
+                                converting_plus_t<edge_t, size_t>{});
       }
 
       rmm::device_uvector<bias_t> mid_frontier_gathered_biases(0, handle.get_stream());
@@ -4440,12 +4438,12 @@ heterogeneous_biased_sample_without_replacement(
       rmm::device_uvector<size_t> mid_frontier_per_type_degree_offsets(mid_frontier_size + 1,
                                                                        handle.get_stream());
       mid_frontier_per_type_degree_offsets.set_element_to_zero_async(0, handle.get_stream());
-      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                      mid_frontier_per_type_degree_first,
-                                      mid_frontier_per_type_degree_first + mid_frontier_size,
-                                      mid_frontier_per_type_degree_offsets.begin() + 1,
-                                      size_t{0},
-                                      converting_plus_t<edge_t, size_t>{});
+      cugraph::inclusive_scan(handle.get_thrust_policy(),
+                              mid_frontier_per_type_degree_first,
+                              mid_frontier_per_type_degree_first + mid_frontier_size,
+                              mid_frontier_per_type_degree_offsets.begin() + 1,
+                              size_t{0},
+                              converting_plus_t<edge_t, size_t>{});
       rmm::device_uvector<bias_t> mid_frontier_biases(mid_frontier_gathered_biases.size(),
                                                       handle.get_stream());
       thrust::for_each(
@@ -4557,7 +4555,7 @@ heterogeneous_biased_sample_without_replacement(
             }));
         aggregate_high_local_frontier_output_offsets.set_element_to_zero_async(0,
                                                                                handle.get_stream());
-        cugraph::inclusive_scan_wrapper(
+        cugraph::inclusive_scan(
           handle.get_thrust_policy(),
           K_first,
           K_first + std::get<1>(aggregate_high_local_frontier_index_type_pairs).size(),
@@ -4663,10 +4661,10 @@ heterogeneous_biased_sample_without_replacement(
               return K_offsets[type + 1] - K_offsets[type];
             }));
         high_frontier_output_offsets.set_element_to_zero_async(0, handle.get_stream());
-        cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                        K_first,
-                                        K_first + high_frontier_size,
-                                        high_frontier_output_offsets.begin() + 1);
+        cugraph::inclusive_scan(handle.get_thrust_policy(),
+                                K_first,
+                                K_first + high_frontier_size,
+                                high_frontier_output_offsets.begin() + 1);
       }
 
       rmm::device_uvector<edge_t> high_frontier_per_type_nbr_indices(
@@ -5476,7 +5474,7 @@ heterogeneous_uniform_sample_and_compute_local_nbr_indices(
 
       aggregate_local_frontier_unique_key_per_type_local_degree_offsets.set_element_to_zero_async(
         0, handle.get_stream());
-      cugraph::inclusive_scan_wrapper(
+      cugraph::inclusive_scan(
         handle.get_thrust_policy(),
         aggregate_local_frontier_unique_key_per_type_local_degrees.begin(),
         aggregate_local_frontier_unique_key_per_type_local_degrees.end(),
@@ -5943,7 +5941,7 @@ heterogeneous_biased_sample_and_compute_local_nbr_indices(
         aggregate_local_frontier_unique_key_per_type_local_degrees.size() + 1, handle.get_stream());
       aggregate_local_frontier_unique_key_per_type_local_degree_offsets.set_element_to_zero_async(
         0, handle.get_stream());
-      cugraph::inclusive_scan_wrapper(
+      cugraph::inclusive_scan(
         handle.get_thrust_policy(),
         aggregate_local_frontier_unique_key_per_type_local_degrees.begin(),
         aggregate_local_frontier_unique_key_per_type_local_degrees.end(),

--- a/cpp/include/cugraph/prims/detail/transform_v_frontier_e.cuh
+++ b/cpp/include/cugraph/prims/detail/transform_v_frontier_e.cuh
@@ -16,6 +16,7 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/iterator_utils.hpp>
 #include <cugraph/utilities/thrust_tuple_utils.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -465,10 +466,10 @@ auto transform_v_frontier_e(raft::handle_t const& handle,
                  edge_partition_frontier_local_degrees.end(),
                  aggregate_local_frontier_local_degree_offsets.begin() + local_frontier_offsets[i]);
   }
-  thrust::exclusive_scan(handle.get_thrust_policy(),
-                         aggregate_local_frontier_local_degree_offsets.begin(),
-                         aggregate_local_frontier_local_degree_offsets.end(),
-                         aggregate_local_frontier_local_degree_offsets.begin());
+  cugraph::exclusive_scan(handle.get_thrust_policy(),
+                          aggregate_local_frontier_local_degree_offsets.begin(),
+                          aggregate_local_frontier_local_degree_offsets.end(),
+                          aggregate_local_frontier_local_degree_offsets.begin());
 
   // 2. update aggregate_value_buffer
 

--- a/cpp/include/cugraph/prims/per_v_random_select_transform_outgoing_e.cuh
+++ b/cpp/include/cugraph/prims/per_v_random_select_transform_outgoing_e.cuh
@@ -571,10 +571,10 @@ per_v_random_select_transform_e(raft::handle_t const& handle,
       (*sample_offsets).set_element_to_zero_async(size_t{0}, handle.get_stream());
       auto typecasted_sample_count_first =
         cuda::make_transform_iterator(sample_counts.begin(), typecast_t<int32_t, size_t>{});
-      thrust::inclusive_scan(handle.get_thrust_policy(),
-                             typecasted_sample_count_first,
-                             typecasted_sample_count_first + sample_counts.size(),
-                             (*sample_offsets).begin() + 1);
+      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                      typecasted_sample_count_first,
+                                      typecasted_sample_count_first + sample_counts.size(),
+                                      (*sample_offsets).begin() + 1);
       sample_counts.resize(0, handle.get_stream());
       sample_counts.shrink_to_fit(handle.get_stream());
 
@@ -610,10 +610,10 @@ per_v_random_select_transform_e(raft::handle_t const& handle,
       (*sample_offsets).set_element_to_zero_async(size_t{0}, handle.get_stream());
       auto typecasted_sample_count_first =
         cuda::make_transform_iterator(sample_counts.begin(), typecast_t<int32_t, size_t>{});
-      thrust::inclusive_scan(handle.get_thrust_policy(),
-                             typecasted_sample_count_first,
-                             typecasted_sample_count_first + sample_counts.size(),
-                             (*sample_offsets).begin() + 1);
+      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                      typecasted_sample_count_first,
+                                      typecasted_sample_count_first + sample_counts.size(),
+                                      (*sample_offsets).begin() + 1);
       sample_counts.resize(0, handle.get_stream());
       sample_counts.shrink_to_fit(handle.get_stream());
 

--- a/cpp/include/cugraph/prims/per_v_random_select_transform_outgoing_e.cuh
+++ b/cpp/include/cugraph/prims/per_v_random_select_transform_outgoing_e.cuh
@@ -571,10 +571,10 @@ per_v_random_select_transform_e(raft::handle_t const& handle,
       (*sample_offsets).set_element_to_zero_async(size_t{0}, handle.get_stream());
       auto typecasted_sample_count_first =
         cuda::make_transform_iterator(sample_counts.begin(), typecast_t<int32_t, size_t>{});
-      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                      typecasted_sample_count_first,
-                                      typecasted_sample_count_first + sample_counts.size(),
-                                      (*sample_offsets).begin() + 1);
+      cugraph::inclusive_scan(handle.get_thrust_policy(),
+                              typecasted_sample_count_first,
+                              typecasted_sample_count_first + sample_counts.size(),
+                              (*sample_offsets).begin() + 1);
       sample_counts.resize(0, handle.get_stream());
       sample_counts.shrink_to_fit(handle.get_stream());
 
@@ -610,10 +610,10 @@ per_v_random_select_transform_e(raft::handle_t const& handle,
       (*sample_offsets).set_element_to_zero_async(size_t{0}, handle.get_stream());
       auto typecasted_sample_count_first =
         cuda::make_transform_iterator(sample_counts.begin(), typecast_t<int32_t, size_t>{});
-      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                      typecasted_sample_count_first,
-                                      typecasted_sample_count_first + sample_counts.size(),
-                                      (*sample_offsets).begin() + 1);
+      cugraph::inclusive_scan(handle.get_thrust_policy(),
+                              typecasted_sample_count_first,
+                              typecasted_sample_count_first + sample_counts.size(),
+                              (*sample_offsets).begin() + 1);
       sample_counts.resize(0, handle.get_stream());
       sample_counts.shrink_to_fit(handle.get_stream());
 

--- a/cpp/include/cugraph/prims/per_v_transform_reduce_dst_key_aggregated_outgoing_e.cuh
+++ b/cpp/include/cugraph/prims/per_v_transform_reduce_dst_key_aggregated_outgoing_e.cuh
@@ -386,10 +386,10 @@ void per_v_transform_reduce_dst_key_aggregated_outgoing_e(
       offsets_with_mask =
         rmm::device_uvector<edge_t>(degrees_with_mask.size() + 1, handle.get_stream());
       (*offsets_with_mask).set_element_to_zero_async(0, handle.get_stream());
-      thrust::inclusive_scan(handle.get_thrust_policy(),
-                             degrees_with_mask.begin(),
-                             degrees_with_mask.end(),
-                             (*offsets_with_mask).begin() + 1);
+      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                      degrees_with_mask.begin(),
+                                      degrees_with_mask.end(),
+                                      (*offsets_with_mask).begin() + 1);
     }
 
     rmm::device_uvector<vertex_t> tmp_majors(
@@ -656,10 +656,10 @@ void per_v_transform_reduce_dst_key_aggregated_outgoing_e(
         {
           rmm::device_uvector<size_t> minor_comm_rank_lasts(d_tx_value_counts.size(),
                                                             handle.get_stream());
-          thrust::inclusive_scan(handle.get_thrust_policy(),
-                                 d_tx_value_counts.begin(),
-                                 d_tx_value_counts.end(),
-                                 minor_comm_rank_lasts.begin());
+          cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                          d_tx_value_counts.begin(),
+                                          d_tx_value_counts.end(),
+                                          minor_comm_rank_lasts.begin());
           rmm::device_uvector<int> minor_comm_ranks(tmp_majors.size(), handle.get_stream());
           thrust::tabulate(
             handle.get_thrust_policy(),

--- a/cpp/include/cugraph/prims/per_v_transform_reduce_dst_key_aggregated_outgoing_e.cuh
+++ b/cpp/include/cugraph/prims/per_v_transform_reduce_dst_key_aggregated_outgoing_e.cuh
@@ -386,10 +386,10 @@ void per_v_transform_reduce_dst_key_aggregated_outgoing_e(
       offsets_with_mask =
         rmm::device_uvector<edge_t>(degrees_with_mask.size() + 1, handle.get_stream());
       (*offsets_with_mask).set_element_to_zero_async(0, handle.get_stream());
-      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                      degrees_with_mask.begin(),
-                                      degrees_with_mask.end(),
-                                      (*offsets_with_mask).begin() + 1);
+      cugraph::inclusive_scan(handle.get_thrust_policy(),
+                              degrees_with_mask.begin(),
+                              degrees_with_mask.end(),
+                              (*offsets_with_mask).begin() + 1);
     }
 
     rmm::device_uvector<vertex_t> tmp_majors(
@@ -656,10 +656,10 @@ void per_v_transform_reduce_dst_key_aggregated_outgoing_e(
         {
           rmm::device_uvector<size_t> minor_comm_rank_lasts(d_tx_value_counts.size(),
                                                             handle.get_stream());
-          cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                          d_tx_value_counts.begin(),
-                                          d_tx_value_counts.end(),
-                                          minor_comm_rank_lasts.begin());
+          cugraph::inclusive_scan(handle.get_thrust_policy(),
+                                  d_tx_value_counts.begin(),
+                                  d_tx_value_counts.end(),
+                                  minor_comm_rank_lasts.begin());
           rmm::device_uvector<int> minor_comm_ranks(tmp_majors.size(), handle.get_stream());
           thrust::tabulate(
             handle.get_thrust_policy(),

--- a/cpp/include/cugraph/prims/transform_reduce_e_by_src_dst_key.cuh
+++ b/cpp/include/cugraph/prims/transform_reduce_e_by_src_dst_key.cuh
@@ -565,10 +565,10 @@ transform_reduce_e_by_src_dst_key(raft::handle_t const& handle,
       edge_offsets_with_mask =
         rmm::device_uvector<edge_t>(edge_partition.major_range_size() + 1, handle.get_stream());
       (*edge_offsets_with_mask).set_element_to_zero_async(0, handle.get_stream());
-      thrust::inclusive_scan(handle.get_thrust_policy(),
-                             local_degrees.begin(),
-                             local_degrees.end(),
-                             (*edge_offsets_with_mask).begin() + 1);
+      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                      local_degrees.begin(),
+                                      local_degrees.end(),
+                                      (*edge_offsets_with_mask).begin() + 1);
       tmp_keys.resize((*edge_offsets_with_mask).back_element(handle.get_stream()),
                       handle.get_stream());
     } else {

--- a/cpp/include/cugraph/prims/transform_reduce_e_by_src_dst_key.cuh
+++ b/cpp/include/cugraph/prims/transform_reduce_e_by_src_dst_key.cuh
@@ -565,10 +565,10 @@ transform_reduce_e_by_src_dst_key(raft::handle_t const& handle,
       edge_offsets_with_mask =
         rmm::device_uvector<edge_t>(edge_partition.major_range_size() + 1, handle.get_stream());
       (*edge_offsets_with_mask).set_element_to_zero_async(0, handle.get_stream());
-      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                      local_degrees.begin(),
-                                      local_degrees.end(),
-                                      (*edge_offsets_with_mask).begin() + 1);
+      cugraph::inclusive_scan(handle.get_thrust_policy(),
+                              local_degrees.begin(),
+                              local_degrees.end(),
+                              (*edge_offsets_with_mask).begin() + 1);
       tmp_keys.resize((*edge_offsets_with_mask).back_element(handle.get_stream()),
                       handle.get_stream());
     } else {

--- a/cpp/include/cugraph/utilities/misc_utils.cuh
+++ b/cpp/include/cugraph/utilities/misc_utils.cuh
@@ -123,7 +123,7 @@ rmm::device_uvector<idx_t> expand_sparse_offsets(raft::device_span<offset_t cons
           atomic_counter.fetch_add(idx_t{1}, cuda::std::memory_order_relaxed);
         }
       });
-    cugraph::inclusive_scan_wrapper(
+    cugraph::inclusive_scan(
       rmm::exec_policy(stream_view), results.begin(), results.end(), results.begin());
   }
 

--- a/cpp/include/cugraph/utilities/misc_utils.cuh
+++ b/cpp/include/cugraph/utilities/misc_utils.cuh
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cugraph/export.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/device_span.hpp>
 #include <raft/core/handle.hpp>
@@ -122,7 +123,7 @@ rmm::device_uvector<idx_t> expand_sparse_offsets(raft::device_span<offset_t cons
           atomic_counter.fetch_add(idx_t{1}, cuda::std::memory_order_relaxed);
         }
       });
-    thrust::inclusive_scan(
+    cugraph::inclusive_scan_wrapper(
       rmm::exec_policy(stream_view), results.begin(), results.end(), results.begin());
   }
 

--- a/cpp/include/cugraph/utilities/shuffle_comm.cuh
+++ b/cpp/include/cugraph/utilities/shuffle_comm.cuh
@@ -8,6 +8,7 @@
 #include <cugraph/large_buffer_manager.hpp>
 #include <cugraph/utilities/dataframe_buffer.hpp>
 #include <cugraph/utilities/device_comm.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/device_span.hpp>
 #include <raft/core/handle.hpp>
@@ -199,7 +200,7 @@ void multi_partition(ValueIterator value_first,
       }));
 
   rmm::device_uvector<size_t> displacements(num_groups, stream_view);
-  thrust::exclusive_scan(
+  cugraph::exclusive_scan(
     rmm::exec_policy(stream_view), counts.begin(), counts.end(), displacements.begin());
 
   auto tmp_value_buffer =
@@ -258,7 +259,7 @@ void multi_partition(KeyIterator key_first,
       }));
 
   rmm::device_uvector<size_t> displacements(num_groups, stream_view);
-  thrust::exclusive_scan(
+  cugraph::exclusive_scan(
     rmm::exec_policy(stream_view), counts.begin(), counts.end(), displacements.begin());
 
   auto map_first = cuda::make_transform_iterator(

--- a/cpp/include/cugraph/utilities/thrust_wrappers.hpp
+++ b/cpp/include/cugraph/utilities/thrust_wrappers.hpp
@@ -82,8 +82,7 @@ template <typename ExecutionPolicy>
 inline constexpr bool is_rmm_exec_policy_v =
   std::is_same_v<std::remove_cv_t<ExecutionPolicy>, rmm::exec_policy>;
 
-/** Input iterator value type for @ref cugraph::inclusive_scan_wrapper / @ref
- * cugraph::exclusive_scan. */
+/** Input iterator value type for @ref cugraph::inclusive_scan / @ref cugraph::exclusive_scan. */
 template <typename Iterator>
 using scan_iterator_value_t =
   std::remove_cv_t<typename std::iterator_traits<std::remove_cv_t<Iterator>>::value_type>;
@@ -214,62 +213,71 @@ void sort_wrapper(ExecutionPolicy const& policy,
  * @p policy is @c rmm::exec_policy and the input element type is @c size_t, @c int32_t, or
  * @c int64_t.
  */
-// FIXME: Would like to call this inclusive_scan, but there's an issue
-// with CCCL and nvcc which results in a runtime error.
-template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator>
-OutputIterator inclusive_scan_wrapper(ExecutionPolicy const& policy,
-                                      InputIterator first,
-                                      InputIterator last,
-                                      OutputIterator result)
-{
-  using value_t = detail::scan_iterator_value_t<InputIterator>;
-  if constexpr (detail::is_rmm_exec_policy_v<ExecutionPolicy> &&
-                detail::scan_scalar_value_v<value_t>) {
-    return detail::inclusive_scan_impl(policy, first, last, result);
-  } else {
-    return thrust::inclusive_scan(policy, first, last, result);
+struct inclusive_scan_t {
+  template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator>
+  OutputIterator operator()(ExecutionPolicy const& policy,
+                            InputIterator first,
+                            InputIterator last,
+                            OutputIterator result) const
+  {
+    using value_t = detail::scan_iterator_value_t<InputIterator>;
+    if constexpr (detail::is_rmm_exec_policy_v<ExecutionPolicy> &&
+                  detail::scan_scalar_value_v<value_t>) {
+      return detail::inclusive_scan_impl(policy, first, last, result);
+    } else {
+      return thrust::inclusive_scan(policy, first, last, result);
+    }
   }
-}
 
-/**
- * @ingroup utility_wrappers_cpp
- * @brief    Inclusive prefix sum on [first, last) with a custom associative operator.
- *
- * Similar to @c thrust::inclusive_scan.
- */
-template <typename ExecutionPolicy,
-          typename InputIterator,
-          typename OutputIterator,
-          typename BinaryFunction>
-OutputIterator inclusive_scan_wrapper(ExecutionPolicy const& policy,
-                                      InputIterator first,
-                                      InputIterator last,
-                                      OutputIterator result,
-                                      BinaryFunction binary_op)
-{
-  return thrust::inclusive_scan(policy, first, last, result, binary_op);
-}
+  /**
+   * @ingroup utility_wrappers_cpp
+   * @brief    Inclusive prefix sum on [first, last) with a custom associative operator.
+   *
+   * Similar to @c thrust::inclusive_scan.
+   */
+  template <typename ExecutionPolicy,
+            typename InputIterator,
+            typename OutputIterator,
+            typename BinaryFunction>
+  OutputIterator operator()(ExecutionPolicy const& policy,
+                            InputIterator first,
+                            InputIterator last,
+                            OutputIterator result,
+                            BinaryFunction binary_op) const
+  {
+    return thrust::inclusive_scan(policy, first, last, result, binary_op);
+  }
 
-/**
- * @ingroup utility_wrappers_cpp
- * @brief    Inclusive prefix sum on [first, last) with initial value and associative operator.
+  /**
+   * @ingroup utility_wrappers_cpp
+   * @brief    Inclusive prefix sum on [first, last) with initial value and associative operator.
+   *
+   * Similar to @c thrust::inclusive_scan.
+   */
+  template <typename ExecutionPolicy,
+            typename InputIterator,
+            typename OutputIterator,
+            typename T,
+            typename BinaryFunction>
+  OutputIterator operator()(ExecutionPolicy const& policy,
+                            InputIterator first,
+                            InputIterator last,
+                            OutputIterator result,
+                            T init,
+                            BinaryFunction binary_op) const
+  {
+    return thrust::inclusive_scan(policy, first, last, result, init, binary_op);
+  }
+};
+
+/** @brief Inclusive prefix sum on [first, last)
  *
- * Similar to @c thrust::inclusive_scan.
+ * This exposes cugraph::inclusive_scan using the inclusive_scan_wrapper_t functor.
+ * This is a workaround to avoid ADL issues with CCCL which result in a runtime error.
+ *
+ * Documentation of the individual inclusive_scan overloads is provided above.
  */
-template <typename ExecutionPolicy,
-          typename InputIterator,
-          typename OutputIterator,
-          typename T,
-          typename BinaryFunction>
-OutputIterator inclusive_scan_wrapper(ExecutionPolicy const& policy,
-                                      InputIterator first,
-                                      InputIterator last,
-                                      OutputIterator result,
-                                      T init,
-                                      BinaryFunction binary_op)
-{
-  return thrust::inclusive_scan(policy, first, last, result, init, binary_op);
-}
+inline constexpr inclusive_scan_t inclusive_scan{};
 
 /**
  * @ingroup utility_wrappers_cpp
@@ -279,62 +287,73 @@ OutputIterator inclusive_scan_wrapper(ExecutionPolicy const& policy,
  * @p policy is @c rmm::exec_policy and the input element type is @c size_t, @c int32_t, or
  * @c int64_t.
  */
-template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator>
-OutputIterator exclusive_scan(ExecutionPolicy const& policy,
-                              InputIterator first,
-                              InputIterator last,
-                              OutputIterator result)
-{
-  using value_t = detail::scan_iterator_value_t<InputIterator>;
-  if constexpr (detail::is_rmm_exec_policy_v<ExecutionPolicy> &&
-                detail::scan_scalar_value_v<value_t>) {
-    return detail::exclusive_scan_impl(policy, first, last, result);
-  } else {
-    return thrust::exclusive_scan(policy, first, last, result);
+struct exclusive_scan_t {
+  template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator>
+  OutputIterator operator()(ExecutionPolicy const& policy,
+                            InputIterator first,
+                            InputIterator last,
+                            OutputIterator result) const
+  {
+    using value_t = detail::scan_iterator_value_t<InputIterator>;
+    if constexpr (detail::is_rmm_exec_policy_v<ExecutionPolicy> &&
+                  detail::scan_scalar_value_v<value_t>) {
+      return detail::exclusive_scan_impl(policy, first, last, result);
+    } else {
+      return thrust::exclusive_scan(policy, first, last, result);
+    }
   }
-}
 
-/**
- * @ingroup utility_wrappers_cpp
- * @brief    Exclusive prefix sum on [first, last) with initial value.
- *
- * Similar to @c thrust::exclusive_scan.
- */
-template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator, typename T>
-OutputIterator exclusive_scan(ExecutionPolicy const& policy,
-                              InputIterator first,
-                              InputIterator last,
-                              OutputIterator result,
-                              T init)
-{
-  using value_t = detail::scan_iterator_value_t<InputIterator>;
-  if constexpr (detail::is_rmm_exec_policy_v<ExecutionPolicy> &&
-                detail::scan_scalar_value_v<value_t>) {
-    return detail::exclusive_scan_impl(policy, first, last, result, init);
-  } else {
-    return thrust::exclusive_scan(policy, first, last, result, init);
+  /**
+   * @ingroup utility_wrappers_cpp
+   * @brief    Exclusive prefix sum on [first, last) with initial value.
+   *
+   * Similar to @c thrust::exclusive_scan.
+   */
+  template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator, typename T>
+  OutputIterator operator()(ExecutionPolicy const& policy,
+                            InputIterator first,
+                            InputIterator last,
+                            OutputIterator result,
+                            T init) const
+  {
+    using value_t = detail::scan_iterator_value_t<InputIterator>;
+    if constexpr (detail::is_rmm_exec_policy_v<ExecutionPolicy> &&
+                  detail::scan_scalar_value_v<value_t>) {
+      return detail::exclusive_scan_impl(policy, first, last, result, init);
+    } else {
+      return thrust::exclusive_scan(policy, first, last, result, init);
+    }
   }
-}
 
-/**
- * @ingroup utility_wrappers_cpp
- * @brief    Exclusive prefix sum on [first, last) with initial value and associative operator.
+  /**
+   * @ingroup utility_wrappers_cpp
+   * @brief    Exclusive prefix sum on [first, last) with initial value and associative operator.
+   *
+   * Similar to @c thrust::exclusive_scan.
+   */
+  template <typename ExecutionPolicy,
+            typename InputIterator,
+            typename OutputIterator,
+            typename T,
+            typename BinaryFunction>
+  OutputIterator operator()(ExecutionPolicy const& policy,
+                            InputIterator first,
+                            InputIterator last,
+                            OutputIterator result,
+                            T init,
+                            BinaryFunction binary_op) const
+  {
+    return thrust::exclusive_scan(policy, first, last, result, init, binary_op);
+  }
+};
+
+/** @brief Exclusive prefix sum on [first, last)
  *
- * Similar to @c thrust::exclusive_scan.
+ * This exposes cugraph::exclusive_scan using the exclusive_scan_t functor.
+ * This is a workaround to avoid ADL issues with CCCL which result in a runtime error.
+ *
+ * Documentation of the individual exclusive_scan overloads is provided above.
  */
-template <typename ExecutionPolicy,
-          typename InputIterator,
-          typename OutputIterator,
-          typename T,
-          typename BinaryFunction>
-OutputIterator exclusive_scan(ExecutionPolicy const& policy,
-                              InputIterator first,
-                              InputIterator last,
-                              OutputIterator result,
-                              T init,
-                              BinaryFunction binary_op)
-{
-  return thrust::exclusive_scan(policy, first, last, result, init, binary_op);
-}
+inline constexpr exclusive_scan_t exclusive_scan{};
 
 }  // namespace CUGRAPH_EXPORT cugraph

--- a/cpp/include/cugraph/utilities/thrust_wrappers.hpp
+++ b/cpp/include/cugraph/utilities/thrust_wrappers.hpp
@@ -10,8 +10,10 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/iterator>
+#include <thrust/scan.h>
 #include <thrust/sort.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <type_traits>
@@ -65,6 +67,58 @@ inline constexpr bool sort_supported_zip_v =
                      std::is_same<std::remove_cv_t<T>, zip_i64_i64_sz_i>,
                      std::is_same<std::remove_cv_t<T>, zip_i32_i32_i32_sz>,
                      std::is_same<std::remove_cv_t<T>, zip_i64_i64_i64_sz>>;
+
+/** @brief True for value types dispatched to @ref inclusive_scan_impl / @ref exclusive_scan_impl.
+ */
+template <typename T>
+inline constexpr bool scan_scalar_value_v =
+  std::disjunction_v<std::is_same<std::remove_cv_t<T>, std::size_t>,
+                     std::is_same<std::remove_cv_t<T>, std::int32_t>,
+                     std::is_same<std::remove_cv_t<T>, std::int64_t>>;
+
+/** @brief True when @p ExecutionPolicy is @c rmm::exec_policy (e.g. @c handle.get_thrust_policy()).
+ */
+template <typename ExecutionPolicy>
+inline constexpr bool is_rmm_exec_policy_v =
+  std::is_same_v<std::remove_cv_t<ExecutionPolicy>, rmm::exec_policy>;
+
+/** Input iterator value type for @ref cugraph::inclusive_scan_wrapper / @ref
+ * cugraph::exclusive_scan. */
+template <typename Iterator>
+using scan_iterator_value_t =
+  std::remove_cv_t<typename std::iterator_traits<std::remove_cv_t<Iterator>>::value_type>;
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Inclusive prefix sum on [first, last) (out-of-line; default @c plus).
+ */
+template <typename InputIterator, typename OutputIterator>
+OutputIterator inclusive_scan_impl(rmm::exec_policy const& policy,
+                                   InputIterator first,
+                                   InputIterator last,
+                                   OutputIterator result);
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Exclusive prefix sum on [first, last) (out-of-line; default @c plus and zero init).
+ */
+template <typename InputIterator, typename OutputIterator>
+OutputIterator exclusive_scan_impl(rmm::exec_policy const& policy,
+                                   InputIterator first,
+                                   InputIterator last,
+                                   OutputIterator result);
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Exclusive prefix sum on [first, last) with initial value (out-of-line; default @c
+ * plus).
+ */
+template <typename InputIterator, typename OutputIterator, typename T>
+OutputIterator exclusive_scan_impl(rmm::exec_policy const& policy,
+                                   InputIterator first,
+                                   InputIterator last,
+                                   OutputIterator result,
+                                   T init);
 
 /**
  * @ingroup utility_wrappers_cpp
@@ -150,6 +204,137 @@ void sort_wrapper(ExecutionPolicy const& policy,
                   Compare compare)
 {
   thrust::sort(policy, first, last, compare);
+}
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Inclusive prefix sum on [first, last)
+ *
+ * Similar to @c thrust::inclusive_scan; dispatches to an explicitly instantiated backend when
+ * @p policy is @c rmm::exec_policy and the input element type is @c size_t, @c int32_t, or
+ * @c int64_t.
+ */
+// FIXME: Would like to call this inclusive_scan, but there's an issue
+// with CCCL and nvcc which results in a runtime error.
+template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator>
+OutputIterator inclusive_scan_wrapper(ExecutionPolicy const& policy,
+                                      InputIterator first,
+                                      InputIterator last,
+                                      OutputIterator result)
+{
+  using value_t = detail::scan_iterator_value_t<InputIterator>;
+  if constexpr (detail::is_rmm_exec_policy_v<ExecutionPolicy> &&
+                detail::scan_scalar_value_v<value_t>) {
+    return detail::inclusive_scan_impl(policy, first, last, result);
+  } else {
+    return thrust::inclusive_scan(policy, first, last, result);
+  }
+}
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Inclusive prefix sum on [first, last) with a custom associative operator.
+ *
+ * Similar to @c thrust::inclusive_scan.
+ */
+template <typename ExecutionPolicy,
+          typename InputIterator,
+          typename OutputIterator,
+          typename BinaryFunction>
+OutputIterator inclusive_scan_wrapper(ExecutionPolicy const& policy,
+                                      InputIterator first,
+                                      InputIterator last,
+                                      OutputIterator result,
+                                      BinaryFunction binary_op)
+{
+  return thrust::inclusive_scan(policy, first, last, result, binary_op);
+}
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Inclusive prefix sum on [first, last) with initial value and associative operator.
+ *
+ * Similar to @c thrust::inclusive_scan.
+ */
+template <typename ExecutionPolicy,
+          typename InputIterator,
+          typename OutputIterator,
+          typename T,
+          typename BinaryFunction>
+OutputIterator inclusive_scan_wrapper(ExecutionPolicy const& policy,
+                                      InputIterator first,
+                                      InputIterator last,
+                                      OutputIterator result,
+                                      T init,
+                                      BinaryFunction binary_op)
+{
+  return thrust::inclusive_scan(policy, first, last, result, init, binary_op);
+}
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Exclusive prefix sum on [first, last)
+ *
+ * Similar to @c thrust::exclusive_scan; dispatches to an explicitly instantiated backend when
+ * @p policy is @c rmm::exec_policy and the input element type is @c size_t, @c int32_t, or
+ * @c int64_t.
+ */
+template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator>
+OutputIterator exclusive_scan(ExecutionPolicy const& policy,
+                              InputIterator first,
+                              InputIterator last,
+                              OutputIterator result)
+{
+  using value_t = detail::scan_iterator_value_t<InputIterator>;
+  if constexpr (detail::is_rmm_exec_policy_v<ExecutionPolicy> &&
+                detail::scan_scalar_value_v<value_t>) {
+    return detail::exclusive_scan_impl(policy, first, last, result);
+  } else {
+    return thrust::exclusive_scan(policy, first, last, result);
+  }
+}
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Exclusive prefix sum on [first, last) with initial value.
+ *
+ * Similar to @c thrust::exclusive_scan.
+ */
+template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator, typename T>
+OutputIterator exclusive_scan(ExecutionPolicy const& policy,
+                              InputIterator first,
+                              InputIterator last,
+                              OutputIterator result,
+                              T init)
+{
+  using value_t = detail::scan_iterator_value_t<InputIterator>;
+  if constexpr (detail::is_rmm_exec_policy_v<ExecutionPolicy> &&
+                detail::scan_scalar_value_v<value_t>) {
+    return detail::exclusive_scan_impl(policy, first, last, result, init);
+  } else {
+    return thrust::exclusive_scan(policy, first, last, result, init);
+  }
+}
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Exclusive prefix sum on [first, last) with initial value and associative operator.
+ *
+ * Similar to @c thrust::exclusive_scan.
+ */
+template <typename ExecutionPolicy,
+          typename InputIterator,
+          typename OutputIterator,
+          typename T,
+          typename BinaryFunction>
+OutputIterator exclusive_scan(ExecutionPolicy const& policy,
+                              InputIterator first,
+                              InputIterator last,
+                              OutputIterator result,
+                              T init,
+                              BinaryFunction binary_op)
+{
+  return thrust::exclusive_scan(policy, first, last, result, init, binary_op);
 }
 
 }  // namespace CUGRAPH_EXPORT cugraph

--- a/cpp/src/centrality/betweenness_centrality_impl.cuh
+++ b/cpp/src/centrality/betweenness_centrality_impl.cuh
@@ -575,10 +575,10 @@ batch_partition_frontier(raft::handle_t const& handle,
       max_pushes_per_batch = (max_pushes + num_batches - 1) / num_batches;
       rmm::device_uvector<size_t> source_out_edge_count_inclusive_sums(num_sources,
                                                                        handle.get_stream());
-      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                      source_out_edge_counts.begin(),
-                                      source_out_edge_counts.end(),
-                                      source_out_edge_count_inclusive_sums.begin());
+      cugraph::inclusive_scan(handle.get_thrust_policy(),
+                              source_out_edge_counts.begin(),
+                              source_out_edge_counts.end(),
+                              source_out_edge_count_inclusive_sums.begin());
       source_lasts     = rmm::device_uvector<size_t>(num_batches, handle.get_stream());
       auto count_first = cuda::make_transform_iterator(thrust::make_counting_iterator(size_t{1}),
                                                        multiplier_t<size_t>{max_pushes_per_batch});

--- a/cpp/src/centrality/betweenness_centrality_impl.cuh
+++ b/cpp/src/centrality/betweenness_centrality_impl.cuh
@@ -575,10 +575,10 @@ batch_partition_frontier(raft::handle_t const& handle,
       max_pushes_per_batch = (max_pushes + num_batches - 1) / num_batches;
       rmm::device_uvector<size_t> source_out_edge_count_inclusive_sums(num_sources,
                                                                        handle.get_stream());
-      thrust::inclusive_scan(handle.get_thrust_policy(),
-                             source_out_edge_counts.begin(),
-                             source_out_edge_counts.end(),
-                             source_out_edge_count_inclusive_sums.begin());
+      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                      source_out_edge_counts.begin(),
+                                      source_out_edge_counts.end(),
+                                      source_out_edge_count_inclusive_sums.begin());
       source_lasts     = rmm::device_uvector<size_t>(num_batches, handle.get_stream());
       auto count_first = cuda::make_transform_iterator(thrust::make_counting_iterator(size_t{1}),
                                                        multiplier_t<size_t>{max_pushes_per_batch});

--- a/cpp/src/components/strongly_connected_components_impl.cuh
+++ b/cpp/src/components/strongly_connected_components_impl.cuh
@@ -1640,10 +1640,10 @@ intersect_reachable_sets(
     new_unresolved_component_offsets.resize(new_unresolved_component_ids.size() + 1,
                                             handle.get_stream());
     new_unresolved_component_offsets.set_element_to_zero_async(0, handle.get_stream());
-    cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                    new_unresolved_component_counts.begin(),
-                                    new_unresolved_component_counts.end(),
-                                    new_unresolved_component_offsets.begin() + 1);
+    cugraph::inclusive_scan(handle.get_thrust_policy(),
+                            new_unresolved_component_counts.begin(),
+                            new_unresolved_component_counts.end(),
+                            new_unresolved_component_offsets.begin() + 1);
 
     new_unresolved_component_vertices = concatenate3(
       raft::device_span<vertex_t const>(fwd_only_vertices.data() + num_fwd_only_size1_vertices,
@@ -1732,10 +1732,10 @@ intersect_reachable_sets(
                                         trivial_singleton_scc_vertices.size()));
     new_scc_component_offsets.resize(new_scc_component_counts.size() + 1, handle.get_stream());
     new_scc_component_offsets.set_element_to_zero_async(0, handle.get_stream());
-    cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                    new_scc_component_counts.begin(),
-                                    new_scc_component_counts.end(),
-                                    new_scc_component_offsets.begin() + 1);
+    cugraph::inclusive_scan(handle.get_thrust_policy(),
+                            new_scc_component_counts.begin(),
+                            new_scc_component_counts.end(),
+                            new_scc_component_offsets.begin() + 1);
   }
 
   return std::make_tuple(std::move(new_unresolved_component_ids),

--- a/cpp/src/components/strongly_connected_components_impl.cuh
+++ b/cpp/src/components/strongly_connected_components_impl.cuh
@@ -1640,10 +1640,10 @@ intersect_reachable_sets(
     new_unresolved_component_offsets.resize(new_unresolved_component_ids.size() + 1,
                                             handle.get_stream());
     new_unresolved_component_offsets.set_element_to_zero_async(0, handle.get_stream());
-    thrust::inclusive_scan(handle.get_thrust_policy(),
-                           new_unresolved_component_counts.begin(),
-                           new_unresolved_component_counts.end(),
-                           new_unresolved_component_offsets.begin() + 1);
+    cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                    new_unresolved_component_counts.begin(),
+                                    new_unresolved_component_counts.end(),
+                                    new_unresolved_component_offsets.begin() + 1);
 
     new_unresolved_component_vertices = concatenate3(
       raft::device_span<vertex_t const>(fwd_only_vertices.data() + num_fwd_only_size1_vertices,
@@ -1732,10 +1732,10 @@ intersect_reachable_sets(
                                         trivial_singleton_scc_vertices.size()));
     new_scc_component_offsets.resize(new_scc_component_counts.size() + 1, handle.get_stream());
     new_scc_component_offsets.set_element_to_zero_async(0, handle.get_stream());
-    thrust::inclusive_scan(handle.get_thrust_policy(),
-                           new_scc_component_counts.begin(),
-                           new_scc_component_counts.end(),
-                           new_scc_component_offsets.begin() + 1);
+    cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                    new_scc_component_counts.begin(),
+                                    new_scc_component_counts.end(),
+                                    new_scc_component_offsets.begin() + 1);
   }
 
   return std::make_tuple(std::move(new_unresolved_component_ids),

--- a/cpp/src/components/weakly_connected_components_impl.cuh
+++ b/cpp/src/components/weakly_connected_components_impl.cuh
@@ -129,10 +129,10 @@ accumulate_new_roots(raft::handle_t const& handle,
         [vertex_partition, degrees] __device__(auto v) {
           return degrees[vertex_partition.local_vertex_partition_offset_from_vertex_nocheck(v)];
         });
-      thrust::inclusive_scan(handle.get_thrust_policy(),
-                             tmp_cumulative_degrees.begin(),
-                             tmp_cumulative_degrees.end(),
-                             tmp_cumulative_degrees.begin());
+      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                      tmp_cumulative_degrees.begin(),
+                                      tmp_cumulative_degrees.end(),
+                                      tmp_cumulative_degrees.begin());
       auto last = thrust::lower_bound(handle.get_thrust_policy(),
                                       tmp_cumulative_degrees.begin(),
                                       tmp_cumulative_degrees.end(),

--- a/cpp/src/components/weakly_connected_components_impl.cuh
+++ b/cpp/src/components/weakly_connected_components_impl.cuh
@@ -129,10 +129,10 @@ accumulate_new_roots(raft::handle_t const& handle,
         [vertex_partition, degrees] __device__(auto v) {
           return degrees[vertex_partition.local_vertex_partition_offset_from_vertex_nocheck(v)];
         });
-      cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                      tmp_cumulative_degrees.begin(),
-                                      tmp_cumulative_degrees.end(),
-                                      tmp_cumulative_degrees.begin());
+      cugraph::inclusive_scan(handle.get_thrust_policy(),
+                              tmp_cumulative_degrees.begin(),
+                              tmp_cumulative_degrees.end(),
+                              tmp_cumulative_degrees.begin());
       auto last = thrust::lower_bound(handle.get_thrust_policy(),
                                       tmp_cumulative_degrees.begin(),
                                       tmp_cumulative_degrees.end(),

--- a/cpp/src/converters/legacy/COOtoCSR.cuh
+++ b/cpp/src/converters/legacy/COOtoCSR.cuh
@@ -111,7 +111,7 @@ void fill_offset(VT* source,
   off[src[0]]                = ET{0};
 
   auto iter = cuda::std::make_reverse_iterator(offsets + number_of_vertices + 1);
-  cugraph::inclusive_scan_wrapper(
+  cugraph::inclusive_scan(
     rmm::exec_policy(stream_view), iter, iter + number_of_vertices + 1, iter, cuda::minimum<ET>());
 }
 

--- a/cpp/src/converters/legacy/COOtoCSR.cuh
+++ b/cpp/src/converters/legacy/COOtoCSR.cuh
@@ -14,6 +14,7 @@
 #include <cugraph/legacy/functions.hpp>
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <rmm/exec_policy.hpp>
 #include <rmm/resource_ref.hpp>
@@ -110,7 +111,7 @@ void fill_offset(VT* source,
   off[src[0]]                = ET{0};
 
   auto iter = cuda::std::make_reverse_iterator(offsets + number_of_vertices + 1);
-  thrust::inclusive_scan(
+  cugraph::inclusive_scan_wrapper(
     rmm::exec_policy(stream_view), iter, iter + number_of_vertices + 1, iter, cuda::minimum<ET>());
 }
 

--- a/cpp/src/link_prediction/detail/similarity_impl.cuh
+++ b/cpp/src/link_prediction/detail/similarity_impl.cuh
@@ -16,6 +16,7 @@
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/error_check_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/device_span.hpp>
 #include <raft/core/handle.hpp>
@@ -369,10 +370,10 @@ all_pairs_similarity(raft::handle_t const& handle,
                         tmp_vertices.begin(),
                         cuda::std::greater<size_t>{});
 
-    thrust::exclusive_scan(handle.get_thrust_policy(),
-                           two_hop_degrees.begin(),
-                           two_hop_degrees.end(),
-                           two_hop_degrees.begin());
+    cugraph::exclusive_scan(handle.get_thrust_policy(),
+                            two_hop_degrees.begin(),
+                            two_hop_degrees.end(),
+                            two_hop_degrees.begin());
 
     auto two_hop_degree_offsets = std::move(two_hop_degrees);
 

--- a/cpp/src/sampling/negative_sampling_impl.cuh
+++ b/cpp/src/sampling/negative_sampling_impl.cuh
@@ -70,10 +70,10 @@ normalize_biases(raft::handle_t const& handle,
                     normalized_biases->begin(),
                     divider_t<weight_t>{sum});
 
-  cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
-                                  normalized_biases->begin(),
-                                  normalized_biases->end(),
-                                  normalized_biases->begin());
+  cugraph::inclusive_scan(handle.get_thrust_policy(),
+                          normalized_biases->begin(),
+                          normalized_biases->end(),
+                          normalized_biases->begin());
 
   if constexpr (multi_gpu) {
     rmm::device_scalar<weight_t> d_sum(sum, handle.get_stream());
@@ -103,7 +103,7 @@ normalize_biases(raft::handle_t const& handle,
                       gpu_biases->begin(),
                       divider_t<weight_t>{aggregate_sum});
 
-    cugraph::inclusive_scan_wrapper(
+    cugraph::inclusive_scan(
       handle.get_thrust_policy(), gpu_biases->begin(), gpu_biases->end(), gpu_biases->begin());
 
     // FIXME: conclusion of above.  Using 1.1 since it is > 1.0 and easy to type

--- a/cpp/src/sampling/negative_sampling_impl.cuh
+++ b/cpp/src/sampling/negative_sampling_impl.cuh
@@ -70,10 +70,10 @@ normalize_biases(raft::handle_t const& handle,
                     normalized_biases->begin(),
                     divider_t<weight_t>{sum});
 
-  thrust::inclusive_scan(handle.get_thrust_policy(),
-                         normalized_biases->begin(),
-                         normalized_biases->end(),
-                         normalized_biases->begin());
+  cugraph::inclusive_scan_wrapper(handle.get_thrust_policy(),
+                                  normalized_biases->begin(),
+                                  normalized_biases->end(),
+                                  normalized_biases->begin());
 
   if constexpr (multi_gpu) {
     rmm::device_scalar<weight_t> d_sum(sum, handle.get_stream());
@@ -103,7 +103,7 @@ normalize_biases(raft::handle_t const& handle,
                       gpu_biases->begin(),
                       divider_t<weight_t>{aggregate_sum});
 
-    thrust::inclusive_scan(
+    cugraph::inclusive_scan_wrapper(
       handle.get_thrust_policy(), gpu_biases->begin(), gpu_biases->end(), gpu_biases->begin());
 
     // FIXME: conclusion of above.  Using 1.1 since it is > 1.0 and easy to type

--- a/cpp/src/sampling/random_walks_impl.cuh
+++ b/cpp/src/sampling/random_walks_impl.cuh
@@ -376,10 +376,10 @@ struct node2vec_selector {
         raft::host_span<size_t const>(displacements.data(), displacements.size()),
         handle.get_stream());
 
-      thrust::exclusive_scan(handle.get_thrust_policy(),
-                             aggregate_offsets.begin(),
-                             aggregate_offsets.end(),
-                             aggregate_offsets.begin());
+      cugraph::exclusive_scan(handle.get_thrust_policy(),
+                              aggregate_offsets.begin(),
+                              aggregate_offsets.end(),
+                              aggregate_offsets.begin());
 
       aggregate_currents.resize(displacements.back() + recv_counts.back(), handle.get_stream());
 

--- a/cpp/src/sampling/sampling_post_processing_impl.cuh
+++ b/cpp/src/sampling/sampling_post_processing_impl.cuh
@@ -2885,10 +2885,10 @@ renumber_and_compress_sampled_edgelist(
                             compressed_offsets.begin());
     }
   }
-  thrust::exclusive_scan(handle.get_thrust_policy(),
-                         compressed_offsets.begin(),
-                         compressed_offsets.end(),
-                         compressed_offsets.begin());
+  cugraph::exclusive_scan(handle.get_thrust_policy(),
+                          compressed_offsets.begin(),
+                          compressed_offsets.end(),
+                          compressed_offsets.begin());
 
   // 5. update compressed_offsets to include zero degree vertices (if doubly_compress is false)
   // and compressed_offset_label_hop_offsets (if edgelist_label_offsets.has_value() or
@@ -3099,10 +3099,10 @@ renumber_and_compress_sampled_edgelist(
         }
         return vertex_count;
       });
-    thrust::exclusive_scan(handle.get_thrust_policy(),
-                           offset_array_offsets.begin(),
-                           offset_array_offsets.end(),
-                           offset_array_offsets.begin());
+    cugraph::exclusive_scan(handle.get_thrust_policy(),
+                            offset_array_offsets.begin(),
+                            offset_array_offsets.end(),
+                            offset_array_offsets.begin());
 
     auto tmp_compressed_offsets = rmm::device_uvector<size_t>(
       offset_array_offsets.back_element(handle.get_stream()) + 1, handle.get_stream());
@@ -3205,10 +3205,10 @@ renumber_and_compress_sampled_edgelist(
       }
     }
 
-    thrust::exclusive_scan(handle.get_thrust_policy(),
-                           tmp_compressed_offsets.begin(),
-                           tmp_compressed_offsets.end(),
-                           tmp_compressed_offsets.begin());
+    cugraph::exclusive_scan(handle.get_thrust_policy(),
+                            tmp_compressed_offsets.begin(),
+                            tmp_compressed_offsets.end(),
+                            tmp_compressed_offsets.begin());
 
     compressed_offsets = std::move(tmp_compressed_offsets);
 
@@ -3364,10 +3364,10 @@ renumber_and_sort_sampled_edgelist(
 
           return end_offset - start_offset;
         }));
-    thrust::exclusive_scan(handle.get_thrust_policy(),
-                           (*edgelist_label_hop_offsets).begin(),
-                           (*edgelist_label_hop_offsets).end(),
-                           (*edgelist_label_hop_offsets).begin());
+    cugraph::exclusive_scan(handle.get_thrust_policy(),
+                            (*edgelist_label_hop_offsets).begin(),
+                            (*edgelist_label_hop_offsets).end(),
+                            (*edgelist_label_hop_offsets).begin());
   }
 
   edgelist_hops = std::nullopt;
@@ -3601,10 +3601,10 @@ heterogeneous_renumber_and_sort_sampled_edgelist(
 
           return end_offset - start_offset;
         }));
-    thrust::exclusive_scan(handle.get_thrust_policy(),
-                           (*edgelist_label_type_hop_offsets).begin(),
-                           (*edgelist_label_type_hop_offsets).end(),
-                           (*edgelist_label_type_hop_offsets).begin());
+    cugraph::exclusive_scan(handle.get_thrust_policy(),
+                            (*edgelist_label_type_hop_offsets).begin(),
+                            (*edgelist_label_type_hop_offsets).end(),
+                            (*edgelist_label_type_hop_offsets).begin());
   }
 
   edgelist_edge_types = std::nullopt;
@@ -3724,10 +3724,10 @@ sort_sampled_edgelist(raft::handle_t const& handle,
           return end_offset - start_offset;
         }));
 
-    thrust::exclusive_scan(handle.get_thrust_policy(),
-                           (*edgelist_label_hop_offsets).begin(),
-                           (*edgelist_label_hop_offsets).end(),
-                           (*edgelist_label_hop_offsets).begin());
+    cugraph::exclusive_scan(handle.get_thrust_policy(),
+                            (*edgelist_label_hop_offsets).begin(),
+                            (*edgelist_label_hop_offsets).end(),
+                            (*edgelist_label_hop_offsets).begin());
 
     edgelist_hops = std::nullopt;
   }

--- a/cpp/src/structure/detail/structure_utils.cuh
+++ b/cpp/src/structure/detail/structure_utils.cuh
@@ -124,7 +124,7 @@ rmm::device_uvector<edge_t> compute_sparse_offsets(
                        });
     }
 
-    thrust::exclusive_scan(
+    cugraph::exclusive_scan(
       handle.get_thrust_policy(), offsets.begin(), offsets.end(), offsets.begin());
   }
 

--- a/cpp/src/structure/edge_partition_device_view_impl.cuh
+++ b/cpp/src/structure/edge_partition_device_view_impl.cuh
@@ -21,7 +21,7 @@ namespace detail {
 // edge_partition_device_view_mg_v32_e32.cu and edge_partition_device_view_mg_v64_e64.cu)
 // ============================================================================
 template <typename vertex_t, typename edge_t>
-CUGRAPH_EXPORT __host__ void compute_number_of_edges_with_mask_async_mg(
+__host__ void compute_number_of_edges_with_mask_async_mg(
   cuda::std::optional<uint32_t const*> edge_mask,
   raft::device_span<vertex_t const> majors,
   raft::device_span<size_t> count,
@@ -43,7 +43,7 @@ CUGRAPH_EXPORT __host__ void compute_number_of_edges_with_mask_async_mg(
 }
 
 template <typename vertex_t, typename edge_t>
-CUGRAPH_EXPORT __host__ void compute_number_of_edges_with_mask_async_mg(
+__host__ void compute_number_of_edges_with_mask_async_mg(
   cuda::std::optional<uint32_t const*> edge_mask,
   std::tuple<vertex_t, vertex_t> local_vertex_partition_range,
   raft::device_span<size_t> count,
@@ -66,7 +66,7 @@ CUGRAPH_EXPORT __host__ void compute_number_of_edges_with_mask_async_mg(
 }
 
 template <typename vertex_t, typename edge_t>
-CUGRAPH_EXPORT __host__ void compute_number_of_edges_with_mask_async_mg(
+__host__ void compute_number_of_edges_with_mask_async_mg(
   cuda::std::optional<uint32_t const*> edge_mask,
   majors_from_offsets_t<uint32_t, vertex_t> majors,
   raft::device_span<size_t> count,
@@ -90,7 +90,7 @@ CUGRAPH_EXPORT __host__ void compute_number_of_edges_with_mask_async_mg(
 }
 
 template <typename vertex_t, typename edge_t>
-CUGRAPH_EXPORT __host__ rmm::device_uvector<edge_t> compute_local_degrees_with_mask_mg(
+__host__ rmm::device_uvector<edge_t> compute_local_degrees_with_mask_mg(
   cuda::std::optional<uint32_t const*> edge_mask,
   raft::device_span<vertex_t const> majors,
   cuda::std::optional<raft::device_span<vertex_t const>> dcs_nzd_vertices,
@@ -110,7 +110,7 @@ CUGRAPH_EXPORT __host__ rmm::device_uvector<edge_t> compute_local_degrees_with_m
 }
 
 template <typename vertex_t, typename edge_t>
-CUGRAPH_EXPORT __host__ rmm::device_uvector<edge_t> compute_local_degrees_with_mask_mg(
+__host__ rmm::device_uvector<edge_t> compute_local_degrees_with_mask_mg(
   cuda::std::optional<uint32_t const*> edge_mask,
   std::tuple<vertex_t, vertex_t> local_vertex_partition_range,
   cuda::std::optional<raft::device_span<vertex_t const>> dcs_nzd_vertices,
@@ -135,7 +135,7 @@ CUGRAPH_EXPORT __host__ rmm::device_uvector<edge_t> compute_local_degrees_with_m
 // ============================================================================
 
 template <typename vertex_t, typename edge_t>
-CUGRAPH_EXPORT __host__ void compute_number_of_edges_with_mask_async_sg(
+__host__ void compute_number_of_edges_with_mask_async_sg(
   cuda::std::optional<uint32_t const*> edge_mask,
   raft::device_span<vertex_t const> majors,
   raft::device_span<size_t> count,
@@ -147,7 +147,7 @@ CUGRAPH_EXPORT __host__ void compute_number_of_edges_with_mask_async_sg(
 }
 
 template <typename vertex_t, typename edge_t>
-CUGRAPH_EXPORT __host__ void compute_number_of_edges_with_mask_async_sg(
+__host__ void compute_number_of_edges_with_mask_async_sg(
   cuda::std::optional<uint32_t const*> edge_mask,
   std::tuple<vertex_t, vertex_t> vertex_partition_range,
   raft::device_span<size_t> count,
@@ -164,7 +164,7 @@ CUGRAPH_EXPORT __host__ void compute_number_of_edges_with_mask_async_sg(
 }
 
 template <typename vertex_t, typename edge_t>
-CUGRAPH_EXPORT __host__ rmm::device_uvector<edge_t> compute_local_degrees_with_mask_sg(
+__host__ rmm::device_uvector<edge_t> compute_local_degrees_with_mask_sg(
   cuda::std::optional<uint32_t const*> edge_mask,
   raft::device_span<vertex_t const> majors,
   raft::device_span<edge_t const> offsets,
@@ -175,7 +175,7 @@ CUGRAPH_EXPORT __host__ rmm::device_uvector<edge_t> compute_local_degrees_with_m
 }
 
 template <typename vertex_t, typename edge_t>
-CUGRAPH_EXPORT __host__ rmm::device_uvector<edge_t> compute_local_degrees_with_mask_sg(
+__host__ rmm::device_uvector<edge_t> compute_local_degrees_with_mask_sg(
   cuda::std::optional<uint32_t const*> edge_mask,
   std::tuple<vertex_t, vertex_t> vertex_partition_range,
   raft::device_span<edge_t const> offsets,

--- a/cpp/src/structure/legacy/graph.cu
+++ b/cpp/src/structure/legacy/graph.cu
@@ -90,10 +90,10 @@ void GraphCompressedSparseBaseView<VT, ET, WT>::get_source_indices(VT* src_indic
                          atomic_counter.fetch_add(VT{1}, cuda::std::memory_order_relaxed);
                        }
                      });
-    cugraph::inclusive_scan_wrapper(rmm::exec_policy(stream_view),
-                                    indices_span.begin(),
-                                    indices_span.end(),
-                                    indices_span.begin());
+    cugraph::inclusive_scan(rmm::exec_policy(stream_view),
+                            indices_span.begin(),
+                            indices_span.end(),
+                            indices_span.begin());
   }
 }
 

--- a/cpp/src/structure/legacy/graph.cu
+++ b/cpp/src/structure/legacy/graph.cu
@@ -5,6 +5,7 @@
 
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/device_span.hpp>
 #include <raft/util/device_atomics.cuh>
@@ -89,10 +90,10 @@ void GraphCompressedSparseBaseView<VT, ET, WT>::get_source_indices(VT* src_indic
                          atomic_counter.fetch_add(VT{1}, cuda::std::memory_order_relaxed);
                        }
                      });
-    thrust::inclusive_scan(rmm::exec_policy(stream_view),
-                           indices_span.begin(),
-                           indices_span.end(),
-                           indices_span.begin());
+    cugraph::inclusive_scan_wrapper(rmm::exec_policy(stream_view),
+                                    indices_span.begin(),
+                                    indices_span.end(),
+                                    indices_span.begin());
   }
 }
 

--- a/cpp/src/traversal/k_hop_nbrs_impl.cuh
+++ b/cpp/src/traversal/k_hop_nbrs_impl.cuh
@@ -205,7 +205,7 @@ k_hop_nbrs(raft::handle_t const& handle,
         start_vertex_displacements[GraphViewType::is_multi_gpu ? handle.get_comms().get_rank()
                                                                : int{0}]}),
     offsets.begin());
-  thrust::exclusive_scan(
+  cugraph::exclusive_scan(
     handle.get_thrust_policy(), offsets.begin(), offsets.end(), offsets.begin(), size_t{0});
 
   return std::make_tuple(std::move(offsets), std::move(nbrs));

--- a/cpp/src/utilities/thrust_wrappers.cu
+++ b/cpp/src/utilities/thrust_wrappers.cu
@@ -10,8 +10,10 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <thrust/scan.h>
 #include <thrust/sort.h>
 
+#include <cstddef>
 #include <cstdint>
 
 namespace cugraph {
@@ -89,5 +91,77 @@ CUGRAPH_SORT_ZIP_INST(zip_i64_i64_i64_sz);
 
 #undef CUGRAPH_SORT_ZIP_INST
 
+template <typename InputIterator, typename OutputIterator>
+OutputIterator inclusive_scan_impl(rmm::exec_policy const& policy,
+                                   InputIterator first,
+                                   InputIterator last,
+                                   OutputIterator result)
+{
+  return thrust::inclusive_scan(policy, first, last, result);
+}
+
+template <typename InputIterator, typename OutputIterator>
+OutputIterator exclusive_scan_impl(rmm::exec_policy const& policy,
+                                   InputIterator first,
+                                   InputIterator last,
+                                   OutputIterator result)
+{
+  return thrust::exclusive_scan(policy, first, last, result);
+}
+
+template <typename InputIterator, typename OutputIterator, typename T>
+OutputIterator exclusive_scan_impl(rmm::exec_policy const& policy,
+                                   InputIterator first,
+                                   InputIterator last,
+                                   OutputIterator result,
+                                   T init)
+{
+  return thrust::exclusive_scan(policy, first, last, result, init);
+}
+
+template CUGRAPH_EXPORT std::size_t* inclusive_scan_impl(rmm::exec_policy const& policy,
+                                                         std::size_t* first,
+                                                         std::size_t* last,
+                                                         std::size_t* result);
+template CUGRAPH_EXPORT std::int32_t* inclusive_scan_impl(rmm::exec_policy const& policy,
+                                                          std::int32_t* first,
+                                                          std::int32_t* last,
+                                                          std::int32_t* result);
+template CUGRAPH_EXPORT std::int64_t* inclusive_scan_impl(rmm::exec_policy const& policy,
+                                                          std::int64_t* first,
+                                                          std::int64_t* last,
+                                                          std::int64_t* result);
+
+template CUGRAPH_EXPORT std::size_t* exclusive_scan_impl(rmm::exec_policy const& policy,
+                                                         std::size_t* first,
+                                                         std::size_t* last,
+                                                         std::size_t* result);
+template CUGRAPH_EXPORT std::size_t* exclusive_scan_impl(rmm::exec_policy const& policy,
+                                                         std::size_t* first,
+                                                         std::size_t* last,
+                                                         std::size_t* result,
+                                                         std::size_t init);
+
+template CUGRAPH_EXPORT std::int32_t* exclusive_scan_impl(rmm::exec_policy const& policy,
+                                                          std::int32_t* first,
+                                                          std::int32_t* last,
+                                                          std::int32_t* result);
+template CUGRAPH_EXPORT std::int32_t* exclusive_scan_impl(rmm::exec_policy const& policy,
+                                                          std::int32_t* first,
+                                                          std::int32_t* last,
+                                                          std::int32_t* result,
+                                                          std::int32_t init);
+
+template CUGRAPH_EXPORT std::int64_t* exclusive_scan_impl(rmm::exec_policy const& policy,
+                                                          std::int64_t* first,
+                                                          std::int64_t* last,
+                                                          std::int64_t* result);
+template CUGRAPH_EXPORT std::int64_t* exclusive_scan_impl(rmm::exec_policy const& policy,
+                                                          std::int64_t* first,
+                                                          std::int64_t* last,
+                                                          std::int64_t* result,
+                                                          std::int64_t init);
+
 }  // namespace detail
+
 }  // namespace cugraph

--- a/cpp/tests/prims/mg_per_v_random_select_transform_outgoing_e.cu
+++ b/cpp/tests/prims/mg_per_v_random_select_transform_outgoing_e.cu
@@ -22,6 +22,7 @@
 #include <cugraph/utilities/high_res_timer.hpp>
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/thrust_tuple_utils.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -405,10 +406,10 @@ class Tests_MGPerVRandomSelectTransformOutgoingE
           mg_aggregate_sample_offsets = rmm::device_uvector<size_t>(
             (*mg_aggregate_sample_counts).size() + 1, handle_->get_stream());
           (*mg_aggregate_sample_offsets).set_element_to_zero_async(0, handle_->get_stream());
-          thrust::inclusive_scan(handle_->get_thrust_policy(),
-                                 (*mg_aggregate_sample_counts).begin(),
-                                 (*mg_aggregate_sample_counts).end(),
-                                 (*mg_aggregate_sample_offsets).begin() + 1);
+          cugraph::inclusive_scan_wrapper(handle_->get_thrust_policy(),
+                                          (*mg_aggregate_sample_counts).begin(),
+                                          (*mg_aggregate_sample_counts).end(),
+                                          (*mg_aggregate_sample_offsets).begin() + 1);
         }
 
         auto sg_graph_view = sg_graph.view();

--- a/cpp/tests/prims/mg_per_v_random_select_transform_outgoing_e.cu
+++ b/cpp/tests/prims/mg_per_v_random_select_transform_outgoing_e.cu
@@ -406,10 +406,10 @@ class Tests_MGPerVRandomSelectTransformOutgoingE
           mg_aggregate_sample_offsets = rmm::device_uvector<size_t>(
             (*mg_aggregate_sample_counts).size() + 1, handle_->get_stream());
           (*mg_aggregate_sample_offsets).set_element_to_zero_async(0, handle_->get_stream());
-          cugraph::inclusive_scan_wrapper(handle_->get_thrust_policy(),
-                                          (*mg_aggregate_sample_counts).begin(),
-                                          (*mg_aggregate_sample_counts).end(),
-                                          (*mg_aggregate_sample_offsets).begin() + 1);
+          cugraph::inclusive_scan(handle_->get_thrust_policy(),
+                                  (*mg_aggregate_sample_counts).begin(),
+                                  (*mg_aggregate_sample_counts).end(),
+                                  (*mg_aggregate_sample_offsets).begin() + 1);
         }
 
         auto sg_graph_view = sg_graph.view();


### PR DESCRIPTION
Next phase of the reduce binary size effort.

This PR creates cugraph::inclusive_scan and cugraph::exclusive_scan as wrappers around the thrust analogs, pre-compiling variations that make sense to reduce the binary size.

The improvement in binary size here is small, only about 0.3%.