### PR TITLE
Fix Louvain bug introduced in new threshold logic

### DIFF
--- a/cpp/src/community/detail/common_methods.cuh
+++ b/cpp/src/community/detail/common_methods.cuh
@@ -30,6 +30,10 @@
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
 
+#include <algorithm>
+#include <limits>
+#include <type_traits>
+
 CUCO_DECLARE_BITWISE_COMPARABLE(float)
 CUCO_DECLARE_BITWISE_COMPARABLE(double)
 // FIXME: a temporary workaround for a compiler error, should be deleted once cuco gets patched.
@@ -40,6 +44,24 @@ struct is_bitwise_comparable<cuco::pair<int32_t, float>> : std::true_type {};
 
 namespace cugraph {
 namespace detail {
+
+template <typename weight_t>
+constexpr weight_t louvain_delta_modularity_noise_floor()
+{
+  if constexpr (std::is_same_v<weight_t, float>) {
+    return weight_t{1e-12};
+  } else {
+    return weight_t{1e-15};
+  }
+}
+
+template <typename weight_t, typename vertex_t>
+weight_t compute_louvain_min_vertex_move_gain(weight_t threshold, vertex_t number_of_vertices)
+{
+  auto const vertex_count     = std::max(number_of_vertices, vertex_t{1});
+  auto const scaled_threshold = threshold / static_cast<weight_t>(vertex_count);
+  return std::max(scaled_threshold, louvain_delta_modularity_noise_floor<weight_t>());
+}
 
 // FIXME: a workaround for cudaErrorInvalidDeviceFunction error when device lambda is used
 template <typename vertex_t, typename weight_t>
@@ -111,6 +133,7 @@ struct count_updown_moves_op_t {
                                          : false;
   }
 };
+
 // FIXME: a workaround for cudaErrorInvalidDeviceFunction error when device lambda is used
 template <typename vertex_t, typename weight_t>
 struct cluster_update_op_t {
@@ -394,13 +417,16 @@ rmm::device_uvector<vertex_t> update_clustering_by_delta_modularity(
     detail::reduce_op_t<vertex_t, weight_t>{},
     cugraph::get_dataframe_buffer_begin(output_buffer));
 
-  int nr_moves =
-    thrust::count_if(handle.get_thrust_policy(),
-                     thrust::make_zip_iterator(next_clusters_v.begin(),
-                                               cugraph::get_dataframe_buffer_begin(output_buffer)),
-                     thrust::make_zip_iterator(next_clusters_v.end(),
-                                               cugraph::get_dataframe_buffer_end(output_buffer)),
-                     detail::count_updown_moves_op_t<vertex_t, weight_t>{up_down, threshold});
+  auto const min_vertex_move_gain =
+    compute_louvain_min_vertex_move_gain(threshold, graph_view.number_of_vertices());
+
+  int nr_moves = thrust::count_if(
+    handle.get_thrust_policy(),
+    thrust::make_zip_iterator(next_clusters_v.begin(),
+                              cugraph::get_dataframe_buffer_begin(output_buffer)),
+    thrust::make_zip_iterator(next_clusters_v.end(),
+                              cugraph::get_dataframe_buffer_end(output_buffer)),
+    detail::count_updown_moves_op_t<vertex_t, weight_t>{up_down, min_vertex_move_gain});
 
   if constexpr (multi_gpu) {
     nr_moves = host_scalar_allreduce(
@@ -414,7 +440,7 @@ rmm::device_uvector<vertex_t> update_clustering_by_delta_modularity(
                     next_clusters_v.end(),
                     cugraph::get_dataframe_buffer_begin(output_buffer),
                     next_clusters_v.begin(),
-                    detail::cluster_update_op_t<vertex_t, weight_t>{up_down, threshold});
+                    detail::cluster_update_op_t<vertex_t, weight_t>{up_down, min_vertex_move_gain});
 
   return std::move(next_clusters_v);
 }

--- a/cpp/tests/community/louvain_test.cpp
+++ b/cpp/tests/community/louvain_test.cpp
@@ -232,7 +232,7 @@ INSTANTIATE_TEST_SUITE_P(
   ::testing::Combine(::testing::Values(
                        Louvain_Usecase{
                          std::nullopt, std::nullopt, std::nullopt, true, 3, 0.39907956},
-                       Louvain_Usecase{20, double{1e-3}, std::nullopt, true, 3, 0.41978961},
+                       Louvain_Usecase{20, double{1e-3}, std::nullopt, true, 3, 0.39907956},
                        Louvain_Usecase{100, double{1e-3}, double{0.8}, true, 3, 0.48573306}),
                      ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
 


### PR DESCRIPTION
#5541 introduced a bug that wasn't detectable in the small test graphs.

Adjust delta modularity from last commit to be scaled based on graph size.  Previously the threshold was treated as an absolute, but the delta modularity is a function of the number of vertices in the graph.

Closes #5516 