### PR TITLE
Create unique, sequence, and fill wrappers in cugraph to reduce binary size

### DIFF
--- a/cpp/include/cugraph/detail/decompress_edge_partition.cuh
+++ b/cpp/include/cugraph/detail/decompress_edge_partition.cuh
@@ -9,6 +9,7 @@
 #include <cugraph/export.hpp>
 #include <cugraph/graph_view.hpp>
 #include <cugraph/utilities/mask_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 

--- a/cpp/include/cugraph/detail/utility_wrappers.hpp
+++ b/cpp/include/cugraph/detail/utility_wrappers.hpp
@@ -12,8 +12,6 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <thrust/sequence.h>
-
 namespace CUGRAPH_EXPORT cugraph {
 namespace detail {
 
@@ -48,37 +46,6 @@ void uniform_random_fill(rmm::cuda_stream_view const& stream_view,
 
 /**
  * @ingroup utility_wrappers_cpp
- * @brief    Fill a buffer with a constant value
- *
- * @tparam      value_t      type of the value to operate on
- *
- * @param [in]  handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator,
- * and handles to various CUDA libraries) to run graph algorithms.
- * @param[out]  d_value      device array to fill
- * @param[in]   size         number of elements in array
- * @param[in]   value        value
- *
- */
-template <typename value_t>
-void scalar_fill(raft::handle_t const& handle, value_t* d_value, size_t size, value_t value);
-
-/**
- * @ingroup utility_wrappers_cpp
- * @brief    Keep unique element from a device span
- *
- * @tparam      value_t      type of the value to operate on. Must be either int32_t or int64_t.
- *
- * @param [in]  handle RAFT handle object to encapsulate resources (e.g. CUDA stream, communicator,
- * and handles to various CUDA libraries) to run graph algorithms.
- * @param[in]  values      device span of unique elements.
- * @return the number of unique elements.
- *
- */
-template <typename value_t>
-size_t unique_ints(raft::handle_t const& handle, raft::device_span<value_t> values);
-
-/**
- * @ingroup utility_wrappers_cpp
  * @brief    Increment the values of a device span by a constant value
  *
  * @tparam      value_t      type of the value to operate on. Must be either int32_t or int64_t.
@@ -110,52 +77,6 @@ void transform_not_equal(raft::device_span<value_t> values,
                          raft::device_span<bool> result,
                          value_t compare,
                          rmm::cuda_stream_view const& stream_view);
-
-/**
- * @ingroup utility_wrappers_cpp
- * @brief    Fill a buffer with a sequence of values
- *
- * Fills the buffer with the sequence:
- *   {start_value, start_value+1, start_value+2, ..., start_value+size-1}
- *
- * Similar to the function std::iota, wraps the function thrust::sequence
- *
- * @tparam      value_t      type of the value to operate on.
- *
- * @param[in]   stream_view  stream view
- * @param[out]  d_value      device array to fill
- * @param[in]   size         number of elements in array
- * @param[in]   start_value  starting value for sequence
- *
- */
-template <typename value_t>
-void sequence_fill(rmm::cuda_stream_view const& stream_view,
-                   value_t* d_value,
-                   size_t size,
-                   value_t start_value);
-
-/**
- * @ingroup utility_wrappers_cpp
- * @brief    Fill a buffer with a sequence of values with the input stride
- *
- * Fills the buffer with the sequence with the input stride:
- *   {start_value, start_value+stride, start_value+stride*2, ..., start_value+stride*(size-1)}
- *
- * @tparam      value_t      type of the value to operate on
- *
- * @param[in]   stream_view  stream view
- * @param[out]  d_value      device array to fill
- * @param[in]   size         number of elements in array
- * @param[in]   start_value  starting value for sequence
- * @param[in]   stride       input stride
- *
- */
-template <typename value_t>
-void stride_fill(rmm::cuda_stream_view const& stream_view,
-                 value_t* d_value,
-                 size_t size,
-                 value_t start_value,
-                 value_t stride);
 
 /**
  * @ingroup utility_wrappers_cpp

--- a/cpp/include/cugraph/prims/detail/extract_transform_if_v_frontier_e.cuh
+++ b/cpp/include/cugraph/prims/detail/extract_transform_if_v_frontier_e.cuh
@@ -843,9 +843,9 @@ extract_transform_if_v_frontier_e(raft::handle_t const& handle,
                  frontier_key_first,
                  frontier_key_last,
                  get_dataframe_buffer_begin(frontier_keys));
-    cugraph::sort_wrapper(handle.get_thrust_policy(),
-                          get_dataframe_buffer_begin(frontier_keys),
-                          get_dataframe_buffer_end(frontier_keys));
+    cugraph::sort(handle.get_thrust_policy(),
+                  get_dataframe_buffer_begin(frontier_keys),
+                  get_dataframe_buffer_end(frontier_keys));
     frontier_key_first = get_dataframe_buffer_begin(frontier_keys);
     frontier_key_last  = get_dataframe_buffer_end(frontier_keys);
   }
@@ -1626,7 +1626,7 @@ extract_transform_if_v_frontier_e(raft::handle_t const& handle,
       if (loop_stream_pool_indices) { RAFT_CUDA_TRY(cudaDeviceSynchronize()); }
     }
 
-    thrust::fill(
+    cugraph::fill(
       handle.get_thrust_policy(), counters.begin(), counters.begin() + loop_count, size_t{0});
     if (loop_stream_pool_indices) { handle.sync_stream(); }
 

--- a/cpp/include/cugraph/prims/detail/nbr_intersection.cuh
+++ b/cpp/include/cugraph/prims/detail/nbr_intersection.cuh
@@ -761,13 +761,12 @@ nbr_intersection(raft::handle_t const& handle,
                      second_element_first + input_size,
                      unique_majors.begin());
 
-        cugraph::sort_wrapper(
-          handle.get_thrust_policy(), unique_majors.begin(), unique_majors.end());
-        unique_majors.resize(
-          cuda::std::distance(
-            unique_majors.begin(),
-            thrust::unique(handle.get_thrust_policy(), unique_majors.begin(), unique_majors.end())),
-          handle.get_stream());
+        cugraph::sort(handle.get_thrust_policy(), unique_majors.begin(), unique_majors.end());
+        unique_majors.resize(cuda::std::distance(unique_majors.begin(),
+                                                 cugraph::unique(handle.get_thrust_policy(),
+                                                                 unique_majors.begin(),
+                                                                 unique_majors.end())),
+                             handle.get_stream());
 
         unique_majors.shrink_to_fit(handle.get_stream());
 
@@ -791,12 +790,11 @@ nbr_intersection(raft::handle_t const& handle,
             handle.get_stream());
           unique_majors = std::move(rx_unique_majors);
 
-          cugraph::sort_wrapper(
-            handle.get_thrust_policy(), unique_majors.begin(), unique_majors.end());
+          cugraph::sort(handle.get_thrust_policy(), unique_majors.begin(), unique_majors.end());
           unique_majors.resize(cuda::std::distance(unique_majors.begin(),
-                                                   thrust::unique(handle.get_thrust_policy(),
-                                                                  unique_majors.begin(),
-                                                                  unique_majors.end())),
+                                                   cugraph::unique(handle.get_thrust_policy(),
+                                                                   unique_majors.begin(),
+                                                                   unique_majors.end())),
                                handle.get_stream());
 
           unique_majors.shrink_to_fit(handle.get_stream());

--- a/cpp/include/cugraph/prims/detail/partition_v_frontier.cuh
+++ b/cpp/include/cugraph/prims/detail/partition_v_frontier.cuh
@@ -13,6 +13,7 @@
 #include <cugraph/utilities/mask_utils.cuh>
 #include <cugraph/utilities/misc_utils.cuh>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <raft/random/rng.cuh>
@@ -49,7 +50,7 @@ partition_v_frontier(raft::handle_t const& handle,
 {
   rmm::device_uvector<size_t> indices(
     cuda::std::distance(frontier_value_first, frontier_value_last), handle.get_stream());
-  thrust::sequence(handle.get_thrust_policy(), indices.begin(), indices.end(), size_t{0});
+  cugraph::sequence(handle.get_thrust_policy(), indices.begin(), indices.end(), size_t{0});
 
   auto num_partitions = thresholds.size() + 1;
   std::vector<size_t> v_frontier_partition_offsets(num_partitions + 1);

--- a/cpp/include/cugraph/prims/detail/per_v_transform_reduce_e.cuh
+++ b/cpp/include/cugraph/prims/detail/per_v_transform_reduce_e.cuh
@@ -27,6 +27,7 @@
 #include <cugraph/utilities/packed_bool_utils.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
 #include <cugraph/utilities/thrust_tuple_utils.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/core/host_span.hpp>
@@ -1004,10 +1005,10 @@ void per_v_transform_reduce_e_edge_partition(
 
       if constexpr (update_major && !use_input_key) {  // this is necessary as we don't visit
                                                        // every vertex in the hypersparse segment
-        thrust::fill(rmm::exec_policy_nosync(exec_stream),
-                     output_buffer + (*key_segment_offsets)[3],
-                     output_buffer + (*key_segment_offsets)[4],
-                     major_init);
+        cugraph::fill(rmm::exec_policy_nosync(exec_stream),
+                      output_buffer + (*key_segment_offsets)[3],
+                      output_buffer + (*key_segment_offsets)[4],
+                      major_init);
       }
 
       auto segment_size = use_input_key
@@ -1331,15 +1332,15 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
   if constexpr (update_major) {  // no vertices in the zero degree segment are visited (otherwise,
                                  // no need to initialize)
     if constexpr (use_input_key) {
-      thrust::fill(handle.get_thrust_policy(),
-                   vertex_value_output_first +
-                     cuda::std::distance(sorted_unique_key_first, sorted_unique_nzd_key_last),
-                   vertex_value_output_first +
-                     cuda::std::distance(sorted_unique_key_first, sorted_unique_key_last),
-                   init);
+      cugraph::fill(handle.get_thrust_policy(),
+                    vertex_value_output_first +
+                      cuda::std::distance(sorted_unique_key_first, sorted_unique_nzd_key_last),
+                    vertex_value_output_first +
+                      cuda::std::distance(sorted_unique_key_first, sorted_unique_key_last),
+                    init);
     } else {
       if (local_vertex_partition_segment_offsets) {
-        thrust::fill(
+        cugraph::fill(
           handle.get_thrust_policy(),
           vertex_value_output_first + *(local_vertex_partition_segment_offsets->rbegin() + 1),
           vertex_value_output_first + *(local_vertex_partition_segment_offsets->rbegin()),
@@ -1350,10 +1351,10 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
     if constexpr (GraphViewType::is_multi_gpu) {
       /* no need to initialize (we use minor_tmp_buffer) */
     } else {
-      thrust::fill(handle.get_thrust_policy(),
-                   vertex_value_output_first,
-                   vertex_value_output_first + graph_view.local_vertex_partition_range_size(),
-                   init);
+      cugraph::fill(handle.get_thrust_policy(),
+                    vertex_value_output_first,
+                    vertex_value_output_first + graph_view.local_vertex_partition_range_size(),
+                    init);
     }
   }
 
@@ -2592,10 +2593,10 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
                       counters.data() + j,
                       typecast_t<vertex_t, size_t>{});
                   } else {
-                    thrust::fill(rmm::exec_policy_nosync(loop_stream),
-                                 counters.data() + j,
-                                 counters.data() + (j + 1),
-                                 size_t{0});
+                    cugraph::fill(rmm::exec_policy_nosync(loop_stream),
+                                  counters.data() + j,
+                                  counters.data() + (j + 1),
+                                  size_t{0});
                   }
                 }
 
@@ -3096,7 +3097,7 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
         }
         auto tx_values =
           allocate_dataframe_buffer<T>(tx_buf_size_per_rank * loop_count, handle.get_stream());
-        thrust::fill(
+        cugraph::fill(
           handle.get_thrust_policy(), counters.data(), counters.data() + loop_count, size_t{0});
         handle.sync_stream();
 
@@ -3308,7 +3309,7 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
           rmm::device_uvector<uint32_t> bitmap(packed_bool_size(key_output_offset_range_size) +
                                                  packed_bool_size(size_dataframe_buffer(rx_values)),
                                                handle.get_stream());
-          thrust::fill(
+          cugraph::fill(
             handle.get_thrust_policy(), bitmap.begin(), bitmap.end(), packed_bool_empty_mask());
           raft::device_span<uint32_t> claimed_bitmap(
             bitmap.data(), packed_bool_size(key_output_offset_range_size));
@@ -3442,11 +3443,11 @@ void per_v_transform_reduce_e(raft::handle_t const& handle,
         auto this_segment_vertex_partition_id =
           compute_local_edge_partition_minor_range_vertex_partition_id_t{
             major_comm_size, minor_comm_size, major_comm_rank, minor_comm_rank}(i);
-        thrust::fill(handle.get_thrust_policy(),
-                     tx_buffer_first,
-                     tx_buffer_first +
-                       graph_view.vertex_partition_range_size(this_segment_vertex_partition_id),
-                     minor_init);
+        cugraph::fill(handle.get_thrust_policy(),
+                      tx_buffer_first,
+                      tx_buffer_first +
+                        graph_view.vertex_partition_range_size(this_segment_vertex_partition_id),
+                      minor_init);
         auto value_first = cuda::make_transform_iterator(
           view.minor_value_first(),
           cuda::proclaim_return_type<T>(

--- a/cpp/include/cugraph/prims/detail/sample_and_compute_local_nbr_indices.cuh
+++ b/cpp/include/cugraph/prims/detail/sample_and_compute_local_nbr_indices.cuh
@@ -403,14 +403,14 @@ compute_unique_keys(raft::handle_t const& handle,
                  aggregate_local_frontier_key_first + local_frontier_offsets[i],
                  aggregate_local_frontier_key_first + local_frontier_offsets[i + 1],
                  get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i]);
-    cugraph::sort_wrapper(handle.get_thrust_policy(),
-                          get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i],
-                          get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i + 1]);
+    cugraph::sort(handle.get_thrust_policy(),
+                  get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i],
+                  get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i + 1]);
     local_frontier_unique_key_sizes[i] = cuda::std::distance(
       get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i],
-      thrust::unique(handle.get_thrust_policy(),
-                     get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i],
-                     get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i + 1]));
+      cugraph::unique(handle.get_thrust_policy(),
+                      get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i],
+                      get_dataframe_buffer_begin(tmp_keys) + local_frontier_offsets[i + 1]));
   }
   std::inclusive_scan(local_frontier_unique_key_sizes.begin(),
                       local_frontier_unique_key_sizes.end(),
@@ -2909,7 +2909,7 @@ shuffle_and_compute_local_nbr_values(
     rmm::device_uvector<size_t>(sample_local_nbr_values.size(), handle.get_stream());
 
   rmm::device_uvector<size_t> d_tx_counts(minor_comm_size, handle.get_stream());
-  thrust::fill(handle.get_thrust_policy(), d_tx_counts.begin(), d_tx_counts.end(), size_t{0});
+  cugraph::fill(handle.get_thrust_policy(), d_tx_counts.begin(), d_tx_counts.end(), size_t{0});
   auto input_pair_first = thrust::make_zip_iterator(
     sample_local_nbr_values.begin(),
     cuda::make_transform_iterator(thrust::make_counting_iterator(size_t{0}), divider_t<size_t>{K}));
@@ -3018,7 +3018,7 @@ shuffle_and_compute_per_type_local_nbr_values(
     rmm::device_uvector<size_t>(sample_per_type_local_nbr_values.size(), handle.get_stream());
 
   rmm::device_uvector<size_t> d_tx_counts(minor_comm_size, handle.get_stream());
-  thrust::fill(handle.get_thrust_policy(), d_tx_counts.begin(), d_tx_counts.end(), size_t{0});
+  cugraph::fill(handle.get_thrust_policy(), d_tx_counts.begin(), d_tx_counts.end(), size_t{0});
   auto input_pair_first   = thrust::make_zip_iterator(sample_per_type_local_nbr_values.begin(),
                                                     thrust::make_counting_iterator(size_t{0}));
   auto output_tuple_first = thrust::make_zip_iterator(minor_comm_ranks.begin(),
@@ -5447,12 +5447,12 @@ heterogeneous_uniform_sample_and_compute_local_nbr_indices(
       rmm::device_uvector<size_t> aggregate_local_frontier_unique_key_indices(
         local_frontier_unique_key_offsets.back(), handle.get_stream());
       for (size_t i = 0; i < local_frontier_unique_key_offsets.size() - 1; ++i) {
-        thrust::sequence(handle.get_thrust_policy(),
-                         aggregate_local_frontier_unique_key_indices.begin() +
-                           local_frontier_unique_key_offsets[i],
-                         aggregate_local_frontier_unique_key_indices.begin() +
-                           local_frontier_unique_key_offsets[i + 1],
-                         size_t{0});
+        cugraph::sequence(handle.get_thrust_policy(),
+                          aggregate_local_frontier_unique_key_indices.begin() +
+                            local_frontier_unique_key_offsets[i],
+                          aggregate_local_frontier_unique_key_indices.begin() +
+                            local_frontier_unique_key_offsets[i + 1],
+                          size_t{0});
       }
 
       auto aggregate_local_frontier_unique_key_per_type_local_degrees =
@@ -5835,7 +5835,7 @@ heterogeneous_biased_sample_and_compute_local_nbr_indices(
                                                             handle.get_stream());
       rmm::device_uvector<size_t> sequences(h_nbr_offsets[i + 1] - h_nbr_offsets[i],
                                             handle.get_stream());
-      thrust::sequence(handle.get_thrust_policy(), sequences.begin(), sequences.end(), size_t{0});
+      cugraph::sequence(handle.get_thrust_policy(), sequences.begin(), sequences.end(), size_t{0});
       rmm::device_uvector<size_t> segment_sorted_sequences(h_nbr_offsets[i + 1] - h_nbr_offsets[i],
                                                            handle.get_stream());
 
@@ -5912,12 +5912,12 @@ heterogeneous_biased_sample_and_compute_local_nbr_indices(
       rmm::device_uvector<size_t> aggregate_local_frontier_unique_key_indices(
         local_frontier_unique_key_offsets.back(), handle.get_stream());
       for (size_t i = 0; i < local_frontier_unique_key_offsets.size() - 1; ++i) {
-        thrust::sequence(handle.get_thrust_policy(),
-                         aggregate_local_frontier_unique_key_indices.begin() +
-                           local_frontier_unique_key_offsets[i],
-                         aggregate_local_frontier_unique_key_indices.begin() +
-                           local_frontier_unique_key_offsets[i + 1],
-                         size_t{0});
+        cugraph::sequence(handle.get_thrust_policy(),
+                          aggregate_local_frontier_unique_key_indices.begin() +
+                            local_frontier_unique_key_offsets[i],
+                          aggregate_local_frontier_unique_key_indices.begin() +
+                            local_frontier_unique_key_offsets[i + 1],
+                          size_t{0});
       }
 
       auto aggregate_local_frontier_unique_key_per_type_local_degrees =

--- a/cpp/include/cugraph/prims/detail/transform_v_frontier_e.cuh
+++ b/cpp/include/cugraph/prims/detail/transform_v_frontier_e.cuh
@@ -495,10 +495,10 @@ auto transform_v_frontier_e(raft::handle_t const& handle,
 
     rmm::device_uvector<size_t> edge_partition_key_indices(
       local_frontier_offsets[i + 1] - local_frontier_offsets[i], handle.get_stream());
-    thrust::sequence(handle.get_thrust_policy(),
-                     edge_partition_key_indices.begin(),
-                     edge_partition_key_indices.end(),
-                     size_t{0});
+    cugraph::sequence(handle.get_thrust_policy(),
+                      edge_partition_key_indices.begin(),
+                      edge_partition_key_indices.end(),
+                      size_t{0});
 
     auto edge_partition_frontier_local_degree_offsets = raft::device_span<size_t const>(
       aggregate_local_frontier_local_degree_offsets.data() + local_frontier_offsets[i],

--- a/cpp/include/cugraph/prims/edge_bucket.cuh
+++ b/cpp/include/cugraph/prims/edge_bucket.cuh
@@ -7,6 +7,7 @@
 #include <cugraph/export.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/host_scalar_comm.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
@@ -105,16 +106,16 @@ class edge_bucket_t {
       majors_.resize(1, handle_ptr_->get_stream());
       minors_.resize(1, handle_ptr_->get_stream());
       auto pair_first = thrust::make_zip_iterator(majors_.data(), minors_.data());
-      thrust::fill(handle_ptr_->get_thrust_policy(),
-                   pair_first,
-                   pair_first + 1,
-                   cuda::std::make_tuple(major, minor));
+      cugraph::fill(handle_ptr_->get_thrust_policy(),
+                    pair_first,
+                    pair_first + 1,
+                    cuda::std::make_tuple(major, minor));
       if (multi_edge_index) {
         multi_edge_indices_->resize(1, handle_ptr_->get_stream());
-        thrust::fill(handle_ptr_->get_thrust_policy(),
-                     multi_edge_indices_->begin(),
-                     multi_edge_indices_->begin() + 1,
-                     *multi_edge_index);
+        cugraph::fill(handle_ptr_->get_thrust_policy(),
+                      multi_edge_indices_->begin(),
+                      multi_edge_indices_->begin() + 1,
+                      *multi_edge_index);
       }
     }
   }
@@ -176,9 +177,9 @@ class edge_bucket_t {
                         merged_triplet_first);
           new_size = static_cast<size_t>(
             cuda::std::distance(merged_triplet_first,
-                                thrust::unique(handle_ptr_->get_thrust_policy(),
-                                               merged_triplet_first,
-                                               merged_triplet_first + merged_majors.size())));
+                                cugraph::unique(handle_ptr_->get_thrust_policy(),
+                                                merged_triplet_first,
+                                                merged_triplet_first + merged_majors.size())));
         } else {
           auto new_pair_first = thrust::make_zip_iterator(major_first, minor_first);
           auto old_pair_first = thrust::make_zip_iterator(majors_.begin(), minors_.begin());
@@ -192,9 +193,9 @@ class edge_bucket_t {
                         merged_pair_first);
           new_size = static_cast<size_t>(
             cuda::std::distance(merged_pair_first,
-                                thrust::unique(handle_ptr_->get_thrust_policy(),
-                                               merged_pair_first,
-                                               merged_pair_first + merged_majors.size())));
+                                cugraph::unique(handle_ptr_->get_thrust_policy(),
+                                                merged_pair_first,
+                                                merged_pair_first + merged_majors.size())));
         }
         merged_minors.resize(new_size, handle_ptr_->get_stream());
         merged_minors.resize(new_size, handle_ptr_->get_stream());

--- a/cpp/include/cugraph/prims/fill_edge_property.cuh
+++ b/cpp/include/cugraph/prims/fill_edge_property.cuh
@@ -9,6 +9,7 @@
 #include <cugraph/export.hpp>
 #include <cugraph/graph_view.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -79,15 +80,16 @@ void fill_edge_property(raft::handle_t const& handle,
             });
         }
       } else {
-        thrust::fill_n(handle.get_thrust_policy(),
-                       value_firsts[i],
-                       packed_bool_size(static_cast<size_t>(edge_counts[i] - rem)),
-                       packed_input);
+        cugraph::fill(
+          handle.get_thrust_policy(),
+          value_firsts[i],
+          (value_firsts[i]) + (packed_bool_size(static_cast<size_t>(edge_counts[i] - rem))),
+          packed_input);
         if (rem > 0) {
-          thrust::fill_n(
+          cugraph::fill(
             handle.get_thrust_policy(),
             value_firsts[i] + packed_bool_size(static_cast<size_t>(edge_counts[i] - rem)),
-            1,
+            (value_firsts[i] + packed_bool_size(static_cast<size_t>(edge_counts[i] - rem))) + (1),
             packed_input & packed_bool_partial_mask(rem));
         }
       }
@@ -103,8 +105,10 @@ void fill_edge_property(raft::handle_t const& handle,
                                return edge_partition_e_mask.get(i);
                              });
       } else {
-        thrust::fill_n(
-          handle.get_thrust_policy(), value_firsts[i], static_cast<size_t>(edge_counts[i]), input);
+        cugraph::fill(handle.get_thrust_policy(),
+                      value_firsts[i],
+                      (value_firsts[i]) + (static_cast<size_t>(edge_counts[i])),
+                      input);
       }
     }
   }

--- a/cpp/include/cugraph/prims/fill_edge_src_dst_property.cuh
+++ b/cpp/include/cugraph/prims/fill_edge_src_dst_property.cuh
@@ -15,6 +15,7 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/packed_bool_utils.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -120,12 +121,15 @@ void fill_edge_major_property(raft::handle_t const& handle,
     }
     if constexpr (contains_packed_bool_element) {
       auto packed_input = input ? packed_bool_full_mask() : packed_bool_empty_mask();
-      thrust::fill_n(handle.get_thrust_policy(),
-                     value_firsts[i],
-                     packed_bool_size(num_buffer_elements),
-                     packed_input);
+      cugraph::fill(handle.get_thrust_policy(),
+                    value_firsts[i],
+                    (value_firsts[i]) + (packed_bool_size(num_buffer_elements)),
+                    packed_input);
     } else {
-      thrust::fill_n(handle.get_thrust_policy(), value_firsts[i], num_buffer_elements, input);
+      cugraph::fill(handle.get_thrust_policy(),
+                    value_firsts[i],
+                    (value_firsts[i]) + (num_buffer_elements),
+                    input);
     }
   }
 }
@@ -293,10 +297,13 @@ void fill_edge_minor_property(raft::handle_t const& handle,
   if constexpr (contains_packed_bool_element) {
     static_assert(std::is_arithmetic_v<T>, "unimplemented for cuda::std::tuple types.");
     auto packed_input = input ? packed_bool_full_mask() : packed_bool_empty_mask();
-    thrust::fill_n(
-      handle.get_thrust_policy(), value_first, packed_bool_size(num_buffer_elements), packed_input);
+    cugraph::fill(handle.get_thrust_policy(),
+                  value_first,
+                  (value_first) + (packed_bool_size(num_buffer_elements)),
+                  packed_input);
   } else {
-    thrust::fill_n(handle.get_thrust_policy(), value_first, num_buffer_elements, input);
+    cugraph::fill(
+      handle.get_thrust_policy(), value_first, (value_first) + (num_buffer_elements), input);
   }
 }
 

--- a/cpp/include/cugraph/prims/key_store.cuh
+++ b/cpp/include/cugraph/prims/key_store.cuh
@@ -191,7 +191,7 @@ class key_binary_search_store_t {
   {
     thrust::copy(rmm::exec_policy(stream), key_first, key_last, store_keys_.begin());
     if (!key_sorted) {
-      cugraph::sort_wrapper(rmm::exec_policy(stream), store_keys_.begin(), store_keys_.end());
+      cugraph::sort(rmm::exec_policy(stream), store_keys_.begin(), store_keys_.end());
     }
   }
 
@@ -204,7 +204,7 @@ class key_binary_search_store_t {
     : store_keys_(std::move(keys))
   {
     if (!key_sorted) {
-      cugraph::sort_wrapper(rmm::exec_policy(stream), store_keys_.begin(), store_keys_.end());
+      cugraph::sort(rmm::exec_policy(stream), store_keys_.begin(), store_keys_.end());
     }
   }
 

--- a/cpp/include/cugraph/prims/kv_store.cuh
+++ b/cpp/include/cugraph/prims/kv_store.cuh
@@ -13,6 +13,7 @@
 
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
 
 #include <cuda/atomic>
@@ -694,7 +695,7 @@ class kv_cuco_store_t {
       // now perform assigns (for k,v pairs that failed to insert)
 
       rmm::device_uvector<size_t> kv_indices(num_keys, stream);
-      thrust::sequence(rmm::exec_policy(), kv_indices.begin(), kv_indices.end(), size_t{0});
+      cugraph::sequence(rmm::exec_policy(), kv_indices.begin(), kv_indices.end(), size_t{0});
       auto pair_first = thrust::make_zip_iterator(store_value_offsets.begin(), kv_indices.begin());
       kv_indices.resize(
         cuda::std::distance(
@@ -708,20 +709,20 @@ class kv_cuco_store_t {
       store_value_offsets.resize(0, stream);
       store_value_offsets.shrink_to_fit(stream);
 
-      cugraph::sort_wrapper(rmm::exec_policy(stream),
-                            kv_indices.begin(),
-                            kv_indices.end(),
-                            [key_first] __device__(auto lhs, auto rhs) {
-                              return *(key_first + lhs) < *(key_first + rhs);
-                            });
+      cugraph::sort(rmm::exec_policy(stream),
+                    kv_indices.begin(),
+                    kv_indices.end(),
+                    [key_first] __device__(auto lhs, auto rhs) {
+                      return *(key_first + lhs) < *(key_first + rhs);
+                    });
       kv_indices.resize(
         cuda::std::distance(kv_indices.begin(),
-                            thrust::unique(rmm::exec_policy(stream),
-                                           kv_indices.begin(),
-                                           kv_indices.end(),
-                                           [key_first] __device__(auto lhs, auto rhs) {
-                                             return *(key_first + lhs) == *(key_first + rhs);
-                                           })),
+                            cugraph::unique(rmm::exec_policy(stream),
+                                            kv_indices.begin(),
+                                            kv_indices.end(),
+                                            [key_first] __device__(auto lhs, auto rhs) {
+                                              return *(key_first + lhs) == *(key_first + rhs);
+                                            })),
         stream);
 
       thrust::for_each(

--- a/cpp/include/cugraph/prims/per_v_pair_transform_src_dst_nbr_intersection.cuh
+++ b/cpp/include/cugraph/prims/per_v_pair_transform_src_dst_nbr_intersection.cuh
@@ -227,14 +227,14 @@ void per_v_pair_transform_minor_nbr_intersection(
                  elem1_first,
                  elem1_first + num_input_pairs,
                  (*sorted_unique_vertices).begin() + num_input_pairs);
-    cugraph::sort_wrapper(handle.get_thrust_policy(),
-                          (*sorted_unique_vertices).begin(),
-                          (*sorted_unique_vertices).end());
+    cugraph::sort(handle.get_thrust_policy(),
+                  (*sorted_unique_vertices).begin(),
+                  (*sorted_unique_vertices).end());
     (*sorted_unique_vertices)
       .resize(cuda::std::distance((*sorted_unique_vertices).begin(),
-                                  thrust::unique(handle.get_thrust_policy(),
-                                                 (*sorted_unique_vertices).begin(),
-                                                 (*sorted_unique_vertices).end())),
+                                  cugraph::unique(handle.get_thrust_policy(),
+                                                  (*sorted_unique_vertices).begin(),
+                                                  (*sorted_unique_vertices).end())),
               handle.get_stream());
 
     property_buffer_for_sorted_unique_vertices = collect_values_for_sorted_unique_int_vertices(
@@ -247,7 +247,7 @@ void per_v_pair_transform_minor_nbr_intersection(
   }
 
   rmm::device_uvector<size_t> vertex_pair_indices(num_input_pairs, handle.get_stream());
-  thrust::sequence(
+  cugraph::sequence(
     handle.get_thrust_policy(), vertex_pair_indices.begin(), vertex_pair_indices.end(), size_t{0});
 
   std::vector<vertex_t> h_edge_partition_major_range_lasts(
@@ -327,12 +327,12 @@ void per_v_pair_transform_minor_nbr_intersection(
     for (size_t j = 0; j < h_chunk_sizes.size(); ++j) {
       auto this_chunk_size = h_chunk_sizes[j];
 
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            chunk_vertex_pair_index_first,
-                            chunk_vertex_pair_index_first + this_chunk_size,
-                            detail::indirection_compare_less_t<VertexPairIterator>{
-                              vertex_pair_first});  // detail::nbr_intersection() requires the input
-                                                    // vertex pairs to be sorted.
+      cugraph::sort(handle.get_thrust_policy(),
+                    chunk_vertex_pair_index_first,
+                    chunk_vertex_pair_index_first + this_chunk_size,
+                    detail::indirection_compare_less_t<VertexPairIterator>{
+                      vertex_pair_first});  // detail::nbr_intersection() requires the input
+                                            // vertex pairs to be sorted.
 
       // FIXME: better restrict detail::nbr_intersection input vertex pairs to a single edge
       // partition? This may provide additional performance improvement opportunities???

--- a/cpp/include/cugraph/prims/per_v_random_select_transform_outgoing_e.cuh
+++ b/cpp/include/cugraph/prims/per_v_random_select_transform_outgoing_e.cuh
@@ -17,6 +17,7 @@
 #include <cugraph/utilities/mask_utils.cuh>
 #include <cugraph/utilities/misc_utils.cuh>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/random/rng.cuh>
 
@@ -533,7 +534,7 @@ per_v_random_select_transform_e(raft::handle_t const& handle,
                      handle.get_stream());
 
     rmm::device_uvector<int32_t> sample_counts(key_list.size(), handle.get_stream());
-    thrust::fill(
+    cugraph::fill(
       handle.get_thrust_policy(), sample_counts.begin(), sample_counts.end(), int32_t{0});
     auto sample_intra_partition_displacements =
       rmm::device_uvector<int32_t>((*sample_key_indices).size(), handle.get_stream());
@@ -550,10 +551,10 @@ per_v_random_select_transform_e(raft::handle_t const& handle,
 
       resize_dataframe_buffer(
         tmp_sample_e_op_results, key_list.size() * K_sum, handle.get_stream());
-      thrust::fill(handle.get_thrust_policy(),
-                   get_dataframe_buffer_begin(tmp_sample_e_op_results),
-                   get_dataframe_buffer_end(tmp_sample_e_op_results),
-                   *invalid_value);
+      cugraph::fill(handle.get_thrust_policy(),
+                    get_dataframe_buffer_begin(tmp_sample_e_op_results),
+                    get_dataframe_buffer_end(tmp_sample_e_op_results),
+                    *invalid_value);
       thrust::scatter(
         handle.get_thrust_policy(),
         get_dataframe_buffer_begin(sample_e_op_results),

--- a/cpp/include/cugraph/prims/per_v_transform_reduce_dst_key_aggregated_outgoing_e.cuh
+++ b/cpp/include/cugraph/prims/per_v_transform_reduce_dst_key_aggregated_outgoing_e.cuh
@@ -676,9 +676,9 @@ void per_v_transform_reduce_dst_key_aggregated_outgoing_e(
             handle.get_thrust_policy(), tmp_majors.begin(), tmp_majors.end(), majors.begin());
 
           auto pair_first = thrust::make_zip_iterator(minor_comm_ranks.begin(), majors.begin());
-          cugraph::sort_wrapper(
+          cugraph::sort(
             handle.get_thrust_policy(), pair_first, pair_first + minor_comm_ranks.size());
-          auto unique_pair_last = thrust::unique(
+          auto unique_pair_last = cugraph::unique(
             handle.get_thrust_policy(), pair_first, pair_first + minor_comm_ranks.size());
           minor_comm_ranks.resize(cuda::std::distance(pair_first, unique_pair_last),
                                   handle.get_stream());
@@ -884,18 +884,18 @@ void per_v_transform_reduce_dst_key_aggregated_outgoing_e(
                                          int{1},
                                          handle.get_stream());
 
-          cugraph::sort_wrapper(handle.get_thrust_policy(), key_pair_first, second_first);
+          cugraph::sort(handle.get_thrust_policy(), key_pair_first, second_first);
 
-          cugraph::sort_wrapper(
+          cugraph::sort(
             handle.get_thrust_policy(), second_first, key_pair_first + rx_majors.size());
         } else {
-          cugraph::sort_wrapper(
+          cugraph::sort(
             handle.get_thrust_policy(), key_pair_first, key_pair_first + rx_majors.size());
         }
 
         auto num_uniques = cuda::std::distance(
           key_pair_first,
-          thrust::unique(
+          cugraph::unique(
             handle.get_thrust_policy(), key_pair_first, key_pair_first + rx_majors.size()));
         tmp_majors.resize(num_uniques, handle.get_stream());
         tmp_minor_keys.resize(tmp_majors.size(), handle.get_stream());
@@ -921,12 +921,11 @@ void per_v_transform_reduce_dst_key_aggregated_outgoing_e(
                    tmp_minor_keys.begin(),
                    tmp_minor_keys.end(),
                    unique_minor_keys.begin());
-      cugraph::sort_wrapper(
-        handle.get_thrust_policy(), unique_minor_keys.begin(), unique_minor_keys.end());
+      cugraph::sort(handle.get_thrust_policy(), unique_minor_keys.begin(), unique_minor_keys.end());
       unique_minor_keys.resize(cuda::std::distance(unique_minor_keys.begin(),
-                                                   thrust::unique(handle.get_thrust_policy(),
-                                                                  unique_minor_keys.begin(),
-                                                                  unique_minor_keys.end())),
+                                                   cugraph::unique(handle.get_thrust_policy(),
+                                                                   unique_minor_keys.begin(),
+                                                                   unique_minor_keys.end())),
                                handle.get_stream());
       unique_minor_keys.shrink_to_fit(handle.get_stream());
 
@@ -1100,10 +1099,10 @@ void per_v_transform_reduce_dst_key_aggregated_outgoing_e(
 
   // 2. update final results
 
-  thrust::fill(handle.get_thrust_policy(),
-               vertex_value_output_first,
-               vertex_value_output_first + graph_view.local_vertex_partition_range_size(),
-               init);
+  cugraph::fill(handle.get_thrust_policy(),
+                vertex_value_output_first,
+                vertex_value_output_first + graph_view.local_vertex_partition_range_size(),
+                init);
 
   auto pair_first =
     thrust::make_zip_iterator(majors.begin(), get_dataframe_buffer_begin(e_op_result_buffer));

--- a/cpp/include/cugraph/prims/transform_gather_e.cuh
+++ b/cpp/include/cugraph/prims/transform_gather_e.cuh
@@ -231,14 +231,14 @@ void transform_gather_e(raft::handle_t const& handle,
     std::conditional_t<!EdgeBucketType::is_sorted_unique, size_t, void>>(edge_list.size(),
                                                                          handle.get_stream());
   if constexpr (!EdgeBucketType::is_sorted_unique) {
-    thrust::sequence(
+    cugraph::sequence(
       handle.get_thrust_policy(), output_indices.begin(), output_indices.end(), size_t{0});
-    cugraph::sort_wrapper(handle.get_thrust_policy(),
-                          output_indices.begin(),
-                          output_indices.end(),
-                          cuda::proclaim_return_type<bool>([edge_first] __device__(auto l, auto r) {
-                            return *(edge_first + l) < *(edge_first + r);
-                          }));
+    cugraph::sort(handle.get_thrust_policy(),
+                  output_indices.begin(),
+                  output_indices.end(),
+                  cuda::proclaim_return_type<bool>([edge_first] __device__(auto l, auto r) {
+                    return *(edge_first + l) < *(edge_first + r);
+                  }));
   }
 
   std::vector<size_t> edge_partition_offsets(graph_view.number_of_local_edge_partitions() + 1, 0);

--- a/cpp/include/cugraph/prims/transform_reduce_e.cuh
+++ b/cpp/include/cugraph/prims/transform_reduce_e.cuh
@@ -17,6 +17,7 @@
 #include <cugraph/utilities/dataframe_buffer.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/thrust_tuple_utils.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
@@ -464,10 +465,10 @@ T transform_reduce_e(raft::handle_t const& handle,
   property_op<T, cuda::std::plus> edge_property_add{};
 
   auto result_buffer = allocate_dataframe_buffer<T>(1, handle.get_stream());
-  thrust::fill(handle.get_thrust_policy(),
-               get_dataframe_buffer_begin(result_buffer),
-               get_dataframe_buffer_begin(result_buffer) + 1,
-               T{});
+  cugraph::fill(handle.get_thrust_policy(),
+                get_dataframe_buffer_begin(result_buffer),
+                get_dataframe_buffer_begin(result_buffer) + 1,
+                T{});
 
   auto edge_mask_view = graph_view.edge_mask_view();
 

--- a/cpp/include/cugraph/prims/transform_reduce_if_v_frontier_outgoing_e_by_dst.cuh
+++ b/cpp/include/cugraph/prims/transform_reduce_if_v_frontier_outgoing_e_by_dst.cuh
@@ -118,10 +118,10 @@ filter_buffer_elements(
 
   rmm::device_uvector<priority_t> priorities(allreduce_count_per_rank * major_comm_size,
                                              handle.get_stream());
-  thrust::fill(handle.get_thrust_policy(),
-               priorities.begin(),
-               priorities.end(),
-               std::numeric_limits<priority_t>::max());
+  cugraph::fill(handle.get_thrust_policy(),
+                priorities.begin(),
+                priorities.end(),
+                std::numeric_limits<priority_t>::max());
   thrust::for_each(
     handle.get_thrust_policy(),
     unique_v_buffer.begin(),
@@ -265,9 +265,9 @@ sort_and_reduce_buffer_elements(
                 if (invalid_key && key == *invalid_key) { return false; }
                 return key < threshold;
               }))));
-        cugraph::sort_wrapper(handle.get_thrust_policy(),
-                              get_dataframe_buffer_begin(key_buffer),
-                              get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements);
+        cugraph::sort(handle.get_thrust_policy(),
+                      get_dataframe_buffer_begin(key_buffer),
+                      get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements);
 
       } else {
         auto pair_first = thrust::make_zip_iterator(get_dataframe_buffer_begin(key_buffer),
@@ -336,7 +336,7 @@ sort_and_reduce_buffer_elements(
       rmm::device_uvector<uint32_t> keep_flags(
         packed_bool_size(size_dataframe_buffer(key_buffer) - num_unique_prefix_elements),
         handle.get_stream());
-      thrust::fill(
+      cugraph::fill(
         handle.get_thrust_policy(), bitmap.begin(), bitmap.end(), packed_bool_empty_mask());
       thrust::for_each(
         handle.get_thrust_policy(),
@@ -396,9 +396,9 @@ sort_and_reduce_buffer_elements(
                         get_dataframe_buffer_begin(tmp_key_buffer) + num_unique_prefix_elements,
                         is_equal_t<bool>{true});
         key_buffer = std::move(tmp_key_buffer);
-        cugraph::sort_wrapper(handle.get_thrust_policy(),
-                              get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements,
-                              get_dataframe_buffer_end(key_buffer));
+        cugraph::sort(handle.get_thrust_policy(),
+                      get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements,
+                      get_dataframe_buffer_end(key_buffer));
       } else {
         static_assert(std::is_same_v<ReduceOp, reduce_op::any<typename ReduceOp::value_type>>);
         auto tmp_key_buffer = allocate_dataframe_buffer<input_key_t>(
@@ -449,9 +449,9 @@ sort_and_reduce_buffer_elements(
   }
 
   if constexpr (std::is_same_v<payload_t, void>) {
-    cugraph::sort_wrapper(handle.get_thrust_policy(),
-                          get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements,
-                          get_dataframe_buffer_end(key_buffer));
+    cugraph::sort(handle.get_thrust_policy(),
+                  get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements,
+                  get_dataframe_buffer_end(key_buffer));
   } else {
     thrust::sort_by_key(handle.get_thrust_policy(),
                         get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements,
@@ -490,9 +490,9 @@ sort_and_reduce_buffer_elements(
         key_buffer,
         cuda::std::distance(
           get_dataframe_buffer_begin(key_buffer),
-          thrust::unique(handle.get_thrust_policy(),
-                         get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements,
-                         get_dataframe_buffer_end(key_buffer))),
+          cugraph::unique(handle.get_thrust_policy(),
+                          get_dataframe_buffer_begin(key_buffer) + num_unique_prefix_elements,
+                          get_dataframe_buffer_end(key_buffer))),
         handle.get_stream());
       output_key_buffer = std::move(key_buffer);
     }

--- a/cpp/include/cugraph/prims/transform_reduce_src_dst_nbr_intersection_of_e_endpoints_by_v.cuh
+++ b/cpp/include/cugraph/prims/transform_reduce_src_dst_nbr_intersection_of_e_endpoints_by_v.cuh
@@ -211,10 +211,10 @@ void transform_reduce_minor_nbr_intersection_of_e_endpoints_by_v(
     // currently, nothing to do.
   }
 
-  thrust::fill(handle.get_thrust_policy(),
-               vertex_value_output_first,
-               vertex_value_output_first + graph_view.local_vertex_partition_range_size(),
-               init);
+  cugraph::fill(handle.get_thrust_policy(),
+                vertex_value_output_first,
+                vertex_value_output_first + graph_view.local_vertex_partition_range_size(),
+                init);
 
   auto edge_mask_view = graph_view.edge_mask_view();
 
@@ -300,7 +300,7 @@ void transform_reduce_minor_nbr_intersection_of_e_endpoints_by_v(
     for (size_t j = 0; j < h_chunk_sizes.size(); ++j) {
       auto this_chunk_size = h_chunk_sizes[j];
 
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(),
         chunk_vertex_pair_first,
         chunk_vertex_pair_first + this_chunk_size);  // detail::nbr_intersection() requires the

--- a/cpp/include/cugraph/prims/vertex_frontier.cuh
+++ b/cpp/include/cugraph/prims/vertex_frontier.cuh
@@ -11,6 +11,7 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/packed_bool_utils.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/device_span.hpp>
 #include <raft/core/handle.hpp>
@@ -19,6 +20,7 @@
 
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <cuda/atomic>
 #include <cuda/functional>
@@ -322,7 +324,7 @@ class key_bucket_t {
       vertices_.resize(1, handle_ptr_->get_stream());
       tags_.resize(1, handle_ptr_->get_stream());
       auto pair_first = thrust::make_zip_iterator(vertices_.begin(), tags_.begin());
-      thrust::fill(handle_ptr_->get_thrust_policy(), pair_first, pair_first + 1, key);
+      cugraph::fill(handle_ptr_->get_thrust_policy(), pair_first, pair_first + 1, key);
     }
   }
 
@@ -354,9 +356,9 @@ class key_bucket_t {
                       vertex_last,
                       merged_vertices.begin());
         merged_vertices.resize(cuda::std::distance(merged_vertices.begin(),
-                                                   thrust::unique(handle_ptr_->get_thrust_policy(),
-                                                                  merged_vertices.begin(),
-                                                                  merged_vertices.end())),
+                                                   cugraph::unique(handle_ptr_->get_thrust_policy(),
+                                                                   merged_vertices.begin(),
+                                                                   merged_vertices.end())),
                                handle_ptr_->get_stream());
         vertices_ = std::move(merged_vertices);
       } else {
@@ -406,9 +408,9 @@ class key_bucket_t {
                       merged_pair_first);
         merged_vertices.resize(
           cuda::std::distance(merged_pair_first,
-                              thrust::unique(handle_ptr_->get_thrust_policy(),
-                                             merged_pair_first,
-                                             merged_pair_first + merged_vertices.size())),
+                              cugraph::unique(handle_ptr_->get_thrust_policy(),
+                                              merged_pair_first,
+                                              merged_pair_first + merged_vertices.size())),
           handle_ptr_->get_stream());
         merged_tags.resize(merged_vertices.size(), handle_ptr_->get_stream());
         vertices_ = std::move(merged_vertices);

--- a/cpp/include/cugraph/utilities/collect_comm.cuh
+++ b/cpp/include/cugraph/utilities/collect_comm.cuh
@@ -160,13 +160,13 @@ dataframe_buffer_type_t<typename KVStoreViewType::value_type> collect_values_for
                collect_key_first,
                collect_key_last,
                get_dataframe_buffer_begin(unique_keys));
-  cugraph::sort_wrapper(rmm::exec_policy_nosync(stream_view),
-                        get_dataframe_buffer_begin(unique_keys),
-                        get_dataframe_buffer_end(unique_keys));
+  cugraph::sort(rmm::exec_policy_nosync(stream_view),
+                get_dataframe_buffer_begin(unique_keys),
+                get_dataframe_buffer_end(unique_keys));
   unique_keys.resize(cuda::std::distance(get_dataframe_buffer_begin(unique_keys),
-                                         thrust::unique(rmm::exec_policy(stream_view),
-                                                        get_dataframe_buffer_begin(unique_keys),
-                                                        get_dataframe_buffer_end(unique_keys))),
+                                         cugraph::unique(rmm::exec_policy(stream_view),
+                                                         get_dataframe_buffer_begin(unique_keys),
+                                                         get_dataframe_buffer_end(unique_keys))),
                      stream_view);
 
   auto values_for_unique_keys = allocate_dataframe_buffer<value_t>(0, stream_view);
@@ -246,14 +246,14 @@ collect_values_for_unique_keys(
                  get_dataframe_buffer_begin(rx_keys),
                  get_dataframe_buffer_end(rx_keys),
                  get_dataframe_buffer_begin(rx_unique_keys));
-    cugraph::sort_wrapper(handle.get_thrust_policy(),
-                          get_dataframe_buffer_begin(rx_unique_keys),
-                          get_dataframe_buffer_end(rx_unique_keys));
+    cugraph::sort(handle.get_thrust_policy(),
+                  get_dataframe_buffer_begin(rx_unique_keys),
+                  get_dataframe_buffer_end(rx_unique_keys));
     rx_unique_keys.resize(
       cuda::std::distance(get_dataframe_buffer_begin(rx_unique_keys),
-                          thrust::unique(handle.get_thrust_policy(),
-                                         get_dataframe_buffer_begin(rx_unique_keys),
-                                         get_dataframe_buffer_end(rx_unique_keys))),
+                          cugraph::unique(handle.get_thrust_policy(),
+                                          get_dataframe_buffer_begin(rx_unique_keys),
+                                          get_dataframe_buffer_end(rx_unique_keys))),
       handle.get_stream());
 
     auto values_for_rx_unique_keys = detail::collect_values_for_keys(
@@ -324,11 +324,11 @@ dataframe_buffer_type_t<typename KVStoreViewType::value_type> collect_values_for
                                          handle.get_stream());
   thrust::copy(
     handle.get_thrust_policy(), collect_key_first, collect_key_last, unique_keys.begin());
-  cugraph::sort_wrapper(handle.get_thrust_policy(), unique_keys.begin(), unique_keys.end());
+  cugraph::sort(handle.get_thrust_policy(), unique_keys.begin(), unique_keys.end());
   unique_keys.resize(
     cuda::std::distance(
       unique_keys.begin(),
-      thrust::unique(handle.get_thrust_policy(), unique_keys.begin(), unique_keys.end())),
+      cugraph::unique(handle.get_thrust_policy(), unique_keys.begin(), unique_keys.end())),
     handle.get_stream());
 
   auto values_for_unique_keys = allocate_dataframe_buffer<value_t>(0, handle.get_stream());
@@ -570,12 +570,12 @@ collect_values_for_int_vertices(
                collect_vertex_first,
                collect_vertex_last,
                sorted_unique_int_vertices.begin());
-  cugraph::sort_wrapper(handle.get_thrust_policy(),
-                        sorted_unique_int_vertices.begin(),
-                        sorted_unique_int_vertices.end());
-  auto last = thrust::unique(handle.get_thrust_policy(),
-                             sorted_unique_int_vertices.begin(),
-                             sorted_unique_int_vertices.end());
+  cugraph::sort(handle.get_thrust_policy(),
+                sorted_unique_int_vertices.begin(),
+                sorted_unique_int_vertices.end());
+  auto last = cugraph::unique(handle.get_thrust_policy(),
+                              sorted_unique_int_vertices.begin(),
+                              sorted_unique_int_vertices.end());
   sorted_unique_int_vertices.resize(cuda::std::distance(sorted_unique_int_vertices.begin(), last),
                                     handle.get_stream());
 

--- a/cpp/include/cugraph/utilities/misc_utils.cuh
+++ b/cpp/include/cugraph/utilities/misc_utils.cuh
@@ -12,6 +12,7 @@
 #include <raft/util/cudart_utils.hpp>
 
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <cuda/atomic>
 #include <cuda/functional>
@@ -108,7 +109,7 @@ rmm::device_uvector<idx_t> expand_sparse_offsets(raft::device_span<offset_t cons
   rmm::device_uvector<idx_t> results(num_entries, stream_view);
 
   if (num_entries > 0) {
-    thrust::fill(rmm::exec_policy(stream_view), results.begin(), results.end(), idx_t{0});
+    cugraph::fill(rmm::exec_policy(stream_view), results.begin(), results.end(), idx_t{0});
 
     if (base_idx != idx_t{0}) { raft::update_device(results.data(), &base_idx, 1, stream_view); }
 

--- a/cpp/include/cugraph/utilities/shuffle_comm.cuh
+++ b/cpp/include/cugraph/utilities/shuffle_comm.cuh
@@ -184,7 +184,7 @@ void multi_partition(ValueIterator value_first,
   rmm::device_uvector<size_t> counts(num_groups, stream_view);
   rmm::device_uvector<gid_offset_t> group_id_offsets(num_values, stream_view);
   rmm::device_uvector<offset_t> intra_partition_displs(num_values, stream_view);
-  thrust::fill(rmm::exec_policy(stream_view), counts.begin(), counts.end(), size_t{0});
+  cugraph::fill(rmm::exec_policy(stream_view), counts.begin(), counts.end(), size_t{0});
   thrust::transform(
     rmm::exec_policy(stream_view),
     value_first,
@@ -243,7 +243,7 @@ void multi_partition(KeyIterator key_first,
   rmm::device_uvector<size_t> counts(num_groups, stream_view);
   rmm::device_uvector<gid_offset_t> group_id_offsets(num_keys, stream_view);
   rmm::device_uvector<offset_t> intra_partition_displs(num_keys, stream_view);
-  thrust::fill(rmm::exec_policy(stream_view), counts.begin(), counts.end(), size_t{0});
+  cugraph::fill(rmm::exec_policy(stream_view), counts.begin(), counts.end(), size_t{0});
   thrust::transform(
     rmm::exec_policy(stream_view),
     key_first,
@@ -1057,10 +1057,10 @@ auto shuffle_values(
       ? large_buffer_manager::allocate_memory_buffer<value_t>(rx_buffer_size, stream_view)
       : allocate_dataframe_buffer<value_t>(rx_buffer_size, stream_view);
   if (fill_value) {
-    thrust::fill(rmm::exec_policy_nosync(stream_view),
-                 get_dataframe_buffer_begin(rx_values),
-                 get_dataframe_buffer_end(rx_values),
-                 *fill_value);
+    cugraph::fill(rmm::exec_policy_nosync(stream_view),
+                  get_dataframe_buffer_begin(rx_values),
+                  get_dataframe_buffer_end(rx_values),
+                  *fill_value);
   }
   cugraph::device_multicast_sendrecv(
     comm,
@@ -1127,9 +1127,9 @@ auto shuffle_and_unique_segment_sorted_values(
     resize_dataframe_buffer(
       sorted_unique_values,
       cuda::std::distance(get_dataframe_buffer_begin(sorted_unique_values),
-                          thrust::unique(rmm::exec_policy_nosync(stream_view),
-                                         get_dataframe_buffer_begin(sorted_unique_values),
-                                         get_dataframe_buffer_end(sorted_unique_values))),
+                          cugraph::unique(rmm::exec_policy_nosync(stream_view),
+                                          get_dataframe_buffer_begin(sorted_unique_values),
+                                          get_dataframe_buffer_end(sorted_unique_values))),
       stream_view);
   } else {
     rmm::device_uvector<size_t> d_tx_value_counts(comm_size, stream_view);
@@ -1192,9 +1192,9 @@ auto shuffle_and_unique_segment_sorted_values(
       resize_dataframe_buffer(
         merged_sorted_values,
         cuda::std::distance(get_dataframe_buffer_begin(merged_sorted_values),
-                            thrust::unique(rmm::exec_policy_nosync(stream_view),
-                                           get_dataframe_buffer_begin(merged_sorted_values),
-                                           get_dataframe_buffer_end(merged_sorted_values))),
+                            cugraph::unique(rmm::exec_policy_nosync(stream_view),
+                                            get_dataframe_buffer_begin(merged_sorted_values),
+                                            get_dataframe_buffer_end(merged_sorted_values))),
         stream_view);
       sorted_unique_values = std::move(merged_sorted_values);
     }

--- a/cpp/include/cugraph/utilities/thrust_wrappers.hpp
+++ b/cpp/include/cugraph/utilities/thrust_wrappers.hpp
@@ -25,6 +25,24 @@
 namespace CUGRAPH_EXPORT cugraph {
 namespace detail {
 
+/** @brief True when @p ExecutionPolicy is @c rmm::exec_policy.
+ */
+template <typename ExecutionPolicy>
+inline constexpr bool is_rmm_exec_policy_v =
+  std::is_same_v<std::remove_cv_t<std::remove_reference_t<ExecutionPolicy>>, rmm::exec_policy>;
+
+/** @brief True when @p ExecutionPolicy is @c rmm::exec_policy_nosync (e.g. @c
+ * handle.get_thrust_policy()).
+ */
+template <typename ExecutionPolicy>
+inline constexpr bool is_rmm_exec_policy_nosync_v =
+  std::is_same_v<std::remove_cv_t<std::remove_reference_t<ExecutionPolicy>>,
+                 rmm::exec_policy_nosync>;
+
+}  // namespace detail
+
+namespace detail {
+
 /** @brief True for scalar value types dispatched to @ref sort_impl / @ref unique_impl. */
 template <typename T>
 inline constexpr bool sort_supported_arithmetic_scalar_v =
@@ -41,8 +59,7 @@ inline constexpr bool sort_supported_arithmetic_scalar_v =
  *
  *  Keep this in lockstep with those explicit instantiations: add a disjunct only when you add the
  *  matching explicit instantiation (otherwise a call through @ref cugraph::sort can fail at
- *  link
- *  time).
+ *  link time).
  */
 template <typename T>
 inline constexpr bool sort_supported_zip_v =
@@ -71,6 +88,157 @@ inline constexpr bool sort_supported_zip_v =
                      std::is_same<std::remove_cv_t<T>, zip_i32_i32_i32_sz>,
                      std::is_same<std::remove_cv_t<T>, zip_i64_i64_i64_sz>>;
 
+/** Value type of @p Iterator for @ref cugraph::sort constraints (C++17-friendly). */
+template <typename Iterator>
+using sort_iterator_value_t =
+  std::remove_cv_t<typename std::iterator_traits<std::remove_cv_t<Iterator>>::value_type>;
+
+/** @brief True when @p Iterator is a pointer to a @ref sort_supported_arithmetic_scalar_v type. */
+template <typename Iterator>
+inline constexpr bool sort_supported_scalar_iterator_v =
+  std::is_pointer_v<std::remove_cv_t<Iterator>> &&
+  sort_supported_arithmetic_scalar_v<sort_iterator_value_t<Iterator>>;
+
+/** @brief True when @p Iterator has an out-of-line @ref sort_impl / @ref unique_impl instantiation.
+ */
+template <typename Iterator>
+inline constexpr bool sort_supported_iterator_v =
+  sort_supported_scalar_iterator_v<Iterator> || sort_supported_zip_v<std::remove_cv_t<Iterator>>;
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Sort elements in [first, last) on the given CUDA stream (out-of-line implementation).
+ */
+template <typename RandomAccessIterator>
+void sort_impl(rmm::exec_policy const& policy,
+               RandomAccessIterator first,
+               RandomAccessIterator last);
+
+template <typename RandomAccessIterator>
+void sort_impl(rmm::exec_policy_nosync const& policy,
+               RandomAccessIterator first,
+               RandomAccessIterator last);
+
+/** @brief True when @p Iterator has an out-of-line @ref unique_impl instantiation.
+ *
+ * Unique and sort currently have the same supported iterator types.
+ */
+template <typename Iterator>
+inline constexpr bool unique_supported_iterator_v = sort_supported_iterator_v<Iterator>;
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Keep unique elements in [first, last) on the given CUDA stream (out-of-line
+ * implementation).
+ */
+template <typename RandomAccessIterator>
+RandomAccessIterator unique_impl(rmm::exec_policy const& policy,
+                                 RandomAccessIterator first,
+                                 RandomAccessIterator last);
+
+template <typename RandomAccessIterator>
+RandomAccessIterator unique_impl(rmm::exec_policy_nosync const& policy,
+                                 RandomAccessIterator first,
+                                 RandomAccessIterator last);
+
+}  // namespace detail
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Sort elements in [first, last)
+ *
+ * Similar to @c thrust::sort; dispatches to an explicitly instantiated backend for supported
+ * scalar and zip-iterator ranges.
+ */
+struct sort_t {
+  template <typename ExecutionPolicy, typename RandomAccessIterator>
+  void operator()(ExecutionPolicy const& policy,
+                  RandomAccessIterator first,
+                  RandomAccessIterator last) const
+  {
+    if constexpr ((detail::is_rmm_exec_policy_v<ExecutionPolicy> ||
+                   detail::is_rmm_exec_policy_nosync_v<ExecutionPolicy>) &&
+                  detail::sort_supported_iterator_v<RandomAccessIterator>) {
+      detail::sort_impl(policy, first, last);
+    } else {
+      thrust::sort(policy, first, last);
+    }
+  }
+
+  /**
+   * @ingroup utility_wrappers_cpp
+   * @brief    Sort elements in [first, last) with a custom comparison
+   *
+   * Similar to @c thrust::sort.
+   */
+  template <typename ExecutionPolicy, typename RandomAccessIterator, typename Compare>
+  void operator()(ExecutionPolicy const& policy,
+                  RandomAccessIterator first,
+                  RandomAccessIterator last,
+                  Compare compare) const
+  {
+    thrust::sort(policy, first, last, compare);
+  }
+};
+
+/** @brief Sort elements in [first, last)
+ *
+ * This exposes cugraph::sort using the sort_t functor.
+ * This is a workaround to avoid ADL issues with CCCL which result in a runtime error.
+ *
+ * Documentation of the individual sort overloads is provided above.
+ */
+inline constexpr sort_t sort{};
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Keep unique elements in [first, last)
+ *
+ * Similar to @c thrust::unique; dispatches to an explicitly instantiated backend for supported
+ * scalar and zip-iterator ranges.
+ */
+struct unique_t {
+  template <typename ExecutionPolicy, typename RandomAccessIterator>
+  RandomAccessIterator operator()(ExecutionPolicy const& policy,
+                                  RandomAccessIterator first,
+                                  RandomAccessIterator last) const
+  {
+    if constexpr ((detail::is_rmm_exec_policy_v<ExecutionPolicy> ||
+                   detail::is_rmm_exec_policy_nosync_v<ExecutionPolicy>) &&
+                  detail::unique_supported_iterator_v<RandomAccessIterator>) {
+      return detail::unique_impl(policy, first, last);
+    } else {
+      return thrust::unique(policy, first, last);
+    }
+  }
+
+  /**
+   * @ingroup utility_wrappers_cpp
+   * @brief    Keep unique elements in [first, last) with a custom equivalence predicate
+   *
+   * Similar to @c thrust::unique.
+   */
+  template <typename ExecutionPolicy, typename ForwardIterator, typename BinaryPredicate>
+  ForwardIterator operator()(ExecutionPolicy const& policy,
+                             ForwardIterator first,
+                             ForwardIterator last,
+                             BinaryPredicate pred) const
+  {
+    return thrust::unique(policy, first, last, pred);
+  }
+};
+
+/** @brief Keep unique elements in [first, last)
+ *
+ * This exposes cugraph::unique using the unique_t functor.
+ * This is a workaround to avoid ADL issues with CCCL which result in a runtime error.
+ *
+ * Documentation of the individual unique overloads is provided above.
+ */
+inline constexpr unique_t unique{};
+
+namespace detail {
+
 /** @brief True for value types dispatched to @ref inclusive_scan_impl / @ref exclusive_scan_impl.
  */
 template <typename T>
@@ -78,20 +246,6 @@ inline constexpr bool scan_scalar_value_v =
   std::disjunction_v<std::is_same<std::remove_cv_t<T>, std::size_t>,
                      std::is_same<std::remove_cv_t<T>, std::int32_t>,
                      std::is_same<std::remove_cv_t<T>, std::int64_t>>;
-
-/** @brief True when @p ExecutionPolicy is @c rmm::exec_policy.
- */
-template <typename ExecutionPolicy>
-inline constexpr bool is_rmm_exec_policy_v =
-  std::is_same_v<std::remove_cv_t<std::remove_reference_t<ExecutionPolicy>>, rmm::exec_policy>;
-
-/** @brief True when @p ExecutionPolicy is @c rmm::exec_policy_nosync (e.g. @c
- * handle.get_thrust_policy()).
- */
-template <typename ExecutionPolicy>
-inline constexpr bool is_rmm_exec_policy_nosync_v =
-  std::is_same_v<std::remove_cv_t<std::remove_reference_t<ExecutionPolicy>>,
-                 rmm::exec_policy_nosync>;
 
 /** Input iterator value type for @ref cugraph::inclusive_scan / @ref cugraph::exclusive_scan. */
 template <typename Iterator>
@@ -158,209 +312,7 @@ OutputIterator exclusive_scan_impl(rmm::exec_policy_nosync const& policy,
                                    OutputIterator result,
                                    T init);
 
-/**
- * @ingroup utility_wrappers_cpp
- * @brief    Sort elements in [first, last) on the given CUDA stream (out-of-line implementation).
- */
-template <typename RandomAccessIterator>
-void sort_impl(rmm::exec_policy const& policy,
-               RandomAccessIterator first,
-               RandomAccessIterator last);
-
-template <typename RandomAccessIterator>
-void sort_impl(rmm::exec_policy_nosync const& policy,
-               RandomAccessIterator first,
-               RandomAccessIterator last);
-
-/**
- * @ingroup utility_wrappers_cpp
- * @brief    Keep unique elements in [first, last) on the given CUDA stream (out-of-line
- * implementation).
- */
-template <typename RandomAccessIterator>
-RandomAccessIterator unique_impl(rmm::exec_policy const& policy,
-                                 RandomAccessIterator first,
-                                 RandomAccessIterator last);
-
-template <typename RandomAccessIterator>
-RandomAccessIterator unique_impl(rmm::exec_policy_nosync const& policy,
-                                 RandomAccessIterator first,
-                                 RandomAccessIterator last);
-
-/** Value type of @p Iterator for @ref cugraph::sort constraints (C++17-friendly). */
-template <typename Iterator>
-using sort_iterator_value_t =
-  std::remove_cv_t<typename std::iterator_traits<std::remove_cv_t<Iterator>>::value_type>;
-
-/** @brief True when @p Iterator is a pointer to a @ref sort_supported_arithmetic_scalar_v type. */
-template <typename Iterator>
-inline constexpr bool sort_supported_scalar_iterator_v =
-  std::is_pointer_v<std::remove_cv_t<Iterator>> &&
-  sort_supported_arithmetic_scalar_v<sort_iterator_value_t<Iterator>>;
-
-/** @brief True when @p Iterator has an out-of-line @ref sort_impl / @ref unique_impl instantiation.
- */
-template <typename Iterator>
-inline constexpr bool sort_supported_iterator_v =
-  sort_supported_scalar_iterator_v<Iterator> || sort_supported_zip_v<std::remove_cv_t<Iterator>>;
-
-/** @brief True for value types dispatched to @ref fill_impl. */
-template <typename T>
-inline constexpr bool fill_supported_scalar_v =
-  std::disjunction_v<std::is_same<std::remove_cv_t<T>, std::size_t>,
-                     std::is_same<std::remove_cv_t<T>, std::uint32_t>,
-                     std::is_same<std::remove_cv_t<T>, std::int32_t>,
-                     std::is_same<std::remove_cv_t<T>, std::int64_t>,
-                     std::is_same<std::remove_cv_t<T>, float>,
-                     std::is_same<std::remove_cv_t<T>, double>>;
-
-/** @brief True for value types dispatched to @ref sequence_impl. */
-template <typename T>
-inline constexpr bool sequence_supported_scalar_v =
-  std::disjunction_v<std::is_same<std::remove_cv_t<T>, std::size_t>,
-                     std::is_same<std::remove_cv_t<T>, std::int32_t>,
-                     std::is_same<std::remove_cv_t<T>, std::int64_t>>;
-
-/** Value type of @p Iterator for @ref cugraph::fill constraints. */
-template <typename Iterator>
-using fill_iterator_value_t =
-  std::remove_cv_t<typename std::iterator_traits<std::remove_cv_t<Iterator>>::value_type>;
-
-/** Value type of @p Iterator for @ref cugraph::sequence constraints. */
-template <typename Iterator>
-using sequence_iterator_value_t =
-  std::remove_cv_t<typename std::iterator_traits<std::remove_cv_t<Iterator>>::value_type>;
-
-/** @brief True when @p Iterator is a pointer to a @ref fill_supported_scalar_v type. */
-template <typename Iterator>
-inline constexpr bool fill_supported_iterator_v =
-  std::is_pointer_v<std::remove_cv_t<Iterator>> &&
-  fill_supported_scalar_v<fill_iterator_value_t<Iterator>>;
-
-/** @brief True when @p Iterator is a pointer to a @ref sequence_supported_scalar_v type. */
-template <typename Iterator>
-inline constexpr bool sequence_supported_iterator_v =
-  std::is_pointer_v<std::remove_cv_t<Iterator>> &&
-  sequence_supported_scalar_v<sequence_iterator_value_t<Iterator>>;
-
-template <typename ForwardIterator, typename T>
-void fill_impl(rmm::exec_policy const& policy,
-               ForwardIterator first,
-               ForwardIterator last,
-               T const& value);
-
-template <typename ForwardIterator, typename T>
-void fill_impl(rmm::exec_policy_nosync const& policy,
-               ForwardIterator first,
-               ForwardIterator last,
-               T const& value);
-
-template <typename ForwardIterator, typename T>
-void sequence_impl(
-  rmm::exec_policy const& policy, ForwardIterator first, ForwardIterator last, T init, T step);
-
-template <typename ForwardIterator, typename T>
-void sequence_impl(rmm::exec_policy_nosync const& policy,
-                   ForwardIterator first,
-                   ForwardIterator last,
-                   T init,
-                   T step);
-
 }  // namespace detail
-
-/**
- * @ingroup utility_wrappers_cpp
- * @brief    Sort elements in [first, last)
- *
- * Similar to @c thrust::sort; dispatches to an explicitly instantiated backend for supported
- * scalar and zip-iterator ranges.
- */
-struct sort_t {
-  template <typename ExecutionPolicy, typename RandomAccessIterator>
-  void operator()(ExecutionPolicy const& policy,
-                  RandomAccessIterator first,
-                  RandomAccessIterator last) const
-  {
-    if constexpr ((detail::is_rmm_exec_policy_v<ExecutionPolicy> ||
-                   detail::is_rmm_exec_policy_nosync_v<ExecutionPolicy>) &&
-                  detail::sort_supported_iterator_v<RandomAccessIterator>) {
-      detail::sort_impl(policy, first, last);
-    } else {
-      thrust::sort(policy, first, last);
-    }
-  }
-
-  /**
-   * @ingroup utility_wrappers_cpp
-   * @brief    Sort elements in [first, last) with a custom comparison
-   *
-   * Similar to @c thrust::sort.
-   */
-  template <typename ExecutionPolicy, typename RandomAccessIterator, typename Compare>
-  void operator()(ExecutionPolicy const& policy,
-                  RandomAccessIterator first,
-                  RandomAccessIterator last,
-                  Compare compare) const
-  {
-    thrust::sort(policy, first, last, compare);
-  }
-};
-
-/** @brief Sort elements in [first, last)
- *
- * This exposes cugraph::sort using the sort_t functor.
- * This is a workaround to avoid ADL issues with CCCL which result in a runtime error.
- *
- * Documentation of the individual sort overloads is provided above.
- */
-inline constexpr sort_t sort{};
-
-/**
- * @ingroup utility_wrappers_cpp
- * @brief    Keep unique elements in [first, last)
- *
- * Similar to @c thrust::unique; dispatches to an explicitly instantiated backend for supported
- * scalar and zip-iterator ranges.
- */
-struct unique_t {
-  template <typename ExecutionPolicy, typename RandomAccessIterator>
-  RandomAccessIterator operator()(ExecutionPolicy const& policy,
-                                  RandomAccessIterator first,
-                                  RandomAccessIterator last) const
-  {
-    if constexpr ((detail::is_rmm_exec_policy_v<ExecutionPolicy> ||
-                   detail::is_rmm_exec_policy_nosync_v<ExecutionPolicy>) &&
-                  detail::sort_supported_iterator_v<RandomAccessIterator>) {
-      return detail::unique_impl(policy, first, last);
-    } else {
-      return thrust::unique(policy, first, last);
-    }
-  }
-
-  /**
-   * @ingroup utility_wrappers_cpp
-   * @brief    Keep unique elements in [first, last) with a custom equivalence predicate
-   *
-   * Similar to @c thrust::unique.
-   */
-  template <typename ExecutionPolicy, typename ForwardIterator, typename BinaryPredicate>
-  ForwardIterator operator()(ExecutionPolicy const& policy,
-                             ForwardIterator first,
-                             ForwardIterator last,
-                             BinaryPredicate pred) const
-  {
-    return thrust::unique(policy, first, last, pred);
-  }
-};
-
-/** @brief Keep unique elements in [first, last)
- *
- * This exposes cugraph::unique using the unique_t functor.
- * This is a workaround to avoid ADL issues with CCCL which result in a runtime error.
- *
- * Documentation of the individual unique overloads is provided above.
- */
-inline constexpr unique_t unique{};
 
 /**
  * @ingroup utility_wrappers_cpp
@@ -517,6 +469,43 @@ struct exclusive_scan_t {
  */
 inline constexpr exclusive_scan_t exclusive_scan{};
 
+namespace detail {
+
+/** @brief True for value types dispatched to @ref fill_impl. */
+template <typename T>
+inline constexpr bool fill_supported_scalar_v =
+  std::disjunction_v<std::is_same<std::remove_cv_t<T>, std::size_t>,
+                     std::is_same<std::remove_cv_t<T>, std::uint32_t>,
+                     std::is_same<std::remove_cv_t<T>, std::int32_t>,
+                     std::is_same<std::remove_cv_t<T>, std::int64_t>,
+                     std::is_same<std::remove_cv_t<T>, float>,
+                     std::is_same<std::remove_cv_t<T>, double>>;
+
+/** Value type of @p Iterator for @ref cugraph::fill constraints. */
+template <typename Iterator>
+using fill_iterator_value_t =
+  std::remove_cv_t<typename std::iterator_traits<std::remove_cv_t<Iterator>>::value_type>;
+
+/** @brief True when @p Iterator is a pointer to a @ref fill_supported_scalar_v type. */
+template <typename Iterator>
+inline constexpr bool fill_supported_iterator_v =
+  std::is_pointer_v<std::remove_cv_t<Iterator>> &&
+  fill_supported_scalar_v<fill_iterator_value_t<Iterator>>;
+
+template <typename ForwardIterator, typename T>
+void fill_impl(rmm::exec_policy const& policy,
+               ForwardIterator first,
+               ForwardIterator last,
+               T const& value);
+
+template <typename ForwardIterator, typename T>
+void fill_impl(rmm::exec_policy_nosync const& policy,
+               ForwardIterator first,
+               ForwardIterator last,
+               T const& value);
+
+}  // namespace detail
+
 /**
  * @ingroup utility_wrappers_cpp
  * @brief    Assign @p value to every element in [first, last)
@@ -550,6 +539,39 @@ struct fill_t {
  * Documentation of the individual fill overloads is provided above.
  */
 inline constexpr fill_t fill{};
+
+namespace detail {
+
+/** @brief True for value types dispatched to @ref sequence_impl. */
+template <typename T>
+inline constexpr bool sequence_supported_scalar_v =
+  std::disjunction_v<std::is_same<std::remove_cv_t<T>, std::size_t>,
+                     std::is_same<std::remove_cv_t<T>, std::int32_t>,
+                     std::is_same<std::remove_cv_t<T>, std::int64_t>>;
+
+/** Value type of @p Iterator for @ref cugraph::sequence constraints. */
+template <typename Iterator>
+using sequence_iterator_value_t =
+  std::remove_cv_t<typename std::iterator_traits<std::remove_cv_t<Iterator>>::value_type>;
+
+/** @brief True when @p Iterator is a pointer to a @ref sequence_supported_scalar_v type. */
+template <typename Iterator>
+inline constexpr bool sequence_supported_iterator_v =
+  std::is_pointer_v<std::remove_cv_t<Iterator>> &&
+  sequence_supported_scalar_v<sequence_iterator_value_t<Iterator>>;
+
+template <typename ForwardIterator, typename T>
+void sequence_impl(
+  rmm::exec_policy const& policy, ForwardIterator first, ForwardIterator last, T init, T step);
+
+template <typename ForwardIterator, typename T>
+void sequence_impl(rmm::exec_policy_nosync const& policy,
+                   ForwardIterator first,
+                   ForwardIterator last,
+                   T init,
+                   T step);
+
+}  // namespace detail
 
 /**
  * @ingroup utility_wrappers_cpp

--- a/cpp/include/cugraph/utilities/thrust_wrappers.hpp
+++ b/cpp/include/cugraph/utilities/thrust_wrappers.hpp
@@ -10,8 +10,11 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/iterator>
+#include <thrust/fill.h>
 #include <thrust/scan.h>
+#include <thrust/sequence.h>
 #include <thrust/sort.h>
+#include <thrust/unique.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -37,7 +40,7 @@ inline constexpr bool sort_supported_arithmetic_scalar_v =
  *  @c rmm::exec_policy_nosync.
  *
  *  Keep this in lockstep with those explicit instantiations: add a disjunct only when you add the
- *  matching explicit instantiation (otherwise a call through @ref cugraph::sort_wrapper can fail at
+ *  matching explicit instantiation (otherwise a call through @ref cugraph::sort can fail at
  *  link
  *  time).
  */
@@ -122,15 +125,6 @@ OutputIterator exclusive_scan_impl(rmm::exec_policy const& policy,
 /**
  * @ingroup utility_wrappers_cpp
  * @brief    Sort elements in [first, last) on the given CUDA stream (out-of-line implementation).
- *
- * @tparam      RandomAccessIterator  iterator type; must match an explicit instantiation in
- *                                     @c thrust_wrappers.cu.
- *
- * @param[in]   policy       @c rmm::exec_policy or @c rmm::exec_policy_nosync (e.g.
- *                           @c handle.get_thrust_policy())
- * @param[in]   first        beginning of the range to sort
- * @param[in]   last         end of the range to sort
- *
  */
 template <typename RandomAccessIterator>
 void sort_impl(rmm::exec_policy const& policy,
@@ -142,10 +136,87 @@ void sort_impl(rmm::exec_policy_nosync const& policy,
                RandomAccessIterator first,
                RandomAccessIterator last);
 
-/** Value type of @p Iterator for @ref cugraph::sort_wrapper constraints (C++17-friendly). */
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Keep unique elements in [first, last) on the given CUDA stream (out-of-line
+ * implementation).
+ */
+template <typename RandomAccessIterator>
+RandomAccessIterator unique_impl(rmm::exec_policy const& policy,
+                                 RandomAccessIterator first,
+                                 RandomAccessIterator last);
+
+template <typename RandomAccessIterator>
+RandomAccessIterator unique_impl(rmm::exec_policy_nosync const& policy,
+                                 RandomAccessIterator first,
+                                 RandomAccessIterator last);
+
+/** Value type of @p Iterator for @ref cugraph::sort constraints (C++17-friendly). */
 template <typename Iterator>
 using sort_iterator_value_t =
   std::remove_cv_t<typename std::iterator_traits<std::remove_cv_t<Iterator>>::value_type>;
+
+/** @brief True for value types dispatched to @ref fill_impl. */
+template <typename T>
+inline constexpr bool fill_supported_scalar_v =
+  std::disjunction_v<std::is_same<std::remove_cv_t<T>, std::size_t>,
+                     std::is_same<std::remove_cv_t<T>, std::uint32_t>,
+                     std::is_same<std::remove_cv_t<T>, std::int32_t>,
+                     std::is_same<std::remove_cv_t<T>, std::int64_t>,
+                     std::is_same<std::remove_cv_t<T>, float>,
+                     std::is_same<std::remove_cv_t<T>, double>>;
+
+/** @brief True for value types dispatched to @ref sequence_impl. */
+template <typename T>
+inline constexpr bool sequence_supported_scalar_v =
+  std::disjunction_v<std::is_same<std::remove_cv_t<T>, std::size_t>,
+                     std::is_same<std::remove_cv_t<T>, std::int32_t>,
+                     std::is_same<std::remove_cv_t<T>, std::int64_t>>;
+
+/** Value type of @p Iterator for @ref cugraph::fill constraints. */
+template <typename Iterator>
+using fill_iterator_value_t =
+  std::remove_cv_t<typename std::iterator_traits<std::remove_cv_t<Iterator>>::value_type>;
+
+/** Value type of @p Iterator for @ref cugraph::sequence constraints. */
+template <typename Iterator>
+using sequence_iterator_value_t =
+  std::remove_cv_t<typename std::iterator_traits<std::remove_cv_t<Iterator>>::value_type>;
+
+/** @brief True when @p Iterator is a pointer to a @ref fill_supported_scalar_v type. */
+template <typename Iterator>
+inline constexpr bool fill_supported_iterator_v =
+  std::is_pointer_v<std::remove_cv_t<Iterator>> &&
+  fill_supported_scalar_v<fill_iterator_value_t<Iterator>>;
+
+/** @brief True when @p Iterator is a pointer to a @ref sequence_supported_scalar_v type. */
+template <typename Iterator>
+inline constexpr bool sequence_supported_iterator_v =
+  std::is_pointer_v<std::remove_cv_t<Iterator>> &&
+  sequence_supported_scalar_v<sequence_iterator_value_t<Iterator>>;
+
+template <typename ForwardIterator, typename T>
+void fill_impl(rmm::exec_policy const& policy,
+               ForwardIterator first,
+               ForwardIterator last,
+               T const& value);
+
+template <typename ForwardIterator, typename T>
+void fill_impl(rmm::exec_policy_nosync const& policy,
+               ForwardIterator first,
+               ForwardIterator last,
+               T const& value);
+
+template <typename ForwardIterator, typename T>
+void sequence_impl(
+  rmm::exec_policy const& policy, ForwardIterator first, ForwardIterator last, T init, T step);
+
+template <typename ForwardIterator, typename T>
+void sequence_impl(rmm::exec_policy_nosync const& policy,
+                   ForwardIterator first,
+                   ForwardIterator last,
+                   T init,
+                   T step);
 
 }  // namespace detail
 
@@ -155,55 +226,93 @@ using sort_iterator_value_t =
  *
  * Similar to @c thrust::sort; dispatches to an explicitly instantiated backend for supported
  * scalar and zip-iterator ranges.
- *
- * @tparam      RandomAccessIterator  random-access iterator
- *
- * @param[in]   policy       Thrust execution policy
- * @param[in]   first        beginning of the range to sort
- * @param[in]   last         end of the range to sort
- *
  */
-// FIXME: Would like to call this sort, but there's an issue
-// with CCCL and nvcc which results in a runtime error.
-template <typename ExecutionPolicy, typename RandomAccessIterator>
-void sort_wrapper(ExecutionPolicy const& policy,
+struct sort_t {
+  template <typename ExecutionPolicy, typename RandomAccessIterator>
+  void operator()(ExecutionPolicy const& policy,
                   RandomAccessIterator first,
-                  RandomAccessIterator last)
-{
-  using value_t = detail::sort_iterator_value_t<RandomAccessIterator>;
-  if constexpr (detail::sort_supported_arithmetic_scalar_v<value_t> ||
-                detail::sort_supported_zip_v<std::remove_cv_t<RandomAccessIterator>>) {
-    detail::sort_impl(policy, first, last);
-  } else {
-    thrust::sort(policy, first, last);
+                  RandomAccessIterator last) const
+  {
+    using value_t = detail::sort_iterator_value_t<RandomAccessIterator>;
+    if constexpr (detail::sort_supported_arithmetic_scalar_v<value_t> ||
+                  detail::sort_supported_zip_v<std::remove_cv_t<RandomAccessIterator>>) {
+      detail::sort_impl(policy, first, last);
+    } else {
+      thrust::sort(policy, first, last);
+    }
   }
-}
+
+  /**
+   * @ingroup utility_wrappers_cpp
+   * @brief    Sort elements in [first, last) with a custom comparison
+   *
+   * Similar to @c thrust::sort.
+   */
+  template <typename ExecutionPolicy, typename RandomAccessIterator, typename Compare>
+  void operator()(ExecutionPolicy const& policy,
+                  RandomAccessIterator first,
+                  RandomAccessIterator last,
+                  Compare compare) const
+  {
+    thrust::sort(policy, first, last, compare);
+  }
+};
+
+/** @brief Sort elements in [first, last)
+ *
+ * This exposes cugraph::sort using the sort_t functor.
+ * This is a workaround to avoid ADL issues with CCCL which result in a runtime error.
+ *
+ * Documentation of the individual sort overloads is provided above.
+ */
+inline constexpr sort_t sort{};
 
 /**
  * @ingroup utility_wrappers_cpp
- * @brief    Sort elements in [first, last) with a custom comparison
+ * @brief    Keep unique elements in [first, last)
  *
- * Similar to @c thrust::sort.
- *
- * @tparam      RandomAccessIterator  random-access iterator
- * @tparam      Compare               comparison functor
- *
- * @param[in]   policy       Thrust execution policy
- * @param[in]   first        beginning of the range to sort
- * @param[in]   last         end of the range to sort
- * @param[in]   compare      comparison functor
- *
+ * Similar to @c thrust::unique; dispatches to an explicitly instantiated backend for supported
+ * scalar and zip-iterator ranges.
  */
-// FIXME: Would like to call this sort, but there's an issue
-// with CCCL and nvcc which results in a runtime error.
-template <typename ExecutionPolicy, typename RandomAccessIterator, typename Compare>
-void sort_wrapper(ExecutionPolicy const& policy,
-                  RandomAccessIterator first,
-                  RandomAccessIterator last,
-                  Compare compare)
-{
-  thrust::sort(policy, first, last, compare);
-}
+struct unique_t {
+  template <typename ExecutionPolicy, typename RandomAccessIterator>
+  RandomAccessIterator operator()(ExecutionPolicy const& policy,
+                                  RandomAccessIterator first,
+                                  RandomAccessIterator last) const
+  {
+    using value_t = detail::sort_iterator_value_t<RandomAccessIterator>;
+    if constexpr (detail::sort_supported_arithmetic_scalar_v<value_t> ||
+                  detail::sort_supported_zip_v<std::remove_cv_t<RandomAccessIterator>>) {
+      return detail::unique_impl(policy, first, last);
+    } else {
+      return thrust::unique(policy, first, last);
+    }
+  }
+
+  /**
+   * @ingroup utility_wrappers_cpp
+   * @brief    Keep unique elements in [first, last) with a custom equivalence predicate
+   *
+   * Similar to @c thrust::unique.
+   */
+  template <typename ExecutionPolicy, typename ForwardIterator, typename BinaryPredicate>
+  ForwardIterator operator()(ExecutionPolicy const& policy,
+                             ForwardIterator first,
+                             ForwardIterator last,
+                             BinaryPredicate pred) const
+  {
+    return thrust::unique(policy, first, last, pred);
+  }
+};
+
+/** @brief Keep unique elements in [first, last)
+ *
+ * This exposes cugraph::unique using the unique_t functor.
+ * This is a workaround to avoid ADL issues with CCCL which result in a runtime error.
+ *
+ * Documentation of the individual unique overloads is provided above.
+ */
+inline constexpr unique_t unique{};
 
 /**
  * @ingroup utility_wrappers_cpp
@@ -355,5 +464,107 @@ struct exclusive_scan_t {
  * Documentation of the individual exclusive_scan overloads is provided above.
  */
 inline constexpr exclusive_scan_t exclusive_scan{};
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Assign @p value to every element in [first, last)
+ *
+ * Similar to @c thrust::fill; dispatches to an explicitly instantiated backend for supported
+ * scalar ranges on @c rmm::exec_policy and @c rmm::exec_policy_nosync.
+ */
+struct fill_t {
+  template <typename ExecutionPolicy, typename ForwardIterator, typename T>
+  void operator()(ExecutionPolicy const& policy,
+                  ForwardIterator first,
+                  ForwardIterator last,
+                  T const& value) const
+  {
+    using value_t = detail::fill_iterator_value_t<ForwardIterator>;
+    if constexpr (detail::fill_supported_iterator_v<ForwardIterator>) {
+      detail::fill_impl(policy, first, last, value_t(value));
+    } else {
+      thrust::fill(policy, first, last, value);
+    }
+  }
+};
+
+/** @brief Assign @p value to every element in [first, last)
+ *
+ * This exposes cugraph::fill using the fill_t functor.
+ * This is a workaround to avoid ADL issues with CCCL which result in a runtime error.
+ *
+ * Documentation of the individual fill overloads is provided above.
+ */
+inline constexpr fill_t fill{};
+
+/**
+ * @ingroup utility_wrappers_cpp
+ * @brief    Fill [first, last) with consecutive integers starting at 0
+ *
+ * Similar to @c thrust::sequence; dispatches to an explicitly instantiated backend for supported
+ * scalar ranges on @c rmm::exec_policy and @c rmm::exec_policy_nosync.
+ */
+struct sequence_t {
+  template <typename ExecutionPolicy, typename ForwardIterator>
+  void operator()(ExecutionPolicy const& policy, ForwardIterator first, ForwardIterator last) const
+  {
+    using value_t = detail::sequence_iterator_value_t<ForwardIterator>;
+    if constexpr (detail::sequence_supported_iterator_v<ForwardIterator>) {
+      detail::sequence_impl(policy, first, last, value_t{}, value_t{1});
+    } else {
+      thrust::sequence(policy, first, last);
+    }
+  }
+
+  /**
+   * @ingroup utility_wrappers_cpp
+   * @brief    Fill [first, last) with consecutive integers starting at @p init
+   *
+   * Similar to @c thrust::sequence.
+   */
+  template <typename ExecutionPolicy, typename ForwardIterator, typename T>
+  void operator()(ExecutionPolicy const& policy,
+                  ForwardIterator first,
+                  ForwardIterator last,
+                  T init) const
+  {
+    using value_t = detail::sequence_iterator_value_t<ForwardIterator>;
+    if constexpr (detail::sequence_supported_iterator_v<ForwardIterator>) {
+      detail::sequence_impl(policy, first, last, value_t(init), value_t{1});
+    } else {
+      thrust::sequence(policy, first, last, init);
+    }
+  }
+
+  /**
+   * @ingroup utility_wrappers_cpp
+   * @brief    Fill [first, last) with consecutive integers starting at @p init with step @p step
+   *
+   * Similar to @c thrust::sequence.
+   */
+  template <typename ExecutionPolicy, typename ForwardIterator, typename T>
+  void operator()(ExecutionPolicy const& policy,
+                  ForwardIterator first,
+                  ForwardIterator last,
+                  T init,
+                  T step) const
+  {
+    using value_t = detail::sequence_iterator_value_t<ForwardIterator>;
+    if constexpr (detail::sequence_supported_iterator_v<ForwardIterator>) {
+      detail::sequence_impl(policy, first, last, value_t(init), value_t(step));
+    } else {
+      thrust::sequence(policy, first, last, init, step);
+    }
+  }
+};
+
+/** @brief Fill [first, last) with consecutive integers
+ *
+ * This exposes cugraph::sequence using the sequence_t functor.
+ * This is a workaround to avoid ADL issues with CCCL which result in a runtime error.
+ *
+ * Documentation of the individual sequence overloads is provided above.
+ */
+inline constexpr sequence_t sequence{};
 
 }  // namespace CUGRAPH_EXPORT cugraph

--- a/cpp/include/cugraph/utilities/thrust_wrappers.hpp
+++ b/cpp/include/cugraph/utilities/thrust_wrappers.hpp
@@ -25,7 +25,7 @@
 namespace CUGRAPH_EXPORT cugraph {
 namespace detail {
 
-/** @brief Whether iterator type @p T has an out-of-line @ref sort_impl lexicographic sort. */
+/** @brief True for scalar value types dispatched to @ref sort_impl / @ref unique_impl. */
 template <typename T>
 inline constexpr bool sort_supported_arithmetic_scalar_v =
   std::disjunction_v<std::is_same<std::remove_cv_t<T>, std::int32_t>,
@@ -35,8 +35,8 @@ inline constexpr bool sort_supported_arithmetic_scalar_v =
 /** @brief Whether iterator type @p T has an out-of-line @ref sort_impl lexicographic sort.
  *
  *  Supported @c thrust::make_zip_iterator(...) iterator types are listed in
- *  thrust_wrappers_zip_types.hpp and instantiated in thrust_wrappers.cu. Scalar element sorts use
- *  @ref sort_supported_arithmetic_scalar_v and @ref sort_impl for @c rmm::exec_policy and
+ *  thrust_wrappers_zip_types.hpp and instantiated in thrust_wrappers.cu. Scalar sorts use
+ *  @ref sort_supported_scalar_iterator_v and @ref sort_impl for @c rmm::exec_policy and
  *  @c rmm::exec_policy_nosync.
  *
  *  Keep this in lockstep with those explicit instantiations: add a disjunct only when you add the
@@ -79,16 +79,33 @@ inline constexpr bool scan_scalar_value_v =
                      std::is_same<std::remove_cv_t<T>, std::int32_t>,
                      std::is_same<std::remove_cv_t<T>, std::int64_t>>;
 
-/** @brief True when @p ExecutionPolicy is @c rmm::exec_policy (e.g. @c handle.get_thrust_policy()).
+/** @brief True when @p ExecutionPolicy is @c rmm::exec_policy.
  */
 template <typename ExecutionPolicy>
 inline constexpr bool is_rmm_exec_policy_v =
-  std::is_same_v<std::remove_cv_t<ExecutionPolicy>, rmm::exec_policy>;
+  std::is_same_v<std::remove_cv_t<std::remove_reference_t<ExecutionPolicy>>, rmm::exec_policy>;
+
+/** @brief True when @p ExecutionPolicy is @c rmm::exec_policy_nosync (e.g. @c
+ * handle.get_thrust_policy()).
+ */
+template <typename ExecutionPolicy>
+inline constexpr bool is_rmm_exec_policy_nosync_v =
+  std::is_same_v<std::remove_cv_t<std::remove_reference_t<ExecutionPolicy>>,
+                 rmm::exec_policy_nosync>;
 
 /** Input iterator value type for @ref cugraph::inclusive_scan / @ref cugraph::exclusive_scan. */
 template <typename Iterator>
 using scan_iterator_value_t =
   std::remove_cv_t<typename std::iterator_traits<std::remove_cv_t<Iterator>>::value_type>;
+
+/** @brief True when @p InputIterator and @p OutputIterator are pointers to the same @ref
+ * scan_scalar_value_v type. */
+template <typename InputIterator, typename OutputIterator>
+inline constexpr bool scan_supported_iterator_v =
+  std::is_pointer_v<std::remove_cv_t<InputIterator>> &&
+  std::is_pointer_v<std::remove_cv_t<OutputIterator>> &&
+  scan_scalar_value_v<scan_iterator_value_t<InputIterator>> &&
+  std::is_same_v<scan_iterator_value_t<InputIterator>, scan_iterator_value_t<OutputIterator>>;
 
 /**
  * @ingroup utility_wrappers_cpp
@@ -96,6 +113,12 @@ using scan_iterator_value_t =
  */
 template <typename InputIterator, typename OutputIterator>
 OutputIterator inclusive_scan_impl(rmm::exec_policy const& policy,
+                                   InputIterator first,
+                                   InputIterator last,
+                                   OutputIterator result);
+
+template <typename InputIterator, typename OutputIterator>
+OutputIterator inclusive_scan_impl(rmm::exec_policy_nosync const& policy,
                                    InputIterator first,
                                    InputIterator last,
                                    OutputIterator result);
@@ -110,6 +133,12 @@ OutputIterator exclusive_scan_impl(rmm::exec_policy const& policy,
                                    InputIterator last,
                                    OutputIterator result);
 
+template <typename InputIterator, typename OutputIterator>
+OutputIterator exclusive_scan_impl(rmm::exec_policy_nosync const& policy,
+                                   InputIterator first,
+                                   InputIterator last,
+                                   OutputIterator result);
+
 /**
  * @ingroup utility_wrappers_cpp
  * @brief    Exclusive prefix sum on [first, last) with initial value (out-of-line; default @c
@@ -117,6 +146,13 @@ OutputIterator exclusive_scan_impl(rmm::exec_policy const& policy,
  */
 template <typename InputIterator, typename OutputIterator, typename T>
 OutputIterator exclusive_scan_impl(rmm::exec_policy const& policy,
+                                   InputIterator first,
+                                   InputIterator last,
+                                   OutputIterator result,
+                                   T init);
+
+template <typename InputIterator, typename OutputIterator, typename T>
+OutputIterator exclusive_scan_impl(rmm::exec_policy_nosync const& policy,
                                    InputIterator first,
                                    InputIterator last,
                                    OutputIterator result,
@@ -155,6 +191,18 @@ RandomAccessIterator unique_impl(rmm::exec_policy_nosync const& policy,
 template <typename Iterator>
 using sort_iterator_value_t =
   std::remove_cv_t<typename std::iterator_traits<std::remove_cv_t<Iterator>>::value_type>;
+
+/** @brief True when @p Iterator is a pointer to a @ref sort_supported_arithmetic_scalar_v type. */
+template <typename Iterator>
+inline constexpr bool sort_supported_scalar_iterator_v =
+  std::is_pointer_v<std::remove_cv_t<Iterator>> &&
+  sort_supported_arithmetic_scalar_v<sort_iterator_value_t<Iterator>>;
+
+/** @brief True when @p Iterator has an out-of-line @ref sort_impl / @ref unique_impl instantiation.
+ */
+template <typename Iterator>
+inline constexpr bool sort_supported_iterator_v =
+  sort_supported_scalar_iterator_v<Iterator> || sort_supported_zip_v<std::remove_cv_t<Iterator>>;
 
 /** @brief True for value types dispatched to @ref fill_impl. */
 template <typename T>
@@ -233,9 +281,9 @@ struct sort_t {
                   RandomAccessIterator first,
                   RandomAccessIterator last) const
   {
-    using value_t = detail::sort_iterator_value_t<RandomAccessIterator>;
-    if constexpr (detail::sort_supported_arithmetic_scalar_v<value_t> ||
-                  detail::sort_supported_zip_v<std::remove_cv_t<RandomAccessIterator>>) {
+    if constexpr ((detail::is_rmm_exec_policy_v<ExecutionPolicy> ||
+                   detail::is_rmm_exec_policy_nosync_v<ExecutionPolicy>) &&
+                  detail::sort_supported_iterator_v<RandomAccessIterator>) {
       detail::sort_impl(policy, first, last);
     } else {
       thrust::sort(policy, first, last);
@@ -280,9 +328,9 @@ struct unique_t {
                                   RandomAccessIterator first,
                                   RandomAccessIterator last) const
   {
-    using value_t = detail::sort_iterator_value_t<RandomAccessIterator>;
-    if constexpr (detail::sort_supported_arithmetic_scalar_v<value_t> ||
-                  detail::sort_supported_zip_v<std::remove_cv_t<RandomAccessIterator>>) {
+    if constexpr ((detail::is_rmm_exec_policy_v<ExecutionPolicy> ||
+                   detail::is_rmm_exec_policy_nosync_v<ExecutionPolicy>) &&
+                  detail::sort_supported_iterator_v<RandomAccessIterator>) {
       return detail::unique_impl(policy, first, last);
     } else {
       return thrust::unique(policy, first, last);
@@ -319,8 +367,9 @@ inline constexpr unique_t unique{};
  * @brief    Inclusive prefix sum on [first, last)
  *
  * Similar to @c thrust::inclusive_scan; dispatches to an explicitly instantiated backend when
- * @p policy is @c rmm::exec_policy and the input element type is @c size_t, @c int32_t, or
- * @c int64_t.
+ * @p policy is @c rmm::exec_policy or @c rmm::exec_policy_nosync and @p first, @p last, and
+ * @p result are pointers to the same supported scalar type (@c size_t, @c int32_t, or
+ * @c int64_t).
  */
 struct inclusive_scan_t {
   template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator>
@@ -329,9 +378,9 @@ struct inclusive_scan_t {
                             InputIterator last,
                             OutputIterator result) const
   {
-    using value_t = detail::scan_iterator_value_t<InputIterator>;
-    if constexpr (detail::is_rmm_exec_policy_v<ExecutionPolicy> &&
-                  detail::scan_scalar_value_v<value_t>) {
+    if constexpr ((detail::is_rmm_exec_policy_v<ExecutionPolicy> ||
+                   detail::is_rmm_exec_policy_nosync_v<ExecutionPolicy>) &&
+                  detail::scan_supported_iterator_v<InputIterator, OutputIterator>) {
       return detail::inclusive_scan_impl(policy, first, last, result);
     } else {
       return thrust::inclusive_scan(policy, first, last, result);
@@ -393,8 +442,9 @@ inline constexpr inclusive_scan_t inclusive_scan{};
  * @brief    Exclusive prefix sum on [first, last)
  *
  * Similar to @c thrust::exclusive_scan; dispatches to an explicitly instantiated backend when
- * @p policy is @c rmm::exec_policy and the input element type is @c size_t, @c int32_t, or
- * @c int64_t.
+ * @p policy is @c rmm::exec_policy or @c rmm::exec_policy_nosync and @p first, @p last, and
+ * @p result are pointers to the same supported scalar type (@c size_t, @c int32_t, or
+ * @c int64_t).
  */
 struct exclusive_scan_t {
   template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator>
@@ -403,9 +453,9 @@ struct exclusive_scan_t {
                             InputIterator last,
                             OutputIterator result) const
   {
-    using value_t = detail::scan_iterator_value_t<InputIterator>;
-    if constexpr (detail::is_rmm_exec_policy_v<ExecutionPolicy> &&
-                  detail::scan_scalar_value_v<value_t>) {
+    if constexpr ((detail::is_rmm_exec_policy_v<ExecutionPolicy> ||
+                   detail::is_rmm_exec_policy_nosync_v<ExecutionPolicy>) &&
+                  detail::scan_supported_iterator_v<InputIterator, OutputIterator>) {
       return detail::exclusive_scan_impl(policy, first, last, result);
     } else {
       return thrust::exclusive_scan(policy, first, last, result);
@@ -425,9 +475,11 @@ struct exclusive_scan_t {
                             OutputIterator result,
                             T init) const
   {
-    using value_t = detail::scan_iterator_value_t<InputIterator>;
-    if constexpr (detail::is_rmm_exec_policy_v<ExecutionPolicy> &&
-                  detail::scan_scalar_value_v<value_t>) {
+    if constexpr ((detail::is_rmm_exec_policy_v<ExecutionPolicy> ||
+                   detail::is_rmm_exec_policy_nosync_v<ExecutionPolicy>) &&
+                  detail::scan_supported_iterator_v<InputIterator, OutputIterator> &&
+                  std::is_same_v<detail::scan_iterator_value_t<InputIterator>,
+                                 std::remove_cv_t<T>>) {
       return detail::exclusive_scan_impl(policy, first, last, result, init);
     } else {
       return thrust::exclusive_scan(policy, first, last, result, init);
@@ -480,7 +532,9 @@ struct fill_t {
                   T const& value) const
   {
     using value_t = detail::fill_iterator_value_t<ForwardIterator>;
-    if constexpr (detail::fill_supported_iterator_v<ForwardIterator>) {
+    if constexpr ((detail::is_rmm_exec_policy_v<ExecutionPolicy> ||
+                   detail::is_rmm_exec_policy_nosync_v<ExecutionPolicy>) &&
+                  detail::fill_supported_iterator_v<ForwardIterator>) {
       detail::fill_impl(policy, first, last, value_t(value));
     } else {
       thrust::fill(policy, first, last, value);
@@ -509,7 +563,9 @@ struct sequence_t {
   void operator()(ExecutionPolicy const& policy, ForwardIterator first, ForwardIterator last) const
   {
     using value_t = detail::sequence_iterator_value_t<ForwardIterator>;
-    if constexpr (detail::sequence_supported_iterator_v<ForwardIterator>) {
+    if constexpr ((detail::is_rmm_exec_policy_v<ExecutionPolicy> ||
+                   detail::is_rmm_exec_policy_nosync_v<ExecutionPolicy>) &&
+                  detail::sequence_supported_iterator_v<ForwardIterator>) {
       detail::sequence_impl(policy, first, last, value_t{}, value_t{1});
     } else {
       thrust::sequence(policy, first, last);
@@ -529,7 +585,9 @@ struct sequence_t {
                   T init) const
   {
     using value_t = detail::sequence_iterator_value_t<ForwardIterator>;
-    if constexpr (detail::sequence_supported_iterator_v<ForwardIterator>) {
+    if constexpr ((detail::is_rmm_exec_policy_v<ExecutionPolicy> ||
+                   detail::is_rmm_exec_policy_nosync_v<ExecutionPolicy>) &&
+                  detail::sequence_supported_iterator_v<ForwardIterator>) {
       detail::sequence_impl(policy, first, last, value_t(init), value_t{1});
     } else {
       thrust::sequence(policy, first, last, init);
@@ -550,7 +608,9 @@ struct sequence_t {
                   T step) const
   {
     using value_t = detail::sequence_iterator_value_t<ForwardIterator>;
-    if constexpr (detail::sequence_supported_iterator_v<ForwardIterator>) {
+    if constexpr ((detail::is_rmm_exec_policy_v<ExecutionPolicy> ||
+                   detail::is_rmm_exec_policy_nosync_v<ExecutionPolicy>) &&
+                  detail::sequence_supported_iterator_v<ForwardIterator>) {
       detail::sequence_impl(policy, first, last, value_t(init), value_t(step));
     } else {
       thrust::sequence(policy, first, last, init, step);

--- a/cpp/src/c_api/capi_helper.cu
+++ b/cpp/src/c_api/capi_helper.cu
@@ -34,9 +34,9 @@ shuffle_vertex_ids_and_offsets(raft::handle_t const& handle,
     cugraph::shuffle_ext_vertices(handle, std::move(vertices), std::move(vertex_properties));
   ids = std::move(std::get<rmm::device_uvector<vertex_t>>(vertex_properties[0]));
 
-  cugraph::sort_wrapper(handle.get_thrust_policy(),
-                        thrust::make_zip_iterator(ids.begin(), vertices.begin()),
-                        thrust::make_zip_iterator(ids.end(), vertices.end()));
+  cugraph::sort(handle.get_thrust_policy(),
+                thrust::make_zip_iterator(ids.begin(), vertices.begin()),
+                thrust::make_zip_iterator(ids.end(), vertices.end()));
 
   auto return_offsets = cugraph::detail::compute_sparse_offsets<size_t>(
     handle, ids.begin(), ids.end(), size_t{0}, size_t{offsets.size() - 1}, true);
@@ -151,8 +151,7 @@ reorder_extracted_egonets(raft::handle_t const& handle,
                         triplet_first + sort_indices.size(),
                         (*edge_weights).begin());
   } else {
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(), triplet_first, triplet_first + sort_indices.size());
+    cugraph::sort(handle.get_thrust_policy(), triplet_first, triplet_first + sort_indices.size());
   }
 
   thrust::tabulate(

--- a/cpp/src/c_api/extract_ego.cpp
+++ b/cpp/src/c_api/extract_ego.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,6 +18,9 @@
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/device_comm.hpp>
 #include <cugraph/utilities/host_scalar_comm.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
+
+#include <rmm/exec_policy.hpp>
 
 #include <numeric>
 #include <optional>
@@ -92,10 +95,10 @@ struct extract_ego_functor : public cugraph::c_api::abstract_functor {
         std::exclusive_scan(
           displacements.begin(), displacements.end(), displacements.begin(), size_t{0});
         source_indices = rmm::device_uvector<size_t>(source_vertices.size(), handle_.get_stream());
-        cugraph::detail::sequence_fill(handle_.get_stream(),
-                                       (*source_indices).data(),
-                                       (*source_indices).size(),
-                                       displacements[handle_.get_comms().get_rank()]);
+        cugraph::sequence(rmm::exec_policy(handle_.get_stream()),
+                          (*source_indices).data(),
+                          (*source_indices).data() + (*source_indices).size(),
+                          displacements[handle_.get_comms().get_rank()]);
 
         std::vector<cugraph::arithmetic_device_uvector_t> vertex_properties{};
         vertex_properties.push_back(std::move(*source_indices));

--- a/cpp/src/c_api/graph_functions.cpp
+++ b/cpp/src/c_api/graph_functions.cpp
@@ -17,6 +17,9 @@
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/shuffle_functions.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
+
+#include <rmm/exec_policy.hpp>
 
 namespace {
 
@@ -153,10 +156,10 @@ struct two_hop_neighbors_functor : public cugraph::c_api::abstract_functor {
 
       } else {
         start_vertices.resize(graph_view.local_vertex_partition_range_size(), handle_.get_stream());
-        cugraph::detail::sequence_fill(handle_.get_stream(),
-                                       start_vertices.data(),
-                                       start_vertices.size(),
-                                       graph_view.local_vertex_partition_range_first());
+        cugraph::sequence(rmm::exec_policy(handle_.get_stream()),
+                          start_vertices.data(),
+                          start_vertices.data() + start_vertices.size(),
+                          graph_view.local_vertex_partition_range_first());
       }
 
       auto [offsets, dst] = cugraph::k_hop_nbrs(

--- a/cpp/src/c_api/graph_generators.cpp
+++ b/cpp/src/c_api/graph_generators.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "c_api/array.hpp"
@@ -13,8 +13,11 @@
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/graph_generators.hpp>
 #include <cugraph/utilities/host_scalar_comm.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
+
+#include <rmm/exec_policy.hpp>
 
 namespace {
 
@@ -356,16 +359,20 @@ extern "C" cugraph_error_code_t cugraph_generate_edge_ids(const cugraph_resource
   if (num_edges < int32_threshold) {
     rmm::device_uvector<int32_t> tmp(local_coo->src_->size_, local_handle.get_stream());
 
-    cugraph::detail::sequence_fill(
-      local_handle.get_stream(), tmp.data(), tmp.size(), static_cast<int32_t>(base_edge_id));
+    cugraph::sequence(rmm::exec_policy(local_handle.get_stream()),
+                      tmp.data(),
+                      tmp.data() + tmp.size(),
+                      static_cast<int32_t>(base_edge_id));
 
     local_coo->id_ = std::make_unique<cugraph::c_api::cugraph_type_erased_device_array_t>(
       tmp, cugraph_data_type_id_t::INT32);
   } else {
     rmm::device_uvector<int64_t> tmp(local_coo->src_->size_, local_handle.get_stream());
 
-    cugraph::detail::sequence_fill(
-      local_handle.get_stream(), tmp.data(), tmp.size(), static_cast<int64_t>(base_edge_id));
+    cugraph::sequence(rmm::exec_policy(local_handle.get_stream()),
+                      tmp.data(),
+                      tmp.data() + tmp.size(),
+                      static_cast<int64_t>(base_edge_id));
 
     local_coo->id_ = std::make_unique<cugraph::c_api::cugraph_type_erased_device_array_t>(
       tmp, cugraph_data_type_id_t::INT64);

--- a/cpp/src/c_api/graph_sg.cpp
+++ b/cpp/src/c_api/graph_sg.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,6 +17,9 @@
 
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/graph_functions.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
+
+#include <rmm/exec_policy.hpp>
 
 #include <limits>
 
@@ -313,10 +316,10 @@ struct create_graph_functor : public cugraph::c_api::abstract_functor {
         *number_map = std::move(new_number_map.value());
       } else {
         number_map->resize(graph->number_of_vertices(), handle_.get_stream());
-        cugraph::detail::sequence_fill(handle_.get_stream(),
-                                       number_map->data(),
-                                       number_map->size(),
-                                       graph->view().local_vertex_partition_range_first());
+        cugraph::sequence(rmm::exec_policy(handle_.get_stream()),
+                          number_map->data(),
+                          number_map->data() + number_map->size(),
+                          graph->view().local_vertex_partition_range_first());
 
         if (vertices_) {
           vertex_list = rmm::device_uvector<vertex_t>(vertices_->size_, handle_.get_stream());
@@ -453,8 +456,10 @@ struct create_graph_csr_functor : public cugraph::c_api::abstract_functor {
       std::optional<rmm::device_uvector<vertex_t>> vertex_list = std::make_optional(
         rmm::device_uvector<vertex_t>(offsets_->size_ - 1, handle_.get_stream()));
 
-      cugraph::detail::sequence_fill(
-        handle_.get_stream(), vertex_list->data(), vertex_list->size(), vertex_t{0});
+      cugraph::sequence(rmm::exec_policy(handle_.get_stream()),
+                        vertex_list->data(),
+                        vertex_list->data() + vertex_list->size(),
+                        vertex_t{0});
 
       rmm::device_uvector<vertex_t> edgelist_srcs(0, handle_.get_stream());
       rmm::device_uvector<vertex_t> edgelist_dsts(indices_->size_, handle_.get_stream());
@@ -576,10 +581,10 @@ struct create_graph_csr_functor : public cugraph::c_api::abstract_functor {
         *number_map = std::move(new_number_map.value());
       } else {
         number_map->resize(graph->number_of_vertices(), handle_.get_stream());
-        cugraph::detail::sequence_fill(handle_.get_stream(),
-                                       number_map->data(),
-                                       number_map->size(),
-                                       graph->view().local_vertex_partition_range_first());
+        cugraph::sequence(rmm::exec_policy(handle_.get_stream()),
+                          number_map->data(),
+                          number_map->data() + number_map->size(),
+                          graph->view().local_vertex_partition_range_first());
       }
 
       cugraph::edge_property_t<edge_t, weight_t>* edge_weights_property{nullptr};

--- a/cpp/src/c_api/katz.cpp
+++ b/cpp/src/c_api/katz.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,6 +15,9 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/graph_functions.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
+
+#include <rmm/exec_policy.hpp>
 
 #include <optional>
 
@@ -89,10 +92,10 @@ struct katz_functor : public cugraph::c_api::abstract_functor {
       if (betas_ != nullptr) {
         rmm::device_uvector<vertex_t> betas_vertex_ids(
           graph_view.local_vertex_partition_range_size(), handle_.get_stream());
-        cugraph::detail::sequence_fill(handle_.get_stream(),
-                                       betas_vertex_ids.data(),
-                                       betas_vertex_ids.size(),
-                                       graph_view.local_vertex_partition_range_first());
+        cugraph::sequence(rmm::exec_policy(handle_.get_stream()),
+                          betas_vertex_ids.data(),
+                          betas_vertex_ids.data() + betas_vertex_ids.size(),
+                          graph_view.local_vertex_partition_range_first());
 
         betas.resize(graph_view.local_vertex_partition_range_size(), handle_.get_stream());
 

--- a/cpp/src/c_api/legacy_fa2.cpp
+++ b/cpp/src/c_api/legacy_fa2.cpp
@@ -16,6 +16,7 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/graph_functions.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <optional>
 
@@ -163,7 +164,10 @@ struct force_atlas2_functor : public cugraph::c_api::abstract_functor {
       rmm::device_uvector<weight_t> tmp_weights(0, handle_.get_stream());
       if (edge_weights == nullptr) {
         tmp_weights.resize(edge_partition_view.indices().size(), handle_.get_stream());
-        cugraph::detail::scalar_fill(handle_, tmp_weights.data(), tmp_weights.size(), weight_t{1});
+        cugraph::fill(handle_.get_thrust_policy(),
+                      tmp_weights.data(),
+                      (tmp_weights.data()) + (tmp_weights.size()),
+                      weight_t{1});
       }
 
       // Decompress to edgelist

--- a/cpp/src/c_api/legacy_mst.cpp
+++ b/cpp/src/c_api/legacy_mst.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,6 +16,7 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/graph_functions.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <optional>
 
@@ -68,7 +69,10 @@ struct minimum_spanning_tree_functor : public cugraph::c_api::abstract_functor {
       rmm::device_uvector<weight_t> tmp_weights(0, handle_.get_stream());
       if (edge_weights == nullptr) {
         tmp_weights.resize(edge_partition_view.indices().size(), handle_.get_stream());
-        cugraph::detail::scalar_fill(handle_, tmp_weights.data(), tmp_weights.size(), weight_t{1});
+        cugraph::fill(handle_.get_thrust_policy(),
+                      tmp_weights.data(),
+                      (tmp_weights.data()) + (tmp_weights.size()),
+                      weight_t{1});
       }
 
       cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> legacy_csr_graph_view(

--- a/cpp/src/c_api/legacy_spectral.cpp
+++ b/cpp/src/c_api/legacy_spectral.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,6 +15,7 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/graph_functions.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <optional>
 
@@ -111,7 +112,10 @@ struct balanced_cut_clustering_functor : public cugraph::c_api::abstract_functor
       rmm::device_uvector<weight_t> tmp_weights(0, handle_.get_stream());
       if (edge_weights == nullptr) {
         tmp_weights.resize(edge_partition_view.indices().size(), handle_.get_stream());
-        cugraph::detail::scalar_fill(handle_, tmp_weights.data(), tmp_weights.size(), weight_t{1});
+        cugraph::fill(handle_.get_thrust_policy(),
+                      tmp_weights.data(),
+                      (tmp_weights.data()) + (tmp_weights.size()),
+                      weight_t{1});
       }
 
       cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> legacy_graph_view(
@@ -228,7 +232,10 @@ struct spectral_clustering_functor : public cugraph::c_api::abstract_functor {
       rmm::device_uvector<weight_t> tmp_weights(0, handle_.get_stream());
       if (edge_weights == nullptr) {
         tmp_weights.resize(edge_partition_view.indices().size(), handle_.get_stream());
-        cugraph::detail::scalar_fill(handle_, tmp_weights.data(), tmp_weights.size(), weight_t{1});
+        cugraph::fill(handle_.get_thrust_policy(),
+                      tmp_weights.data(),
+                      (tmp_weights.data()) + (tmp_weights.size()),
+                      weight_t{1});
       }
 
       cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> legacy_graph_view(
@@ -332,7 +339,10 @@ struct analyze_clustering_ratio_cut_functor : public cugraph::c_api::abstract_fu
       rmm::device_uvector<weight_t> tmp_weights(0, handle_.get_stream());
       if (edge_weights == nullptr) {
         tmp_weights.resize(edge_partition_view.indices().size(), handle_.get_stream());
-        cugraph::detail::scalar_fill(handle_, tmp_weights.data(), tmp_weights.size(), weight_t{1});
+        cugraph::fill(handle_.get_thrust_policy(),
+                      tmp_weights.data(),
+                      (tmp_weights.data()) + (tmp_weights.size()),
+                      weight_t{1});
       }
 
       cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> legacy_graph_view(
@@ -452,7 +462,10 @@ struct analyze_clustering_edge_cut_functor : public cugraph::c_api::abstract_fun
       rmm::device_uvector<weight_t> tmp_weights(0, handle_.get_stream());
       if (edge_weights == nullptr) {
         tmp_weights.resize(edge_partition_view.indices().size(), handle_.get_stream());
-        cugraph::detail::scalar_fill(handle_, tmp_weights.data(), tmp_weights.size(), weight_t{1});
+        cugraph::fill(handle_.get_thrust_policy(),
+                      tmp_weights.data(),
+                      (tmp_weights.data()) + (tmp_weights.size()),
+                      weight_t{1});
       }
 
       cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> legacy_graph_view(
@@ -572,7 +585,10 @@ struct analyze_clustering_modularity_functor : public cugraph::c_api::abstract_f
       rmm::device_uvector<weight_t> tmp_weights(0, handle_.get_stream());
       if (edge_weights == nullptr) {
         tmp_weights.resize(edge_partition_view.indices().size(), handle_.get_stream());
-        cugraph::detail::scalar_fill(handle_, tmp_weights.data(), tmp_weights.size(), weight_t{1});
+        cugraph::fill(handle_.get_thrust_policy(),
+                      tmp_weights.data(),
+                      (tmp_weights.data()) + (tmp_weights.size()),
+                      weight_t{1});
       }
 
       cugraph::legacy::GraphCSRView<vertex_t, edge_t, weight_t> legacy_graph_view(

--- a/cpp/src/c_api/neighbor_sampling.cpp
+++ b/cpp/src/c_api/neighbor_sampling.cpp
@@ -25,6 +25,8 @@
 
 #include <raft/core/handle.hpp>
 
+#include <rmm/exec_policy.hpp>
+
 namespace {
 
 struct neighbor_sampling_functor : public cugraph::c_api::abstract_functor {
@@ -174,21 +176,20 @@ struct neighbor_sampling_functor : public cugraph::c_api::abstract_functor {
 
           // Get unique labels
           // sort the start_vertex_labels
-          cugraph::sort_wrapper(
-            handle_.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
+          cugraph::sort(handle_.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
 
-          auto num_unique_labels = cugraph::detail::unique_ints(
-            handle_.get_stream(),
-            raft::device_span<label_t>{unique_labels.data(), unique_labels.size()});
+          auto num_unique_labels = static_cast<size_t>(cuda::std::distance(
+            unique_labels.begin(),
+            cugraph::unique(
+              handle_.get_thrust_policy(), unique_labels.begin(), unique_labels.end())));
 
           rmm::device_uvector<label_t> local_label_to_comm_rank(num_unique_labels,
                                                                 handle_.get_stream());
 
-          cugraph::detail::scalar_fill(
-            handle_.get_stream(),
-            local_label_to_comm_rank.begin(),  // This should be rename to rank
-            local_label_to_comm_rank.size(),
-            label_t{handle_.get_comms().get_rank()});
+          cugraph::fill(rmm::exec_policy(handle_.get_stream()),
+                        local_label_to_comm_rank.begin(),
+                        local_label_to_comm_rank.end(),
+                        label_t{handle_.get_comms().get_rank()});  // This should be rename to rank
 
           // Perform allgather to get global_label_to_comm_rank_d_vector
           auto recvcounts = cugraph::host_scalar_allgather(
@@ -567,13 +568,11 @@ struct neighbor_sampling_functor : public cugraph::c_api::abstract_functor {
             if (vertex_type_offsets_ == nullptr) {
               // If no 'vertex_type_offsets' is provided, all vertices are assumed to have
               // a vertex type of value 1.
-              cugraph::detail::stride_fill(handle_.get_stream(),
-                                           vertex_type_offsets.begin(),
-                                           vertex_type_offsets.size(),
-                                           vertex_t{0},
-                                           vertex_t{graph_view.local_vertex_partition_range_size()}
-
-              );
+              cugraph::sequence(rmm::exec_policy(handle_.get_stream()),
+                                vertex_type_offsets.begin(),
+                                vertex_type_offsets.begin() + vertex_type_offsets.size(),
+                                vertex_t{0},
+                                vertex_t{graph_view.local_vertex_partition_range_size()});
             }
 
             rmm::device_uvector<vertex_t> output_majors(0, handle_.get_stream());
@@ -635,10 +634,10 @@ struct neighbor_sampling_functor : public cugraph::c_api::abstract_functor {
                             .back() -
                           1,
                         handle_.get_stream());
-              cugraph::detail::sequence_fill(handle_.get_stream(),
-                                             (*sampled_edge_type).begin(),
-                                             (*sampled_edge_type).size(),
-                                             edge_type_t{0});
+              cugraph::sequence(rmm::exec_policy(handle_.get_stream()),
+                                (*sampled_edge_type).begin(),
+                                (*sampled_edge_type).begin() + (*sampled_edge_type).size(),
+                                edge_type_t{0});
             }
 
             size_t pos = 0;

--- a/cpp/src/c_api/renumber_arbitrary_edgelist.cu
+++ b/cpp/src/c_api/renumber_arbitrary_edgelist.cu
@@ -36,18 +36,18 @@ cugraph_error_code_t renumber_arbitrary_edgelist(
                  dsts->size_,
                  vertices.data() + srcs->size_);
 
-  cugraph::sort_wrapper(handle.get_thrust_policy(), vertices.begin(), vertices.end());
+  cugraph::sort(handle.get_thrust_policy(), vertices.begin(), vertices.end());
   vertices.resize(cuda::std::distance(
                     vertices.begin(),
-                    thrust::unique(handle.get_thrust_policy(), vertices.begin(), vertices.end())),
+                    cugraph::unique(handle.get_thrust_policy(), vertices.begin(), vertices.end())),
                   handle.get_stream());
 
   vertices.shrink_to_fit(handle.get_stream());
   rmm::device_uvector<vertex_t> ids(vertices.size(), handle.get_stream());
-  thrust::fill(handle.get_thrust_policy(),
-               ids.begin(),
-               ids.end(),
-               cugraph::invalid_vertex_id<vertex_t>::value);
+  cugraph::fill(handle.get_thrust_policy(),
+                ids.begin(),
+                ids.end(),
+                cugraph::invalid_vertex_id<vertex_t>::value);
 
   raft::device_span<vertex_t const> vertices_span{vertices.data(), vertices.size()};
   raft::device_span<vertex_t> ids_span{ids.data(), ids.size()};

--- a/cpp/src/c_api/temporal_neighbor_sampling.cpp
+++ b/cpp/src/c_api/temporal_neighbor_sampling.cpp
@@ -25,6 +25,8 @@
 
 #include <raft/core/handle.hpp>
 
+#include <rmm/exec_policy.hpp>
+
 namespace {
 
 struct temporal_neighbor_sampling_functor : public cugraph::c_api::abstract_functor {
@@ -205,21 +207,20 @@ struct temporal_neighbor_sampling_functor : public cugraph::c_api::abstract_func
 
           // Get unique labels
           // sort the start_vertex_labels
-          cugraph::sort_wrapper(
-            handle_.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
+          cugraph::sort(handle_.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
 
-          auto num_unique_labels = cugraph::detail::unique_ints(
-            handle_.get_stream(),
-            raft::device_span<label_t>{unique_labels.data(), unique_labels.size()});
+          auto num_unique_labels = static_cast<size_t>(cuda::std::distance(
+            unique_labels.begin(),
+            cugraph::unique(
+              handle_.get_thrust_policy(), unique_labels.begin(), unique_labels.end())));
 
           rmm::device_uvector<label_t> local_label_to_comm_rank(num_unique_labels,
                                                                 handle_.get_stream());
 
-          cugraph::detail::scalar_fill(
-            handle_.get_stream(),
-            local_label_to_comm_rank.begin(),  // This should be rename to rank
-            local_label_to_comm_rank.size(),
-            label_t{handle_.get_comms().get_rank()});
+          cugraph::fill(rmm::exec_policy(handle_.get_stream()),
+                        local_label_to_comm_rank.begin(),
+                        local_label_to_comm_rank.end(),
+                        label_t{handle_.get_comms().get_rank()});  // This should be rename to rank
 
           // Perform allgather to get global_label_to_comm_rank_d_vector
           auto recvcounts = cugraph::host_scalar_allgather(
@@ -702,13 +703,11 @@ struct temporal_neighbor_sampling_functor : public cugraph::c_api::abstract_func
             if (vertex_type_offsets_ == nullptr) {
               // If no 'vertex_type_offsets' is provided, all vertices are assumed to have
               // a vertex type of value 1.
-              cugraph::detail::stride_fill(handle_.get_stream(),
-                                           vertex_type_offsets.begin(),
-                                           vertex_type_offsets.size(),
-                                           vertex_t{0},
-                                           vertex_t{graph_view.local_vertex_partition_range_size()}
-
-              );
+              cugraph::sequence(rmm::exec_policy(handle_.get_stream()),
+                                vertex_type_offsets.begin(),
+                                vertex_type_offsets.begin() + vertex_type_offsets.size(),
+                                vertex_t{0},
+                                vertex_t{graph_view.local_vertex_partition_range_size()});
             }
 
             rmm::device_uvector<vertex_t> output_majors(0, handle_.get_stream());
@@ -777,10 +776,10 @@ struct temporal_neighbor_sampling_functor : public cugraph::c_api::abstract_func
                             .back() -
                           1,
                         handle_.get_stream());
-              cugraph::detail::sequence_fill(handle_.get_stream(),
-                                             (*sampled_edge_types).begin(),
-                                             (*sampled_edge_types).size(),
-                                             edge_type_t{0});
+              cugraph::sequence(rmm::exec_policy(handle_.get_stream()),
+                                (*sampled_edge_types).begin(),
+                                (*sampled_edge_types).begin() + (*sampled_edge_types).size(),
+                                edge_type_t{0});
             }
 
             size_t pos = 0;

--- a/cpp/src/centrality/betweenness_centrality_impl.cuh
+++ b/cpp/src/centrality/betweenness_centrality_impl.cuh
@@ -146,8 +146,12 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<edge_t>> brandes_b
                                      handle.get_stream());
   rmm::device_uvector<vertex_t> distances(graph_view.local_vertex_partition_range_size(),
                                           handle.get_stream());
-  detail::scalar_fill(handle, distances.data(), distances.size(), invalid_distance);
-  detail::scalar_fill(handle, sigmas.data(), sigmas.size(), edge_t{0});
+  cugraph::fill(handle.get_thrust_policy(),
+                distances.data(),
+                (distances.data()) + (distances.size()),
+                invalid_distance);
+  cugraph::fill(
+    handle.get_thrust_policy(), sigmas.data(), (sigmas.data()) + (sigmas.size()), edge_t{0});
 
   edge_src_property_t<vertex_t, edge_t> src_sigmas(handle, graph_view);
   edge_dst_property_t<vertex_t, vertex_t> dst_distances(handle, graph_view);
@@ -281,11 +285,11 @@ void accumulate_vertex_results(
     // Copy distances for sorting (preserve original)
     raft::copy(distance_keys.data(), distances.data(), distances.size(), handle.get_stream());
 
-    // Use thrust::sequence instead of thrust::copy for vertices
-    thrust::sequence(handle.get_thrust_policy(),
-                     vertices_sorted.begin(),
-                     vertices_sorted.end(),
-                     graph_view.local_vertex_partition_range_first());
+    // Use cugraph::sequence instead of thrust::copy for vertices
+    cugraph::sequence(handle.get_thrust_policy(),
+                      vertices_sorted.begin(),
+                      vertices_sorted.end(),
+                      graph_view.local_vertex_partition_range_first());
 
     // Sort vertices by distance using stable_sort_by_key
     thrust::stable_sort_by_key(handle.get_thrust_policy(),
@@ -408,7 +412,8 @@ void accumulate_edge_results(
     do_expensive_check);
 
   rmm::device_uvector<weight_t> deltas(sigmas.size(), handle.get_stream());
-  detail::scalar_fill(handle, deltas.data(), deltas.size(), weight_t{0});
+  cugraph::fill(
+    handle.get_thrust_policy(), deltas.data(), (deltas.data()) + (deltas.size()), weight_t{0});
 
   edge_src_property_t<vertex_t, cuda::std::tuple<vertex_t, edge_t, weight_t>> src_properties(
     handle, graph_view);
@@ -458,7 +463,7 @@ void accumulate_edge_results(
                                                              do_expensive_check);
 
       auto triplet_first = thrust::make_zip_iterator(srcs.begin(), dsts.begin(), indices->begin());
-      cugraph::sort_wrapper(handle.get_thrust_policy(), triplet_first, triplet_first + srcs.size());
+      cugraph::sort(handle.get_thrust_policy(), triplet_first, triplet_first + srcs.size());
     } else {
       std::tie(srcs, dsts) = extract_transform_if_e(handle,
                                                     graph_view,
@@ -469,7 +474,7 @@ void accumulate_edge_results(
                                                     extract_edge_pred_op_t<vertex_t>{d},
                                                     do_expensive_check);
       auto pair_first      = thrust::make_zip_iterator(srcs.begin(), dsts.begin());
-      cugraph::sort_wrapper(handle.get_thrust_policy(), pair_first, pair_first + srcs.size());
+      cugraph::sort(handle.get_thrust_policy(), pair_first, pair_first + srcs.size());
     }
     edge_list.insert(srcs.begin(),
                      srcs.end(),
@@ -546,7 +551,7 @@ batch_partition_frontier(raft::handle_t const& handle,
     std::nullopt};  // last source IDs (exclusive) for each batch ID
   if (num_sources > 1) {
     rmm::device_uvector<size_t> source_out_edge_counts(num_sources, handle.get_stream());
-    thrust::fill(
+    cugraph::fill(
       handle.get_thrust_policy(), source_out_edge_counts.begin(), source_out_edge_counts.end(), 0);
     thrust::for_each(
       handle.get_thrust_policy(),
@@ -593,7 +598,7 @@ batch_partition_frontier(raft::handle_t const& handle,
 
   std::vector<size_t> batch_offsets{0, frontier.size()};
   if (source_lasts) {
-    cugraph::sort_wrapper(
+    cugraph::sort(
       handle.get_thrust_policy(),
       frontier.begin(),
       frontier.end(),
@@ -673,8 +678,14 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<edge_t>> multisour
                                         handle.get_stream());
   rmm::device_uvector<vertex_t> distances_2d(num_sources * local_vertex_partition_range_size,
                                              handle.get_stream());
-  detail::scalar_fill(handle, sigmas_2d.data(), sigmas_2d.size(), edge_t{0});
-  detail::scalar_fill(handle, distances_2d.data(), distances_2d.size(), invalid_distance);
+  cugraph::fill(handle.get_thrust_policy(),
+                sigmas_2d.data(),
+                (sigmas_2d.data()) + (sigmas_2d.size()),
+                edge_t{0});
+  cugraph::fill(handle.get_thrust_policy(),
+                distances_2d.data(),
+                (distances_2d.data()) + (distances_2d.size()),
+                invalid_distance);
 
   {
     auto tagged_source_first =
@@ -885,11 +896,11 @@ void multisource_backward_pass(
     num_sources <= std::numeric_limits<origin_t>::max(),
     "Number of sources exceeds maximum value for origin_t (uint16_t), would cause overflow");
 
-  thrust::fill(handle.get_thrust_policy(), centralities.begin(), centralities.end(), weight_t{0});
+  cugraph::fill(handle.get_thrust_policy(), centralities.begin(), centralities.end(), weight_t{0});
 
   rmm::device_uvector<weight_t> delta_buffer(num_sources * local_vertex_partition_range_size,
                                              handle.get_stream());
-  thrust::fill(handle.get_thrust_policy(), delta_buffer.begin(), delta_buffer.end(), weight_t{0});
+  cugraph::fill(handle.get_thrust_policy(), delta_buffer.begin(), delta_buffer.end(), weight_t{0});
 
   // (vertex, source idx) pairs for each distance level [0, global_max_distance + 1)
   rmm::device_uvector<vertex_t> all_vertices(0, handle.get_stream());
@@ -909,7 +920,7 @@ void multisource_backward_pass(
                                                   thrust::maximum<vertex_t>());
 
     rmm::device_uvector<size_t> d_distance_counts(global_max_distance + 1, handle.get_stream());
-    thrust::fill(
+    cugraph::fill(
       handle.get_thrust_policy(), d_distance_counts.begin(), d_distance_counts.end(), size_t{0});
 
     thrust::for_each_n(
@@ -951,7 +962,7 @@ void multisource_backward_pass(
 
     all_vertices.resize(h_distance_offsets.back(), handle.get_stream());
     all_sources.resize(h_distance_offsets.back(), handle.get_stream());
-    thrust::fill(
+    cugraph::fill(
       handle.get_thrust_policy(), d_distance_counts.begin(), d_distance_counts.end(), size_t{0});
 
     thrust::for_each_n(
@@ -1313,7 +1324,10 @@ rmm::device_uvector<weight_t> betweenness_centrality(
 
   rmm::device_uvector<weight_t> centralities(graph_view.local_vertex_partition_range_size(),
                                              handle.get_stream());
-  detail::scalar_fill(handle, centralities.data(), centralities.size(), weight_t{0});
+  cugraph::fill(handle.get_thrust_policy(),
+                centralities.data(),
+                (centralities.data()) + (centralities.size()),
+                weight_t{0});
 
   size_t num_sources = cuda::std::distance(vertices_begin, vertices_end);
   std::vector<size_t> source_offsets{{0, num_sources}};

--- a/cpp/src/centrality/eigenvector_centrality_impl.cuh
+++ b/cpp/src/centrality/eigenvector_centrality_impl.cuh
@@ -16,6 +16,7 @@
 #include <cugraph/prims/transform_reduce_v.cuh>
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -67,10 +68,10 @@ rmm::device_uvector<weight_t> eigenvector_centrality(
                  initial_centralities->end(),
                  centralities.begin());
   } else {
-    thrust::fill(handle.get_thrust_policy(),
-                 centralities.begin(),
-                 centralities.end(),
-                 weight_t{1.0} / static_cast<weight_t>(num_vertices));
+    cugraph::fill(handle.get_thrust_policy(),
+                  centralities.begin(),
+                  centralities.end(),
+                  weight_t{1.0} / static_cast<weight_t>(num_vertices));
   }
 
   // Power iteration

--- a/cpp/src/centrality/katz_centrality_impl.cuh
+++ b/cpp/src/centrality/katz_centrality_impl.cuh
@@ -13,6 +13,7 @@
 #include <cugraph/prims/transform_reduce_v.cuh>
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -75,10 +76,10 @@ void katz_centrality(
   // 2. initialize katz centrality values
 
   if (!has_initial_guess) {
-    thrust::fill(handle.get_thrust_policy(),
-                 katz_centralities,
-                 katz_centralities + pull_graph_view.local_vertex_partition_range_size(),
-                 result_t{0.0});
+    cugraph::fill(handle.get_thrust_policy(),
+                  katz_centralities,
+                  katz_centralities + pull_graph_view.local_vertex_partition_range_size(),
+                  result_t{0.0});
   }
 
   // 3. katz centrality iteration

--- a/cpp/src/community/approx_weighted_matching_impl.cuh
+++ b/cpp/src/community/approx_weighted_matching_impl.cuh
@@ -16,8 +16,11 @@
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/collect_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
+
+#include <rmm/exec_policy.hpp>
 
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
@@ -66,18 +69,18 @@ std::tuple<rmm::device_uvector<vertex_t>, weight_t> approximate_weighted_matchin
   rmm::device_uvector<vertex_t> partners(current_graph_view.local_vertex_partition_range_size(),
                                          handle.get_stream());
 
-  thrust::fill(handle.get_thrust_policy(), partners.begin(), partners.end(), invalid_partner);
-  thrust::fill(handle.get_thrust_policy(),
-               offers_from_partners.begin(),
-               offers_from_partners.end(),
-               weight_t{0.0});
+  cugraph::fill(handle.get_thrust_policy(), partners.begin(), partners.end(), invalid_partner);
+  cugraph::fill(handle.get_thrust_policy(),
+                offers_from_partners.begin(),
+                offers_from_partners.end(),
+                weight_t{0.0});
 
   rmm::device_uvector<vertex_t> local_vertices(
     current_graph_view.local_vertex_partition_range_size(), handle.get_stream());
-  detail::sequence_fill(handle.get_stream(),
-                        local_vertices.begin(),
-                        local_vertices.size(),
-                        current_graph_view.local_vertex_partition_range_first());
+  cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                    local_vertices.begin(),
+                    local_vertices.begin() + local_vertices.size(),
+                    current_graph_view.local_vertex_partition_range_first());
 
   cugraph::edge_src_property_t<vertex_t, vertex_t> src_key_cache(handle);
   cugraph::edge_src_property_t<vertex_t, bool> src_match_flags(handle);
@@ -231,7 +234,7 @@ std::tuple<rmm::device_uvector<vertex_t>, weight_t> approximate_weighted_matchin
 
     rmm::device_uvector<bool> is_vertex_matched = rmm::device_uvector<bool>(
       current_graph_view.local_vertex_partition_range_size(), handle.get_stream());
-    thrust::fill(
+    cugraph::fill(
       handle.get_thrust_policy(), is_vertex_matched.begin(), is_vertex_matched.end(), bool{false});
 
     thrust::for_each(

--- a/cpp/src/community/detail/common_methods.cuh
+++ b/cpp/src/community/detail/common_methods.cuh
@@ -17,6 +17,9 @@
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
 #include <cugraph/utilities/collect_comm.cuh>
 #include <cugraph/utilities/graph_partition_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
+
+#include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/iterator>
@@ -216,10 +219,10 @@ graph_contraction(raft::handle_t const& handle,
   auto new_graph_view = new_graph.view();
 
   rmm::device_uvector<vertex_t> numbering_indices((*numbering_map).size(), handle.get_stream());
-  detail::sequence_fill(handle.get_stream(),
-                        numbering_indices.data(),
-                        numbering_indices.size(),
-                        new_graph_view.local_vertex_partition_range_first());
+  cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                    numbering_indices.data(),
+                    numbering_indices.data() + numbering_indices.size(),
+                    new_graph_view.local_vertex_partition_range_first());
 
   relabel<vertex_t, multi_gpu>(
     handle,

--- a/cpp/src/community/detail/decision_graph_mis.cuh
+++ b/cpp/src/community/detail/decision_graph_mis.cuh
@@ -13,6 +13,9 @@
 #include <cugraph/graph.hpp>
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/shuffle_functions.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
+
+#include <rmm/exec_policy.hpp>
 
 #include <optional>
 #include <tuple>
@@ -62,10 +65,10 @@ rmm::device_uvector<vertex_t> vertices_in_mis_from_decision_edgelist(
     maximal_independent_moves<vertex_t, edge_t, multi_gpu>(handle, decision_graph_view, rng_state);
 
   rmm::device_uvector<vertex_t> numbering_indices((*renumber_map).size(), handle.get_stream());
-  detail::sequence_fill(handle.get_stream(),
-                        numbering_indices.data(),
-                        numbering_indices.size(),
-                        decision_graph_view.local_vertex_partition_range_first());
+  cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                    numbering_indices.data(),
+                    numbering_indices.data() + numbering_indices.size(),
+                    decision_graph_view.local_vertex_partition_range_first());
 
   relabel<vertex_t, multi_gpu>(
     handle,

--- a/cpp/src/community/detail/refine_impl.cuh
+++ b/cpp/src/community/detail/refine_impl.cuh
@@ -24,6 +24,8 @@
 
 #include <raft/random/rng_device.cuh>
 
+#include <rmm/exec_policy.hpp>
+
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/functional>
@@ -279,10 +281,10 @@ refine_clustering(raft::handle_t const& handle,
   rmm::device_uvector<vertex_t> leiden_assignment = rmm::device_uvector<vertex_t>(
     graph_view.local_vertex_partition_range_size(), handle.get_stream());
 
-  detail::sequence_fill(handle.get_stream(),
-                        leiden_assignment.begin(),
-                        leiden_assignment.size(),
-                        graph_view.local_vertex_partition_range_first());
+  cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                    leiden_assignment.begin(),
+                    leiden_assignment.begin() + leiden_assignment.size(),
+                    graph_view.local_vertex_partition_range_first());
 
   edge_src_property_t<vertex_t, vertex_t> src_leiden_assignment_cache(handle);
   edge_dst_property_t<vertex_t, vertex_t> dst_leiden_assignment_cache(handle);
@@ -586,10 +588,10 @@ refine_clustering(raft::handle_t const& handle,
     }
 
     rmm::device_uvector<vertex_t> d_srcs(n_local_vertices, handle.get_stream());
-    detail::sequence_fill(handle.get_stream(),
-                          d_srcs.data(),
-                          d_srcs.size(),
-                          graph_view.local_vertex_partition_range_first());
+    cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                      d_srcs.data(),
+                      d_srcs.data() + d_srcs.size(),
+                      graph_view.local_vertex_partition_range_first());
 
     rmm::device_uvector<vertex_t> d_dsts(keep_count, handle.get_stream());
     copy_if_mask_set(handle,
@@ -646,12 +648,12 @@ refine_clustering(raft::handle_t const& handle,
     vertices_in_mis.resize(0, handle.get_stream());
     vertices_in_mis.shrink_to_fit(handle.get_stream());
 
-    cugraph::sort_wrapper(handle.get_thrust_policy(), dst_vertices.begin(), dst_vertices.end());
+    cugraph::sort(handle.get_thrust_policy(), dst_vertices.begin(), dst_vertices.end());
 
     dst_vertices.resize(
       static_cast<size_t>(cuda::std::distance(
         dst_vertices.begin(),
-        thrust::unique(handle.get_thrust_policy(), dst_vertices.begin(), dst_vertices.end()))),
+        cugraph::unique(handle.get_thrust_policy(), dst_vertices.begin(), dst_vertices.end()))),
       handle.get_stream());
 
     // Shuffle dst vertices to owner GPU, according to vetex partitioning
@@ -662,12 +664,12 @@ refine_clustering(raft::handle_t const& handle,
                                       std::vector<cugraph::arithmetic_device_uvector_t>{},
                                       graph_view.vertex_partition_range_lasts());
 
-      cugraph::sort_wrapper(handle.get_thrust_policy(), dst_vertices.begin(), dst_vertices.end());
+      cugraph::sort(handle.get_thrust_policy(), dst_vertices.begin(), dst_vertices.end());
 
       dst_vertices.resize(
         static_cast<size_t>(cuda::std::distance(
           dst_vertices.begin(),
-          thrust::unique(handle.get_thrust_policy(), dst_vertices.begin(), dst_vertices.end()))),
+          cugraph::unique(handle.get_thrust_policy(), dst_vertices.begin(), dst_vertices.end()))),
         handle.get_stream());
     }
 
@@ -707,15 +709,15 @@ refine_clustering(raft::handle_t const& handle,
                leiden_assignment.end(),
                leiden_keys_to_read_louvain.begin());
 
-  cugraph::sort_wrapper(handle.get_thrust_policy(),
-                        leiden_keys_to_read_louvain.begin(),
-                        leiden_keys_to_read_louvain.end());
+  cugraph::sort(handle.get_thrust_policy(),
+                leiden_keys_to_read_louvain.begin(),
+                leiden_keys_to_read_louvain.end());
 
   auto nr_unique_leiden_clusters =
     static_cast<size_t>(cuda::std::distance(leiden_keys_to_read_louvain.begin(),
-                                            thrust::unique(handle.get_thrust_policy(),
-                                                           leiden_keys_to_read_louvain.begin(),
-                                                           leiden_keys_to_read_louvain.end())));
+                                            cugraph::unique(handle.get_thrust_policy(),
+                                                            leiden_keys_to_read_louvain.begin(),
+                                                            leiden_keys_to_read_louvain.end())));
 
   leiden_keys_to_read_louvain.resize(nr_unique_leiden_clusters, handle.get_stream());
 
@@ -728,15 +730,15 @@ refine_clustering(raft::handle_t const& handle,
                                     std::vector<cugraph::arithmetic_device_uvector_t>{},
                                     graph_view.vertex_partition_range_lasts());
 
-    cugraph::sort_wrapper(handle.get_thrust_policy(),
-                          leiden_keys_to_read_louvain.begin(),
-                          leiden_keys_to_read_louvain.end());
+    cugraph::sort(handle.get_thrust_policy(),
+                  leiden_keys_to_read_louvain.begin(),
+                  leiden_keys_to_read_louvain.end());
 
     nr_unique_leiden_clusters =
       static_cast<size_t>(cuda::std::distance(leiden_keys_to_read_louvain.begin(),
-                                              thrust::unique(handle.get_thrust_policy(),
-                                                             leiden_keys_to_read_louvain.begin(),
-                                                             leiden_keys_to_read_louvain.end())));
+                                              cugraph::unique(handle.get_thrust_policy(),
+                                                              leiden_keys_to_read_louvain.begin(),
+                                                              leiden_keys_to_read_louvain.end())));
     leiden_keys_to_read_louvain.resize(nr_unique_leiden_clusters, handle.get_stream());
 
     auto& comm                 = handle.get_comms();

--- a/cpp/src/community/edge_triangle_count_impl.cuh
+++ b/cpp/src/community/edge_triangle_count_impl.cuh
@@ -172,7 +172,7 @@ edge_property_t<edge_t, edge_t> edge_triangle_count_impl(
   }
 
   // Need to ensure that the vector has its values initialized to 0 before incrementing
-  thrust::fill(handle.get_thrust_policy(), num_triangles.begin(), num_triangles.end(), 0);
+  cugraph::fill(handle.get_thrust_policy(), num_triangles.begin(), num_triangles.end(), 0);
 
   for (size_t i = 0; i < num_chunks; ++i) {
     auto chunk_size = std::min(edges_to_intersect_per_iteration, num_remaining_edges);
@@ -228,16 +228,16 @@ edge_property_t<edge_t, edge_t> edge_triangle_count_impl(
                                             intersection_indices.size()),
           edge_first});
 
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            get_dataframe_buffer_begin(vertex_pair_buffer_tmp),
-                            get_dataframe_buffer_end(vertex_pair_buffer_tmp));
+      cugraph::sort(handle.get_thrust_policy(),
+                    get_dataframe_buffer_begin(vertex_pair_buffer_tmp),
+                    get_dataframe_buffer_end(vertex_pair_buffer_tmp));
 
       rmm::device_uvector<edge_t> increase_count_tmp(2 * intersection_indices.size(),
                                                      handle.get_stream());
-      thrust::fill(handle.get_thrust_policy(),
-                   increase_count_tmp.begin(),
-                   increase_count_tmp.end(),
-                   size_t{1});
+      cugraph::fill(handle.get_thrust_policy(),
+                    increase_count_tmp.begin(),
+                    increase_count_tmp.end(),
+                    size_t{1});
 
       auto count_p_r_q_r = thrust::unique_count(handle.get_thrust_policy(),
                                                 get_dataframe_buffer_begin(vertex_pair_buffer_tmp),

--- a/cpp/src/community/egonet_impl.cuh
+++ b/cpp/src/community/egonet_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -14,6 +14,7 @@
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #ifdef TIMING
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #endif
 
 #include <rmm/cuda_stream_view.hpp>
@@ -106,10 +107,10 @@ extract(raft::handle_t const& handle,
     // BFS with cutoff
     // consider adding a device API to BFS (ie. accept source on the device)
     bool direction_optimizing = false;
-    thrust::fill(rmm::exec_policy(worker_stream_view),
-                 reached[i].begin(),
-                 reached[i].end(),
-                 std::numeric_limits<vertex_t>::max());
+    cugraph::fill(rmm::exec_policy(worker_stream_view),
+                  reached[i].begin(),
+                  reached[i].end(),
+                  std::numeric_limits<vertex_t>::max());
 
     raft::device_span<vertex_t const> source{source_vertex.data() + i, 1};
 

--- a/cpp/src/community/flatten_dendrogram.hpp
+++ b/cpp/src/community/flatten_dendrogram.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -7,6 +7,7 @@
 #include <cugraph/dendrogram.hpp>
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/graph_functions.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -33,10 +34,10 @@ void partition_at_level(raft::handle_t const& handle,
     thrust::make_counting_iterator<size_t>(level),
     [&handle, &dendrogram, &local_vertex_ids_v, d_vertex_ids, &d_partition, local_num_verts](
       size_t l) {
-      detail::sequence_fill(handle.get_stream(),
-                            local_vertex_ids_v.begin(),
-                            dendrogram.get_level_size_nocheck(l),
-                            dendrogram.get_level_first_index_nocheck(l));
+      cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                        local_vertex_ids_v.begin(),
+                        local_vertex_ids_v.begin() + dendrogram.get_level_size_nocheck(l),
+                        dendrogram.get_level_first_index_nocheck(l));
 
       cugraph::relabel<vertex_t, multi_gpu>(
         handle,

--- a/cpp/src/community/k_truss_impl.cuh
+++ b/cpp/src/community/k_truss_impl.cuh
@@ -327,7 +327,7 @@ k_truss(raft::handle_t const& handle,
       auto weak_edgelist_last =
         thrust::make_zip_iterator(weak_edgelist_srcs.end(), weak_edgelist_dsts.end());
 
-      cugraph::sort_wrapper(handle.get_thrust_policy(), weak_edgelist_first, weak_edgelist_last);
+      cugraph::sort(handle.get_thrust_policy(), weak_edgelist_first, weak_edgelist_last);
 
       // Perform nbr_intersection of the weak edges from the undirected
       // graph view
@@ -358,13 +358,13 @@ k_truss(raft::handle_t const& handle,
           raft::device_span<vertex_t const>(weak_edgelist_srcs.data(), weak_edgelist_srcs.size()),
           raft::device_span<vertex_t const>(weak_edgelist_dsts.data(), weak_edgelist_dsts.size())});
 
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            get_dataframe_buffer_begin(triangles_endpoints),
-                            get_dataframe_buffer_end(triangles_endpoints));
+      cugraph::sort(handle.get_thrust_policy(),
+                    get_dataframe_buffer_begin(triangles_endpoints),
+                    get_dataframe_buffer_end(triangles_endpoints));
 
-      auto unique_triangle_end = thrust::unique(handle.get_thrust_policy(),
-                                                get_dataframe_buffer_begin(triangles_endpoints),
-                                                get_dataframe_buffer_end(triangles_endpoints));
+      auto unique_triangle_end = cugraph::unique(handle.get_thrust_policy(),
+                                                 get_dataframe_buffer_begin(triangles_endpoints),
+                                                 get_dataframe_buffer_end(triangles_endpoints));
 
       auto num_unique_triangles =
         cuda::std::distance(  // Triangles are represented by their endpoints
@@ -398,13 +398,13 @@ k_truss(raft::handle_t const& handle,
             std::move(std::get<rmm::device_uvector<vertex_t>>(edge_properties[0]));
         }
 
-        cugraph::sort_wrapper(handle.get_thrust_policy(),
-                              get_dataframe_buffer_begin(triangles_endpoints),
-                              get_dataframe_buffer_end(triangles_endpoints));
+        cugraph::sort(handle.get_thrust_policy(),
+                      get_dataframe_buffer_begin(triangles_endpoints),
+                      get_dataframe_buffer_end(triangles_endpoints));
 
-        unique_triangle_end = thrust::unique(handle.get_thrust_policy(),
-                                             get_dataframe_buffer_begin(triangles_endpoints),
-                                             get_dataframe_buffer_end(triangles_endpoints));
+        unique_triangle_end = cugraph::unique(handle.get_thrust_policy(),
+                                              get_dataframe_buffer_begin(triangles_endpoints),
+                                              get_dataframe_buffer_end(triangles_endpoints));
 
         num_unique_triangles =
           cuda::std::distance(get_dataframe_buffer_begin(triangles_endpoints), unique_triangle_end);
@@ -463,9 +463,9 @@ k_truss(raft::handle_t const& handle,
                                                   cur_graph_view.vertex_partition_range_lasts());
       }
 
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            get_dataframe_buffer_begin(edgelist_to_update_count),
-                            get_dataframe_buffer_end(edgelist_to_update_count));
+      cugraph::sort(handle.get_thrust_policy(),
+                    get_dataframe_buffer_begin(edgelist_to_update_count),
+                    get_dataframe_buffer_end(edgelist_to_update_count));
 
       auto unique_pair_count =
         thrust::unique_count(handle.get_thrust_policy(),
@@ -591,7 +591,7 @@ k_truss(raft::handle_t const& handle,
 
       edgelist_weak.clear();
 
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(),
         thrust::make_zip_iterator(weak_edgelist_srcs.begin(), weak_edgelist_dsts.begin()),
         thrust::make_zip_iterator(weak_edgelist_srcs.end(), weak_edgelist_dsts.end()));
@@ -637,7 +637,7 @@ k_truss(raft::handle_t const& handle,
                             cur_graph_view.vertex_partition_range_lasts());
       }
 
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(),
         thrust::make_zip_iterator(weak_edgelist_dsts.begin(), weak_edgelist_srcs.begin()),
         thrust::make_zip_iterator(weak_edgelist_dsts.end(), weak_edgelist_srcs.end()));

--- a/cpp/src/community/leiden_impl.cuh
+++ b/cpp/src/community/leiden_impl.cuh
@@ -16,6 +16,7 @@
 #include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <cuda/std/iterator>
 #include <thrust/sort.h>
@@ -37,11 +38,11 @@ void check_clustering(graph_view_t<vertex_t, edge_t, false, multi_gpu> const& gr
 template <typename vertex_t, bool multi_gpu>
 vertex_t remove_duplicates(raft::handle_t const& handle, rmm::device_uvector<vertex_t>& input_array)
 {
-  cugraph::sort_wrapper(handle.get_thrust_policy(), input_array.begin(), input_array.end());
+  cugraph::sort(handle.get_thrust_policy(), input_array.begin(), input_array.end());
 
   auto nr_unique_elements = static_cast<vertex_t>(cuda::std::distance(
     input_array.begin(),
-    thrust::unique(handle.get_thrust_policy(), input_array.begin(), input_array.end())));
+    cugraph::unique(handle.get_thrust_policy(), input_array.begin(), input_array.end())));
 
   input_array.resize(nr_unique_elements, handle.get_stream());
 
@@ -49,11 +50,11 @@ vertex_t remove_duplicates(raft::handle_t const& handle, rmm::device_uvector<ver
     std::tie(input_array, std::ignore) = shuffle_ext_vertices(
       handle, std::move(input_array), std::vector<cugraph::arithmetic_device_uvector_t>{});
 
-    cugraph::sort_wrapper(handle.get_thrust_policy(), input_array.begin(), input_array.end());
+    cugraph::sort(handle.get_thrust_policy(), input_array.begin(), input_array.end());
 
     nr_unique_elements = static_cast<vertex_t>(cuda::std::distance(
       input_array.begin(),
-      thrust::unique(handle.get_thrust_policy(), input_array.begin(), input_array.end())));
+      cugraph::unique(handle.get_thrust_policy(), input_array.begin(), input_array.end())));
 
     input_array.resize(nr_unique_elements, handle.get_stream());
 
@@ -126,15 +127,15 @@ std::pair<std::unique_ptr<Dendrogram<vertex_t>>, weight_t> leiden(
       cluster_keys.resize(vertex_weights.size(), handle.get_stream());
       cluster_weights.resize(vertex_weights.size(), handle.get_stream());
 
-      detail::sequence_fill(handle.get_stream(),
-                            dendrogram->current_level_begin(),
-                            dendrogram->current_level_size(),
-                            current_graph_view.local_vertex_partition_range_first());
+      cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                        dendrogram->current_level_begin(),
+                        dendrogram->current_level_begin() + dendrogram->current_level_size(),
+                        current_graph_view.local_vertex_partition_range_first());
 
-      detail::sequence_fill(handle.get_stream(),
-                            cluster_keys.begin(),
-                            cluster_keys.size(),
-                            current_graph_view.local_vertex_partition_range_first());
+      cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                        cluster_keys.begin(),
+                        cluster_keys.begin() + cluster_keys.size(),
+                        current_graph_view.local_vertex_partition_range_first());
 
       raft::copy(cluster_weights.begin(),
                  vertex_weights.begin(),
@@ -491,10 +492,10 @@ std::pair<std::unique_ptr<Dendrogram<vertex_t>>, weight_t> leiden(
         rmm::device_uvector<vertex_t> numeric_sequence(
           current_graph_view.local_vertex_partition_range_size(), handle.get_stream());
 
-        detail::sequence_fill(handle.get_stream(),
-                              numeric_sequence.data(),
-                              numeric_sequence.size(),
-                              current_graph_view.local_vertex_partition_range_first());
+        cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                          numeric_sequence.data(),
+                          numeric_sequence.data() + numeric_sequence.size(),
+                          current_graph_view.local_vertex_partition_range_first());
 
         relabel<vertex_t, multi_gpu>(
           handle,
@@ -527,10 +528,9 @@ std::pair<std::unique_ptr<Dendrogram<vertex_t>>, weight_t> leiden(
                    louvain_of_refined_graph.size(),
                    handle.get_stream());
 
-        cugraph::sort_wrapper(
-          handle.get_thrust_policy(),
-          thrust::make_zip_iterator(numbering_map->begin(), numeric_sequence.begin()),
-          thrust::make_zip_iterator(numbering_map->end(), numeric_sequence.end()));
+        cugraph::sort(handle.get_thrust_policy(),
+                      thrust::make_zip_iterator(numbering_map->begin(), numeric_sequence.begin()),
+                      thrust::make_zip_iterator(numbering_map->end(), numeric_sequence.end()));
 
         size_t new_size = cuda::std::distance(numbering_map->begin(),
                                               thrust::unique_by_key(handle.get_thrust_policy(),
@@ -552,10 +552,9 @@ std::pair<std::unique_ptr<Dendrogram<vertex_t>>, weight_t> leiden(
               std::move(std::get<rmm::device_uvector<vertex_t>>(vertex_properties[0]));
           }
 
-          cugraph::sort_wrapper(
-            handle.get_thrust_policy(),
-            thrust::make_zip_iterator(numbering_map->begin(), numeric_sequence.begin()),
-            thrust::make_zip_iterator(numbering_map->end(), numeric_sequence.end()));
+          cugraph::sort(handle.get_thrust_policy(),
+                        thrust::make_zip_iterator(numbering_map->begin(), numeric_sequence.begin()),
+                        thrust::make_zip_iterator(numbering_map->end(), numeric_sequence.end()));
 
           size_t new_size = cuda::std::distance(numbering_map->begin(),
                                                 thrust::unique_by_key(handle.get_thrust_policy(),
@@ -580,10 +579,10 @@ std::pair<std::unique_ptr<Dendrogram<vertex_t>>, weight_t> leiden(
     } else {
       // Reset dendrogram.
       //    FIXME: Revisit how dendrogram is populated
-      detail::sequence_fill(handle.get_stream(),
-                            dendrogram->current_level_begin(),
-                            dendrogram->current_level_size(),
-                            current_graph_view.local_vertex_partition_range_first());
+      cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                        dendrogram->current_level_begin(),
+                        dendrogram->current_level_begin() + dendrogram->current_level_size(),
+                        current_graph_view.local_vertex_partition_range_first());
     }
 
     copied_louvain_partition.resize(0, handle.get_stream());
@@ -627,10 +626,10 @@ void relabel_cluster_ids(raft::handle_t const& handle,
   }
 
   rmm::device_uvector<vertex_t> numbering_indices(unique_cluster_ids.size(), handle.get_stream());
-  detail::sequence_fill(handle.get_stream(),
-                        numbering_indices.data(),
-                        numbering_indices.size(),
-                        local_cluster_id_first);
+  cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                    numbering_indices.data(),
+                    numbering_indices.data() + numbering_indices.size(),
+                    local_cluster_id_first);
 
   relabel<vertex_t, multi_gpu>(
     handle,
@@ -651,10 +650,10 @@ void flatten_leiden_dendrogram(raft::handle_t const& handle,
   rmm::device_uvector<vertex_t> vertex_ids_v(graph_view.local_vertex_partition_range_size(),
                                              handle.get_stream());
 
-  detail::sequence_fill(handle.get_stream(),
-                        vertex_ids_v.begin(),
-                        vertex_ids_v.size(),
-                        graph_view.local_vertex_partition_range_first());
+  cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                    vertex_ids_v.begin(),
+                    vertex_ids_v.begin() + vertex_ids_v.size(),
+                    graph_view.local_vertex_partition_range_first());
 
   partition_at_level<vertex_t, multi_gpu>(
     handle, dendrogram, vertex_ids_v.data(), clustering, dendrogram.num_levels());

--- a/cpp/src/community/louvain_impl.cuh
+++ b/cpp/src/community/louvain_impl.cuh
@@ -18,10 +18,12 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
 #include <cugraph/shuffle_functions.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/random/rng_state.hpp>
 
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cugraph {
 
@@ -91,10 +93,10 @@ std::pair<std::unique_ptr<Dendrogram<vertex_t>>, weight_t> louvain(
                  handle.get_stream());
 
     } else {
-      detail::sequence_fill(handle.get_stream(),
-                            dendrogram->current_level_begin(),
-                            dendrogram->current_level_size(),
-                            current_graph_view.local_vertex_partition_range_first());
+      cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                        dendrogram->current_level_begin(),
+                        dendrogram->current_level_begin() + dendrogram->current_level_size(),
+                        current_graph_view.local_vertex_partition_range_first());
     }
     //
     //  Compute the vertex and cluster weights, these are different for each
@@ -111,10 +113,10 @@ std::pair<std::unique_ptr<Dendrogram<vertex_t>>, weight_t> louvain(
     cluster_keys_v.resize(vertex_weights_v.size(), handle.get_stream());
     cluster_weights_v.resize(vertex_weights_v.size(), handle.get_stream());
 
-    detail::sequence_fill(handle.get_stream(),
-                          cluster_keys_v.begin(),
-                          cluster_keys_v.size(),
-                          current_graph_view.local_vertex_partition_range_first());
+    cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                      cluster_keys_v.begin(),
+                      cluster_keys_v.begin() + cluster_keys_v.size(),
+                      current_graph_view.local_vertex_partition_range_first());
 
     raft::copy(cluster_weights_v.begin(),
                vertex_weights_v.begin(),
@@ -293,10 +295,10 @@ void flatten_dendrogram(raft::handle_t const& handle,
   rmm::device_uvector<vertex_t> vertex_ids_v(graph_view.local_vertex_partition_range_size(),
                                              handle.get_stream());
 
-  detail::sequence_fill(handle.get_stream(),
-                        vertex_ids_v.begin(),
-                        vertex_ids_v.size(),
-                        graph_view.local_vertex_partition_range_first());
+  cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                    vertex_ids_v.begin(),
+                    vertex_ids_v.begin() + vertex_ids_v.size(),
+                    graph_view.local_vertex_partition_range_first());
 
   partition_at_level<vertex_t, multi_gpu>(
     handle, dendrogram, vertex_ids_v.data(), clustering, dendrogram.num_levels());

--- a/cpp/src/community/triangle_count_impl.cuh
+++ b/cpp/src/community/triangle_count_impl.cuh
@@ -196,13 +196,12 @@ void triangle_count(raft::handle_t const& handle,
     rmm::device_uvector<vertex_t> unique_vertices((*vertices).size(), handle.get_stream());
     thrust::copy(
       handle.get_thrust_policy(), (*vertices).begin(), (*vertices).end(), unique_vertices.begin());
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(), unique_vertices.begin(), unique_vertices.end());
-    unique_vertices.resize(
-      cuda::std::distance(
-        unique_vertices.begin(),
-        thrust::unique(handle.get_thrust_policy(), unique_vertices.begin(), unique_vertices.end())),
-      handle.get_stream());
+    cugraph::sort(handle.get_thrust_policy(), unique_vertices.begin(), unique_vertices.end());
+    unique_vertices.resize(cuda::std::distance(unique_vertices.begin(),
+                                               cugraph::unique(handle.get_thrust_policy(),
+                                                               unique_vertices.begin(),
+                                                               unique_vertices.end())),
+                           handle.get_stream());
 
     rmm::device_uvector<vertex_t> one_hop_nbrs(0, handle.get_stream());
     std::tie(std::ignore, one_hop_nbrs) = cugraph::k_hop_nbrs(
@@ -218,12 +217,12 @@ void triangle_count(raft::handle_t const& handle,
                  unique_one_hop_nbrs.begin());
     one_hop_nbrs.resize(0, handle.get_stream());
     one_hop_nbrs.shrink_to_fit(handle.get_stream());
-    cugraph::sort_wrapper(
+    cugraph::sort(
       handle.get_thrust_policy(), unique_one_hop_nbrs.begin(), unique_one_hop_nbrs.end());
     unique_one_hop_nbrs.resize(cuda::std::distance(unique_one_hop_nbrs.begin(),
-                                                   thrust::unique(handle.get_thrust_policy(),
-                                                                  unique_one_hop_nbrs.begin(),
-                                                                  unique_one_hop_nbrs.end())),
+                                                   cugraph::unique(handle.get_thrust_policy(),
+                                                                   unique_one_hop_nbrs.begin(),
+                                                                   unique_one_hop_nbrs.end())),
                                handle.get_stream());
 
     if constexpr (multi_gpu) {
@@ -232,12 +231,12 @@ void triangle_count(raft::handle_t const& handle,
                              std::move(unique_one_hop_nbrs),
                              std::vector<cugraph::arithmetic_device_uvector_t>{},
                              cur_graph_view.vertex_partition_range_lasts());
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(), unique_one_hop_nbrs.begin(), unique_one_hop_nbrs.end());
       unique_one_hop_nbrs.resize(cuda::std::distance(unique_one_hop_nbrs.begin(),
-                                                     thrust::unique(handle.get_thrust_policy(),
-                                                                    unique_one_hop_nbrs.begin(),
-                                                                    unique_one_hop_nbrs.end())),
+                                                     cugraph::unique(handle.get_thrust_policy(),
+                                                                     unique_one_hop_nbrs.begin(),
+                                                                     unique_one_hop_nbrs.end())),
                                  handle.get_stream());
     }
 
@@ -255,12 +254,12 @@ void triangle_count(raft::handle_t const& handle,
                  unique_two_hop_nbrs.begin());
     two_hop_nbrs.resize(0, handle.get_stream());
     two_hop_nbrs.shrink_to_fit(handle.get_stream());
-    cugraph::sort_wrapper(
+    cugraph::sort(
       handle.get_thrust_policy(), unique_two_hop_nbrs.begin(), unique_two_hop_nbrs.end());
     unique_two_hop_nbrs.resize(cuda::std::distance(unique_two_hop_nbrs.begin(),
-                                                   thrust::unique(handle.get_thrust_policy(),
-                                                                  unique_two_hop_nbrs.begin(),
-                                                                  unique_two_hop_nbrs.end())),
+                                                   cugraph::unique(handle.get_thrust_policy(),
+                                                                   unique_two_hop_nbrs.begin(),
+                                                                   unique_two_hop_nbrs.end())),
                                handle.get_stream());
 
     if constexpr (multi_gpu) {
@@ -269,19 +268,19 @@ void triangle_count(raft::handle_t const& handle,
                              std::move(unique_two_hop_nbrs),
                              std::vector<cugraph::arithmetic_device_uvector_t>{},
                              cur_graph_view.vertex_partition_range_lasts());
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(), unique_two_hop_nbrs.begin(), unique_two_hop_nbrs.end());
       unique_two_hop_nbrs.resize(cuda::std::distance(unique_two_hop_nbrs.begin(),
-                                                     thrust::unique(handle.get_thrust_policy(),
-                                                                    unique_two_hop_nbrs.begin(),
-                                                                    unique_two_hop_nbrs.end())),
+                                                     cugraph::unique(handle.get_thrust_policy(),
+                                                                     unique_two_hop_nbrs.begin(),
+                                                                     unique_two_hop_nbrs.end())),
                                  handle.get_stream());
     }
 
     rmm::device_uvector<bool> within_two_hop_flags(
       cur_graph_view.local_vertex_partition_range_size(), handle.get_stream());
 
-    thrust::fill(
+    cugraph::fill(
       handle.get_thrust_policy(), within_two_hop_flags.begin(), within_two_hop_flags.end(), false);
     thrust::for_each(handle.get_thrust_policy(),
                      unique_vertices.begin(),
@@ -476,7 +475,7 @@ void triangle_count(raft::handle_t const& handle,
   // 7. update counts
 
   {
-    thrust::fill(handle.get_thrust_policy(), counts.begin(), counts.end(), edge_t{0});
+    cugraph::fill(handle.get_thrust_policy(), counts.begin(), counts.end(), edge_t{0});
     auto local_vertices = std::move(*renumber_map);
     auto local_counts   = std::move(cur_graph_counts);
 

--- a/cpp/src/components/strongly_connected_components_impl.cuh
+++ b/cpp/src/components/strongly_connected_components_impl.cuh
@@ -127,7 +127,7 @@ rmm::device_uvector<typename GraphViewType::vertex_type> find_trivial_singleton_
   rmm::device_uvector<uint32_t> bitmap(
     packed_bool_size(graph_view.local_vertex_partition_range_size()),
     handle.get_stream());  // to enusre candidate vertices enter frontier only once.
-  thrust::fill(handle.get_thrust_policy(), bitmap.begin(), bitmap.end(), packed_bool_empty_mask());
+  cugraph::fill(handle.get_thrust_policy(), bitmap.begin(), bitmap.end(), packed_bool_empty_mask());
 
   auto cur_in_degrees  = std::move(in_degrees);
   auto cur_out_degrees = std::move(out_degrees);
@@ -151,8 +151,7 @@ rmm::device_uvector<typename GraphViewType::vertex_type> find_trivial_singleton_
             return (cur_in_degrees[v_offset] == 0) || (cur_out_degrees[v_offset] == 0);
           }))),
     handle.get_stream());
-  cugraph::sort_wrapper(
-    handle.get_thrust_policy(), frontier_vertices.begin(), frontier_vertices.end());
+  cugraph::sort(handle.get_thrust_policy(), frontier_vertices.begin(), frontier_vertices.end());
 
   rmm::device_uvector<vertex_t> peeled_vertices(0, handle.get_stream());
   peeled_vertices.reserve(candidate_vertices.size(), handle.get_stream());
@@ -248,7 +247,7 @@ rmm::device_uvector<typename GraphViewType::vertex_type> find_trivial_singleton_
                                  repetitively rebuilding a kv_store_t object for the entire local
                                  vertex partition range */
 
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(), inv_frontier_vertices.begin(), inv_frontier_vertices.end());
 
       key_bucket_t<vertex_t, void, multi_gpu, true> inv_frontier(handle,
@@ -333,16 +332,15 @@ rmm::device_uvector<typename GraphViewType::vertex_type> find_trivial_singleton_
                            is_newly_peeled);
     frontier_vertices.resize(cuda::std::distance(frontier_vertices.begin(), last),
                              handle.get_stream());
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(), frontier_vertices.begin(), frontier_vertices.end());
+    cugraph::sort(handle.get_thrust_policy(), frontier_vertices.begin(), frontier_vertices.end());
     frontier_vertices.resize(cuda::std::distance(frontier_vertices.begin(),
-                                                 thrust::unique(handle.get_thrust_policy(),
-                                                                frontier_vertices.begin(),
-                                                                frontier_vertices.end())),
+                                                 cugraph::unique(handle.get_thrust_policy(),
+                                                                 frontier_vertices.begin(),
+                                                                 frontier_vertices.end())),
                              handle.get_stream());
     ++iter;
   }
-  cugraph::sort_wrapper(handle.get_thrust_policy(), peeled_vertices.begin(), peeled_vertices.end());
+  cugraph::sort(handle.get_thrust_policy(), peeled_vertices.begin(), peeled_vertices.end());
 
   if (aggregate_frontier_size > 0) {  // check for chains from or to peeled vertices
     // find in-degree 1 and out-degree 1 vertices and their predecessors and successors
@@ -372,9 +370,8 @@ rmm::device_uvector<typename GraphViewType::vertex_type> find_trivial_singleton_
 
     rmm::device_uvector<vertex_t> descendants(one_vertices.size(), handle.get_stream());
     {
-      cugraph::sort_wrapper(
-        handle.get_thrust_policy(), peeled_vertices.begin(), peeled_vertices.end());
-      cugraph::sort_wrapper(handle.get_thrust_policy(), one_vertices.begin(), one_vertices.end());
+      cugraph::sort(handle.get_thrust_policy(), peeled_vertices.begin(), peeled_vertices.end());
+      cugraph::sort(handle.get_thrust_policy(), one_vertices.begin(), one_vertices.end());
       auto edge_dst_peeled_flags = make_initialized_edge_dst_property(handle, graph_view, false);
       fill_edge_dst_property(
         handle,
@@ -436,10 +433,9 @@ rmm::device_uvector<typename GraphViewType::vertex_type> find_trivial_singleton_
         handle.get_stream()); /* functionally identical to renumber_local_ext_vertices but to avoid
                                  repetitively rebuilding a kv_store_t object for the entire local
                                  vertex partition range */
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(), inv_peeled_vertices.begin(), inv_peeled_vertices.end());
-      cugraph::sort_wrapper(
-        handle.get_thrust_policy(), inv_one_vertices.begin(), inv_one_vertices.end());
+      cugraph::sort(handle.get_thrust_policy(), inv_one_vertices.begin(), inv_one_vertices.end());
       auto edge_dst_peeled_flags =
         make_initialized_edge_dst_property(handle, inverse_graph_view, false);
       fill_edge_dst_property(
@@ -512,7 +508,7 @@ rmm::device_uvector<typename GraphViewType::vertex_type> find_trivial_singleton_
     // pointer jumping to find a chain of vertices from/to an already peeled vertex
 
     rmm::device_uvector<vertex_t> indices(one_vertices.size(), handle.get_stream());
-    thrust::sequence(handle.get_thrust_policy(), indices.begin(), indices.end());
+    cugraph::sequence(handle.get_thrust_policy(), indices.begin(), indices.end());
 
     std::optional<kv_store_t<vertex_t, bool, true>> peeled_vertex_store{std::nullopt};
     std::optional<rmm::device_uvector<vertex_t>> d_vertex_partition_range_lasts{std::nullopt};
@@ -751,8 +747,7 @@ rmm::device_uvector<typename GraphViewType::vertex_type> find_trivial_singleton_
       }
     }
 
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(), peeled_vertices.begin(), peeled_vertices.end());
+    cugraph::sort(handle.get_thrust_policy(), peeled_vertices.begin(), peeled_vertices.end());
   }
 
   peeled_vertices.shrink_to_fit(handle.get_stream());
@@ -1077,7 +1072,7 @@ reachable_sets(
 
   {
     auto pair_first = thrust::make_zip_iterator(idxs.begin(), vertices.begin());
-    cugraph::sort_wrapper(handle.get_thrust_policy(), pair_first, pair_first + idxs.size());
+    cugraph::sort(handle.get_thrust_policy(), pair_first, pair_first + idxs.size());
   }
 
   // starting_vertices => component indices
@@ -1369,10 +1364,10 @@ intersect_reachable_sets(
     // remaining_0, remaining_1, ..., scc_0, scc_1, ...]
 
     component_global_min_vertex_ids.resize(4 * num_old_unresolved_components, handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(),
-                 component_global_min_vertex_ids.begin(),
-                 component_global_min_vertex_ids.end(),
-                 std::numeric_limits<vertex_t>::max());
+    cugraph::fill(handle.get_thrust_policy(),
+                  component_global_min_vertex_ids.begin(),
+                  component_global_min_vertex_ids.end(),
+                  std::numeric_limits<vertex_t>::max());
 
     // Scatter each subset's local min vertex ids into the interleaved array.
     auto scatter_mins = [&handle,
@@ -1472,10 +1467,10 @@ intersect_reachable_sets(
 
     // [fwd_only_0, fwd_only_1, ..., bwd_only_0, bwd_only_1, ..., remaining_0, remaining_1, ...]
     component_local_sizes.resize(3 * num_old_unresolved_components, handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(),
-                 component_local_sizes.begin(),
-                 component_local_sizes.end(),
-                 vertex_t{0});
+    cugraph::fill(handle.get_thrust_policy(),
+                  component_local_sizes.begin(),
+                  component_local_sizes.end(),
+                  vertex_t{0});
 
     auto scatter_sizes = [&handle,
                           component_sizes = raft::device_span<vertex_t>(
@@ -1723,7 +1718,7 @@ intersect_reachable_sets(
                    unique_bwd_only_size1_component_idxs.size() +
                    unique_remaining_size1_component_idxs.size() + unique_scc_component_idxs.size());
     rmm::device_uvector<vertex_t> ones(trivial_singleton_scc_vertices.size(), handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(), ones.begin(), ones.end(), vertex_t{1});
+    cugraph::fill(handle.get_thrust_policy(), ones.begin(), ones.end(), vertex_t{1});
     auto new_scc_component_counts =
       concatenate5(raft::device_span<vertex_t const>(unique_fwd_only_size1_component_sizes.data(),
                                                      unique_fwd_only_size1_component_sizes.size()),
@@ -1886,10 +1881,10 @@ forward_backward_intersect(
                      static_cast<vertex_t>(unresolved_component_offsets.size() - 1));
   } else {
     forward_set_offsets.resize(unresolved_component_offsets.size() - 1, handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(),
-                 forward_set_offsets.begin(),
-                 forward_set_offsets.end(),
-                 vertex_t{0});
+    cugraph::fill(handle.get_thrust_policy(),
+                  forward_set_offsets.begin(),
+                  forward_set_offsets.end(),
+                  vertex_t{0});
   }
 
   rmm::device_uvector<vertex_t> backward_set_offsets(0, handle.get_stream());
@@ -1951,7 +1946,7 @@ forward_backward_intersect(
         std::move(std::get<rmm::device_uvector<vertex_t>>(vertex_properties[0]));
       auto pair_first = thrust::make_zip_iterator(tmp_unresolved_component_idxs.begin(),
                                                   backward_set_vertices.begin());
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(), pair_first, pair_first + tmp_unresolved_component_idxs.size());
       backward_set_offsets.set_element_to_zero_async(0, handle.get_stream());
       thrust::upper_bound(
@@ -1964,15 +1959,15 @@ forward_backward_intersect(
     } else {
       auto pair_first = thrust::make_zip_iterator(tmp_unresolved_component_idxs.begin(),
                                                   backward_set_vertices.begin());
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(), pair_first, pair_first + tmp_unresolved_component_idxs.size());
     }
   } else {
     backward_set_offsets.resize(unresolved_component_offsets.size() - 1, handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(),
-                 backward_set_offsets.begin(),
-                 backward_set_offsets.end(),
-                 vertex_t{0});
+    cugraph::fill(handle.get_thrust_policy(),
+                  backward_set_offsets.begin(),
+                  backward_set_offsets.end(),
+                  vertex_t{0});
   }
 
   return intersect_reachable_sets<GraphViewType>(handle,
@@ -2019,7 +2014,7 @@ void strongly_connected_components_impl(
 
   // 2. initialize component IDs (initially, every vertex belongs to one unresolved component)
 
-  thrust::fill(handle.get_thrust_policy(), components.begin(), components.end(), vertex_t{0});
+  cugraph::fill(handle.get_thrust_policy(), components.begin(), components.end(), vertex_t{0});
 
   // 3. create an edge mask and mask out self-loops & multi-edges (except for the first one); this
   // edge mask will be used to mask out edges between different components
@@ -2061,10 +2056,10 @@ void strongly_connected_components_impl(
   {
     rmm::device_uvector<vertex_t> vertices(graph_view.local_vertex_partition_range_size(),
                                            handle.get_stream());
-    thrust::sequence(handle.get_thrust_policy(),
-                     vertices.begin(),
-                     vertices.end(),
-                     graph_view.local_vertex_partition_range_first());
+    cugraph::sequence(handle.get_thrust_policy(),
+                      vertices.begin(),
+                      vertices.end(),
+                      graph_view.local_vertex_partition_range_first());
     if constexpr (multi_gpu) {
       std::tie(vertices, std::ignore) = shuffle_ext_vertices(
         handle, std::move(vertices), std::vector<cugraph::arithmetic_device_uvector_t>{});
@@ -2119,10 +2114,10 @@ void strongly_connected_components_impl(
   unresolved_component_offsets.set_element_to_zero_async(0, handle.get_stream());
   unresolved_component_offsets.set_element(
     1, forward_graph_view.local_vertex_partition_range_size(), handle.get_stream());
-  thrust::sequence(handle.get_thrust_policy(),
-                   unresolved_component_vertices.begin(),
-                   unresolved_component_vertices.end(),
-                   forward_graph_view.local_vertex_partition_range_first());
+  cugraph::sequence(handle.get_thrust_policy(),
+                    unresolved_component_vertices.begin(),
+                    unresolved_component_vertices.end(),
+                    forward_graph_view.local_vertex_partition_range_first());
 
   auto edge_src_components = multi_gpu
                                ? edge_src_property_t<vertex_t, vertex_t>(handle, forward_graph_view)
@@ -2234,7 +2229,7 @@ void strongly_connected_components_impl(
                    scc_component_vertices.begin(),
                    scc_component_vertices.end(),
                    tmp_vertices.begin() + unresolved_component_vertices.size());
-      cugraph::sort_wrapper(handle.get_thrust_policy(), tmp_vertices.begin(), tmp_vertices.end());
+      cugraph::sort(handle.get_thrust_policy(), tmp_vertices.begin(), tmp_vertices.end());
       rmm::device_uvector<vertex_t> tmp_components(tmp_vertices.size(), handle.get_stream());
       auto map_first = cuda::make_transform_iterator(
         tmp_vertices.begin(),

--- a/cpp/src/components/vertex_coloring_impl.cuh
+++ b/cpp/src/components/vertex_coloring_impl.cuh
@@ -9,6 +9,7 @@
 #include <cugraph/prims/make_initialized_edge_property.cuh>
 #include <cugraph/prims/transform_e.cuh>
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/random/rng_state.hpp>
@@ -49,7 +50,7 @@ rmm::device_uvector<vertex_t> vertex_coloring(
   // device vector to store colors of vertices
   rmm::device_uvector<vertex_t> colors = rmm::device_uvector<vertex_t>(
     current_graph_view.local_vertex_partition_range_size(), handle.get_stream());
-  thrust::fill(
+  cugraph::fill(
     handle.get_thrust_policy(), colors.begin(), colors.end(), std::numeric_limits<vertex_t>::max());
 
   vertex_t color_id = 0;
@@ -60,7 +61,7 @@ rmm::device_uvector<vertex_t> vertex_coloring(
     using flag_t                                 = uint8_t;
     rmm::device_uvector<flag_t> is_vertex_in_mis = rmm::device_uvector<flag_t>(
       current_graph_view.local_vertex_partition_range_size(), handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(), is_vertex_in_mis.begin(), is_vertex_in_mis.end(), 0);
+    cugraph::fill(handle.get_thrust_policy(), is_vertex_in_mis.begin(), is_vertex_in_mis.end(), 0);
 
     thrust::for_each(
       handle.get_thrust_policy(),

--- a/cpp/src/components/weakly_connected_components_impl.cuh
+++ b/cpp/src/components/weakly_connected_components_impl.cuh
@@ -500,15 +500,15 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
                                                        GraphViewType::is_multi_gpu>(
           handle, tmp_graph_view, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
       }
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            get_dataframe_buffer_begin(edge_buffer),
-                            get_dataframe_buffer_end(edge_buffer));
+      cugraph::sort(handle.get_thrust_policy(),
+                    get_dataframe_buffer_begin(edge_buffer),
+                    get_dataframe_buffer_end(edge_buffer));
       resize_dataframe_buffer(
         edge_buffer,
         cuda::std::distance(get_dataframe_buffer_begin(edge_buffer),
-                            thrust::unique(handle.get_thrust_policy(),
-                                           get_dataframe_buffer_begin(edge_buffer),
-                                           get_dataframe_buffer_end(edge_buffer))),
+                            cugraph::unique(handle.get_thrust_policy(),
+                                            get_dataframe_buffer_begin(edge_buffer),
+                                            get_dataframe_buffer_end(edge_buffer))),
         handle.get_stream());
       auto num_edges = size_dataframe_buffer(edge_buffer);
       num_edge_inserts.set_value_async(num_edges, handle.get_stream());
@@ -710,7 +710,7 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
           next_candidate_offset += num_scanned;
           edge_count += degree_sum;
 
-          cugraph::sort_wrapper(handle.get_thrust_policy(), new_roots.begin(), new_roots.end());
+          cugraph::sort(handle.get_thrust_policy(), new_roots.begin(), new_roots.end());
 
           thrust::for_each(
             handle.get_thrust_policy(),
@@ -828,9 +828,9 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
         auto new_num_edge_inserts = num_edge_inserts.value(handle.get_stream());
         if (new_num_edge_inserts > old_num_edge_inserts) {
           auto edge_first = get_dataframe_buffer_begin(edge_buffer);
-          cugraph::sort_wrapper(handle.get_thrust_policy(),
-                                edge_first + old_num_edge_inserts,
-                                edge_first + new_num_edge_inserts);
+          cugraph::sort(handle.get_thrust_policy(),
+                        edge_first + old_num_edge_inserts,
+                        edge_first + new_num_edge_inserts);
           if (old_num_edge_inserts > 0) {
             auto tmp_edge_buffer = allocate_dataframe_buffer<cuda::std::tuple<vertex_t, vertex_t>>(
               new_num_edge_inserts, handle.get_stream());
@@ -844,7 +844,7 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
             edge_buffer = std::move(tmp_edge_buffer);
           }
           edge_first            = get_dataframe_buffer_begin(edge_buffer);
-          auto unique_edge_last = thrust::unique(
+          auto unique_edge_last = cugraph::unique(
             handle.get_thrust_policy(), edge_first, edge_first + new_num_edge_inserts);
           auto num_unique_edges =
             static_cast<size_t>(cuda::std::distance(edge_first, unique_edge_last));
@@ -910,8 +910,8 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
                             GraphViewType::is_storage_transposed);
         auto edge_first = get_dataframe_buffer_begin(edge_buffer);
         auto edge_last  = get_dataframe_buffer_end(edge_buffer);
-        cugraph::sort_wrapper(handle.get_thrust_policy(), edge_first, edge_last);
-        auto unique_edge_last = thrust::unique(handle.get_thrust_policy(), edge_first, edge_last);
+        cugraph::sort(handle.get_thrust_policy(), edge_first, edge_last);
+        auto unique_edge_last = cugraph::unique(handle.get_thrust_policy(), edge_first, edge_last);
         resize_dataframe_buffer(
           edge_buffer,
           static_cast<size_t>(cuda::std::distance(edge_first, unique_edge_last)),
@@ -982,12 +982,12 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
                    current_level_components,
                    current_level_components + current_level_local_vertex_partition_range_size,
                    sorted_unique_keys.begin());
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(), sorted_unique_keys.begin(), sorted_unique_keys.end());
       sorted_unique_keys.resize(cuda::std::distance(sorted_unique_keys.begin(),
-                                                    thrust::unique(handle.get_thrust_policy(),
-                                                                   sorted_unique_keys.begin(),
-                                                                   sorted_unique_keys.end())),
+                                                    cugraph::unique(handle.get_thrust_policy(),
+                                                                    sorted_unique_keys.begin(),
+                                                                    sorted_unique_keys.end())),
                                 handle.get_stream());
       auto [unique_keys, values_for_unique_keys] = collect_values_for_unique_keys(
         handle,

--- a/cpp/src/converters/legacy/COOtoCSR.cuh
+++ b/cpp/src/converters/legacy/COOtoCSR.cuh
@@ -97,7 +97,7 @@ void fill_offset(VT* source,
                  ET number_of_edges,
                  rmm::cuda_stream_view stream_view)
 {
-  thrust::fill(
+  cugraph::fill(
     rmm::exec_policy(stream_view), offsets, offsets + number_of_vertices + 1, number_of_edges);
   thrust::for_each(rmm::exec_policy(stream_view),
                    thrust::make_counting_iterator<ET>(1),

--- a/cpp/src/dag/topological_sort_impl.cuh
+++ b/cpp/src/dag/topological_sort_impl.cuh
@@ -51,7 +51,7 @@ rmm::device_uvector<vertex_t> topological_sort(
 
     auto components = strongly_connected_components(handle, graph_view, true);
 
-    cugraph::sort_wrapper(handle.get_thrust_policy(), components.begin(), components.end());
+    cugraph::sort(handle.get_thrust_policy(), components.begin(), components.end());
     CUGRAPH_EXPECTS(
       static_cast<size_t>(thrust::unique_count(
         handle.get_thrust_policy(), components.begin(), components.end())) == components.size(),
@@ -61,7 +61,7 @@ rmm::device_uvector<vertex_t> topological_sort(
       std::tie(components, std::ignore) = shuffle_ext_vertices(
         handle, std::move(components), std::vector<arithmetic_device_uvector_t>{});
 
-      cugraph::sort_wrapper(handle.get_thrust_policy(), components.begin(), components.end());
+      cugraph::sort(handle.get_thrust_policy(), components.begin(), components.end());
       CUGRAPH_EXPECTS(
         static_cast<size_t>(thrust::unique_count(
           handle.get_thrust_policy(), components.begin(), components.end())) == components.size(),
@@ -91,7 +91,7 @@ rmm::device_uvector<vertex_t> topological_sort(
 
   rmm::device_uvector<vertex_t> topological_levels(graph_view.local_vertex_partition_range_size(),
                                                    handle.get_stream());
-  thrust::fill(
+  cugraph::fill(
     handle.get_thrust_policy(), topological_levels.begin(), topological_levels.end(), vertex_t{0});
 
   auto level                       = 0;

--- a/cpp/src/detail/collect_local_vertex_values.cuh
+++ b/cpp/src/detail/collect_local_vertex_values.cuh
@@ -8,6 +8,7 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <cuda/functional>
 #include <cuda/iterator>
@@ -61,7 +62,7 @@ rmm::device_uvector<value_t> collect_local_vertex_values_from_ext_vertex_value_p
       [local_vertex_first] __device__(vertex_t v) { return v - local_vertex_first; }));
 
   d_local_values.resize(local_vertex_last - local_vertex_first, handle.get_stream());
-  thrust::fill(
+  cugraph::fill(
     handle.get_thrust_policy(), d_local_values.begin(), d_local_values.end(), default_value);
 
   thrust::scatter(handle.get_thrust_policy(),

--- a/cpp/src/detail/groupby_and_count.cuh
+++ b/cpp/src/detail/groupby_and_count.cuh
@@ -14,6 +14,7 @@
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/device_span.hpp>
 #include <raft/core/host_span.hpp>
@@ -114,8 +115,10 @@ rmm::device_uvector<size_t> groupby_and_count_edgelist_by_local_partition_id(
       large_buffer_type ? large_buffer_manager::allocate_memory_buffer<size_t>(
                             edgelist_majors.size(), handle.get_stream())
                         : rmm::device_uvector<size_t>(edgelist_majors.size(), handle.get_stream());
-    detail::sequence_fill(
-      handle.get_stream(), property_positions.data(), property_positions.size(), size_t{0});
+    cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                      property_positions.data(),
+                      property_positions.data() + property_positions.size(),
+                      size_t{0});
 
     if (groupby_and_count_local_partition_by_minor) {
       counts = cugraph::groupby_and_count(pair_first,

--- a/cpp/src/detail/permute_range.cuh
+++ b/cpp/src/detail/permute_range.cuh
@@ -9,6 +9,7 @@
 #include <cugraph/detail/utility_wrappers.hpp>
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/device_span.hpp>
 #include <raft/core/handle.hpp>
@@ -53,8 +54,10 @@ rmm::device_uvector<vertex_t> permute_range(raft::handle_t const& handle,
   rmm::device_uvector<vertex_t> permuted_integers(local_range_size, handle.get_stream());
 
   // generate as many integers as #local_range_size on each GPU
-  detail::sequence_fill(
-    handle.get_stream(), permuted_integers.begin(), permuted_integers.size(), local_range_start);
+  cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                    permuted_integers.begin(),
+                    permuted_integers.begin() + permuted_integers.size(),
+                    local_range_start);
 
   if (multi_gpu) {
     // randomly distribute integers to all GPUs

--- a/cpp/src/detail/utility_wrappers_32_common.cu
+++ b/cpp/src/detail/utility_wrappers_32_common.cu
@@ -21,7 +21,6 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/remove.h>
-#include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
@@ -43,34 +42,6 @@ template CUGRAPH_EXPORT void uniform_random_fill(rmm::cuda_stream_view const& st
                                                  float max_value,
                                                  raft::random::RngState& rng_state);
 
-template CUGRAPH_EXPORT void scalar_fill(raft::handle_t const& handle,
-                                         int32_t* d_value,
-                                         size_t size,
-                                         int32_t value);
-
-template CUGRAPH_EXPORT void scalar_fill(raft::handle_t const& handle,
-                                         size_t* d_value,
-                                         size_t size,
-                                         size_t value);
-
-template CUGRAPH_EXPORT void scalar_fill(raft::handle_t const& handle,
-                                         float* d_value,
-                                         size_t size,
-                                         float value);
-
-template CUGRAPH_EXPORT size_t unique_ints(raft::handle_t const& handle,
-                                           raft::device_span<int32_t> values);
-
-template CUGRAPH_EXPORT void sequence_fill(rmm::cuda_stream_view const& stream_view,
-                                           int32_t* d_value,
-                                           size_t size,
-                                           int32_t start_value);
-
-template CUGRAPH_EXPORT void sequence_fill(rmm::cuda_stream_view const& stream_view,
-                                           uint32_t* d_value,
-                                           size_t size,
-                                           uint32_t start_value);
-
 template CUGRAPH_EXPORT void transform_increment_ints(raft::device_span<int32_t> values,
                                                       int32_t value,
                                                       rmm::cuda_stream_view const& stream_view);
@@ -79,18 +50,6 @@ template CUGRAPH_EXPORT void transform_not_equal(raft::device_span<int32_t> valu
                                                  raft::device_span<bool> result,
                                                  int32_t compare,
                                                  rmm::cuda_stream_view const& stream_view);
-
-template CUGRAPH_EXPORT void stride_fill(rmm::cuda_stream_view const& stream_view,
-                                         int32_t* d_value,
-                                         size_t size,
-                                         int32_t start_value,
-                                         int32_t stride);
-
-template CUGRAPH_EXPORT void stride_fill(rmm::cuda_stream_view const& stream_view,
-                                         uint32_t* d_value,
-                                         size_t size,
-                                         uint32_t start_value,
-                                         uint32_t stride);
 
 template CUGRAPH_EXPORT int32_t compute_maximum_vertex_id(rmm::cuda_stream_view const& stream_view,
                                                           int32_t const* d_edgelist_srcs,

--- a/cpp/src/detail/utility_wrappers_64_common.cu
+++ b/cpp/src/detail/utility_wrappers_64_common.cu
@@ -21,7 +21,6 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/remove.h>
-#include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
@@ -43,29 +42,6 @@ template CUGRAPH_EXPORT void uniform_random_fill(rmm::cuda_stream_view const& st
                                                  double max_value,
                                                  raft::random::RngState& rng_state);
 
-template CUGRAPH_EXPORT void scalar_fill(raft::handle_t const& handle,
-                                         int64_t* d_value,
-                                         size_t size,
-                                         int64_t value);
-
-template CUGRAPH_EXPORT void scalar_fill(raft::handle_t const& handle,
-                                         double* d_value,
-                                         size_t size,
-                                         double value);
-
-template CUGRAPH_EXPORT size_t unique_ints(raft::handle_t const& handle,
-                                           raft::device_span<int64_t> values);
-
-template CUGRAPH_EXPORT void sequence_fill(rmm::cuda_stream_view const& stream_view,
-                                           int64_t* d_value,
-                                           size_t size,
-                                           int64_t start_value);
-
-template CUGRAPH_EXPORT void sequence_fill(rmm::cuda_stream_view const& stream_view,
-                                           uint64_t* d_value,
-                                           size_t size,
-                                           uint64_t start_value);
-
 template CUGRAPH_EXPORT void transform_increment_ints(raft::device_span<int64_t> values,
                                                       int64_t value,
                                                       rmm::cuda_stream_view const& stream_view);
@@ -74,18 +50,6 @@ template CUGRAPH_EXPORT void transform_not_equal(raft::device_span<int64_t> valu
                                                  raft::device_span<bool> result,
                                                  int64_t compare,
                                                  rmm::cuda_stream_view const& stream_view);
-
-template CUGRAPH_EXPORT void stride_fill(rmm::cuda_stream_view const& stream_view,
-                                         int64_t* d_value,
-                                         size_t size,
-                                         int64_t start_value,
-                                         int64_t stride);
-
-template CUGRAPH_EXPORT void stride_fill(rmm::cuda_stream_view const& stream_view,
-                                         uint64_t* d_value,
-                                         size_t size,
-                                         uint64_t start_value,
-                                         uint64_t stride);
 
 template CUGRAPH_EXPORT int64_t compute_maximum_vertex_id(rmm::cuda_stream_view const& stream_view,
                                                           int64_t const* d_edgelist_srcs,

--- a/cpp/src/detail/utility_wrappers_impl.cuh
+++ b/cpp/src/detail/utility_wrappers_impl.cuh
@@ -21,11 +21,9 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/remove.h>
-#include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 #include <thrust/transform_reduce.h>
-#include <thrust/unique.h>
 
 namespace cugraph {
 namespace detail {
@@ -45,29 +43,6 @@ void uniform_random_fill(rmm::cuda_stream_view const& stream_view,
     raft::random::uniform<value_t, size_t>(
       rng_state, d_value, size, min_value, max_value, stream_view.value());
   }
-}
-
-template <typename value_t>
-void scalar_fill(raft::handle_t const& handle, value_t* d_value, size_t size, value_t value)
-{
-  thrust::fill_n(handle.get_thrust_policy(), d_value, size, value);
-}
-
-template <typename value_t>
-size_t unique_ints(raft::handle_t const& handle, raft::device_span<value_t> values)
-{
-  auto unique_element_last =
-    thrust::unique(handle.get_thrust_policy(), values.begin(), values.end());
-  return cuda::std::distance(values.begin(), unique_element_last);
-}
-
-template <typename value_t>
-void sequence_fill(rmm::cuda_stream_view const& stream_view,
-                   value_t* d_value,
-                   size_t size,
-                   value_t start_value)
-{
-  thrust::sequence(rmm::exec_policy(stream_view), d_value, d_value + size, start_value);
 }
 
 template <typename value_t>
@@ -96,22 +71,6 @@ void transform_not_equal(raft::device_span<value_t> values,
                     result.begin(),
                     cuda::proclaim_return_type<bool>(
                       [compare] __device__(value_t value) { return compare != value; }));
-}
-
-template <typename value_t>
-void stride_fill(rmm::cuda_stream_view const& stream_view,
-                 value_t* d_value,
-                 size_t size,
-                 value_t start_value,
-                 value_t stride)
-{
-  thrust::transform(rmm::exec_policy(stream_view),
-                    thrust::make_counting_iterator(size_t{0}),
-                    thrust::make_counting_iterator(size),
-                    d_value,
-                    cuda::proclaim_return_type<value_t>([start_value, stride] __device__(size_t i) {
-                      return static_cast<value_t>(start_value + stride * i);
-                    }));
 }
 
 template <typename vertex_t>

--- a/cpp/src/generators/generator_tools.cuh
+++ b/cpp/src/generators/generator_tools.cuh
@@ -123,10 +123,9 @@ combine_edgelists(raft::handle_t const& handle,
     size_t number_of_edges{srcs_v.size()};
 
     if (optional_d_weights) {
-      cugraph::sort_wrapper(
-        handle.get_thrust_policy(),
-        thrust::make_zip_iterator(srcs_v.begin(), dsts_v.begin(), weights_v.begin()),
-        thrust::make_zip_iterator(srcs_v.end(), dsts_v.end(), weights_v.end()));
+      cugraph::sort(handle.get_thrust_policy(),
+                    thrust::make_zip_iterator(srcs_v.begin(), dsts_v.begin(), weights_v.begin()),
+                    thrust::make_zip_iterator(srcs_v.end(), dsts_v.end(), weights_v.end()));
 
       auto pair_first = thrust::make_zip_iterator(srcs_v.begin(), dsts_v.begin());
       auto end_iter   = thrust::unique_by_key(
@@ -134,15 +133,15 @@ combine_edgelists(raft::handle_t const& handle,
 
       number_of_edges = cuda::std::distance(pair_first, cuda::std::get<0>(end_iter));
     } else {
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            thrust::make_zip_iterator(srcs_v.begin(), dsts_v.begin()),
-                            thrust::make_zip_iterator(srcs_v.end(), dsts_v.end()));
+      cugraph::sort(handle.get_thrust_policy(),
+                    thrust::make_zip_iterator(srcs_v.begin(), dsts_v.begin()),
+                    thrust::make_zip_iterator(srcs_v.end(), dsts_v.end()));
 
       auto pair_first = thrust::make_zip_iterator(srcs_v.begin(), dsts_v.begin());
 
-      auto end_iter = thrust::unique(handle.get_thrust_policy(),
-                                     thrust::make_zip_iterator(srcs_v.begin(), dsts_v.begin()),
-                                     thrust::make_zip_iterator(srcs_v.end(), dsts_v.end()));
+      auto end_iter = cugraph::unique(handle.get_thrust_policy(),
+                                      thrust::make_zip_iterator(srcs_v.begin(), dsts_v.begin()),
+                                      thrust::make_zip_iterator(srcs_v.end(), dsts_v.end()));
 
       number_of_edges = cuda::std::distance(pair_first, end_iter);
     }

--- a/cpp/src/generators/simple_generators.cuh
+++ b/cpp/src/generators/simple_generators.cuh
@@ -7,6 +7,7 @@
 
 #include <cugraph/graph_generators.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/util/cudart_utils.hpp>
 
@@ -65,10 +66,10 @@ generate_path_graph_edgelist(raft::handle_t const& handle,
 
     if (edge_off_end) ++num_edges;
 
-    thrust::sequence(
+    cugraph::sequence(
       handle.get_thrust_policy(), src_iterator, src_iterator + num_edges, base_vertex_id);
 
-    thrust::sequence(
+    cugraph::sequence(
       handle.get_thrust_policy(), dst_iterator, dst_iterator + num_edges, base_vertex_id + 1);
 
     src_iterator += num_edges;

--- a/cpp/src/layout/legacy/barnes_hut.cuh
+++ b/cpp/src/layout/legacy/barnes_hut.cuh
@@ -14,6 +14,7 @@
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/legacy/internals.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
@@ -147,7 +148,7 @@ void barnes_hut(raft::handle_t const& handle,
   swinging   = d_swinging.data();
   traction   = d_traction.data();
 
-  thrust::fill(handle.get_thrust_policy(), d_old_forces.begin(), d_old_forces.end(), 0.f);
+  cugraph::fill(handle.get_thrust_policy(), d_old_forces.begin(), d_old_forces.end(), 0.f);
 
   if (graph.number_of_edges > 0) {
     // Sort COO for coalesced memory access.
@@ -157,12 +158,12 @@ void barnes_hut(raft::handle_t const& handle,
 
   if (vertex_mass != nullptr) {
     // Fill masses with 1 (because `nnodes + 1 > n`)
-    thrust::fill(handle.get_thrust_policy(), d_massl.begin() + n, d_massl.end(), 1.f);
+    cugraph::fill(handle.get_thrust_policy(), d_massl.begin() + n, d_massl.end(), 1.f);
     raft::copy(massl, vertex_mass, n, stream_view.value());
   } else {
     // FA2 requires degree + 1
     d_massl_edge_t.resize(nnodes + 1, handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(), d_massl_edge_t.begin(), d_massl_edge_t.end(), 1);
+    cugraph::fill(handle.get_thrust_policy(), d_massl_edge_t.begin(), d_massl_edge_t.end(), 1);
     massl_edge_t = d_massl_edge_t.data();
     graph.degree(massl_edge_t, cugraph::legacy::DegreeDirection::OUT);
     RAFT_CHECK_CUDA(stream_view.value());
@@ -210,10 +211,10 @@ void barnes_hut(raft::handle_t const& handle,
 
   for (int iter = 0; iter < max_iter; ++iter) {
     // Reset force values
-    thrust::fill(handle.get_thrust_policy(), d_rep_forces.begin(), d_rep_forces.end(), 0.f);
-    thrust::fill(handle.get_thrust_policy(), d_attract.begin(), d_attract.end(), 0.f);
-    thrust::fill(handle.get_thrust_policy(), d_swinging.begin(), d_swinging.end(), 0.f);
-    thrust::fill(handle.get_thrust_policy(), d_traction.begin(), d_traction.end(), 0.f);
+    cugraph::fill(handle.get_thrust_policy(), d_rep_forces.begin(), d_rep_forces.end(), 0.f);
+    cugraph::fill(handle.get_thrust_policy(), d_attract.begin(), d_attract.end(), 0.f);
+    cugraph::fill(handle.get_thrust_policy(), d_swinging.begin(), d_swinging.end(), 0.f);
+    cugraph::fill(handle.get_thrust_policy(), d_traction.begin(), d_traction.end(), 0.f);
 
     ResetKernel<<<1, 1, 0, stream_view.value()>>>(radiusd_squared, bottomd, NNODES, radiusd);
     RAFT_CHECK_CUDA(stream_view.value());

--- a/cpp/src/layout/legacy/exact_fa2.cuh
+++ b/cpp/src/layout/legacy/exact_fa2.cuh
@@ -14,6 +14,7 @@
 #include <cugraph/legacy/graph.hpp>
 #include <cugraph/legacy/internals.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
@@ -63,7 +64,7 @@ void exact_fa2(raft::handle_t const& handle,
   rmm::device_uvector<float> repel(n * 2, stream_view);
   rmm::device_uvector<float> attract(n * 2, stream_view);
   rmm::device_uvector<float> old_forces(n * 2, stream_view);
-  thrust::fill(handle.get_thrust_policy(), old_forces.begin(), old_forces.end(), 0.f);
+  cugraph::fill(handle.get_thrust_policy(), old_forces.begin(), old_forces.end(), 0.f);
   rmm::device_uvector<edge_t> mass_edge_t(0, stream_view);
   rmm::device_uvector<float> mass(n, stream_view);
   rmm::device_uvector<float> swinging(n, stream_view);
@@ -95,7 +96,7 @@ void exact_fa2(raft::handle_t const& handle,
   } else {
     // FA2 requires degree + 1.
     mass_edge_t.resize(n, handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(), mass_edge_t.begin(), mass_edge_t.end(), 1);
+    cugraph::fill(handle.get_thrust_policy(), mass_edge_t.begin(), mass_edge_t.end(), 1);
     d_mass_edge_t = mass_edge_t.data();
     graph.degree(d_mass_edge_t, cugraph::legacy::DegreeDirection::OUT);
     RAFT_CHECK_CUDA(stream_view.value());
@@ -129,10 +130,10 @@ void exact_fa2(raft::handle_t const& handle,
 
   for (int iter = 0; iter < max_iter; ++iter) {
     // Reset force arrays
-    thrust::fill(handle.get_thrust_policy(), repel.begin(), repel.end(), 0.f);
-    thrust::fill(handle.get_thrust_policy(), attract.begin(), attract.end(), 0.f);
-    thrust::fill(handle.get_thrust_policy(), swinging.begin(), swinging.end(), 0.f);
-    thrust::fill(handle.get_thrust_policy(), traction.begin(), traction.end(), 0.f);
+    cugraph::fill(handle.get_thrust_policy(), repel.begin(), repel.end(), 0.f);
+    cugraph::fill(handle.get_thrust_policy(), attract.begin(), attract.end(), 0.f);
+    cugraph::fill(handle.get_thrust_policy(), swinging.begin(), swinging.end(), 0.f);
+    cugraph::fill(handle.get_thrust_policy(), traction.begin(), traction.end(), 0.f);
 
     // Exact repulsion
     apply_repulsion<vertex_t>(pos,

--- a/cpp/src/linear_assignment/legacy/hungarian.cu
+++ b/cpp/src/linear_assignment/legacy/hungarian.cu
@@ -11,6 +11,7 @@
 #endif
 
 #include <cugraph/export.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/solver/linear_assignment.cuh>
 
@@ -156,7 +157,7 @@ weight_t hungarian_sparse(raft::handle_t const& handle,
   //  Renumber vertices internally.  Workers will become
   //  rows, tasks will become columns
   //
-  thrust::sequence(handle.get_thrust_policy(), temp_tasks_v.begin(), temp_tasks_v.end());
+  cugraph::sequence(handle.get_thrust_policy(), temp_tasks_v.begin(), temp_tasks_v.end());
 
   thrust::for_each(handle.get_thrust_policy(),
                    workers,
@@ -175,10 +176,10 @@ weight_t hungarian_sparse(raft::handle_t const& handle,
   //
   // Now we'll assign costs into the dense array
   //
-  thrust::fill(
+  cugraph::fill(
     handle.get_thrust_policy(), temp_workers_v.begin(), temp_workers_v.end(), vertex_t{-1});
-  thrust::fill(handle.get_thrust_policy(), temp_tasks_v.begin(), temp_tasks_v.end(), vertex_t{-1});
-  thrust::fill(handle.get_thrust_policy(), cost_v.begin(), cost_v.end(), weight_t{0});
+  cugraph::fill(handle.get_thrust_policy(), temp_tasks_v.begin(), temp_tasks_v.end(), vertex_t{-1});
+  cugraph::fill(handle.get_thrust_policy(), cost_v.begin(), cost_v.end(), weight_t{0});
 
   thrust::for_each(
     handle.get_thrust_policy(),

--- a/cpp/src/link_analysis/hits_impl.cuh
+++ b/cpp/src/link_analysis/hits_impl.cuh
@@ -14,6 +14,7 @@
 #include <cugraph/prims/reduce_v.cuh>
 #include <cugraph/prims/transform_reduce_v.cuh>
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/functional>
@@ -97,10 +98,10 @@ std::tuple<result_t, size_t> hits(raft::handle_t const& handle,
   } else {
     fill_edge_src_property(
       handle, graph_view, prev_src_hubs.mutable_view(), result_t{1.0} / num_vertices);
-    thrust::fill(handle.get_thrust_policy(),
-                 prev_hubs,
-                 prev_hubs + graph_view.local_vertex_partition_range_size(),
-                 result_t{1.0} / num_vertices);
+    cugraph::fill(handle.get_thrust_policy(),
+                  prev_hubs,
+                  prev_hubs + graph_view.local_vertex_partition_range_size(),
+                  result_t{1.0} / num_vertices);
   }
 
   size_t iter{0};

--- a/cpp/src/link_analysis/pagerank_impl.cuh
+++ b/cpp/src/link_analysis/pagerank_impl.cuh
@@ -159,7 +159,7 @@ centrality_algorithm_metadata_t pagerank(
                    std::get<0>(*personalization).end(),
                    check_for_duplicates.begin());
 
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(), check_for_duplicates.begin(), check_for_duplicates.end());
 
       auto num_uniques =
@@ -370,10 +370,10 @@ void pagerank(raft::handle_t const& handle,
                       pageranks,
                       [sum] __device__(auto val) { return val / sum; });
   } else {
-    thrust::fill(handle.get_thrust_policy(),
-                 pageranks,
-                 pageranks + graph_view.local_vertex_partition_range_size(),
-                 result_t{1.0} / static_cast<result_t>(graph_view.number_of_vertices()));
+    cugraph::fill(handle.get_thrust_policy(),
+                  pageranks,
+                  pageranks + graph_view.local_vertex_partition_range_size(),
+                  result_t{1.0} / static_cast<result_t>(graph_view.number_of_vertices()));
   }
 
   auto metadata = detail::pagerank(
@@ -419,10 +419,10 @@ std::tuple<rmm::device_uvector<result_t>, centrality_algorithm_metadata_t> pager
   rmm::device_uvector<result_t> local_pageranks(graph_view.local_vertex_partition_range_size(),
                                                 handle.get_stream());
   if (!initial_pageranks) {
-    thrust::fill(handle.get_thrust_policy(),
-                 local_pageranks.begin(),
-                 local_pageranks.end(),
-                 result_t{1.0} / graph_view.number_of_vertices());
+    cugraph::fill(handle.get_thrust_policy(),
+                  local_pageranks.begin(),
+                  local_pageranks.end(),
+                  result_t{1.0} / graph_view.number_of_vertices());
   } else {
     thrust::copy(handle.get_thrust_policy(),
                  initial_pageranks->begin(),

--- a/cpp/src/link_prediction/detail/similarity_impl.cuh
+++ b/cpp/src/link_prediction/detail/similarity_impl.cuh
@@ -311,10 +311,10 @@ all_pairs_similarity(raft::handle_t const& handle,
         handle.get_thrust_policy(), vertices->begin(), vertices->end(), tmp_vertices.begin());
     } else {
       tmp_vertices.resize(graph_view.local_vertex_partition_range_size(), handle.get_stream());
-      thrust::sequence(handle.get_thrust_policy(),
-                       tmp_vertices.begin(),
-                       tmp_vertices.end(),
-                       graph_view.local_vertex_partition_range_first());
+      cugraph::sequence(handle.get_thrust_policy(),
+                        tmp_vertices.begin(),
+                        tmp_vertices.end(),
+                        graph_view.local_vertex_partition_range_first());
     }
 
     //  We can reduce memory footprint by doing work in batches and
@@ -599,10 +599,10 @@ all_pairs_similarity(raft::handle_t const& handle,
       vertices_span = raft::device_span<vertex_t const>{vertices->data(), vertices->size()};
     } else {
       tmp_vertices.resize(graph_view.local_vertex_partition_range_size(), handle.get_stream());
-      thrust::sequence(handle.get_thrust_policy(),
-                       tmp_vertices.begin(),
-                       tmp_vertices.end(),
-                       graph_view.local_vertex_partition_range_first());
+      cugraph::sequence(handle.get_thrust_policy(),
+                        tmp_vertices.begin(),
+                        tmp_vertices.end(),
+                        graph_view.local_vertex_partition_range_first());
       vertices_span = raft::device_span<vertex_t const>{tmp_vertices.data(), tmp_vertices.size()};
     }
 

--- a/cpp/src/lookup/lookup_src_dst_impl.cuh
+++ b/cpp/src/lookup/lookup_src_dst_impl.cuh
@@ -153,7 +153,7 @@ struct lookup_container_t<edge_id_t, edge_type_t, vertex_t, value_t>::lookup_con
 
     rmm::device_uvector<edge_id_t> original_idxs(edge_ids_to_lookup.size(), handle.get_stream());
 
-    thrust::sequence(
+    cugraph::sequence(
       handle.get_thrust_policy(), original_idxs.begin(), original_idxs.end(), edge_id_t{0});
 
     thrust::copy(handle.get_thrust_policy(),
@@ -233,12 +233,12 @@ struct lookup_container_t<edge_id_t, edge_type_t, vertex_t, value_t>::lookup_con
         handle.get_stream());
       unique_types = std::move(rx_unique_types);
 
-      cugraph::sort_wrapper(handle.get_thrust_policy(), unique_types.begin(), unique_types.end());
+      cugraph::sort(handle.get_thrust_policy(), unique_types.begin(), unique_types.end());
 
       unique_types.resize(
         cuda::std::distance(
           unique_types.begin(),
-          thrust::unique(handle.get_thrust_policy(), unique_types.begin(), unique_types.end())),
+          cugraph::unique(handle.get_thrust_policy(), unique_types.begin(), unique_types.end())),
         handle.get_stream());
     }
 
@@ -426,9 +426,9 @@ EdgeTypeAndIdToSrcDstLookupContainerType build_edge_id_and_type_to_src_dst_looku
     auto type_and_gpu_id_pair_begin =
       thrust::make_zip_iterator(edge_types.begin(), gpu_ids.begin());
 
-    cugraph::sort_wrapper(handle.get_thrust_policy(),
-                          type_and_gpu_id_pair_begin,
-                          type_and_gpu_id_pair_begin + edge_types.size());
+    cugraph::sort(handle.get_thrust_policy(),
+                  type_and_gpu_id_pair_begin,
+                  type_and_gpu_id_pair_begin + edge_types.size());
 
     auto nr_unique_pairs = thrust::count_if(
       handle.get_thrust_policy(),
@@ -517,7 +517,7 @@ EdgeTypeAndIdToSrcDstLookupContainerType build_edge_id_and_type_to_src_dst_looku
           return et;
         }));
 
-    cugraph::sort_wrapper(handle.get_thrust_policy(), edge_types.begin(), edge_types.end());
+    cugraph::sort(handle.get_thrust_policy(), edge_types.begin(), edge_types.end());
 
     auto nr_unique_types =
       thrust::count_if(handle.get_thrust_policy(),

--- a/cpp/src/mtmg/vertex_pairs_result.cuh
+++ b/cpp/src/mtmg/vertex_pairs_result.cuh
@@ -12,7 +12,10 @@
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/collect_comm.cuh>
 #include <cugraph/utilities/graph_partition_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
+
+#include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/std/iterator>
@@ -44,8 +47,10 @@ std::
   rmm::device_uvector<int> vertex_gpu_ids(vertices.size(), stream);
 
   raft::copy(local_vertices.data(), vertices.data(), vertices.size(), stream);
-  cugraph::detail::scalar_fill(
-    stream, vertex_gpu_ids.data(), vertex_gpu_ids.size(), handle.get_rank());
+  cugraph::fill(rmm::exec_policy(stream),
+                vertex_gpu_ids.data(),
+                (vertex_gpu_ids.data()) + (vertex_gpu_ids.size()),
+                handle.get_rank());
 
   if (renumber_map_view) {
     cugraph::renumber_ext_vertices<vertex_t, multi_gpu>(

--- a/cpp/src/mtmg/vertex_result.cuh
+++ b/cpp/src/mtmg/vertex_result.cuh
@@ -10,7 +10,10 @@
 #include <cugraph/mtmg/vertex_result_view.hpp>
 #include <cugraph/utilities/device_functors.cuh>
 #include <cugraph/utilities/graph_partition_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
+
+#include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/iterator>
@@ -39,9 +42,14 @@ rmm::device_uvector<result_t> vertex_result_view_t<result_t>::gather(
   raft::copy(local_vertices.data(), vertices.data(), vertices.size(), stream);
 
   if constexpr (multi_gpu) {
-    cugraph::detail::scalar_fill(
-      stream, vertex_gpu_ids.data(), vertex_gpu_ids.size(), handle.get_rank());
-    cugraph::detail::sequence_fill(stream, vertex_pos.data(), vertex_pos.size(), size_t{0});
+    cugraph::fill(rmm::exec_policy(stream),
+                  vertex_gpu_ids.data(),
+                  (vertex_gpu_ids.data()) + (vertex_gpu_ids.size()),
+                  handle.get_rank());
+    cugraph::sequence(rmm::exec_policy(stream),
+                      vertex_pos.data(),
+                      vertex_pos.data() + vertex_pos.size(),
+                      size_t{0});
 
     auto const comm_size = handle.raft_handle().get_comms().get_size();
     auto const major_comm_size =
@@ -91,7 +99,8 @@ rmm::device_uvector<result_t> vertex_result_view_t<result_t>::gather(
   //  Now gather
   //
   rmm::device_uvector<result_t> result(local_vertices.size(), stream);
-  cugraph::detail::scalar_fill(stream, result.data(), result.size(), default_value);
+  cugraph::fill(
+    rmm::exec_policy(stream), result.data(), (result.data()) + (result.size()), default_value);
 
   auto& wrapped = this->get(handle);
 
@@ -126,7 +135,8 @@ rmm::device_uvector<result_t> vertex_result_view_t<result_t>::gather(
     // Finally, reorder result
     //
     result.resize(tmp_result.size(), stream);
-    cugraph::detail::scalar_fill(stream, result.data(), result.size(), default_value);
+    cugraph::fill(
+      rmm::exec_policy(stream), result.data(), (result.data()) + (result.size()), default_value);
 
     thrust::scatter(rmm::exec_policy(stream),
                     tmp_result.begin(),

--- a/cpp/src/sampling/detail/conversion_utilities_impl.cuh
+++ b/cpp/src/sampling/detail/conversion_utilities_impl.cuh
@@ -9,6 +9,7 @@
 
 #include <cugraph/export.hpp>
 #include <cugraph/utilities/misc_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <cuda/functional>
 
@@ -35,7 +36,7 @@ rmm::device_uvector<int32_t> flatten_label_map(
 
   rmm::device_uvector<int32_t> label_map(max_label + 1, handle.get_stream());
 
-  thrust::fill(handle.get_thrust_policy(), label_map.begin(), label_map.end(), int32_t{0});
+  cugraph::fill(handle.get_thrust_policy(), label_map.begin(), label_map.end(), int32_t{0});
   thrust::scatter(handle.get_thrust_policy(),
                   std::get<1>(label_to_output_comm_rank).begin(),
                   std::get<1>(label_to_output_comm_rank).end(),

--- a/cpp/src/sampling/detail/deduplicate_edges_by_minor_impl.cuh
+++ b/cpp/src/sampling/detail/deduplicate_edges_by_minor_impl.cuh
@@ -110,19 +110,19 @@ deduplicate_edges_by_minor(raft::handle_t const& handle,
     if (has_types) {
       auto& types = std::get<rmm::device_uvector<int32_t>>(result_types);
       if (has_labels) {
-        cugraph::sort_wrapper(handle.get_thrust_policy(),
-                              thrust::make_zip_iterator(result_labels->begin(),
-                                                        result_minors.begin(),
-                                                        result_majors.begin(),
-                                                        property.begin(),
-                                                        types.begin()),
-                              thrust::make_zip_iterator(result_labels->end(),
-                                                        result_minors.end(),
-                                                        result_majors.end(),
-                                                        property.end(),
-                                                        types.end()));
+        cugraph::sort(handle.get_thrust_policy(),
+                      thrust::make_zip_iterator(result_labels->begin(),
+                                                result_minors.begin(),
+                                                result_majors.begin(),
+                                                property.begin(),
+                                                types.begin()),
+                      thrust::make_zip_iterator(result_labels->end(),
+                                                result_minors.end(),
+                                                result_majors.end(),
+                                                property.end(),
+                                                types.end()));
       } else {
-        cugraph::sort_wrapper(
+        cugraph::sort(
           handle.get_thrust_policy(),
           thrust::make_zip_iterator(
             result_minors.begin(), result_majors.begin(), property.begin(), types.begin()),
@@ -130,14 +130,14 @@ deduplicate_edges_by_minor(raft::handle_t const& handle,
             result_minors.end(), result_majors.end(), property.end(), types.end()));
       }
     } else if (has_labels) {
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(),
         thrust::make_zip_iterator(
           result_labels->begin(), result_minors.begin(), result_majors.begin(), property.begin()),
         thrust::make_zip_iterator(
           result_labels->end(), result_minors.end(), result_majors.end(), property.end()));
     } else {
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(),
         thrust::make_zip_iterator(result_minors.begin(), result_majors.begin(), property.begin()),
         thrust::make_zip_iterator(result_minors.end(), result_majors.end(), property.end()));
@@ -146,28 +146,28 @@ deduplicate_edges_by_minor(raft::handle_t const& handle,
     if (has_types) {
       auto& types = std::get<rmm::device_uvector<int32_t>>(result_types);
       if (has_labels) {
-        cugraph::sort_wrapper(
+        cugraph::sort(
           handle.get_thrust_policy(),
           thrust::make_zip_iterator(
             result_labels->begin(), result_minors.begin(), result_majors.begin(), types.begin()),
           thrust::make_zip_iterator(
             result_labels->end(), result_minors.end(), result_majors.end(), types.end()));
       } else {
-        cugraph::sort_wrapper(
+        cugraph::sort(
           handle.get_thrust_policy(),
           thrust::make_zip_iterator(result_minors.begin(), result_majors.begin(), types.begin()),
           thrust::make_zip_iterator(result_minors.end(), result_majors.end(), types.end()));
       }
     } else if (has_labels) {
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(),
         thrust::make_zip_iterator(
           result_labels->begin(), result_minors.begin(), result_majors.begin()),
         thrust::make_zip_iterator(result_labels->end(), result_minors.end(), result_majors.end()));
     } else {
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            thrust::make_zip_iterator(result_minors.begin(), result_majors.begin()),
-                            thrust::make_zip_iterator(result_minors.end(), result_majors.end()));
+      cugraph::sort(handle.get_thrust_policy(),
+                    thrust::make_zip_iterator(result_minors.begin(), result_majors.begin()),
+                    thrust::make_zip_iterator(result_minors.end(), result_majors.end()));
     }
   }
 

--- a/cpp/src/sampling/detail/gather_one_hop_impl.cuh
+++ b/cpp/src/sampling/detail/gather_one_hop_impl.cuh
@@ -21,6 +21,7 @@
 #include <cugraph/utilities/assert.cuh>
 #include <cugraph/utilities/collect_comm.cuh>
 #include <cugraph/utilities/mask_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/util/cudart_utils.hpp>
 
@@ -496,10 +497,10 @@ temporal_gather_one_hop_edgelist(
       starting_pos = sizes[handle.get_comms().get_rank()];
     }
 
-    thrust::sequence(handle.get_thrust_policy(),
-                     vertex_label_time_positions.begin(),
-                     vertex_label_time_positions.end(),
-                     starting_pos);
+    cugraph::sequence(handle.get_thrust_policy(),
+                      vertex_label_time_positions.begin(),
+                      vertex_label_time_positions.end(),
+                      starting_pos);
 
     if constexpr (multi_gpu) {
       auto& minor_comm = handle.get_subcomm(cugraph::partition_manager::minor_comm_name());

--- a/cpp/src/sampling/detail/gather_sampled_properties_impl.cuh
+++ b/cpp/src/sampling/detail/gather_sampled_properties_impl.cuh
@@ -14,11 +14,13 @@
 #include <cugraph/prims/transform_gather_e.cuh>
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/graph_partition_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/core/host_span.hpp>
 
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace cugraph {
 namespace detail {
@@ -72,14 +74,16 @@ gather_sampled_properties(
     std::vector<cugraph::arithmetic_device_uvector_t> edge_properties{};
 
     original_positions.resize(majors.size(), handle.get_stream());
-    detail::sequence_fill(
-      handle.get_stream(), original_positions.data(), original_positions.size(), size_t{0});
+    cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                      original_positions.data(),
+                      original_positions.data() + original_positions.size(),
+                      size_t{0});
     edge_properties.push_back(std::move(original_positions));
     original_gpu_ids.resize(majors.size(), handle.get_stream());
-    detail::scalar_fill(handle.get_stream(),
-                        original_gpu_ids.data(),
-                        original_gpu_ids.size(),
-                        handle.get_comms().get_rank());
+    cugraph::fill(rmm::exec_policy(handle.get_stream()),
+                  original_gpu_ids.data(),
+                  (original_gpu_ids.data()) + (original_gpu_ids.size()),
+                  handle.get_comms().get_rank());
     edge_properties.push_back(std::move(original_gpu_ids));
 
     if (std::holds_alternative<rmm::device_uvector<edge_t>>(multi_index))
@@ -153,8 +157,10 @@ gather_sampled_properties(
     result_properties.pop_back();
 
     rmm::device_uvector<size_t> property_position(majors.size(), handle.get_stream());
-    detail::sequence_fill(
-      handle.get_stream(), property_position.data(), property_position.size(), size_t{0});
+    cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                      property_position.data(),
+                      property_position.data() + property_position.size(),
+                      size_t{0});
     thrust::sort_by_key(handle.get_thrust_policy(),
                         original_positions.begin(),
                         original_positions.end(),

--- a/cpp/src/sampling/detail/prepare_next_frontier_impl.cuh
+++ b/cpp/src/sampling/detail/prepare_next_frontier_impl.cuh
@@ -199,8 +199,7 @@ prepare_next_frontier(
                           frontier_vertex_times->begin());
 
     } else {
-      cugraph::sort_wrapper(
-        handle.get_thrust_policy(), begin_iter, begin_iter + frontier_vertices.size());
+      cugraph::sort(handle.get_thrust_policy(), begin_iter, begin_iter + frontier_vertices.size());
     }
   } else {
     if (frontier_vertex_times) {
@@ -210,8 +209,7 @@ prepare_next_frontier(
                           frontier_vertex_times->begin());
 
     } else {
-      cugraph::sort_wrapper(
-        handle.get_thrust_policy(), frontier_vertices.begin(), frontier_vertices.end());
+      cugraph::sort(handle.get_thrust_policy(), frontier_vertices.begin(), frontier_vertices.end());
     }
   }
 
@@ -252,10 +250,10 @@ prepare_next_frontier(
       if (sampled_src_vertex_times) {
         auto begin_iter = thrust::make_zip_iterator(verts.begin(), labels->begin(), times->begin());
 
-        cugraph::sort_wrapper(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
+        cugraph::sort(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
 
         auto end_iter =
-          thrust::unique(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
+          cugraph::unique(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
 
         verts.resize(cuda::std::distance(begin_iter, end_iter), handle.get_stream());
         labels->resize(cuda::std::distance(begin_iter, end_iter), handle.get_stream());
@@ -263,10 +261,10 @@ prepare_next_frontier(
       } else {
         auto begin_iter = thrust::make_zip_iterator(verts.begin(), labels->begin());
 
-        cugraph::sort_wrapper(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
+        cugraph::sort(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
 
         auto end_iter =
-          thrust::unique(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
+          cugraph::unique(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
 
         verts.resize(cuda::std::distance(begin_iter, end_iter), handle.get_stream());
         labels->resize(cuda::std::distance(begin_iter, end_iter), handle.get_stream());
@@ -275,18 +273,18 @@ prepare_next_frontier(
       if (sampled_src_vertex_times) {
         auto begin_iter = thrust::make_zip_iterator(verts.begin(), times->begin());
 
-        cugraph::sort_wrapper(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
+        cugraph::sort(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
 
         auto end_iter =
-          thrust::unique(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
+          cugraph::unique(handle.get_thrust_policy(), begin_iter, begin_iter + new_verts_size);
 
         verts.resize(cuda::std::distance(begin_iter, end_iter), handle.get_stream());
         times->resize(cuda::std::distance(begin_iter, end_iter), handle.get_stream());
 
       } else {
-        cugraph::sort_wrapper(handle.get_thrust_policy(), verts.begin(), verts.end());
+        cugraph::sort(handle.get_thrust_policy(), verts.begin(), verts.end());
 
-        auto end_iter = thrust::unique(handle.get_thrust_policy(), verts.begin(), verts.end());
+        auto end_iter = cugraph::unique(handle.get_thrust_policy(), verts.begin(), verts.end());
 
         verts.resize(cuda::std::distance(verts.begin(), end_iter), handle.get_stream());
       }
@@ -312,7 +310,7 @@ prepare_next_frontier(
                                                     frontier_vertex_labels->begin(),
                                                     frontier_vertex_times->begin());
 
-        auto new_end = thrust::unique(
+        auto new_end = cugraph::unique(
           handle.get_thrust_policy(), begin_iter, begin_iter + frontier_vertices.size());
 
         frontier_vertices.resize(cuda::std::distance(begin_iter, new_end), handle.get_stream());
@@ -325,7 +323,7 @@ prepare_next_frontier(
         auto begin_iter =
           thrust::make_zip_iterator(frontier_vertices.begin(), frontier_vertex_labels->begin());
 
-        auto new_end = thrust::unique(
+        auto new_end = cugraph::unique(
           handle.get_thrust_policy(), begin_iter, begin_iter + frontier_vertices.size());
 
         frontier_vertices.resize(cuda::std::distance(begin_iter, new_end), handle.get_stream());
@@ -337,7 +335,7 @@ prepare_next_frontier(
         auto begin_iter =
           thrust::make_zip_iterator(frontier_vertices.begin(), frontier_vertex_times->begin());
 
-        auto new_end = thrust::unique(
+        auto new_end = cugraph::unique(
           handle.get_thrust_policy(), begin_iter, begin_iter + frontier_vertices.size());
 
         frontier_vertices.resize(cuda::std::distance(begin_iter, new_end), handle.get_stream());
@@ -345,7 +343,7 @@ prepare_next_frontier(
                                       handle.get_stream());
 
       } else {
-        auto new_end = thrust::unique(
+        auto new_end = cugraph::unique(
           handle.get_thrust_policy(), frontier_vertices.begin(), frontier_vertices.end());
 
         frontier_vertices.resize(cuda::std::distance(frontier_vertices.begin(), new_end),

--- a/cpp/src/sampling/detail/remove_visited_vertices_from_frontier.cuh
+++ b/cpp/src/sampling/detail/remove_visited_vertices_from_frontier.cuh
@@ -39,8 +39,7 @@ remove_visited_vertices_from_frontier(
     if (frontier_vertex_labels) {
       auto sort_iter = thrust::make_zip_iterator(
         frontier_vertex_labels->begin(), frontier_vertices.begin(), frontier_vertex_times->begin());
-      cugraph::sort_wrapper(
-        handle.get_thrust_policy(), sort_iter, sort_iter + frontier_vertices.size());
+      cugraph::sort(handle.get_thrust_policy(), sort_iter, sort_iter + frontier_vertices.size());
 
       auto begin_iter =
         thrust::make_zip_iterator(frontier_vertex_labels->begin(), frontier_vertices.begin());
@@ -62,8 +61,7 @@ remove_visited_vertices_from_frontier(
     } else {
       auto sort_iter =
         thrust::make_zip_iterator(frontier_vertices.begin(), frontier_vertex_times->begin());
-      cugraph::sort_wrapper(
-        handle.get_thrust_policy(), sort_iter, sort_iter + frontier_vertices.size());
+      cugraph::sort(handle.get_thrust_policy(), sort_iter, sort_iter + frontier_vertices.size());
 
       auto new_end = thrust::reduce_by_key(handle.get_thrust_policy(),
                                            frontier_vertices.begin(),

--- a/cpp/src/sampling/detail/sample_edges.cuh
+++ b/cpp/src/sampling/detail/sample_edges.cuh
@@ -1076,11 +1076,11 @@ sample_unvisited_with_one_property(
 
       if (num_types == size_t{1}) {
         if (agg_labels) {
-          cugraph::sort_wrapper(handle.get_thrust_policy(),
-                                thrust::make_zip_iterator(agg_labels->begin(), agg_majors.begin()),
-                                thrust::make_zip_iterator(agg_labels->end(), agg_majors.end()));
+          cugraph::sort(handle.get_thrust_policy(),
+                        thrust::make_zip_iterator(agg_labels->begin(), agg_majors.begin()),
+                        thrust::make_zip_iterator(agg_labels->end(), agg_majors.end()));
         } else {
-          cugraph::sort_wrapper(handle.get_thrust_policy(), agg_majors.begin(), agg_majors.end());
+          cugraph::sort(handle.get_thrust_policy(), agg_majors.begin(), agg_majors.end());
         }
 
         rmm::device_uvector<size_t> agg_counts(agg_majors.size(), handle.get_stream());
@@ -1120,14 +1120,14 @@ sample_unvisited_with_one_property(
           std::get<rmm::device_uvector<edge_type_t>>(std::move(discarded_types));
 
         if (agg_labels) {
-          cugraph::sort_wrapper(
+          cugraph::sort(
             handle.get_thrust_policy(),
             thrust::make_zip_iterator(agg_labels->begin(), agg_majors.begin(), types.begin()),
             thrust::make_zip_iterator(agg_labels->end(), agg_majors.end(), types.end()));
         } else {
-          cugraph::sort_wrapper(handle.get_thrust_policy(),
-                                thrust::make_zip_iterator(agg_majors.begin(), types.begin()),
-                                thrust::make_zip_iterator(agg_majors.end(), types.end()));
+          cugraph::sort(handle.get_thrust_policy(),
+                        thrust::make_zip_iterator(agg_majors.begin(), types.begin()),
+                        thrust::make_zip_iterator(agg_majors.end(), types.end()));
         }
 
         rmm::device_uvector<size_t> kr_cnt(agg_majors.size(), handle.get_stream());

--- a/cpp/src/sampling/detail/shuffle_and_organize_output_common.cu
+++ b/cpp/src/sampling/detail/shuffle_and_organize_output_common.cu
@@ -14,6 +14,7 @@
 #include <raft/core/handle.hpp>
 
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <cuda/std/iterator>
 #include <thrust/binary_search.h>
@@ -56,8 +57,10 @@ shuffle_and_organize_output(
         static_cast<double>(total_global_mem / element_size) * mem_frugal_ratio);
 
       rmm::device_uvector<size_t> property_position(labels->size(), handle.get_stream());
-      detail::sequence_fill(
-        handle.get_stream(), property_position.data(), property_position.size(), size_t{0});
+      cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                        property_position.data(),
+                        property_position.data() + property_position.size(),
+                        size_t{0});
 
       auto d_tx_value_counts = cugraph::groupby_and_count(labels->begin(),
                                                           labels->end(),
@@ -108,7 +111,7 @@ shuffle_and_organize_output(
 
     // Sort the tuples by hop/label
     rmm::device_uvector<size_t> indices(labels->size(), handle.get_stream());
-    thrust::sequence(handle.get_thrust_policy(), indices.begin(), indices.end(), size_t{0});
+    cugraph::sequence(handle.get_thrust_policy(), indices.begin(), indices.end(), size_t{0});
     if (hops) {
       thrust::sort_by_key(handle.get_thrust_policy(),
                           thrust::make_zip_iterator(labels->begin(), hops->begin()),
@@ -137,9 +140,9 @@ shuffle_and_organize_output(
     // Need to generate offsets for each unique label (not each seed) on each GPU
     rmm::device_uvector<int32_t> unique_labels(labels->size(), handle.get_stream());
     raft::copy(unique_labels.data(), labels->data(), labels->size(), handle.get_stream());
-    cugraph::sort_wrapper(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
+    cugraph::sort(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
     auto unique_end =
-      thrust::unique(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
+      cugraph::unique(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
     size_t num_unique_labels =
       static_cast<size_t>(cuda::std::distance(unique_labels.begin(), unique_end));
 

--- a/cpp/src/sampling/detail/temporal_partition_vertices_impl.cuh
+++ b/cpp/src/sampling/detail/temporal_partition_vertices_impl.cuh
@@ -58,15 +58,15 @@ temporal_partition_vertices(raft::handle_t const& handle,
                  vertex_labels->end(),
                  vertex_labels_p1->begin());
 
-    cugraph::sort_wrapper(
+    cugraph::sort(
       handle.get_thrust_policy(),
       thrust::make_zip_iterator(
         vertices_p1.begin(), vertex_times_p1.begin(), vertex_labels_p1->begin()),
       thrust::make_zip_iterator(vertices_p1.end(), vertex_times_p1.end(), vertex_labels_p1->end()));
   } else {
-    cugraph::sort_wrapper(handle.get_thrust_policy(),
-                          thrust::make_zip_iterator(vertices_p1.begin(), vertex_times_p1.begin()),
-                          thrust::make_zip_iterator(vertices_p1.end(), vertex_times_p1.end()));
+    cugraph::sort(handle.get_thrust_policy(),
+                  thrust::make_zip_iterator(vertices_p1.begin(), vertex_times_p1.begin()),
+                  thrust::make_zip_iterator(vertices_p1.end(), vertex_times_p1.end()));
   }
 
   rmm::device_uvector<uint32_t> vertex_partition_mask(cugraph::packed_bool_size(vertices_p1.size()),

--- a/cpp/src/sampling/detail/update_visited_utils_impl.cuh
+++ b/cpp/src/sampling/detail/update_visited_utils_impl.cuh
@@ -71,22 +71,21 @@ update_dst_visited_vertices_and_labels(
 
   // 2) Sort and dedupe the new sampled items (reduce comm and storage)
   if (new_sample_labels) {
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(),
-      thrust::make_zip_iterator(new_samples.begin(), new_sample_labels->begin()),
-      thrust::make_zip_iterator(new_samples.end(), new_sample_labels->end()));
+    cugraph::sort(handle.get_thrust_policy(),
+                  thrust::make_zip_iterator(new_samples.begin(), new_sample_labels->begin()),
+                  thrust::make_zip_iterator(new_samples.end(), new_sample_labels->end()));
     auto new_zip_end =
-      thrust::unique(handle.get_thrust_policy(),
-                     thrust::make_zip_iterator(new_samples.begin(), new_sample_labels->begin()),
-                     thrust::make_zip_iterator(new_samples.end(), new_sample_labels->end()));
+      cugraph::unique(handle.get_thrust_policy(),
+                      thrust::make_zip_iterator(new_samples.begin(), new_sample_labels->begin()),
+                      thrust::make_zip_iterator(new_samples.end(), new_sample_labels->end()));
     size_t new_size = static_cast<size_t>(cuda::std::get<0>(new_zip_end.get_iterator_tuple()) -
                                           new_samples.begin());
     new_samples.resize(new_size, handle.get_stream());
     new_sample_labels->resize(new_size, handle.get_stream());
   } else {
-    cugraph::sort_wrapper(handle.get_thrust_policy(), new_samples.begin(), new_samples.end());
+    cugraph::sort(handle.get_thrust_policy(), new_samples.begin(), new_samples.end());
     auto new_end =
-      thrust::unique(handle.get_thrust_policy(), new_samples.begin(), new_samples.end());
+      cugraph::unique(handle.get_thrust_policy(), new_samples.begin(), new_samples.end());
     size_t n_keep = static_cast<size_t>(new_end - new_samples.begin());
     new_samples.resize(n_keep, handle.get_stream());
   }
@@ -122,12 +121,11 @@ update_dst_visited_vertices_and_labels(
                  new_sample_labels->end(),
                  visited_minor_labels->begin() + orig_size);
 
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(),
-      thrust::make_zip_iterator(visited_minors.begin(), visited_minor_labels->begin()),
-      thrust::make_zip_iterator(visited_minors.end(), visited_minor_labels->end()));
+    cugraph::sort(handle.get_thrust_policy(),
+                  thrust::make_zip_iterator(visited_minors.begin(), visited_minor_labels->begin()),
+                  thrust::make_zip_iterator(visited_minors.end(), visited_minor_labels->end()));
   } else {
-    cugraph::sort_wrapper(handle.get_thrust_policy(), visited_minors.begin(), visited_minors.end());
+    cugraph::sort(handle.get_thrust_policy(), visited_minors.begin(), visited_minors.end());
   }
 
   return std::make_tuple(std::move(visited_minors), std::move(visited_minor_labels));

--- a/cpp/src/sampling/negative_sampling_impl.cuh
+++ b/cpp/src/sampling/negative_sampling_impl.cuh
@@ -147,8 +147,8 @@ rmm::device_uvector<vertex_t> create_local_samples(
       rmm::device_uvector<size_t> gpu_counts(comm_size, handle.get_stream());
       position.resize(samples_in_this_batch, handle.get_stream());
 
-      thrust::fill(handle.get_thrust_policy(), gpu_counts.begin(), gpu_counts.end(), size_t{0});
-      thrust::sequence(handle.get_thrust_policy(), position.begin(), position.end());
+      cugraph::fill(handle.get_thrust_policy(), gpu_counts.begin(), gpu_counts.end(), size_t{0});
+      cugraph::sequence(handle.get_thrust_policy(), position.begin(), position.end());
 
       rmm::device_uvector<weight_t> random_values(samples_in_this_batch, handle.get_stream());
       detail::uniform_random_fill(handle.get_stream(),
@@ -158,9 +158,9 @@ rmm::device_uvector<vertex_t> create_local_samples(
                                   weight_t{1},
                                   rng_state);
 
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            thrust::make_zip_iterator(random_values.begin(), position.begin()),
-                            thrust::make_zip_iterator(random_values.end(), position.end()));
+      cugraph::sort(handle.get_thrust_policy(),
+                    thrust::make_zip_iterator(random_values.begin(), position.begin()),
+                    thrust::make_zip_iterator(random_values.end(), position.end()));
 
       thrust::upper_bound(handle.get_thrust_policy(),
                           random_values.begin(),
@@ -237,9 +237,9 @@ rmm::device_uvector<vertex_t> create_local_samples(
                                                      sample_count_from_each_gpu.size()),
                        handle.get_stream());
 
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            thrust::make_zip_iterator(position.begin(), samples.begin()),
-                            thrust::make_zip_iterator(position.end(), samples.begin()));
+      cugraph::sort(handle.get_thrust_policy(),
+                    thrust::make_zip_iterator(position.begin(), samples.begin()),
+                    thrust::make_zip_iterator(position.end(), samples.begin()));
     }
   } else {
     samples.resize(samples_in_this_batch, handle.get_stream());
@@ -353,14 +353,14 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> negativ
     }
 
     if (remove_duplicates) {
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            thrust::make_zip_iterator(batch_srcs.begin(), batch_dsts.begin()),
-                            thrust::make_zip_iterator(batch_srcs.end(), batch_dsts.end()));
+      cugraph::sort(handle.get_thrust_policy(),
+                    thrust::make_zip_iterator(batch_srcs.begin(), batch_dsts.begin()),
+                    thrust::make_zip_iterator(batch_srcs.end(), batch_dsts.end()));
 
       auto new_end =
-        thrust::unique(handle.get_thrust_policy(),
-                       thrust::make_zip_iterator(batch_srcs.begin(), batch_dsts.begin()),
-                       thrust::make_zip_iterator(batch_srcs.end(), batch_dsts.end()));
+        cugraph::unique(handle.get_thrust_policy(),
+                        thrust::make_zip_iterator(batch_srcs.begin(), batch_dsts.begin()),
+                        thrust::make_zip_iterator(batch_srcs.end(), batch_dsts.end()));
 
       size_t new_size = cuda::std::distance(
         thrust::make_zip_iterator(batch_srcs.begin(), batch_dsts.begin()), new_end);
@@ -376,9 +376,9 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> negativ
                       thrust::make_zip_iterator(srcs.end(), dsts.end()),
                       thrust::make_zip_iterator(new_src.begin(), new_dst.begin()));
 
-        new_end = thrust::unique(handle.get_thrust_policy(),
-                                 thrust::make_zip_iterator(new_src.begin(), new_dst.begin()),
-                                 thrust::make_zip_iterator(new_src.end(), new_dst.end()));
+        new_end = cugraph::unique(handle.get_thrust_policy(),
+                                  thrust::make_zip_iterator(new_src.begin(), new_dst.begin()),
+                                  thrust::make_zip_iterator(new_src.end(), new_dst.end()));
 
         new_size =
           cuda::std::distance(thrust::make_zip_iterator(new_src.begin(), new_dst.begin()), new_end);

--- a/cpp/src/sampling/neighbor_sampling_impl.hpp
+++ b/cpp/src/sampling/neighbor_sampling_impl.hpp
@@ -13,6 +13,7 @@
 #include <cugraph/graph.hpp>
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/sampling_functions.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_view.hpp>
 
 #include <raft/core/handle.hpp>
@@ -569,8 +570,10 @@ neighbor_sample_impl(raft::handle_t const& handle,
     result_hops   = rmm::device_uvector<int32_t>(result_size, handle.get_stream());
     output_offset = 0;
     for (size_t i = 0; i < num_hops; ++i) {
-      scalar_fill(
-        handle, result_hops->data() + output_offset, result_sizes[i], static_cast<int32_t>(i));
+      cugraph::fill(handle.get_thrust_policy(),
+                    result_hops->data() + output_offset,
+                    (result_hops->data() + output_offset) + (result_sizes[i]),
+                    static_cast<int32_t>(i));
       output_offset += result_sizes[i];
     }
   }

--- a/cpp/src/sampling/random_walks_impl.cuh
+++ b/cpp/src/sampling/random_walks_impl.cuh
@@ -29,6 +29,7 @@
 #include <raft/random/rng.cuh>
 
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/optional>
@@ -562,12 +563,15 @@ random_walk_impl(raft::handle_t const& handle,
                               start_vertices.size() * max_length, handle.get_stream())
                           : std::nullopt;
 
-  detail::scalar_fill(handle,
-                      result_vertices.data(),
-                      result_vertices.size(),
-                      cugraph::invalid_vertex_id<vertex_t>::value);
+  cugraph::fill(handle.get_thrust_policy(),
+                result_vertices.data(),
+                (result_vertices.data()) + (result_vertices.size()),
+                cugraph::invalid_vertex_id<vertex_t>::value);
   if (result_weights)
-    detail::scalar_fill(handle, result_weights->data(), result_weights->size(), weight_t{0});
+    cugraph::fill(handle.get_thrust_policy(),
+                  result_weights->data(),
+                  (result_weights->data()) + (result_weights->size()),
+                  weight_t{0});
 
   rmm::device_uvector<vertex_t> current_vertices(start_vertices.size(), handle.get_stream());
   rmm::device_uvector<size_t> current_position(start_vertices.size(), handle.get_stream());
@@ -588,14 +592,18 @@ random_walk_impl(raft::handle_t const& handle,
   }
   raft::copy(
     current_vertices.data(), start_vertices.data(), start_vertices.size(), handle.get_stream());
-  detail::sequence_fill(
-    handle.get_stream(), current_position.data(), current_position.size(), size_t{0});
+  cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                    current_position.data(),
+                    current_position.data() + current_position.size(),
+                    size_t{0});
 
   if constexpr (multi_gpu) {
     current_gpu.resize(start_vertices.size(), handle.get_stream());
 
-    detail::scalar_fill(
-      handle, current_gpu.data(), current_gpu.size(), handle.get_comms().get_rank());
+    cugraph::fill(handle.get_thrust_policy(),
+                  current_gpu.data(),
+                  (current_gpu.data()) + (current_gpu.size()),
+                  handle.get_comms().get_rank());
   }
 
   thrust::for_each(
@@ -643,17 +651,17 @@ random_walk_impl(raft::handle_t const& handle,
     //  Sort for nbr_intersection, must sort all together
     if (previous_vertices) {
       if constexpr (multi_gpu) {
-        cugraph::sort_wrapper(handle.get_thrust_policy(),
-                              thrust::make_zip_iterator(current_vertices.begin(),
-                                                        (*previous_vertices).begin(),
-                                                        current_position.begin(),
-                                                        current_gpu.begin()),
-                              thrust::make_zip_iterator(current_vertices.end(),
-                                                        (*previous_vertices).end(),
-                                                        current_position.end(),
-                                                        current_gpu.end()));
+        cugraph::sort(handle.get_thrust_policy(),
+                      thrust::make_zip_iterator(current_vertices.begin(),
+                                                (*previous_vertices).begin(),
+                                                current_position.begin(),
+                                                current_gpu.begin()),
+                      thrust::make_zip_iterator(current_vertices.end(),
+                                                (*previous_vertices).end(),
+                                                current_position.end(),
+                                                current_gpu.end()));
       } else {
-        cugraph::sort_wrapper(
+        cugraph::sort(
           handle.get_thrust_policy(),
           thrust::make_zip_iterator(
             current_vertices.begin(), (*previous_vertices).begin(), current_position.begin()),
@@ -830,8 +838,10 @@ random_walk_impl(raft::handle_t const& handle,
         std::move(std::get<rmm::device_uvector<vertex_t>>(vertex_properties[pos++]));
 
       current_gpu = rmm::device_uvector<int>{current_vertices.size(), handle.get_stream()};
-      detail::scalar_fill(
-        handle, current_gpu.data(), current_gpu.size(), handle.get_comms().get_rank());
+      cugraph::fill(handle.get_thrust_policy(),
+                    current_gpu.data(),
+                    (current_gpu.data()) + (current_gpu.size()),
+                    handle.get_comms().get_rank());
 
       current_position = std::move(std::get<rmm::device_uvector<size_t>>(vertex_properties[pos++]));
       if (new_weights)

--- a/cpp/src/sampling/sampling_post_processing_impl.cuh
+++ b/cpp/src/sampling/sampling_post_processing_impl.cuh
@@ -348,8 +348,7 @@ void check_input_edges(raft::handle_t const& handle,
           handle.get_thrust_policy(), edge_types.begin(), edge_types.end(), tmp_edge_types.begin());
         auto triplet_first =
           thrust::make_zip_iterator(tmp_edge_types.begin(), tmp_majors.begin(), tmp_minors.begin());
-        cugraph::sort_wrapper(
-          handle.get_thrust_policy(), triplet_first, triplet_first + tmp_majors.size());
+        cugraph::sort(handle.get_thrust_policy(), triplet_first, triplet_first + tmp_majors.size());
         CUGRAPH_EXPECTS(
           thrust::count_if(
             handle.get_thrust_policy(),
@@ -396,8 +395,7 @@ void check_input_edges(raft::handle_t const& handle,
           "have an identical vertex type.");
       } else {
         auto pair_first = thrust::make_zip_iterator(tmp_majors.begin(), tmp_minors.begin());
-        cugraph::sort_wrapper(
-          handle.get_thrust_policy(), pair_first, pair_first + tmp_majors.size());
+        cugraph::sort(handle.get_thrust_policy(), pair_first, pair_first + tmp_majors.size());
         CUGRAPH_EXPECTS(
           thrust::count_if(
             handle.get_thrust_policy(),
@@ -461,14 +459,14 @@ void check_input_edges(raft::handle_t const& handle,
                        (*seed_vertices).begin() + start_offset,
                        (*seed_vertices).begin() + end_offset,
                        this_label_seed_vertices.begin());
-          cugraph::sort_wrapper(handle.get_thrust_policy(),
-                                this_label_seed_vertices.begin(),
-                                this_label_seed_vertices.end());
+          cugraph::sort(handle.get_thrust_policy(),
+                        this_label_seed_vertices.begin(),
+                        this_label_seed_vertices.end());
           this_label_seed_vertices.resize(
             cuda::std::distance(this_label_seed_vertices.begin(),
-                                thrust::unique(handle.get_thrust_policy(),
-                                               this_label_seed_vertices.begin(),
-                                               this_label_seed_vertices.end())),
+                                cugraph::unique(handle.get_thrust_policy(),
+                                                this_label_seed_vertices.begin(),
+                                                this_label_seed_vertices.end())),
             handle.get_stream());
         }
 
@@ -500,14 +498,14 @@ void check_input_edges(raft::handle_t const& handle,
                          edgelist_majors.begin() + end_offset,
                          this_label_zero_hop_majors.begin());
           }
-          cugraph::sort_wrapper(handle.get_thrust_policy(),
-                                this_label_zero_hop_majors.begin(),
-                                this_label_zero_hop_majors.end());
+          cugraph::sort(handle.get_thrust_policy(),
+                        this_label_zero_hop_majors.begin(),
+                        this_label_zero_hop_majors.end());
           this_label_zero_hop_majors.resize(
             cuda::std::distance(this_label_zero_hop_majors.begin(),
-                                thrust::unique(handle.get_thrust_policy(),
-                                               this_label_zero_hop_majors.begin(),
-                                               this_label_zero_hop_majors.end())),
+                                cugraph::unique(handle.get_thrust_policy(),
+                                                this_label_zero_hop_majors.begin(),
+                                                this_label_zero_hop_majors.end())),
             handle.get_stream());
         }
 
@@ -560,13 +558,13 @@ compute_min_hop_for_unique_label_vertex_pairs(
 
     if (edgelist_hops) {
       rmm::device_uvector<size_t> tmp_indices(edgelist_vertices.size(), handle.get_stream());
-      thrust::sequence(
+      cugraph::sequence(
         handle.get_thrust_policy(), tmp_indices.begin(), tmp_indices.end(), size_t{0});
 
       // cub::DeviceSegmentedSort currently does not suuport cuda::std::tuple type keys, sorting in
       // chunks still helps in limiting the binary search range and improving memory locality
       for (size_t i = 0; i < num_chunks; ++i) {
-        cugraph::sort_wrapper(
+        cugraph::sort(
           handle.get_thrust_policy(),
           tmp_indices.begin() + h_edge_offsets[i],
           tmp_indices.begin() + h_edge_offsets[i + 1],
@@ -594,25 +592,25 @@ compute_min_hop_for_unique_label_vertex_pairs(
       tmp_indices.resize(
         cuda::std::distance(
           tmp_indices.begin(),
-          thrust::unique(handle.get_thrust_policy(),
-                         tmp_indices.begin(),
-                         tmp_indices.end(),
-                         [edgelist_label_offsets = *edgelist_label_offsets,
-                          edgelist_vertices] __device__(size_t l_idx, size_t r_idx) -> bool {
-                           auto l_it = thrust::upper_bound(thrust::seq,
-                                                           edgelist_label_offsets.begin() + 1,
-                                                           edgelist_label_offsets.end(),
-                                                           l_idx);
-                           auto r_it = thrust::upper_bound(thrust::seq,
-                                                           edgelist_label_offsets.begin() + 1,
-                                                           edgelist_label_offsets.end(),
-                                                           r_idx);
-                           if (l_it != r_it) { return false; }
+          cugraph::unique(handle.get_thrust_policy(),
+                          tmp_indices.begin(),
+                          tmp_indices.end(),
+                          [edgelist_label_offsets = *edgelist_label_offsets,
+                           edgelist_vertices] __device__(size_t l_idx, size_t r_idx) -> bool {
+                            auto l_it = thrust::upper_bound(thrust::seq,
+                                                            edgelist_label_offsets.begin() + 1,
+                                                            edgelist_label_offsets.end(),
+                                                            l_idx);
+                            auto r_it = thrust::upper_bound(thrust::seq,
+                                                            edgelist_label_offsets.begin() + 1,
+                                                            edgelist_label_offsets.end(),
+                                                            r_idx);
+                            if (l_it != r_it) { return false; }
 
-                           auto l_vertex = edgelist_vertices[l_idx];
-                           auto r_vertex = edgelist_vertices[r_idx];
-                           return l_vertex == r_vertex;
-                         })),
+                            auto l_vertex = edgelist_vertices[l_idx];
+                            auto r_vertex = edgelist_vertices[r_idx];
+                            return l_vertex == r_vertex;
+                          })),
         handle.get_stream());
 
       tmp_label_indices.resize(tmp_indices.size(), handle.get_stream());
@@ -920,8 +918,7 @@ compute_min_hop_for_unique_label_vertex_pairs(
       auto pair_first = thrust::make_zip_iterator(
         tmp_vertices.begin(),
         (*tmp_hops).begin());  // vertex is a primary key, hop is a secondary key
-      cugraph::sort_wrapper(
-        handle.get_thrust_policy(), pair_first, pair_first + tmp_vertices.size());
+      cugraph::sort(handle.get_thrust_policy(), pair_first, pair_first + tmp_vertices.size());
       tmp_vertices.resize(
         cuda::std::distance(tmp_vertices.begin(),
                             cuda::std::get<0>(thrust::unique_by_key(handle.get_thrust_policy(),
@@ -933,11 +930,11 @@ compute_min_hop_for_unique_label_vertex_pairs(
       tmp_vertices.shrink_to_fit(handle.get_stream());
       (*tmp_hops).shrink_to_fit(handle.get_stream());
     } else {
-      cugraph::sort_wrapper(handle.get_thrust_policy(), tmp_vertices.begin(), tmp_vertices.end());
+      cugraph::sort(handle.get_thrust_policy(), tmp_vertices.begin(), tmp_vertices.end());
       tmp_vertices.resize(
         cuda::std::distance(
           tmp_vertices.begin(),
-          thrust::unique(handle.get_thrust_policy(), tmp_vertices.begin(), tmp_vertices.end())),
+          cugraph::unique(handle.get_thrust_policy(), tmp_vertices.begin(), tmp_vertices.end())),
         handle.get_stream());
       tmp_vertices.shrink_to_fit(handle.get_stream());
     }
@@ -951,12 +948,12 @@ compute_min_hop_for_unique_label_vertex_pairs(
                    (*seed_vertices).begin(),
                    (*seed_vertices).end(),
                    unique_seed_vertices.begin());
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(), unique_seed_vertices.begin(), unique_seed_vertices.end());
       unique_seed_vertices.resize(cuda::std::distance(unique_seed_vertices.begin(),
-                                                      thrust::unique(handle.get_thrust_policy(),
-                                                                     unique_seed_vertices.begin(),
-                                                                     unique_seed_vertices.end())),
+                                                      cugraph::unique(handle.get_thrust_policy(),
+                                                                      unique_seed_vertices.begin(),
+                                                                      unique_seed_vertices.end())),
                                   handle.get_stream());
 
       /* merge with the (vertex, min. hop) pairs from the edgelist */
@@ -1161,7 +1158,7 @@ compute_vertex_renumber_map(
                                                             merged_vertices.begin(),
                                                             merged_hops.begin(),
                                                             merged_flags.begin());
-          cugraph::sort_wrapper(
+          cugraph::sort(
             handle.get_thrust_policy(),
             quadraplet_first,
             quadraplet_first + merged_vertices.size(),
@@ -1224,7 +1221,7 @@ compute_vertex_renumber_map(
         if (vertex_type_offsets) {
           auto triplet_first = thrust::make_zip_iterator(
             merged_label_indices.begin(), merged_vertices.begin(), merged_flags.begin());
-          cugraph::sort_wrapper(
+          cugraph::sort(
             handle.get_thrust_policy(),
             triplet_first,
             triplet_first + merged_vertices.size(),
@@ -1348,7 +1345,7 @@ compute_vertex_renumber_map(
       if (vertex_type_offsets) {
         auto triplet_first = thrust::make_zip_iterator(
           merged_vertices.begin(), merged_hops.begin(), merged_flags.begin());
-        cugraph::sort_wrapper(
+        cugraph::sort(
           handle.get_thrust_policy(),
           triplet_first,
           triplet_first + merged_vertices.size(),
@@ -1464,14 +1461,15 @@ compute_edge_id_renumber_map(
     auto num_chunks = h_label_offsets.size() - 1;
 
     rmm::device_uvector<size_t> tmp_indices(edgelist_edge_ids.size(), handle.get_stream());
-    thrust::sequence(handle.get_thrust_policy(), tmp_indices.begin(), tmp_indices.end(), size_t{0});
+    cugraph::sequence(
+      handle.get_thrust_policy(), tmp_indices.begin(), tmp_indices.end(), size_t{0});
 
     // cub::DeviceSegmentedSort currently does not suuport cuda::std::tuple type keys, sorting in
     // chunks still helps in limiting the binary search range and improving memory locality
     for (size_t i = 0; i < num_chunks; ++i) {
       // sort by (label, (type), id, (hop))
 
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(),
         tmp_indices.begin() + h_edge_offsets[i],
         tmp_indices.begin() + h_edge_offsets[i + 1],
@@ -1509,7 +1507,7 @@ compute_edge_id_renumber_map(
 
       // find unique (label, (type), id, (min_hop)) tuples
 
-      auto last = thrust::unique(
+      auto last = cugraph::unique(
         handle.get_thrust_policy(),
         tmp_indices.begin() + h_edge_offsets[i],
         tmp_indices.begin() + h_edge_offsets[i + 1],
@@ -1536,7 +1534,7 @@ compute_edge_id_renumber_map(
       // sort by (label, (type), (min_hop), id)
 
       if (edgelist_hops) {
-        cugraph::sort_wrapper(
+        cugraph::sort(
           handle.get_thrust_policy(),
           tmp_indices.begin() + h_edge_offsets[i],
           last,
@@ -1575,10 +1573,10 @@ compute_edge_id_renumber_map(
 
       // mark invalid indices
 
-      thrust::fill(handle.get_thrust_policy(),
-                   last,
-                   tmp_indices.begin() + h_edge_offsets[i + 1],
-                   std::numeric_limits<size_t>::max());
+      cugraph::fill(handle.get_thrust_policy(),
+                    last,
+                    tmp_indices.begin() + h_edge_offsets[i + 1],
+                    std::numeric_limits<size_t>::max());
     }
 
     tmp_indices.resize(cuda::std::distance(tmp_indices.begin(),
@@ -1675,18 +1673,17 @@ compute_edge_id_renumber_map(
       if (tmp_hops) {
         auto triplet_first =
           thrust::make_zip_iterator((*tmp_types).begin(), tmp_ids.begin(), (*tmp_hops).begin());
-        cugraph::sort_wrapper(
-          handle.get_thrust_policy(), triplet_first, triplet_first + tmp_ids.size());
+        cugraph::sort(handle.get_thrust_policy(), triplet_first, triplet_first + tmp_ids.size());
       } else {
         auto pair_first = thrust::make_zip_iterator((*tmp_types).begin(), tmp_ids.begin());
-        cugraph::sort_wrapper(handle.get_thrust_policy(), pair_first, pair_first + tmp_ids.size());
+        cugraph::sort(handle.get_thrust_policy(), pair_first, pair_first + tmp_ids.size());
       }
     } else {
       if (tmp_hops) {
         auto pair_first = thrust::make_zip_iterator(tmp_ids.begin(), (*tmp_hops).begin());
-        cugraph::sort_wrapper(handle.get_thrust_policy(), pair_first, pair_first + tmp_ids.size());
+        cugraph::sort(handle.get_thrust_policy(), pair_first, pair_first + tmp_ids.size());
       } else {
-        cugraph::sort_wrapper(handle.get_thrust_policy(), tmp_ids.begin(), tmp_ids.end());
+        cugraph::sort(handle.get_thrust_policy(), tmp_ids.begin(), tmp_ids.end());
       }
     }
 
@@ -1707,7 +1704,7 @@ compute_edge_id_renumber_map(
         tmp_ids.resize(
           cuda::std::distance(
             pair_first,
-            thrust::unique(handle.get_thrust_policy(), pair_first, pair_first + tmp_ids.size())),
+            cugraph::unique(handle.get_thrust_policy(), pair_first, pair_first + tmp_ids.size())),
           handle.get_stream());
       }
       (*tmp_types).resize(tmp_ids.size(), handle.get_stream());
@@ -1724,7 +1721,7 @@ compute_edge_id_renumber_map(
         tmp_ids.resize(
           cuda::std::distance(
             tmp_ids.begin(),
-            thrust::unique(handle.get_thrust_policy(), tmp_ids.begin(), tmp_ids.end())),
+            cugraph::unique(handle.get_thrust_policy(), tmp_ids.begin(), tmp_ids.end())),
           handle.get_stream());
       }
     }
@@ -1735,11 +1732,10 @@ compute_edge_id_renumber_map(
       if (tmp_types) {
         auto triplet_first =
           thrust::make_zip_iterator((*tmp_types).begin(), (*tmp_hops).begin(), tmp_ids.begin());
-        cugraph::sort_wrapper(
-          handle.get_thrust_policy(), triplet_first, triplet_first + tmp_ids.size());
+        cugraph::sort(handle.get_thrust_policy(), triplet_first, triplet_first + tmp_ids.size());
       } else {
         auto pair_first = thrust::make_zip_iterator((*tmp_hops).begin(), tmp_ids.begin());
-        cugraph::sort_wrapper(handle.get_thrust_policy(), pair_first, pair_first + tmp_ids.size());
+        cugraph::sort(handle.get_thrust_policy(), pair_first, pair_first + tmp_ids.size());
       }
     }
 
@@ -2302,7 +2298,7 @@ heterogeneous_renumber_sampled_edgelist(
                          return static_cast<edge_id_t>(i - start_offset);
                        });
     } else {
-      thrust::sequence(
+      cugraph::sequence(
         handle.get_thrust_policy(), new_edge_ids.begin(), new_edge_ids.end(), edge_id_t{0});
     }
 
@@ -2517,7 +2513,7 @@ sort_sampled_edge_tuples(raft::handle_t const& handle,
   for (size_t i = 0; i < num_chunks; ++i) {
     rmm::device_uvector<size_t> indices(h_edge_offsets[i + 1] - h_edge_offsets[i],
                                         handle.get_stream());
-    thrust::sequence(handle.get_thrust_policy(), indices.begin(), indices.end(), size_t{0});
+    cugraph::sequence(handle.get_thrust_policy(), indices.begin(), indices.end(), size_t{0});
     edge_order_t<vertex_t, edge_type_t> edge_order_comp{
       edgelist_label_offsets ? cuda::std::make_optional<raft::device_span<size_t const>>(
                                  (*edgelist_label_offsets).data() + h_label_offsets[i],
@@ -2534,8 +2530,7 @@ sort_sampled_edge_tuples(raft::handle_t const& handle,
       raft::device_span<vertex_t const>(edgelist_majors.data() + h_edge_offsets[i], indices.size()),
       raft::device_span<vertex_t const>(edgelist_minors.data() + h_edge_offsets[i],
                                         indices.size())};
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(), indices.begin(), indices.end(), edge_order_comp);
+    cugraph::sort(handle.get_thrust_policy(), indices.begin(), indices.end(), edge_order_comp);
 
     permute_array(handle,
                   indices.begin(),
@@ -2704,12 +2699,11 @@ renumber_and_compress_sampled_edgelist(
         *seed_vertex_label_offsets, label_index_t{0}, handle.get_stream());
       auto pair_first =
         thrust::make_zip_iterator(label_indices.begin(), (*renumbered_seed_vertices).begin());
-      cugraph::sort_wrapper(
-        handle.get_thrust_policy(), pair_first, pair_first + label_indices.size());
+      cugraph::sort(handle.get_thrust_policy(), pair_first, pair_first + label_indices.size());
     } else {
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            (*renumbered_seed_vertices).begin(),
-                            (*renumbered_seed_vertices).end());
+      cugraph::sort(handle.get_thrust_policy(),
+                    (*renumbered_seed_vertices).begin(),
+                    (*renumbered_seed_vertices).end());
     }
   }
 
@@ -3020,10 +3014,10 @@ renumber_and_compress_sampled_edgelist(
     if (compress_per_hop) {
       minor_vertex_counts =
         rmm::device_uvector<vertex_t>(major_vertex_counts.size(), handle.get_stream());
-      thrust::fill(handle.get_thrust_policy(),
-                   (*minor_vertex_counts).begin(),
-                   (*minor_vertex_counts).end(),
-                   vertex_t{0});
+      cugraph::fill(handle.get_thrust_policy(),
+                    (*minor_vertex_counts).begin(),
+                    (*minor_vertex_counts).end(),
+                    vertex_t{0});
       if (edgelist_label_offsets) {
         auto triplet_first = thrust::make_zip_iterator((*compressed_label_indices).begin(),
                                                        (*compressed_hops).begin(),
@@ -3106,10 +3100,10 @@ renumber_and_compress_sampled_edgelist(
 
     auto tmp_compressed_offsets = rmm::device_uvector<size_t>(
       offset_array_offsets.back_element(handle.get_stream()) + 1, handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(),
-                 tmp_compressed_offsets.begin(),
-                 tmp_compressed_offsets.end(),
-                 size_t{0});
+    cugraph::fill(handle.get_thrust_policy(),
+                  tmp_compressed_offsets.begin(),
+                  tmp_compressed_offsets.end(),
+                  size_t{0});
 
     if (edgelist_label_offsets) {
       if (edgelist_hops) {
@@ -3321,10 +3315,10 @@ renumber_and_sort_sampled_edgelist(
   if (edgelist_label_offsets || edgelist_hops) {
     edgelist_label_hop_offsets =
       rmm::device_uvector<size_t>(num_labels * num_hops + 1, handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(),
-                 (*edgelist_label_hop_offsets).begin(),
-                 (*edgelist_label_hop_offsets).end(),
-                 size_t{0});
+    cugraph::fill(handle.get_thrust_policy(),
+                  (*edgelist_label_hop_offsets).begin(),
+                  (*edgelist_label_hop_offsets).end(),
+                  size_t{0});
     thrust::transform(
       handle.get_thrust_policy(),
       thrust::make_counting_iterator(size_t{0}),
@@ -3537,10 +3531,10 @@ heterogeneous_renumber_and_sort_sampled_edgelist(
   if (edgelist_label_offsets || edgelist_edge_types || edgelist_hops) {
     edgelist_label_type_hop_offsets =
       rmm::device_uvector<size_t>(num_labels * num_edge_types * num_hops + 1, handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(),
-                 (*edgelist_label_type_hop_offsets).begin(),
-                 (*edgelist_label_type_hop_offsets).end(),
-                 size_t{0});
+    cugraph::fill(handle.get_thrust_policy(),
+                  (*edgelist_label_type_hop_offsets).begin(),
+                  (*edgelist_label_type_hop_offsets).end(),
+                  size_t{0});
     thrust::transform(
       handle.get_thrust_policy(),
       thrust::make_counting_iterator(size_t{0}),
@@ -3679,10 +3673,10 @@ sort_sampled_edgelist(raft::handle_t const& handle,
   if (edgelist_label_offsets || edgelist_hops) {
     edgelist_label_hop_offsets =
       rmm::device_uvector<size_t>(num_labels * num_hops + 1, handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(),
-                 (*edgelist_label_hop_offsets).begin(),
-                 (*edgelist_label_hop_offsets).end(),
-                 size_t{0});
+    cugraph::fill(handle.get_thrust_policy(),
+                  (*edgelist_label_hop_offsets).begin(),
+                  (*edgelist_label_hop_offsets).end(),
+                  size_t{0});
 
     thrust::transform(
       handle.get_thrust_policy(),

--- a/cpp/src/sampling/temporal_sampling_impl.hpp
+++ b/cpp/src/sampling/temporal_sampling_impl.hpp
@@ -17,6 +17,7 @@
 #include <cugraph/utilities/device_functors.cuh>
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/host_scalar_comm.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_view.hpp>
 
 #include <raft/core/device_span.hpp>
@@ -779,8 +780,10 @@ temporal_neighbor_sample_impl(
     result_hops   = rmm::device_uvector<int32_t>(result_size, handle.get_stream());
     output_offset = 0;
     for (size_t i = 0; i < result_vector_hops.size(); ++i) {
-      scalar_fill(
-        handle, result_hops->data() + output_offset, result_vector_sizes[i], result_vector_hops[i]);
+      cugraph::fill(handle.get_thrust_policy(),
+                    result_hops->data() + output_offset,
+                    (result_hops->data() + output_offset) + (result_vector_sizes[i]),
+                    result_vector_hops[i]);
       output_offset += result_vector_sizes[i];
     }
   }

--- a/cpp/src/structure/coarsen_graph_impl.cuh
+++ b/cpp/src/structure/coarsen_graph_impl.cuh
@@ -110,11 +110,10 @@ groupby_e_and_coarsen_edgelist(rmm::device_uvector<vertex_t>&& edgelist_majors,
                            std::move(tmp_edgelist_minors),
                            std::move(tmp_edgelist_weights));
   } else {
-    cugraph::sort_wrapper(
-      rmm::exec_policy(stream_view), pair_first, pair_first + edgelist_majors.size());
+    cugraph::sort(rmm::exec_policy(stream_view), pair_first, pair_first + edgelist_majors.size());
     auto num_uniques = static_cast<size_t>(cuda::std::distance(
       pair_first,
-      thrust::unique(
+      cugraph::unique(
         rmm::exec_policy(stream_view), pair_first, pair_first + edgelist_majors.size())));
     edgelist_majors.resize(num_uniques, stream_view);
     edgelist_majors.shrink_to_fit(stream_view);
@@ -507,21 +506,21 @@ coarsen_graph(raft::handle_t const& handle,
                                               handle.get_stream());
   thrust::copy(
     handle.get_thrust_policy(), labels, labels + unique_labels.size(), unique_labels.begin());
-  cugraph::sort_wrapper(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
+  cugraph::sort(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
   unique_labels.resize(
     cuda::std::distance(
       unique_labels.begin(),
-      thrust::unique(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end())),
+      cugraph::unique(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end())),
     handle.get_stream());
 
   std::tie(unique_labels, std::ignore) = cugraph::shuffle_ext_vertices(
     handle, std::move(unique_labels), std::vector<cugraph::arithmetic_device_uvector_t>{});
 
-  cugraph::sort_wrapper(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
+  cugraph::sort(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end());
   unique_labels.resize(
     cuda::std::distance(
       unique_labels.begin(),
-      thrust::unique(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end())),
+      cugraph::unique(handle.get_thrust_policy(), unique_labels.begin(), unique_labels.end())),
     handle.get_stream());
 
   // 4. create a graph
@@ -668,11 +667,12 @@ coarsen_graph(raft::handle_t const& handle,
   rmm::device_uvector<vertex_t> vertices(graph_view.number_of_vertices(), handle.get_stream());
   if (renumber) {
     thrust::copy(handle.get_thrust_policy(), labels, labels + vertices.size(), vertices.begin());
-    cugraph::sort_wrapper(handle.get_thrust_policy(), vertices.begin(), vertices.end());
-    vertices.resize(cuda::std::distance(
-                      vertices.begin(),
-                      thrust::unique(handle.get_thrust_policy(), vertices.begin(), vertices.end())),
-                    handle.get_stream());
+    cugraph::sort(handle.get_thrust_policy(), vertices.begin(), vertices.end());
+    vertices.resize(
+      cuda::std::distance(
+        vertices.begin(),
+        cugraph::unique(handle.get_thrust_policy(), vertices.begin(), vertices.end())),
+      handle.get_stream());
   } else {
     vertex_t number_of_vertices = thrust::reduce(handle.get_thrust_policy(),
                                                  labels,
@@ -681,7 +681,7 @@ coarsen_graph(raft::handle_t const& handle,
                                                  cuda::maximum<vertex_t>{}) +
                                   1;
     vertices = rmm::device_uvector<vertex_t>(number_of_vertices, handle.get_stream());
-    thrust::sequence(handle.get_thrust_policy(), vertices.begin(), vertices.end(), vertex_t{0});
+    cugraph::sequence(handle.get_thrust_policy(), vertices.begin(), vertices.end(), vertex_t{0});
   }
 
   graph_t<vertex_t, edge_t, store_transposed, multi_gpu> coarsened_graph(handle);

--- a/cpp/src/structure/create_graph_from_edgelist_impl.cuh
+++ b/cpp/src/structure/create_graph_from_edgelist_impl.cuh
@@ -23,6 +23,8 @@
 
 #include <raft/core/handle.hpp>
 
+#include <rmm/exec_policy.hpp>
+
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/tuple>
@@ -74,13 +76,12 @@ void expensive_check_edgelist(raft::handle_t const& handle,
     rmm::device_uvector<vertex_t> sorted_vertices((*vertices).size(), handle.get_stream());
     thrust::copy(
       handle.get_thrust_policy(), (*vertices).begin(), (*vertices).end(), sorted_vertices.begin());
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(), sorted_vertices.begin(), sorted_vertices.end());
+    cugraph::sort(handle.get_thrust_policy(), sorted_vertices.begin(), sorted_vertices.end());
     CUGRAPH_EXPECTS(static_cast<size_t>(cuda::std::distance(
                       sorted_vertices.begin(),
-                      thrust::unique(handle.get_thrust_policy(),
-                                     sorted_vertices.begin(),
-                                     sorted_vertices.end()))) == sorted_vertices.size(),
+                      cugraph::unique(handle.get_thrust_policy(),
+                                      sorted_vertices.begin(),
+                                      sorted_vertices.end()))) == sorted_vertices.size(),
                     "Invalid input argument: vertices should not have duplicates.");
     if (!renumber) {
       CUGRAPH_EXPECTS(static_cast<size_t>(thrust::count_if(
@@ -93,7 +94,8 @@ void expensive_check_edgelist(raft::handle_t const& handle,
                       "std::numeric_limits<vertex_t>::max()) if renumber is false.");
       assert(!multi_gpu);  // renumbering is required in multi-GPU
       rmm::device_uvector<vertex_t> sequences(sorted_vertices.size(), handle.get_stream());
-      thrust::sequence(handle.get_thrust_policy(), sequences.begin(), sequences.end(), vertex_t{0});
+      cugraph::sequence(
+        handle.get_thrust_policy(), sequences.begin(), sequences.end(), vertex_t{0});
       CUGRAPH_EXPECTS(thrust::equal(handle.get_thrust_policy(),
                                     sorted_vertices.begin(),
                                     sorted_vertices.end(),
@@ -192,8 +194,7 @@ void expensive_check_edgelist(raft::handle_t const& handle,
                           raft::host_span<size_t const>(recvcounts.data(), recvcounts.size()),
                           raft::host_span<size_t const>(displacements.data(), displacements.size()),
                           handle.get_stream());
-        cugraph::sort_wrapper(
-          handle.get_thrust_policy(), sorted_majors.begin(), sorted_majors.end());
+        cugraph::sort(handle.get_thrust_policy(), sorted_majors.begin(), sorted_majors.end());
       }
 
       rmm::device_uvector<vertex_t> sorted_minors(0, handle.get_stream());
@@ -214,8 +215,7 @@ void expensive_check_edgelist(raft::handle_t const& handle,
                           raft::host_span<size_t const>(recvcounts.data(), recvcounts.size()),
                           raft::host_span<size_t const>(displacements.data(), displacements.size()),
                           handle.get_stream());
-        cugraph::sort_wrapper(
-          handle.get_thrust_policy(), sorted_minors.begin(), sorted_minors.end());
+        cugraph::sort(handle.get_thrust_policy(), sorted_minors.begin(), sorted_minors.end());
       }
 
       auto edge_first = thrust::make_zip_iterator(edgelist_majors.begin(), edgelist_minors.begin());
@@ -237,8 +237,7 @@ void expensive_check_edgelist(raft::handle_t const& handle,
                    (*vertices).begin(),
                    (*vertices).end(),
                    sorted_vertices.begin());
-      cugraph::sort_wrapper(
-        handle.get_thrust_policy(), sorted_vertices.begin(), sorted_vertices.end());
+      cugraph::sort(handle.get_thrust_policy(), sorted_vertices.begin(), sorted_vertices.end());
       auto edge_first = thrust::make_zip_iterator(edgelist_majors.begin(), edgelist_minors.begin());
       CUGRAPH_EXPECTS(
         thrust::count_if(handle.get_thrust_policy(),
@@ -298,13 +297,12 @@ bool check_symmetric(raft::handle_t const& handle,
   if (org_srcs.size() != symmetrized_srcs.size()) { return false; }
 
   auto org_edge_first = thrust::make_zip_iterator(org_srcs.begin(), org_dsts.begin());
-  cugraph::sort_wrapper(
-    handle.get_thrust_policy(), org_edge_first, org_edge_first + org_srcs.size());
+  cugraph::sort(handle.get_thrust_policy(), org_edge_first, org_edge_first + org_srcs.size());
   auto symmetrized_edge_first =
     thrust::make_zip_iterator(symmetrized_srcs.begin(), symmetrized_dsts.begin());
-  cugraph::sort_wrapper(handle.get_thrust_policy(),
-                        symmetrized_edge_first,
-                        symmetrized_edge_first + symmetrized_srcs.size());
+  cugraph::sort(handle.get_thrust_policy(),
+                symmetrized_edge_first,
+                symmetrized_edge_first + symmetrized_srcs.size());
 
   return thrust::equal(handle.get_thrust_policy(),
                        org_edge_first,
@@ -325,9 +323,8 @@ bool check_no_parallel_edge(raft::handle_t const& handle,
     handle.get_thrust_policy(), edgelist_dsts.begin(), edgelist_dsts.end(), org_dsts.begin());
 
   auto org_edge_first = thrust::make_zip_iterator(org_srcs.begin(), org_dsts.begin());
-  cugraph::sort_wrapper(
-    handle.get_thrust_policy(), org_edge_first, org_edge_first + org_srcs.size());
-  return thrust::unique(
+  cugraph::sort(handle.get_thrust_policy(), org_edge_first, org_edge_first + org_srcs.size());
+  return cugraph::unique(
            handle.get_thrust_policy(), org_edge_first, org_edge_first + edgelist_srcs.size()) ==
          (org_edge_first + edgelist_srcs.size());
 }
@@ -601,8 +598,10 @@ create_graph_from_partitioned_edgelist(
                                       edge_partition_edgelist_srcs[i].size(), handle.get_stream())
                                   : rmm::device_uvector<edge_t>(
                                       edge_partition_edgelist_srcs[i].size(), handle.get_stream());
-      detail::sequence_fill(
-        handle.get_stream(), property_positions.data(), property_positions.size(), edge_t{0});
+      cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                        property_positions.data(),
+                        property_positions.data() + property_positions.size(),
+                        edge_t{0});
 
       std::tie(offsets, indices, property_positions, dcs_nzd_vertices) =
         detail::sort_and_compress_edgelist<vertex_t, edge_t, edge_t, store_transposed>(
@@ -678,8 +677,10 @@ create_graph_from_partitioned_edgelist(
           ? large_buffer_manager::allocate_memory_buffer<edge_t>(edge_partition_indices[i].size(),
                                                                  handle.get_stream())
           : rmm::device_uvector<edge_t>(edge_partition_indices[i].size(), handle.get_stream());
-      detail::sequence_fill(
-        handle.get_stream(), property_positions.data(), property_positions.size(), edge_t{0});
+      cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                        property_positions.data(),
+                        property_positions.data() + property_positions.size(),
+                        edge_t{0});
 
       detail::sort_adjacency_list(handle,
                                   raft::device_span<edge_t const>(edge_partition_offsets[i].data(),
@@ -1598,8 +1599,10 @@ create_graph_from_edgelist_impl(raft::handle_t const& handle,
         ? large_buffer_manager::allocate_memory_buffer<edge_t>(edgelist_srcs.size(),
                                                                handle.get_stream())
         : rmm::device_uvector<edge_t>(edgelist_srcs.size(), handle.get_stream());
-    detail::sequence_fill(
-      handle.get_stream(), property_positions.data(), property_positions.size(), edge_t{0});
+    cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                      property_positions.data(),
+                      property_positions.data() + property_positions.size(),
+                      edge_t{0});
 
     std::tie(offsets, indices, property_positions, std::ignore) =
       detail::sort_and_compress_edgelist<vertex_t, edge_t, edge_t, store_transposed>(

--- a/cpp/src/structure/detail/structure_utils.cuh
+++ b/cpp/src/structure/detail/structure_utils.cuh
@@ -69,7 +69,7 @@ rmm::device_uvector<edge_t> compute_sparse_offsets(
                         thrust::make_counting_iterator(major_range_last),
                         offsets.begin() + 1);
   } else {
-    thrust::fill(handle.get_thrust_policy(), offsets.begin(), offsets.end(), edge_t{0});
+    cugraph::fill(handle.get_thrust_policy(), offsets.begin(), offsets.end(), edge_t{0});
 
     if (large_buffer_type) {
       auto num_edges =
@@ -96,7 +96,7 @@ rmm::device_uvector<edge_t> compute_sparse_offsets(
           indices.begin(),
           cuda::proclaim_return_type<vertex_t>(
             [major_range_first] __device__(auto major) { return major - major_range_first; }));
-        cugraph::sort_wrapper(
+        cugraph::sort(
           handle.get_thrust_policy(), indices.begin(), indices.begin() + num_edges_to_process);
         auto it          = thrust::reduce_by_key(handle.get_thrust_policy(),
                                         indices.begin(),
@@ -372,10 +372,10 @@ sort_and_compress_edgelist(
                                      pivots[2],
                                      handle.get_stream(),
                                      large_edge_buffer_type);
-      cugraph::sort_wrapper(handle.get_thrust_policy(), pair_first, second_quarter_first);
-      cugraph::sort_wrapper(handle.get_thrust_policy(), second_quarter_first, second_half_first);
-      cugraph::sort_wrapper(handle.get_thrust_policy(), second_half_first, last_quarter_first);
-      cugraph::sort_wrapper(
+      cugraph::sort(handle.get_thrust_policy(), pair_first, second_quarter_first);
+      cugraph::sort(handle.get_thrust_policy(), second_quarter_first, second_half_first);
+      cugraph::sort(handle.get_thrust_policy(), second_half_first, last_quarter_first);
+      cugraph::sort(
         handle.get_thrust_policy(), last_quarter_first, pair_first + edgelist_major_offsets.size());
     } else {
       offsets = compute_sparse_offsets<edge_t>(handle,
@@ -418,10 +418,10 @@ sort_and_compress_edgelist(
                                      pivots[2],
                                      handle.get_stream(),
                                      large_edge_buffer_type);
-      cugraph::sort_wrapper(handle.get_thrust_policy(), edge_first, second_quarter_first);
-      cugraph::sort_wrapper(handle.get_thrust_policy(), second_quarter_first, second_half_first);
-      cugraph::sort_wrapper(handle.get_thrust_policy(), second_half_first, last_quarter_first);
-      cugraph::sort_wrapper(
+      cugraph::sort(handle.get_thrust_policy(), edge_first, second_quarter_first);
+      cugraph::sort(handle.get_thrust_policy(), second_quarter_first, second_half_first);
+      cugraph::sort(handle.get_thrust_policy(), second_half_first, last_quarter_first);
+      cugraph::sort(
         handle.get_thrust_policy(), last_quarter_first, edge_first + edgelist_majors.size());
       edgelist_majors.resize(0, handle.get_stream());
       edgelist_majors.shrink_to_fit(handle.get_stream());
@@ -432,7 +432,7 @@ sort_and_compress_edgelist(
       large_edge_buffer_type
         ? rmm::exec_policy_nosync(handle.get_stream(), large_buffer_manager::memory_buffer_mr())
         : handle.get_thrust_policy();
-    cugraph::sort_wrapper(exec_policy, edge_first, edge_first + edgelist_minors.size());
+    cugraph::sort(exec_policy, edge_first, edge_first + edgelist_minors.size());
     offsets = compute_sparse_offsets<edge_t>(handle,
                                              edgelist_majors.begin(),
                                              edgelist_majors.end(),
@@ -539,10 +539,10 @@ void sort_adjacency_list(raft::handle_t const& handle,
     rmm::device_uvector<edge_t> input_edge_value_offsets(max_chunk_size, handle.get_stream());
     rmm::device_uvector<edge_t> segment_sorted_edge_value_offsets(max_chunk_size,
                                                                   handle.get_stream());
-    thrust::sequence(handle.get_thrust_policy(),
-                     input_edge_value_offsets.begin(),
-                     input_edge_value_offsets.end(),
-                     edge_t{0});
+    cugraph::sequence(handle.get_thrust_policy(),
+                      input_edge_value_offsets.begin(),
+                      input_edge_value_offsets.end(),
+                      edge_t{0});
     for (size_t i = 0; i < num_chunks; ++i) {
       size_t tmp_storage_bytes{0};
       auto offset_first = cuda::make_transform_iterator(offsets.data() + h_vertex_offsets[i],

--- a/cpp/src/structure/graph_impl.cuh
+++ b/cpp/src/structure/graph_impl.cuh
@@ -15,6 +15,7 @@
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/misc_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/util/device_atomics.cuh>
@@ -158,10 +159,10 @@ update_local_sorted_unique_edge_majors_minors(
     auto minor_range_size = meta.partition.local_edge_partition_minor_range_size();
     rmm::device_uvector<uint32_t> minor_bitmaps(packed_bool_size(minor_range_size),
                                                 handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(),
-                 minor_bitmaps.begin(),
-                 minor_bitmaps.end(),
-                 packed_bool_empty_mask());
+    cugraph::fill(handle.get_thrust_policy(),
+                  minor_bitmaps.begin(),
+                  minor_bitmaps.end(),
+                  packed_bool_empty_mask());
     for (size_t i = 0; i < edge_partition_indices.size(); ++i) {
       thrust::for_each(handle.get_thrust_policy(),
                        edge_partition_indices[i].begin(),
@@ -398,7 +399,7 @@ compute_edge_partition_dcs_nzd_range_bitmaps(
       packed_bool_size(segment_offsets[detail::num_sparse_segments_per_vertex_partition + 1] -
                        segment_offsets[detail::num_sparse_segments_per_vertex_partition]),
       handle.get_stream());
-    thrust::fill(
+    cugraph::fill(
       handle.get_thrust_policy(), bitmap.begin(), bitmap.end(), packed_bool_empty_mask());
     auto major_range_first = meta.partition.local_edge_partition_major_range_first(i);
     auto major_hypersparse_first =

--- a/cpp/src/structure/graph_view_impl.cuh
+++ b/cpp/src/structure/graph_view_impl.cuh
@@ -100,7 +100,7 @@ rmm::device_uvector<edge_t> compute_major_degrees(
     max_num_local_degrees = std::max(max_num_local_degrees, num_local_degrees);
     if (i == minor_comm_rank) {
       degrees.resize(major_range_vertex_partition_size, handle.get_stream());
-      thrust::fill(
+      cugraph::fill(
         handle.get_thrust_policy(), degrees.begin() + num_local_degrees, degrees.end(), edge_t{0});
     }
   }
@@ -140,10 +140,10 @@ rmm::device_uvector<edge_t> compute_major_degrees(
                       }));
     if (use_dcs) {
       auto dcs_nzd_vertices = (*edge_partition_dcs_nzd_vertices)[i];
-      thrust::fill(execution_policy,
-                   local_degrees.begin() + (major_hypersparse_first - major_range_first),
-                   local_degrees.begin() + num_local_degrees,
-                   edge_t{0});
+      cugraph::fill(execution_policy,
+                    local_degrees.begin() + (major_hypersparse_first - major_range_first),
+                    local_degrees.begin() + num_local_degrees,
+                    edge_t{0});
       thrust::for_each(
         execution_policy,
         thrust::make_counting_iterator(vertex_t{0}),
@@ -428,13 +428,14 @@ compute_edge_indices_and_edge_partition_offsets(
   auto edge_first = thrust::make_zip_iterator(edge_majors.begin(), edge_minors.begin());
 
   rmm::device_uvector<size_t> edge_indices(edge_majors.size(), handle.get_stream());
-  thrust::sequence(handle.get_thrust_policy(), edge_indices.begin(), edge_indices.end(), size_t{0});
-  cugraph::sort_wrapper(handle.get_thrust_policy(),
-                        edge_indices.begin(),
-                        edge_indices.end(),
-                        [edge_first] __device__(size_t lhs, size_t rhs) {
-                          return *(edge_first + lhs) < *(edge_first + rhs);
-                        });
+  cugraph::sequence(
+    handle.get_thrust_policy(), edge_indices.begin(), edge_indices.end(), size_t{0});
+  cugraph::sort(handle.get_thrust_policy(),
+                edge_indices.begin(),
+                edge_indices.end(),
+                [edge_first] __device__(size_t lhs, size_t rhs) {
+                  return *(edge_first + lhs) < *(edge_first + rhs);
+                });
 
   std::vector<size_t> h_major_range_lasts(graph_view.number_of_local_edge_partitions());
   for (size_t i = 0; i < h_major_range_lasts.size(); ++i) {

--- a/cpp/src/structure/induced_subgraph_impl.cuh
+++ b/cpp/src/structure/induced_subgraph_impl.cuh
@@ -182,10 +182,9 @@ extract_induced_subgraphs(
     graph_ids_v = cugraph::detail::device_allgatherv(
       handle, major_comm, raft::device_span<size_t const>(graph_ids_v.data(), graph_ids_v.size()));
 
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(),
-      thrust::make_zip_iterator(graph_ids_v.begin(), dst_subgraph_vertices_v.begin()),
-      thrust::make_zip_iterator(graph_ids_v.end(), dst_subgraph_vertices_v.end()));
+    cugraph::sort(handle.get_thrust_policy(),
+                  thrust::make_zip_iterator(graph_ids_v.begin(), dst_subgraph_vertices_v.begin()),
+                  thrust::make_zip_iterator(graph_ids_v.end(), dst_subgraph_vertices_v.end()));
 
     dst_subgraph_offsets_v =
       detail::compute_sparse_offsets<size_t>(handle,
@@ -203,10 +202,9 @@ extract_induced_subgraphs(
                subgraph_vertices.data(),
                subgraph_vertices.size(),
                handle.get_stream());
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(),
-      thrust::make_zip_iterator(graph_ids_v.begin(), dst_subgraph_vertices_v.begin()),
-      thrust::make_zip_iterator(graph_ids_v.end(), dst_subgraph_vertices_v.end()));
+    cugraph::sort(handle.get_thrust_policy(),
+                  thrust::make_zip_iterator(graph_ids_v.begin(), dst_subgraph_vertices_v.begin()),
+                  thrust::make_zip_iterator(graph_ids_v.end(), dst_subgraph_vertices_v.end()));
   }
 
   graph_ids_v.resize(0, handle.get_stream());
@@ -271,12 +269,11 @@ extract_induced_subgraphs(
           dst_subgraph_offsets, dst_subgraph_vertices},
         do_expensive_check);
 
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(),
-      thrust::make_zip_iterator(
-        subgraph_edge_graph_ids.begin(), edge_majors.begin(), edge_minors.begin()),
-      thrust::make_zip_iterator(
-        subgraph_edge_graph_ids.end(), edge_majors.end(), edge_minors.end()));
+    cugraph::sort(handle.get_thrust_policy(),
+                  thrust::make_zip_iterator(
+                    subgraph_edge_graph_ids.begin(), edge_majors.begin(), edge_minors.begin()),
+                  thrust::make_zip_iterator(
+                    subgraph_edge_graph_ids.end(), edge_majors.end(), edge_minors.end()));
   }
 
   auto subgraph_edge_offsets =

--- a/cpp/src/structure/legacy/graph.cu
+++ b/cpp/src/structure/legacy/graph.cu
@@ -61,10 +61,10 @@ namespace legacy {
 template <typename VT, typename ET, typename WT>
 void GraphViewBase<VT, ET, WT>::get_vertex_identifiers(VT* identifiers) const
 {
-  thrust::sequence(thrust::device,
-                   thrust::device_pointer_cast(identifiers),
-                   thrust::device_pointer_cast(identifiers + number_of_vertices),
-                   VT{0});
+  cugraph::sequence(thrust::device,
+                    thrust::device_pointer_cast(identifiers),
+                    thrust::device_pointer_cast(identifiers + number_of_vertices),
+                    VT{0});
   RAFT_CHECK_CUDA(nullptr);
 }
 

--- a/cpp/src/structure/legacy/graph.cu
+++ b/cpp/src/structure/legacy/graph.cu
@@ -78,7 +78,7 @@ void GraphCompressedSparseBaseView<VT, ET, WT>::get_source_indices(VT* src_indic
   raft::device_span<VT> indices_span(src_indices, GraphViewBase<VT, ET, WT>::number_of_edges);
 
   if (indices_span.size() > 0) {
-    thrust::fill(rmm::exec_policy(stream_view), indices_span.begin(), indices_span.end(), VT{0});
+    cugraph::fill(rmm::exec_policy(stream_view), indices_span.begin(), indices_span.end(), VT{0});
 
     thrust::for_each(rmm::exec_policy(stream_view),
                      offsets + 1,

--- a/cpp/src/structure/relabel_impl.cuh
+++ b/cpp/src/structure/relabel_impl.cuh
@@ -63,12 +63,11 @@ void relabel(raft::handle_t const& handle,
 
     rmm::device_uvector<vertex_t> unique_old_labels(num_labels, handle.get_stream());
     thrust::copy(handle.get_thrust_policy(), labels, labels + num_labels, unique_old_labels.data());
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(), unique_old_labels.begin(), unique_old_labels.end());
+    cugraph::sort(handle.get_thrust_policy(), unique_old_labels.begin(), unique_old_labels.end());
     unique_old_labels.resize(cuda::std::distance(unique_old_labels.begin(),
-                                                 thrust::unique(handle.get_thrust_policy(),
-                                                                unique_old_labels.begin(),
-                                                                unique_old_labels.end())),
+                                                 cugraph::unique(handle.get_thrust_policy(),
+                                                                 unique_old_labels.begin(),
+                                                                 unique_old_labels.end())),
                              handle.get_stream());
     unique_old_labels.shrink_to_fit(handle.get_stream());
 

--- a/cpp/src/structure/remove_multi_edges_impl.cuh
+++ b/cpp/src/structure/remove_multi_edges_impl.cuh
@@ -18,6 +18,7 @@
 #include <raft/core/handle.hpp>
 
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/std/cstddef>
@@ -190,7 +191,7 @@ std::vector<rmm::device_uvector<bool>> compute_multi_edge_flags(
   size_t num_possibly_multi_edges{0};
   {
     if (tot_edges < mem_frugal_threshold) {
-      cugraph::sort_wrapper(handle.get_thrust_policy(), hashes.begin(), hashes.end());
+      cugraph::sort(handle.get_thrust_policy(), hashes.begin(), hashes.end());
     } else {
       auto second_first =
         mem_frugal_partition(hashes.begin(),
@@ -199,8 +200,8 @@ std::vector<rmm::device_uvector<bool>> compute_multi_edge_flags(
                                [] __device__(auto hash) { return static_cast<int>(hash % 2); }),
                              int{1},
                              handle.get_stream());
-      cugraph::sort_wrapper(handle.get_thrust_policy(), hashes.begin(), second_first);
-      cugraph::sort_wrapper(handle.get_thrust_policy(), second_first, hashes.end());
+      cugraph::sort(handle.get_thrust_policy(), hashes.begin(), second_first);
+      cugraph::sort(handle.get_thrust_policy(), second_first, hashes.end());
     }
     auto is_definitely_not_multi_edge_hashes =
       large_buffer_type
@@ -238,14 +239,14 @@ std::vector<rmm::device_uvector<bool>> compute_multi_edge_flags(
     is_definitely_not_multi_edge_hashes.resize(0, handle.get_stream());
     is_definitely_not_multi_edge_hashes.shrink_to_fit(handle.get_stream());
 
-    cugraph::sort_wrapper(handle.get_thrust_policy(),
-                          unique_possibly_multi_edge_hashes.begin(),
-                          unique_possibly_multi_edge_hashes.end());
+    cugraph::sort(handle.get_thrust_policy(),
+                  unique_possibly_multi_edge_hashes.begin(),
+                  unique_possibly_multi_edge_hashes.end());
     unique_possibly_multi_edge_hashes.resize(
       cuda::std::distance(unique_possibly_multi_edge_hashes.begin(),
-                          thrust::unique(handle.get_thrust_policy(),
-                                         unique_possibly_multi_edge_hashes.begin(),
-                                         unique_possibly_multi_edge_hashes.end())),
+                          cugraph::unique(handle.get_thrust_policy(),
+                                          unique_possibly_multi_edge_hashes.begin(),
+                                          unique_possibly_multi_edge_hashes.end())),
       handle.get_stream());
   }
   hashes.resize(0, handle.get_stream());
@@ -280,14 +281,14 @@ std::vector<rmm::device_uvector<bool>> compute_multi_edge_flags(
       offset += cuda::std::distance(output_pair_first + offset, output_pair_last);
     }
 
-    cugraph::sort_wrapper(handle.get_thrust_policy(),
-                          output_pair_first,
-                          output_pair_first + unique_multi_edge_srcs.size());
+    cugraph::sort(handle.get_thrust_policy(),
+                  output_pair_first,
+                  output_pair_first + unique_multi_edge_srcs.size());
     unique_multi_edge_srcs.resize(
       cuda::std::distance(output_pair_first,
-                          thrust::unique(handle.get_thrust_policy(),
-                                         output_pair_first,
-                                         output_pair_first + unique_multi_edge_srcs.size())),
+                          cugraph::unique(handle.get_thrust_policy(),
+                                          output_pair_first,
+                                          output_pair_first + unique_multi_edge_srcs.size())),
       handle.get_stream());
     unique_multi_edge_dsts.resize(unique_multi_edge_srcs.size(), handle.get_stream());
   }
@@ -333,8 +334,7 @@ void sort_multi_edges(raft::handle_t const& handle,
     if (keep_min_value_edge) {
       auto edge_first = thrust::make_zip_iterator(
         edgelist_srcs.begin(), edgelist_dsts.begin(), edgelist_values->begin());
-      cugraph::sort_wrapper(
-        handle.get_thrust_policy(), edge_first, edge_first + edgelist_srcs.size());
+      cugraph::sort(handle.get_thrust_policy(), edge_first, edge_first + edgelist_srcs.size());
     } else {
       thrust::sort_by_key(handle.get_thrust_policy(),
                           pair_first,
@@ -342,8 +342,7 @@ void sort_multi_edges(raft::handle_t const& handle,
                           edgelist_values->begin());
     }
   } else {
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(), pair_first, pair_first + edgelist_srcs.size());
+    cugraph::sort(handle.get_thrust_policy(), pair_first, pair_first + edgelist_srcs.size());
   }
 
   return;
@@ -377,7 +376,7 @@ void sort_multi_edges(
     };
     auto edge_first = thrust::make_zip_iterator(
       edgelist_srcs.begin(), edgelist_dsts.begin(), edgelist_indices.begin());
-    cugraph::sort_wrapper(
+    cugraph::sort(
       handle.get_thrust_policy(), edge_first, edge_first + edgelist_srcs.size(), edge_compare);
   } else {
     thrust::sort_by_key(handle.get_thrust_policy(),
@@ -541,10 +540,10 @@ remove_multi_edges_impl(
         (*edgelist_edge_end_times)[i] = std::move(*tmp);
       }
     } else {
-      detail::sequence_fill(handle.get_stream(),
-                            (*edgelist_indices)[i].data(),
-                            (*edgelist_indices)[i].size(),
-                            size_t{0});
+      cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                        (*edgelist_indices)[i].data(),
+                        (*edgelist_indices)[i].data() + (*edgelist_indices)[i].size(),
+                        size_t{0});
       std::optional<rmm::device_uvector<size_t>> tmp{std::nullopt};
       std::tie(edgelist_srcs[i], edgelist_dsts[i], tmp, group_counts[i]) =
         detail::group_edges<vertex_t, size_t>(handle,
@@ -784,10 +783,10 @@ remove_multi_edges_impl(
       }
       auto multi_edge_indices =
         rmm::device_uvector<size_t>(tot_multi_edge_count, handle.get_stream());
-      thrust::sequence(handle.get_thrust_policy(),
-                       multi_edge_indices.begin(),
-                       multi_edge_indices.end(),
-                       size_t{0});
+      cugraph::sequence(handle.get_thrust_policy(),
+                        multi_edge_indices.begin(),
+                        multi_edge_indices.end(),
+                        size_t{0});
 
       // 4. for each group, sort the aggregate multi-edge list
 

--- a/cpp/src/structure/renumber_edgelist_impl.cuh
+++ b/cpp/src/structure/renumber_edgelist_impl.cuh
@@ -124,12 +124,11 @@ rmm::device_uvector<vertex_t> find_uniques(raft::handle_t const& handle,
                  vertices.begin(),
                  vertices.begin() + first_half_size,
                  first_half_uniques.begin());
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(), first_half_uniques.begin(), first_half_uniques.end());
+    cugraph::sort(handle.get_thrust_policy(), first_half_uniques.begin(), first_half_uniques.end());
     first_half_uniques.resize(cuda::std::distance(first_half_uniques.begin(),
-                                                  thrust::unique(handle.get_thrust_policy(),
-                                                                 first_half_uniques.begin(),
-                                                                 first_half_uniques.end())),
+                                                  cugraph::unique(handle.get_thrust_policy(),
+                                                                  first_half_uniques.begin(),
+                                                                  first_half_uniques.end())),
                               handle.get_stream());
     first_half_uniques.shrink_to_fit(handle.get_stream());
 
@@ -144,12 +143,12 @@ rmm::device_uvector<vertex_t> find_uniques(raft::handle_t const& handle,
                  vertices.begin() + first_half_size,
                  vertices.end(),
                  second_half_uniques.begin());
-    cugraph::sort_wrapper(
+    cugraph::sort(
       handle.get_thrust_policy(), second_half_uniques.begin(), second_half_uniques.end());
     second_half_uniques.resize(cuda::std::distance(second_half_uniques.begin(),
-                                                   thrust::unique(handle.get_thrust_policy(),
-                                                                  second_half_uniques.begin(),
-                                                                  second_half_uniques.end())),
+                                                   cugraph::unique(handle.get_thrust_policy(),
+                                                                   second_half_uniques.begin(),
+                                                                   second_half_uniques.end())),
                                handle.get_stream());
     second_half_uniques.shrink_to_fit(handle.get_stream());
 
@@ -169,7 +168,7 @@ rmm::device_uvector<vertex_t> find_uniques(raft::handle_t const& handle,
                   uniques.begin());
     uniques.resize(cuda::std::distance(
                      uniques.begin(),
-                     thrust::unique(handle.get_thrust_policy(), uniques.begin(), uniques.end())),
+                     cugraph::unique(handle.get_thrust_policy(), uniques.begin(), uniques.end())),
                    handle.get_stream());
     uniques.shrink_to_fit(handle.get_stream());
 
@@ -180,10 +179,10 @@ rmm::device_uvector<vertex_t> find_uniques(raft::handle_t const& handle,
                                                                               handle.get_stream())
                      : rmm::device_uvector<vertex_t>(vertices.size(), handle.get_stream());
     thrust::copy(handle.get_thrust_policy(), vertices.begin(), vertices.end(), uniques.begin());
-    cugraph::sort_wrapper(handle.get_thrust_policy(), uniques.begin(), uniques.end());
+    cugraph::sort(handle.get_thrust_policy(), uniques.begin(), uniques.end());
     uniques.resize(cuda::std::distance(
                      uniques.begin(),
-                     thrust::unique(handle.get_thrust_policy(), uniques.begin(), uniques.end())),
+                     cugraph::unique(handle.get_thrust_policy(), uniques.begin(), uniques.end())),
                    handle.get_stream());
     uniques.shrink_to_fit(handle.get_stream());
 
@@ -336,10 +335,10 @@ void compute_sorted_local_major_degrees_without_atomics(
   raft::device_span<vertex_t const> edgelist_majors,
   raft::device_span<edge_t> sorted_local_major_degrees)
 {
-  thrust::fill(handle.get_thrust_policy(),
-               sorted_local_major_degrees.begin(),
-               sorted_local_major_degrees.end(),
-               edge_t{0});
+  cugraph::fill(handle.get_thrust_policy(),
+                sorted_local_major_degrees.begin(),
+                sorted_local_major_degrees.end(),
+                edge_t{0});
 
   auto max_edges_to_process_per_iteration =
     std::min(static_cast<size_t>(handle.get_device_properties().multiProcessorCount) * 4096,
@@ -392,7 +391,7 @@ void compute_sorted_local_major_degrees_without_atomics(
           return static_cast<vertex_t>(cuda::std::distance(
             sorted_local_majors.begin(), thrust::lower_bound(thrust::seq, first, last, major)));
         }));
-    cugraph::sort_wrapper(
+    cugraph::sort(
       handle.get_thrust_policy(), indices.begin(), indices.begin() + num_edges_to_process);
     auto it          = thrust::reduce_by_key(handle.get_thrust_policy(),
                                     indices.begin(),
@@ -577,9 +576,9 @@ compute_renumber_map(raft::handle_t const& handle,
           tmp_minors.resize(0, handle.get_stream());
           tmp_minors.shrink_to_fit(handle.get_stream());
           merged_minors.resize(cuda::std::distance(merged_minors.begin(),
-                                                   thrust::unique(handle.get_thrust_policy(),
-                                                                  merged_minors.begin(),
-                                                                  merged_minors.end())),
+                                                   cugraph::unique(handle.get_thrust_policy(),
+                                                                   merged_minors.begin(),
+                                                                   merged_minors.end())),
                                handle.get_stream());
           merged_minors.shrink_to_fit(handle.get_stream());
           sorted_unique_minors = std::move(merged_minors);
@@ -600,14 +599,14 @@ compute_renumber_map(raft::handle_t const& handle,
     sorted_unique_minors.resize(0, handle.get_stream());
     sorted_unique_minors.shrink_to_fit(handle.get_stream());
     sorted_local_vertices.resize(cuda::std::distance(sorted_local_vertices.begin(),
-                                                     thrust::unique(handle.get_thrust_policy(),
-                                                                    sorted_local_vertices.begin(),
-                                                                    sorted_local_vertices.end())),
+                                                     cugraph::unique(handle.get_thrust_policy(),
+                                                                     sorted_local_vertices.begin(),
+                                                                     sorted_local_vertices.end())),
                                  handle.get_stream());
     sorted_local_vertices.shrink_to_fit(handle.get_stream());
   } else {
     sorted_local_vertices = std::move(*local_vertices);
-    cugraph::sort_wrapper(
+    cugraph::sort(
       handle.get_thrust_policy(), sorted_local_vertices.begin(), sorted_local_vertices.end());
   }
 
@@ -662,10 +661,10 @@ compute_renumber_map(raft::handle_t const& handle,
           raft::device_span<vertex_t const>(edgelist_majors[i].data(), edgelist_majors[i].size()),
           raft::device_span<edge_t>(sorted_major_degrees.data(), sorted_major_degrees.size()));
       } else {
-        thrust::fill(handle.get_thrust_policy(),
-                     sorted_major_degrees.begin(),
-                     sorted_major_degrees.end(),
-                     edge_t{0});
+        cugraph::fill(handle.get_thrust_policy(),
+                      sorted_major_degrees.begin(),
+                      sorted_major_degrees.end(),
+                      edge_t{0});
         thrust::for_each(
           handle.get_thrust_policy(),
           edgelist_majors[i].begin(),
@@ -705,10 +704,10 @@ compute_renumber_map(raft::handle_t const& handle,
         raft::device_span<edge_t>(sorted_local_vertex_degrees.data(),
                                   sorted_local_vertex_degrees.size()));
     } else {
-      thrust::fill(handle.get_thrust_policy(),
-                   sorted_local_vertex_degrees.begin(),
-                   sorted_local_vertex_degrees.end(),
-                   edge_t{0});
+      cugraph::fill(handle.get_thrust_policy(),
+                    sorted_local_vertex_degrees.begin(),
+                    sorted_local_vertex_degrees.end(),
+                    edge_t{0});
       thrust::for_each(handle.get_thrust_policy(),
                        edgelist_majors[0].begin(),
                        edgelist_majors[0].end(),
@@ -842,13 +841,13 @@ void expensive_check_edgelist(
                  (*local_vertices).begin(),
                  (*local_vertices).end(),
                  (*sorted_local_vertices).begin());
-    cugraph::sort_wrapper(
+    cugraph::sort(
       handle.get_thrust_policy(), (*sorted_local_vertices).begin(), (*sorted_local_vertices).end());
     CUGRAPH_EXPECTS(
       static_cast<size_t>(cuda::std::distance((*sorted_local_vertices).begin(),
-                                              thrust::unique(handle.get_thrust_policy(),
-                                                             (*sorted_local_vertices).begin(),
-                                                             (*sorted_local_vertices).end()))) ==
+                                              cugraph::unique(handle.get_thrust_policy(),
+                                                              (*sorted_local_vertices).begin(),
+                                                              (*sorted_local_vertices).end()))) ==
         (*sorted_local_vertices).size(),
       "Invalid input argument: (local_)vertices should not have duplicates.");
   }
@@ -950,7 +949,7 @@ void expensive_check_edgelist(
                         raft::host_span<size_t const>(recvcounts.data(), recvcounts.size()),
                         raft::host_span<size_t const>(displacements.data(), displacements.size()),
                         handle.get_stream());
-      cugraph::sort_wrapper(handle.get_thrust_policy(), sorted_minors.begin(), sorted_minors.end());
+      cugraph::sort(handle.get_thrust_policy(), sorted_minors.begin(), sorted_minors.end());
 
       auto major_range_sizes =
         host_scalar_allgather(minor_comm, (*sorted_local_vertices).size(), handle.get_stream());

--- a/cpp/src/structure/renumber_utils_impl.cuh
+++ b/cpp/src/structure/renumber_utils_impl.cuh
@@ -344,9 +344,9 @@ void renumber_ext_vertices(raft::handle_t const& handle,
                  renumber_map_labels,
                  renumber_map_labels + labels.size(),
                  labels.begin());
-    cugraph::sort_wrapper(handle.get_thrust_policy(), labels.begin(), labels.end());
+    cugraph::sort(handle.get_thrust_policy(), labels.begin(), labels.end());
     CUGRAPH_EXPECTS(
-      thrust::unique(handle.get_thrust_policy(), labels.begin(), labels.end()) == labels.end(),
+      cugraph::unique(handle.get_thrust_policy(), labels.begin(), labels.end()) == labels.end(),
       "Invalid input arguments: renumber_map_labels have duplicate elements.");
   }
 
@@ -369,14 +369,14 @@ void renumber_ext_vertices(raft::handle_t const& handle,
                         sorted_unique_ext_vertices.begin(),
                         [] __device__(auto v) { return v != invalid_vertex_id<vertex_t>::value; })),
       handle.get_stream());
-    cugraph::sort_wrapper(handle.get_thrust_policy(),
-                          sorted_unique_ext_vertices.begin(),
-                          sorted_unique_ext_vertices.end());
+    cugraph::sort(handle.get_thrust_policy(),
+                  sorted_unique_ext_vertices.begin(),
+                  sorted_unique_ext_vertices.end());
     sorted_unique_ext_vertices.resize(
       cuda::std::distance(sorted_unique_ext_vertices.begin(),
-                          thrust::unique(handle.get_thrust_policy(),
-                                         sorted_unique_ext_vertices.begin(),
-                                         sorted_unique_ext_vertices.end())),
+                          cugraph::unique(handle.get_thrust_policy(),
+                                          sorted_unique_ext_vertices.begin(),
+                                          sorted_unique_ext_vertices.end())),
       handle.get_stream());
 
     kv_store_t<vertex_t, vertex_t, false> local_renumber_map(
@@ -452,9 +452,9 @@ void renumber_local_ext_vertices(raft::handle_t const& handle,
                  renumber_map_labels,
                  renumber_map_labels + labels.size(),
                  labels.begin());
-    cugraph::sort_wrapper(handle.get_thrust_policy(), labels.begin(), labels.end());
+    cugraph::sort(handle.get_thrust_policy(), labels.begin(), labels.end());
     CUGRAPH_EXPECTS(
-      thrust::unique(handle.get_thrust_policy(), labels.begin(), labels.end()) == labels.end(),
+      cugraph::unique(handle.get_thrust_policy(), labels.begin(), labels.end()) == labels.end(),
       "Invalid input arguments: renumber_map_labels have duplicate elements.");
   }
 
@@ -572,14 +572,14 @@ void unrenumber_int_vertices(raft::handle_t const& handle,
                         sorted_unique_int_vertices.begin(),
                         [] __device__(auto v) { return v != invalid_vertex_id<vertex_t>::value; })),
       handle.get_stream());
-    cugraph::sort_wrapper(handle.get_thrust_policy(),
-                          sorted_unique_int_vertices.begin(),
-                          sorted_unique_int_vertices.end());
+    cugraph::sort(handle.get_thrust_policy(),
+                  sorted_unique_int_vertices.begin(),
+                  sorted_unique_int_vertices.end());
     sorted_unique_int_vertices.resize(
       cuda::std::distance(sorted_unique_int_vertices.begin(),
-                          thrust::unique(handle.get_thrust_policy(),
-                                         sorted_unique_int_vertices.begin(),
-                                         sorted_unique_int_vertices.end())),
+                          cugraph::unique(handle.get_thrust_policy(),
+                                          sorted_unique_int_vertices.begin(),
+                                          sorted_unique_int_vertices.end())),
       handle.get_stream());
 
     auto ext_vertices_for_sorted_unique_int_vertices =

--- a/cpp/src/structure/select_random_vertices_impl.hpp
+++ b/cpp/src/structure/select_random_vertices_impl.hpp
@@ -138,10 +138,10 @@ rmm::device_uvector<vertex_t> select_random_vertices(
   } else {
     mg_sample_buffer = rmm::device_uvector<vertex_t>(local_int_vertex_last - local_int_vertex_first,
                                                      handle.get_stream());
-    thrust::sequence(handle.get_thrust_policy(),
-                     mg_sample_buffer.begin(),
-                     mg_sample_buffer.end(),
-                     local_int_vertex_first);
+    cugraph::sequence(handle.get_thrust_policy(),
+                      mg_sample_buffer.begin(),
+                      mg_sample_buffer.end(),
+                      local_int_vertex_first);
 
     {  // random shuffle (use this instead of thrust::shuffle to use raft::random::RngState)
       rmm::device_uvector<float> random_numbers(mg_sample_buffer.size(), handle.get_stream());
@@ -248,8 +248,7 @@ rmm::device_uvector<vertex_t> select_random_vertices(
   }
 
   if (sort_vertices) {
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(), mg_sample_buffer.begin(), mg_sample_buffer.end());
+    cugraph::sort(handle.get_thrust_policy(), mg_sample_buffer.begin(), mg_sample_buffer.end());
   }
 
   return mg_sample_buffer;

--- a/cpp/src/structure/symmetrize_edgelist_impl.cuh
+++ b/cpp/src/structure/symmetrize_edgelist_impl.cuh
@@ -12,6 +12,7 @@
 #include <raft/core/handle.hpp>
 
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/tuple>
@@ -208,19 +209,18 @@ merge_lower_triangular(raft::handle_t const& handle,
   auto lower_triangular_edge_first = thrust::make_zip_iterator(lower_triangular_majors.begin(),
                                                                lower_triangular_minors.begin(),
                                                                lower_triangular_properties.begin());
-  cugraph::sort_wrapper(handle.get_thrust_policy(),
-                        lower_triangular_edge_first,
-                        lower_triangular_edge_first + lower_triangular_majors.size());
+  cugraph::sort(handle.get_thrust_policy(),
+                lower_triangular_edge_first,
+                lower_triangular_edge_first + lower_triangular_majors.size());
   auto upper_triangular_edge_first = thrust::make_zip_iterator(
     upper_triangular_majors.begin(),
     upper_triangular_minors.begin(),
     upper_triangular_properties
       .begin());  // do not flip here to use "lower_triangular = major > minor"
-  cugraph::sort_wrapper(
-    handle.get_thrust_policy(),
-    upper_triangular_edge_first,
-    upper_triangular_edge_first + upper_triangular_majors.size(),
-    compare_upper_triangular_edges_as_lower_triangular_t<vertex_t, property_t>{});
+  cugraph::sort(handle.get_thrust_policy(),
+                upper_triangular_edge_first,
+                upper_triangular_edge_first + upper_triangular_majors.size(),
+                compare_upper_triangular_edges_as_lower_triangular_t<vertex_t, property_t>{});
 
   merged_majors.resize(lower_triangular_majors.size() + upper_triangular_majors.size(),
                        handle.get_stream());
@@ -300,14 +300,14 @@ std::tuple<rmm::device_uvector<vertex_t>, rmm::device_uvector<vertex_t>> merge_l
 
   auto lower_triangular_edge_first =
     thrust::make_zip_iterator(lower_triangular_majors.begin(), lower_triangular_minors.begin());
-  cugraph::sort_wrapper(handle.get_thrust_policy(),
-                        lower_triangular_edge_first,
-                        lower_triangular_edge_first + lower_triangular_majors.size());
+  cugraph::sort(handle.get_thrust_policy(),
+                lower_triangular_edge_first,
+                lower_triangular_edge_first + lower_triangular_majors.size());
   auto upper_triangular_edge_first = thrust::make_zip_iterator(
     upper_triangular_minors.begin(), upper_triangular_majors.begin());  // flip
-  cugraph::sort_wrapper(handle.get_thrust_policy(),
-                        upper_triangular_edge_first,
-                        upper_triangular_edge_first + upper_triangular_majors.size());
+  cugraph::sort(handle.get_thrust_policy(),
+                upper_triangular_edge_first,
+                upper_triangular_edge_first + upper_triangular_majors.size());
 
   merged_majors.resize(reciprocal
                          ? std::min(num_lower_triangular_edges, upper_triangular_majors.size())
@@ -496,8 +496,10 @@ symmetrize_edgelist(raft::handle_t const& handle,
     }
   } else {
     rmm::device_uvector<edge_t> property_position(edgelist_majors.size(), handle.get_stream());
-    detail::sequence_fill(
-      handle.get_stream(), property_position.data(), property_position.size(), edge_t{0});
+    cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                      property_position.data(),
+                      property_position.data() + property_position.size(),
+                      edge_t{0});
 
     auto edge_first = thrust::make_zip_iterator(
       edgelist_majors.begin(), edgelist_minors.begin(), property_position.begin());
@@ -841,8 +843,10 @@ symmetrize_edgelist(raft::handle_t const& handle,
   } else {
     rmm::device_uvector<edge_t> property_position(
       lower_triangular_majors.size() + upper_triangular_majors.size(), handle.get_stream());
-    detail::sequence_fill(
-      handle.get_stream(), property_position.data(), property_position.size(), edge_t{0});
+    cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                      property_position.data(),
+                      property_position.data() + property_position.size(),
+                      edge_t{0});
 
     std::tie(merged_lower_triangular_majors, merged_lower_triangular_minors, property_position) =
       merge_lower_triangular(handle,

--- a/cpp/src/structure/symmetrize_graph_impl.cuh
+++ b/cpp/src/structure/symmetrize_graph_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,6 +8,7 @@
 #include <cugraph/graph.hpp>
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -192,7 +193,7 @@ symmetrize_graph_impl(raft::handle_t const& handle,
                            : std::make_optional<rmm::device_uvector<vertex_t>>(number_of_vertices,
                                                                                handle.get_stream());
   if (!renumber) {
-    thrust::sequence(
+    cugraph::sequence(
       handle.get_thrust_policy(), (*vertices).begin(), (*vertices).end(), vertex_t{0});
   }
 

--- a/cpp/src/structure/transpose_graph_impl.cuh
+++ b/cpp/src/structure/transpose_graph_impl.cuh
@@ -9,6 +9,7 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -162,7 +163,7 @@ transpose_graph_impl(raft::handle_t const& handle,
                            : std::make_optional<rmm::device_uvector<vertex_t>>(number_of_vertices,
                                                                                handle.get_stream());
   if (!renumber) {
-    thrust::sequence(
+    cugraph::sequence(
       handle.get_thrust_policy(), (*vertices).begin(), (*vertices).end(), vertex_t{0});
   }
 

--- a/cpp/src/structure/transpose_graph_storage_impl.cuh
+++ b/cpp/src/structure/transpose_graph_storage_impl.cuh
@@ -9,6 +9,7 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -162,7 +163,7 @@ transpose_graph_storage_impl(raft::handle_t const& handle,
                            : std::make_optional<rmm::device_uvector<vertex_t>>(number_of_vertices,
                                                                                handle.get_stream());
   if (!renumber) {
-    thrust::sequence(
+    cugraph::sequence(
       handle.get_thrust_policy(), (*vertices).begin(), (*vertices).end(), vertex_t{0});
   }
 

--- a/cpp/src/traversal/bfs_impl.cuh
+++ b/cpp/src/traversal/bfs_impl.cuh
@@ -15,6 +15,7 @@
 #include <cugraph/prims/transform_reduce_if_v_frontier_outgoing_e_by_dst.cuh>
 #include <cugraph/prims/vertex_frontier.cuh>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <raft/core/handle.hpp>
@@ -268,19 +269,19 @@ void bfs(raft::handle_t const& handle,
   auto constexpr invalid_distance = std::numeric_limits<vertex_t>::max();
   auto constexpr invalid_vertex   = invalid_vertex_id<vertex_t>::value;
 
-  thrust::fill(handle.get_thrust_policy(),
-               distances,
-               distances + graph_view.local_vertex_partition_range_size(),
-               invalid_distance);
-  thrust::fill(handle.get_thrust_policy(),
-               predecessor_first,
-               predecessor_first + graph_view.local_vertex_partition_range_size(),
-               invalid_vertex);
+  cugraph::fill(handle.get_thrust_policy(),
+                distances,
+                distances + graph_view.local_vertex_partition_range_size(),
+                invalid_distance);
+  cugraph::fill(handle.get_thrust_policy(),
+                predecessor_first,
+                predecessor_first + graph_view.local_vertex_partition_range_size(),
+                invalid_vertex);
   auto output_first = thrust::make_permutation_iterator(
     distances,
     cuda::make_transform_iterator(
       sources, detail::shift_left_t<vertex_t>{graph_view.local_vertex_partition_range_first()}));
-  thrust::fill(handle.get_thrust_policy(), output_first, output_first + n_sources, vertex_t{0});
+  cugraph::fill(handle.get_thrust_policy(), output_first, output_first + n_sources, vertex_t{0});
 
   // 3. update meta data for direction optimizing BFS
 
@@ -354,10 +355,10 @@ void bfs(raft::handle_t const& handle,
 
     rmm::device_uvector<uint32_t> visited_bitmap(
       packed_bool_size(graph_view.local_vertex_partition_range_size()), handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(),
-                 visited_bitmap.begin(),
-                 visited_bitmap.end(),
-                 packed_bool_empty_mask());
+    cugraph::fill(handle.get_thrust_policy(),
+                  visited_bitmap.begin(),
+                  visited_bitmap.end(),
+                  packed_bool_empty_mask());
     thrust::for_each(
       handle.get_thrust_policy(),
       sources,

--- a/cpp/src/traversal/extract_bfs_paths_impl.cuh
+++ b/cpp/src/traversal/extract_bfs_paths_impl.cuh
@@ -12,6 +12,7 @@
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <raft/core/handle.hpp>
@@ -180,7 +181,7 @@ std::tuple<rmm::device_uvector<vertex_t>, vertex_t> extract_bfs_paths(
   rmm::device_uvector<vertex_t> current_frontier(n_destinations, handle.get_stream());
   rmm::device_uvector<size_t> current_position(n_destinations, handle.get_stream());
 
-  thrust::fill(handle.get_thrust_policy(), paths.begin(), paths.end(), invalid_vertex);
+  cugraph::fill(handle.get_thrust_policy(), paths.begin(), paths.end(), invalid_vertex);
   raft::copy(current_frontier.data(), destinations, n_destinations, handle.get_stream());
 
   auto h_vertex_partition_range_lasts = graph_view.vertex_partition_range_lasts();

--- a/cpp/src/traversal/k_hop_nbrs_impl.cuh
+++ b/cpp/src/traversal/k_hop_nbrs_impl.cuh
@@ -13,6 +13,7 @@
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <raft/core/handle.hpp>
@@ -194,7 +195,7 @@ k_hop_nbrs(raft::handle_t const& handle,
                         tmp_counts.begin());
 
   rmm::device_uvector<size_t> offsets(start_vertices.size() + size_t{1}, handle.get_stream());
-  thrust::fill(handle.get_thrust_policy(), offsets.begin(), offsets.end(), size_t{0});
+  cugraph::fill(handle.get_thrust_policy(), offsets.begin(), offsets.end(), size_t{0});
   thrust::scatter(
     handle.get_thrust_policy(),
     tmp_counts.begin(),

--- a/cpp/src/traversal/od_shortest_distances_impl.cuh
+++ b/cpp/src/traversal/od_shortest_distances_impl.cuh
@@ -495,9 +495,9 @@ rmm::device_uvector<weight_t> od_shortest_distances(
 
     rmm::device_uvector<vertex_t> tmp_origins(origins.size(), handle.get_stream());
     thrust::copy(handle.get_thrust_policy(), origins.begin(), origins.end(), tmp_origins.begin());
-    cugraph::sort_wrapper(handle.get_thrust_policy(), tmp_origins.begin(), tmp_origins.end());
+    cugraph::sort(handle.get_thrust_policy(), tmp_origins.begin(), tmp_origins.end());
     CUGRAPH_EXPECTS(
-      thrust::unique(handle.get_thrust_policy(), tmp_origins.begin(), tmp_origins.end()) ==
+      cugraph::unique(handle.get_thrust_policy(), tmp_origins.begin(), tmp_origins.end()) ==
         tmp_origins.end(),
       "Invalid input arguments: origins should not have duplicates.");
 
@@ -506,11 +506,10 @@ rmm::device_uvector<weight_t> od_shortest_distances(
                  destinations.begin(),
                  destinations.end(),
                  tmp_destinations.begin());
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(), tmp_destinations.begin(), tmp_destinations.end());
-    CUGRAPH_EXPECTS(thrust::unique(handle.get_thrust_policy(),
-                                   tmp_destinations.begin(),
-                                   tmp_destinations.end()) == tmp_destinations.end(),
+    cugraph::sort(handle.get_thrust_policy(), tmp_destinations.begin(), tmp_destinations.end());
+    CUGRAPH_EXPECTS(cugraph::unique(handle.get_thrust_policy(),
+                                    tmp_destinations.begin(),
+                                    tmp_destinations.end()) == tmp_destinations.end(),
                     "Invalid input arguments: destinations should not have duplicates.");
   }
 
@@ -549,18 +548,18 @@ rmm::device_uvector<weight_t> od_shortest_distances(
 
   auto od_matrix_size = origins.size() * destinations.size();
   rmm::device_uvector<weight_t> od_matrix(od_matrix_size, handle.get_stream());
-  thrust::fill(handle.get_thrust_policy(),
-               od_matrix.begin(),
-               od_matrix.end(),
-               std::numeric_limits<weight_t>::max());
+  cugraph::fill(handle.get_thrust_policy(),
+                od_matrix.begin(),
+                od_matrix.end(),
+                std::numeric_limits<weight_t>::max());
 
   if (num_vertices == 0 || num_edges == 0 || od_matrix.size() == 0) { return od_matrix; }
 
   rmm::device_uvector<od_idx_t> v_to_destination_indices(num_vertices, handle.get_stream());
-  thrust::fill(handle.get_thrust_policy(),
-               v_to_destination_indices.begin(),
-               v_to_destination_indices.end(),
-               invalid_od_idx);
+  cugraph::fill(handle.get_thrust_policy(),
+                v_to_destination_indices.begin(),
+                v_to_destination_indices.end(),
+                invalid_od_idx);
   thrust::for_each(handle.get_thrust_policy(),
                    thrust::make_counting_iterator(od_idx_t{0}),
                    thrust::make_counting_iterator(static_cast<od_idx_t>(destinations.size())),
@@ -772,7 +771,7 @@ rmm::device_uvector<weight_t> od_shortest_distances(
                           handle.get_stream());
 
       rmm::device_uvector<size_t> d_counters(d_split_thresholds.size() + 1, handle.get_stream());
-      thrust::fill(handle.get_thrust_policy(), d_counters.begin(), d_counters.end(), size_t{0});
+      cugraph::fill(handle.get_thrust_policy(), d_counters.begin(), d_counters.end(), size_t{0});
 
       auto num_tagged_vertices = new_frontier_keys.size();
       rmm::device_uvector<key_t> tmp_near_q_keys(0, handle.get_stream());
@@ -841,12 +840,11 @@ rmm::device_uvector<weight_t> od_shortest_distances(
         num_copied += this_loop_size;
       }
 
-      cugraph::sort_wrapper(
-        handle.get_thrust_policy(), tmp_near_q_keys.begin(), tmp_near_q_keys.end());
+      cugraph::sort(handle.get_thrust_policy(), tmp_near_q_keys.begin(), tmp_near_q_keys.end());
       tmp_near_q_keys.resize(cuda::std::distance(tmp_near_q_keys.begin(),
-                                                 thrust::unique(handle.get_thrust_policy(),
-                                                                tmp_near_q_keys.begin(),
-                                                                tmp_near_q_keys.end())),
+                                                 cugraph::unique(handle.get_thrust_policy(),
+                                                                 tmp_near_q_keys.begin(),
+                                                                 tmp_near_q_keys.end())),
                              handle.get_stream());
       auto near_vi_first = cuda::make_transform_iterator(
         tmp_near_q_keys.begin(),
@@ -943,7 +941,7 @@ rmm::device_uvector<weight_t> od_shortest_distances(
                                   handle.get_stream());
               rmm::device_uvector<size_t> d_counters(num_near_q_insert_buffers + 1,
                                                      handle.get_stream());
-              thrust::fill(
+              cugraph::fill(
                 handle.get_thrust_policy(), d_counters.begin(), d_counters.end(), size_t{0});
               if (tmp_buffer.size() > 0) {
                 raft::grid_1d_thread_t update_grid(tmp_buffer.size(),
@@ -1005,12 +1003,11 @@ rmm::device_uvector<weight_t> od_shortest_distances(
             }
           }
 
-          cugraph::sort_wrapper(
-            handle.get_thrust_policy(), new_near_q_keys.begin(), new_near_q_keys.end());
+          cugraph::sort(handle.get_thrust_policy(), new_near_q_keys.begin(), new_near_q_keys.end());
           new_near_q_keys.resize(cuda::std::distance(new_near_q_keys.begin(),
-                                                     thrust::unique(handle.get_thrust_policy(),
-                                                                    new_near_q_keys.begin(),
-                                                                    new_near_q_keys.end())),
+                                                     cugraph::unique(handle.get_thrust_policy(),
+                                                                     new_near_q_keys.begin(),
+                                                                     new_near_q_keys.end())),
                                  handle.get_stream());
           auto near_vi_first = cuda::make_transform_iterator(
             new_near_q_keys.begin(),

--- a/cpp/src/traversal/sssp_impl.cuh
+++ b/cpp/src/traversal/sssp_impl.cuh
@@ -16,6 +16,7 @@
 #include <cugraph/prims/update_v_frontier.cuh>
 #include <cugraph/prims/vertex_frontier.cuh>
 #include <cugraph/utilities/error.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 #include <cugraph/vertex_partition_device_view.cuh>
 
 #include <raft/util/cudart_utils.hpp>
@@ -98,7 +99,7 @@ std::tuple<size_t, size_t> compute_new_near_near_partition_range(
 
   rmm::device_uvector<vertex_t> d_counts(last_subpartition_idx - first_subpartition_idx,
                                          handle.get_stream());
-  thrust::fill(handle.get_thrust_policy(), d_counts.begin(), d_counts.end(), vertex_t{0});
+  cugraph::fill(handle.get_thrust_policy(), d_counts.begin(), d_counts.end(), vertex_t{0});
   std::vector<weight_t> h_thresholds(d_counts.size() - 1);
   for (size_t i = 0; i < h_thresholds.size(); ++i) {
     h_thresholds[i] = compute_subpartition_start(

--- a/cpp/src/utilities/path_retrieval.cuh
+++ b/cpp/src/utilities/path_retrieval.cuh
@@ -1,10 +1,11 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/path_retrieval.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -66,7 +67,7 @@ void get_traversed_cost_impl(raft::handle_t const& handle,
   vertex_t* vtx_keys = vtx_keys_v.data();
   raft::copy(vtx_keys, vertices, num_vertices, stream);
 
-  thrust::sequence(handle.get_thrust_policy(), vtx_map, vtx_map + num_vertices);
+  cugraph::sequence(handle.get_thrust_policy(), vtx_map, vtx_map + num_vertices);
 
   thrust::stable_sort_by_key(
     handle.get_thrust_policy(), vtx_keys, vtx_keys + num_vertices, vtx_map);

--- a/cpp/src/utilities/shuffle_local_edge_srcs_dsts.cuh
+++ b/cpp/src/utilities/shuffle_local_edge_srcs_dsts.cuh
@@ -128,7 +128,7 @@ shuffle_local_edge_majors_to_local_gpu_by_vertex_partitioning(
   auto& minor_comm = handle.get_subcomm(cugraph::partition_manager::minor_comm_name());
 
   if (edge_major_properties.size() == 0) {
-    cugraph::sort_wrapper(handle.get_thrust_policy(), edge_majors.begin(), edge_majors.end());
+    cugraph::sort(handle.get_thrust_policy(), edge_majors.begin(), edge_majors.end());
   } else if (edge_major_properties.size() == 1) {
     cugraph::variant_type_dispatch(edge_major_properties[0], [&handle, &edge_majors](auto& prop) {
       thrust::sort_by_key(
@@ -136,7 +136,7 @@ shuffle_local_edge_majors_to_local_gpu_by_vertex_partitioning(
     });
   } else {
     rmm::device_uvector<size_t> property_positions(edge_majors.size(), handle.get_stream());
-    thrust::sequence(
+    cugraph::sequence(
       handle.get_thrust_policy(), property_positions.begin(), property_positions.end(), size_t{0});
     thrust::sort_by_key(handle.get_thrust_policy(),
                         edge_majors.begin(),
@@ -198,7 +198,7 @@ shuffle_local_edge_minors_to_local_gpu_by_vertex_partitioning(
   auto& major_comm = handle.get_subcomm(cugraph::partition_manager::major_comm_name());
 
   if (edge_minor_properties.size() == 0) {
-    cugraph::sort_wrapper(handle.get_thrust_policy(), edge_minors.begin(), edge_minors.end());
+    cugraph::sort(handle.get_thrust_policy(), edge_minors.begin(), edge_minors.end());
   } else if (edge_minor_properties.size() == 1) {
     cugraph::variant_type_dispatch(edge_minor_properties[0], [&handle, &edge_minors](auto& prop) {
       thrust::sort_by_key(
@@ -206,7 +206,7 @@ shuffle_local_edge_minors_to_local_gpu_by_vertex_partitioning(
     });
   } else {
     rmm::device_uvector<size_t> property_positions(edge_minors.size(), handle.get_stream());
-    thrust::sequence(
+    cugraph::sequence(
       handle.get_thrust_policy(), property_positions.begin(), property_positions.end(), size_t{0});
     thrust::sort_by_key(handle.get_thrust_policy(),
                         edge_minors.begin(),

--- a/cpp/src/utilities/shuffle_properties_common.cu
+++ b/cpp/src/utilities/shuffle_properties_common.cu
@@ -9,6 +9,7 @@
 #include <cugraph/export.hpp>
 #include <cugraph/large_buffer_manager.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -70,7 +71,7 @@ CUGRAPH_EXPORT std::vector<arithmetic_device_uvector_t> shuffle_properties(
       large_buffer_type
         ? large_buffer_manager::allocate_memory_buffer<size_t>(gpus.size(), handle.get_stream())
         : rmm::device_uvector<size_t>(gpus.size(), handle.get_stream());
-    thrust::sequence(
+    cugraph::sequence(
       handle.get_thrust_policy(), property_positions.begin(), property_positions.end(), size_t{0});
     thrust::sort_by_key(
       handle.get_thrust_policy(), gpus.begin(), gpus.end(), property_positions.begin());

--- a/cpp/src/utilities/shuffle_vertex_pairs.cuh
+++ b/cpp/src/utilities/shuffle_vertex_pairs.cuh
@@ -14,6 +14,9 @@
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
+
+#include <rmm/exec_policy.hpp>
 
 #include <cuda/std/tuple>
 #include <thrust/gather.h>
@@ -147,8 +150,10 @@ shuffle_vertex_pairs_with_values_by_gpu_id_impl(
                                    large_buffer_type);
     } else {
       rmm::device_uvector<size_t> property_position(majors.size(), handle.get_stream());
-      detail::sequence_fill(
-        handle.get_stream(), property_position.data(), property_position.size(), size_t{0});
+      cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                        property_position.data(),
+                        property_position.data() + property_position.size(),
+                        size_t{0});
 
       d_tx_value_counts = cugraph::groupby_and_count(
         thrust::make_zip_iterator(majors.begin(), minors.begin(), property_position.begin()),

--- a/cpp/src/utilities/shuffle_vertices.cuh
+++ b/cpp/src/utilities/shuffle_vertices.cuh
@@ -12,6 +12,7 @@
 #include <cugraph/large_buffer_manager.hpp>
 #include <cugraph/utilities/graph_partition_utils.cuh>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <cuda/std/tuple>
 #include <thrust/gather.h>
@@ -137,10 +138,10 @@ shuffle_vertices(raft::handle_t const& handle,
                              ? large_buffer_manager::allocate_memory_buffer<size_t>(
                                  vertices.size(), handle.get_stream())
                              : rmm::device_uvector<size_t>(vertices.size(), handle.get_stream());
-      thrust::sequence(handle.get_thrust_policy(),
-                       property_positions->begin(),
-                       property_positions->end(),
-                       size_t{0});
+      cugraph::sequence(handle.get_thrust_policy(),
+                        property_positions->begin(),
+                        property_positions->end(),
+                        size_t{0});
 
       d_tx_value_counts = cugraph::groupby_and_count(vertices.begin(),
                                                      vertices.end(),

--- a/cpp/src/utilities/thrust_wrappers.cu
+++ b/cpp/src/utilities/thrust_wrappers.cu
@@ -176,7 +176,25 @@ OutputIterator inclusive_scan_impl(rmm::exec_policy const& policy,
 }
 
 template <typename InputIterator, typename OutputIterator>
+OutputIterator inclusive_scan_impl(rmm::exec_policy_nosync const& policy,
+                                   InputIterator first,
+                                   InputIterator last,
+                                   OutputIterator result)
+{
+  return thrust::inclusive_scan(policy, first, last, result);
+}
+
+template <typename InputIterator, typename OutputIterator>
 OutputIterator exclusive_scan_impl(rmm::exec_policy const& policy,
+                                   InputIterator first,
+                                   InputIterator last,
+                                   OutputIterator result)
+{
+  return thrust::exclusive_scan(policy, first, last, result);
+}
+
+template <typename InputIterator, typename OutputIterator>
+OutputIterator exclusive_scan_impl(rmm::exec_policy_nosync const& policy,
                                    InputIterator first,
                                    InputIterator last,
                                    OutputIterator result)
@@ -194,7 +212,21 @@ OutputIterator exclusive_scan_impl(rmm::exec_policy const& policy,
   return thrust::exclusive_scan(policy, first, last, result, init);
 }
 
+template <typename InputIterator, typename OutputIterator, typename T>
+OutputIterator exclusive_scan_impl(rmm::exec_policy_nosync const& policy,
+                                   InputIterator first,
+                                   InputIterator last,
+                                   OutputIterator result,
+                                   T init)
+{
+  return thrust::exclusive_scan(policy, first, last, result, init);
+}
+
 template CUGRAPH_EXPORT std::size_t* inclusive_scan_impl(rmm::exec_policy const& policy,
+                                                         std::size_t* first,
+                                                         std::size_t* last,
+                                                         std::size_t* result);
+template CUGRAPH_EXPORT std::size_t* inclusive_scan_impl(rmm::exec_policy_nosync const& policy,
                                                          std::size_t* first,
                                                          std::size_t* last,
                                                          std::size_t* result);
@@ -202,7 +234,15 @@ template CUGRAPH_EXPORT std::int32_t* inclusive_scan_impl(rmm::exec_policy const
                                                           std::int32_t* first,
                                                           std::int32_t* last,
                                                           std::int32_t* result);
+template CUGRAPH_EXPORT std::int32_t* inclusive_scan_impl(rmm::exec_policy_nosync const& policy,
+                                                          std::int32_t* first,
+                                                          std::int32_t* last,
+                                                          std::int32_t* result);
 template CUGRAPH_EXPORT std::int64_t* inclusive_scan_impl(rmm::exec_policy const& policy,
+                                                          std::int64_t* first,
+                                                          std::int64_t* last,
+                                                          std::int64_t* result);
+template CUGRAPH_EXPORT std::int64_t* inclusive_scan_impl(rmm::exec_policy_nosync const& policy,
                                                           std::int64_t* first,
                                                           std::int64_t* last,
                                                           std::int64_t* result);
@@ -211,7 +251,16 @@ template CUGRAPH_EXPORT std::size_t* exclusive_scan_impl(rmm::exec_policy const&
                                                          std::size_t* first,
                                                          std::size_t* last,
                                                          std::size_t* result);
+template CUGRAPH_EXPORT std::size_t* exclusive_scan_impl(rmm::exec_policy_nosync const& policy,
+                                                         std::size_t* first,
+                                                         std::size_t* last,
+                                                         std::size_t* result);
 template CUGRAPH_EXPORT std::size_t* exclusive_scan_impl(rmm::exec_policy const& policy,
+                                                         std::size_t* first,
+                                                         std::size_t* last,
+                                                         std::size_t* result,
+                                                         std::size_t init);
+template CUGRAPH_EXPORT std::size_t* exclusive_scan_impl(rmm::exec_policy_nosync const& policy,
                                                          std::size_t* first,
                                                          std::size_t* last,
                                                          std::size_t* result,
@@ -221,7 +270,16 @@ template CUGRAPH_EXPORT std::int32_t* exclusive_scan_impl(rmm::exec_policy const
                                                           std::int32_t* first,
                                                           std::int32_t* last,
                                                           std::int32_t* result);
+template CUGRAPH_EXPORT std::int32_t* exclusive_scan_impl(rmm::exec_policy_nosync const& policy,
+                                                          std::int32_t* first,
+                                                          std::int32_t* last,
+                                                          std::int32_t* result);
 template CUGRAPH_EXPORT std::int32_t* exclusive_scan_impl(rmm::exec_policy const& policy,
+                                                          std::int32_t* first,
+                                                          std::int32_t* last,
+                                                          std::int32_t* result,
+                                                          std::int32_t init);
+template CUGRAPH_EXPORT std::int32_t* exclusive_scan_impl(rmm::exec_policy_nosync const& policy,
                                                           std::int32_t* first,
                                                           std::int32_t* last,
                                                           std::int32_t* result,
@@ -231,7 +289,16 @@ template CUGRAPH_EXPORT std::int64_t* exclusive_scan_impl(rmm::exec_policy const
                                                           std::int64_t* first,
                                                           std::int64_t* last,
                                                           std::int64_t* result);
+template CUGRAPH_EXPORT std::int64_t* exclusive_scan_impl(rmm::exec_policy_nosync const& policy,
+                                                          std::int64_t* first,
+                                                          std::int64_t* last,
+                                                          std::int64_t* result);
 template CUGRAPH_EXPORT std::int64_t* exclusive_scan_impl(rmm::exec_policy const& policy,
+                                                          std::int64_t* first,
+                                                          std::int64_t* last,
+                                                          std::int64_t* result,
+                                                          std::int64_t init);
+template CUGRAPH_EXPORT std::int64_t* exclusive_scan_impl(rmm::exec_policy_nosync const& policy,
                                                           std::int64_t* first,
                                                           std::int64_t* last,
                                                           std::int64_t* result,

--- a/cpp/src/utilities/thrust_wrappers.cu
+++ b/cpp/src/utilities/thrust_wrappers.cu
@@ -10,8 +10,11 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <thrust/fill.h>
 #include <thrust/scan.h>
+#include <thrust/sequence.h>
 #include <thrust/sort.h>
+#include <thrust/unique.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -91,6 +94,78 @@ CUGRAPH_SORT_ZIP_INST(zip_i64_i64_i64_sz);
 
 #undef CUGRAPH_SORT_ZIP_INST
 
+template <typename RandomAccessIterator>
+RandomAccessIterator unique_impl(rmm::exec_policy const& policy,
+                                 RandomAccessIterator first,
+                                 RandomAccessIterator last)
+{
+  return thrust::unique(policy, first, last);
+}
+
+template <typename RandomAccessIterator>
+RandomAccessIterator unique_impl(rmm::exec_policy_nosync const& policy,
+                                 RandomAccessIterator first,
+                                 RandomAccessIterator last)
+{
+  return thrust::unique(policy, first, last);
+}
+
+template CUGRAPH_EXPORT int32_t* unique_impl<int32_t*>(rmm::exec_policy const& policy,
+                                                       int32_t* first,
+                                                       int32_t* last);
+template CUGRAPH_EXPORT int32_t* unique_impl<int32_t*>(rmm::exec_policy_nosync const& policy,
+                                                       int32_t* first,
+                                                       int32_t* last);
+
+template CUGRAPH_EXPORT uint32_t* unique_impl<uint32_t*>(rmm::exec_policy const& policy,
+                                                         uint32_t* first,
+                                                         uint32_t* last);
+template CUGRAPH_EXPORT uint32_t* unique_impl<uint32_t*>(rmm::exec_policy_nosync const& policy,
+                                                         uint32_t* first,
+                                                         uint32_t* last);
+
+template CUGRAPH_EXPORT int64_t* unique_impl<int64_t*>(rmm::exec_policy const& policy,
+                                                       int64_t* first,
+                                                       int64_t* last);
+template CUGRAPH_EXPORT int64_t* unique_impl<int64_t*>(rmm::exec_policy_nosync const& policy,
+                                                       int64_t* first,
+                                                       int64_t* last);
+
+#define CUGRAPH_UNIQUE_ZIP_INST(ZipType)                          \
+  template CUGRAPH_EXPORT ZipType unique_impl<ZipType>(           \
+    rmm::exec_policy const& policy, ZipType first, ZipType last); \
+  template CUGRAPH_EXPORT ZipType unique_impl<ZipType>(           \
+    rmm::exec_policy_nosync const& policy, ZipType first, ZipType last)
+
+CUGRAPH_UNIQUE_ZIP_INST(zip_i32_i32);
+CUGRAPH_UNIQUE_ZIP_INST(zip_i64_i64);
+CUGRAPH_UNIQUE_ZIP_INST(zip_i64_i32);
+CUGRAPH_UNIQUE_ZIP_INST(zip_i32_i64);
+CUGRAPH_UNIQUE_ZIP_INST(zip_sz_i32);
+CUGRAPH_UNIQUE_ZIP_INST(zip_sz_i64);
+CUGRAPH_UNIQUE_ZIP_INST(zip_f_sz);
+CUGRAPH_UNIQUE_ZIP_INST(zip_d_sz);
+
+CUGRAPH_UNIQUE_ZIP_INST(zip_i32_i32_f);
+CUGRAPH_UNIQUE_ZIP_INST(zip_i32_i32_d);
+CUGRAPH_UNIQUE_ZIP_INST(zip_i64_i64_f);
+CUGRAPH_UNIQUE_ZIP_INST(zip_i64_i64_d);
+CUGRAPH_UNIQUE_ZIP_INST(zip_sz_i32_i32);
+CUGRAPH_UNIQUE_ZIP_INST(zip_sz_i64_i64);
+CUGRAPH_UNIQUE_ZIP_INST(zip_i32_i32_sz);
+CUGRAPH_UNIQUE_ZIP_INST(zip_i64_i64_sz);
+CUGRAPH_UNIQUE_ZIP_INST(zip_i32_i32_i32);
+CUGRAPH_UNIQUE_ZIP_INST(zip_i32_i64_i32);
+CUGRAPH_UNIQUE_ZIP_INST(zip_i64_i32_i32);
+CUGRAPH_UNIQUE_ZIP_INST(zip_i64_i64_i32);
+
+CUGRAPH_UNIQUE_ZIP_INST(zip_i32_i32_sz_i);
+CUGRAPH_UNIQUE_ZIP_INST(zip_i64_i64_sz_i);
+CUGRAPH_UNIQUE_ZIP_INST(zip_i32_i32_i32_sz);
+CUGRAPH_UNIQUE_ZIP_INST(zip_i64_i64_i64_sz);
+
+#undef CUGRAPH_UNIQUE_ZIP_INST
+
 template <typename InputIterator, typename OutputIterator>
 OutputIterator inclusive_scan_impl(rmm::exec_policy const& policy,
                                    InputIterator first,
@@ -161,6 +236,77 @@ template CUGRAPH_EXPORT std::int64_t* exclusive_scan_impl(rmm::exec_policy const
                                                           std::int64_t* last,
                                                           std::int64_t* result,
                                                           std::int64_t init);
+
+template <typename ForwardIterator, typename T>
+void fill_impl(rmm::exec_policy const& policy,
+               ForwardIterator first,
+               ForwardIterator last,
+               T const& value)
+{
+  thrust::fill(policy, first, last, value);
+}
+
+template <typename ForwardIterator, typename T>
+void fill_impl(rmm::exec_policy_nosync const& policy,
+               ForwardIterator first,
+               ForwardIterator last,
+               T const& value)
+{
+  thrust::fill(policy, first, last, value);
+}
+
+template <typename ForwardIterator, typename T>
+void sequence_impl(
+  rmm::exec_policy const& policy, ForwardIterator first, ForwardIterator last, T init, T step)
+{
+  thrust::sequence(policy, first, last, init, step);
+}
+
+template <typename ForwardIterator, typename T>
+void sequence_impl(rmm::exec_policy_nosync const& policy,
+                   ForwardIterator first,
+                   ForwardIterator last,
+                   T init,
+                   T step)
+{
+  thrust::sequence(policy, first, last, init, step);
+}
+
+#define CUGRAPH_FILL_SCALAR_INST(ScalarType)                                                       \
+  template CUGRAPH_EXPORT void fill_impl<ScalarType*>(                                             \
+    rmm::exec_policy const& policy, ScalarType* first, ScalarType* last, ScalarType const& value); \
+  template CUGRAPH_EXPORT void fill_impl<ScalarType*>(rmm::exec_policy_nosync const& policy,       \
+                                                      ScalarType* first,                           \
+                                                      ScalarType* last,                            \
+                                                      ScalarType const& value)
+
+#define CUGRAPH_SEQUENCE_SCALAR_INST(ScalarType)                       \
+  template CUGRAPH_EXPORT void sequence_impl<ScalarType*, ScalarType>( \
+    rmm::exec_policy const& policy,                                    \
+    ScalarType* first,                                                 \
+    ScalarType* last,                                                  \
+    ScalarType init,                                                   \
+    ScalarType step);                                                  \
+  template CUGRAPH_EXPORT void sequence_impl<ScalarType*, ScalarType>( \
+    rmm::exec_policy_nosync const& policy,                             \
+    ScalarType* first,                                                 \
+    ScalarType* last,                                                  \
+    ScalarType init,                                                   \
+    ScalarType step)
+
+CUGRAPH_FILL_SCALAR_INST(std::size_t);
+CUGRAPH_FILL_SCALAR_INST(std::uint32_t);
+CUGRAPH_FILL_SCALAR_INST(std::int32_t);
+CUGRAPH_FILL_SCALAR_INST(std::int64_t);
+CUGRAPH_FILL_SCALAR_INST(float);
+CUGRAPH_FILL_SCALAR_INST(double);
+
+CUGRAPH_SEQUENCE_SCALAR_INST(std::size_t);
+CUGRAPH_SEQUENCE_SCALAR_INST(std::int32_t);
+CUGRAPH_SEQUENCE_SCALAR_INST(std::int64_t);
+
+#undef CUGRAPH_FILL_SCALAR_INST
+#undef CUGRAPH_SEQUENCE_SCALAR_INST
 
 }  // namespace detail
 

--- a/cpp/tests/community/egonet_validate.cu
+++ b/cpp/tests/community/egonet_validate.cu
@@ -142,8 +142,8 @@ egonet_reference(
           return !thrust::binary_search(thrust::seq, visited_begin, visited_end, v);
         });
       frontier.resize(cuda::std::distance(frontier.begin(), new_end), handle.get_stream());
-      cugraph::sort_wrapper(handle.get_thrust_policy(), frontier.begin(), frontier.end());
-      new_end = thrust::unique(handle.get_thrust_policy(), frontier.begin(), frontier.end());
+      cugraph::sort(handle.get_thrust_policy(), frontier.begin(), frontier.end());
+      new_end = cugraph::unique(handle.get_thrust_policy(), frontier.begin(), frontier.end());
       frontier.resize(cuda::std::distance(frontier.begin(), new_end), handle.get_stream());
 
       size_t old_visited_size = visited.size();
@@ -152,7 +152,7 @@ egonet_reference(
                    frontier.begin(),
                    frontier.end(),
                    visited.begin() + old_visited_size);
-      cugraph::sort_wrapper(handle.get_thrust_policy(), visited.begin(), visited.end());
+      cugraph::sort(handle.get_thrust_policy(), visited.begin(), visited.end());
 
       offset += new_entries;
     }
@@ -257,24 +257,24 @@ void egonet_validate(raft::handle_t const& handle,
 
   for (size_t i = 0; i < (h_offsets.size() - 1); ++i) {
     if (d_reference_egonet_wgt) {
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            thrust::make_zip_iterator(d_reference_egonet_src.begin(),
-                                                      d_reference_egonet_dst.begin(),
-                                                      d_reference_egonet_wgt->begin()) +
-                              h_offsets[i],
-                            thrust::make_zip_iterator(d_reference_egonet_src.begin(),
-                                                      d_reference_egonet_dst.begin(),
-                                                      d_reference_egonet_wgt->begin()) +
-                              h_offsets[i + 1]);
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            thrust::make_zip_iterator(d_cugraph_egonet_src.begin(),
-                                                      d_cugraph_egonet_dst.begin(),
-                                                      d_cugraph_egonet_wgt->begin()) +
-                              h_offsets[i],
-                            thrust::make_zip_iterator(d_cugraph_egonet_src.begin(),
-                                                      d_cugraph_egonet_dst.begin(),
-                                                      d_cugraph_egonet_wgt->begin()) +
-                              h_offsets[i + 1]);
+      cugraph::sort(handle.get_thrust_policy(),
+                    thrust::make_zip_iterator(d_reference_egonet_src.begin(),
+                                              d_reference_egonet_dst.begin(),
+                                              d_reference_egonet_wgt->begin()) +
+                      h_offsets[i],
+                    thrust::make_zip_iterator(d_reference_egonet_src.begin(),
+                                              d_reference_egonet_dst.begin(),
+                                              d_reference_egonet_wgt->begin()) +
+                      h_offsets[i + 1]);
+      cugraph::sort(handle.get_thrust_policy(),
+                    thrust::make_zip_iterator(d_cugraph_egonet_src.begin(),
+                                              d_cugraph_egonet_dst.begin(),
+                                              d_cugraph_egonet_wgt->begin()) +
+                      h_offsets[i],
+                    thrust::make_zip_iterator(d_cugraph_egonet_src.begin(),
+                                              d_cugraph_egonet_dst.begin(),
+                                              d_cugraph_egonet_wgt->begin()) +
+                      h_offsets[i + 1]);
 
       ASSERT_TRUE(thrust::equal(handle.get_thrust_policy(),
                                 thrust::make_zip_iterator(d_reference_egonet_src.begin(),
@@ -309,13 +309,13 @@ void egonet_validate(raft::handle_t const& handle,
         << "Extracted egonet edges do not match with the edges extracted by the reference "
            "implementation.";
     } else {
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(),
         thrust::make_zip_iterator(d_reference_egonet_src.begin(), d_reference_egonet_dst.begin()) +
           h_offsets[i],
         thrust::make_zip_iterator(d_reference_egonet_src.begin(), d_reference_egonet_dst.begin()) +
           h_offsets[i + 1]);
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(),
         thrust::make_zip_iterator(d_cugraph_egonet_src.begin(), d_cugraph_egonet_dst.begin()) +
           h_offsets[i],

--- a/cpp/tests/community/mg_egonet_test.cu
+++ b/cpp/tests/community/mg_egonet_test.cu
@@ -186,9 +186,9 @@ class Tests_MGEgonet
                             triplet_first + d_mg_aggregate_edgelist_src.size(),
                             d_mg_aggregate_edgelist_wgt->begin());
       } else {
-        cugraph::sort_wrapper(handle_->get_thrust_policy(),
-                              triplet_first,
-                              triplet_first + d_mg_aggregate_edgelist_src.size());
+        cugraph::sort(handle_->get_thrust_policy(),
+                      triplet_first,
+                      triplet_first + d_mg_aggregate_edgelist_src.size());
       }
 
       cugraph::graph_t<vertex_t, edge_t, false, false> sg_graph(*handle_);

--- a/cpp/tests/generators/erdos_renyi_test.cpp
+++ b/cpp/tests/generators/erdos_renyi_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,6 +8,7 @@
 
 #include <cugraph/graph.hpp>
 #include <cugraph/graph_generators.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <cuda/std/tuple>
 #include <thrust/execution_policy.h>
@@ -27,13 +28,13 @@ void test_symmetric(std::vector<vertex_t>& h_src_v, std::vector<vertex_t>& h_dst
   std::copy(h_src_v.begin(), h_src_v.end(), reverse_dst_v.begin());
   std::copy(h_dst_v.begin(), h_dst_v.end(), reverse_src_v.begin());
 
-  thrust::sort(thrust::host,
-               thrust::make_zip_iterator(h_src_v.begin(), h_dst_v.begin()),
-               thrust::make_zip_iterator(h_src_v.end(), h_dst_v.end()));
+  cugraph::sort(thrust::host,
+                thrust::make_zip_iterator(h_src_v.begin(), h_dst_v.begin()),
+                thrust::make_zip_iterator(h_src_v.end(), h_dst_v.end()));
 
-  thrust::sort(thrust::host,
-               thrust::make_zip_iterator(reverse_src_v.begin(), reverse_dst_v.begin()),
-               thrust::make_zip_iterator(reverse_src_v.end(), reverse_dst_v.end()));
+  cugraph::sort(thrust::host,
+                thrust::make_zip_iterator(reverse_src_v.begin(), reverse_dst_v.begin()),
+                thrust::make_zip_iterator(reverse_src_v.end(), reverse_dst_v.end()));
 
   EXPECT_EQ(reverse_src_v, h_src_v);
   EXPECT_EQ(reverse_dst_v, h_dst_v);

--- a/cpp/tests/generators/generators_test.cpp
+++ b/cpp/tests/generators/generators_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,6 +8,7 @@
 #include "utilities/conversion_utilities.hpp"
 
 #include <cugraph/graph_generators.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <cuda/std/tuple>
 #include <thrust/execution_policy.h>
@@ -62,12 +63,12 @@ TEST_F(GeneratorsTest, Mesh2DGraphTest)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(thrust::host,
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
-                 expected_src_v.size());
+  cugraph::sort(thrust::host,
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
+                  expected_src_v.size());
 
-  thrust::sort(
+  cugraph::sort(
     thrust::host,
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()),
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()) + actual_src_v.size());
@@ -111,12 +112,12 @@ TEST_F(GeneratorsTest, Mesh3DGraphTest)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(thrust::host,
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
-                 expected_src_v.size());
+  cugraph::sort(thrust::host,
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
+                  expected_src_v.size());
 
-  thrust::sort(
+  cugraph::sort(
     thrust::host,
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()),
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()) + actual_src_v.size());
@@ -144,12 +145,12 @@ TEST_F(GeneratorsTest, CompleteGraphTestTriangles)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(thrust::host,
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
-                 expected_src_v.size());
+  cugraph::sort(thrust::host,
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
+                  expected_src_v.size());
 
-  thrust::sort(
+  cugraph::sort(
     thrust::host,
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()),
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()) + actual_src_v.size());
@@ -181,12 +182,12 @@ TEST_F(GeneratorsTest, CompleteGraphTest5)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(thrust::host,
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
-                 expected_src_v.size());
+  cugraph::sort(thrust::host,
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
+                  expected_src_v.size());
 
-  thrust::sort(
+  cugraph::sort(
     thrust::host,
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()),
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()) + actual_src_v.size());
@@ -218,12 +219,12 @@ TEST_F(GeneratorsTest, LineGraphTestSymmetric)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(thrust::host,
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
-                 expected_src_v.size());
+  cugraph::sort(thrust::host,
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
+                  expected_src_v.size());
 
-  thrust::sort(
+  cugraph::sort(
     thrust::host,
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()),
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()) + actual_src_v.size());
@@ -265,12 +266,12 @@ TEST_F(GeneratorsTest, Mesh2DGraphTestSymmetric)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(thrust::host,
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
-                 expected_src_v.size());
+  cugraph::sort(thrust::host,
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
+                  expected_src_v.size());
 
-  thrust::sort(
+  cugraph::sort(
     thrust::host,
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()),
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()) + actual_src_v.size());
@@ -336,12 +337,12 @@ TEST_F(GeneratorsTest, Mesh3DGraphTestSymmetric)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(thrust::host,
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
-                 expected_src_v.size());
+  cugraph::sort(thrust::host,
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
+                  expected_src_v.size());
 
-  thrust::sort(
+  cugraph::sort(
     thrust::host,
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()),
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()) + actual_src_v.size());
@@ -375,12 +376,12 @@ TEST_F(GeneratorsTest, CompleteGraphTestTrianglesSymmetric)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(thrust::host,
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
-                 expected_src_v.size());
+  cugraph::sort(thrust::host,
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
+                  expected_src_v.size());
 
-  thrust::sort(
+  cugraph::sort(
     thrust::host,
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()),
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()) + actual_src_v.size());
@@ -420,12 +421,12 @@ TEST_F(GeneratorsTest, CompleteGraphTest5Symmetric)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(thrust::host,
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
-                 expected_src_v.size());
+  cugraph::sort(thrust::host,
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
+                  expected_src_v.size());
 
-  thrust::sort(
+  cugraph::sort(
     thrust::host,
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()),
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()) + actual_src_v.size());
@@ -478,12 +479,12 @@ TEST_F(GeneratorsTest, CombineGraphsTest)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(thrust::host,
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
-                 expected_src_v.size());
+  cugraph::sort(thrust::host,
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
+                  expected_src_v.size());
 
-  thrust::sort(
+  cugraph::sort(
     thrust::host,
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()),
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()) + actual_src_v.size());
@@ -539,12 +540,12 @@ TEST_F(GeneratorsTest, CombineGraphsOffsetsTest)
   auto actual_src_v = cugraph::test::to_host(handle, src_v);
   auto actual_dst_v = cugraph::test::to_host(handle, dst_v);
 
-  thrust::sort(thrust::host,
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
-               thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
-                 expected_src_v.size());
+  cugraph::sort(thrust::host,
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()),
+                thrust::make_zip_iterator(expected_src_v.begin(), expected_dst_v.begin()) +
+                  expected_src_v.size());
 
-  thrust::sort(
+  cugraph::sort(
     thrust::host,
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()),
     thrust::make_zip_iterator(actual_src_v.begin(), actual_dst_v.begin()) + actual_src_v.size());

--- a/cpp/tests/link_prediction/similarity_test.cu
+++ b/cpp/tests/link_prediction/similarity_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "link_prediction/similarity_compare.hpp"
@@ -13,6 +13,7 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
 #include <cugraph/utilities/misc_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <gtest/gtest.h>
 
@@ -109,7 +110,7 @@ class Tests_Similarity
     } else {
       if (!sources_span) {
         sources.resize(graph_view.number_of_vertices(), handle.get_stream());
-        thrust::sequence(handle.get_thrust_policy(), sources.begin(), sources.end(), vertex_t{0});
+        cugraph::sequence(handle.get_thrust_policy(), sources.begin(), sources.end(), vertex_t{0});
         sources_span = raft::device_span<vertex_t const>{sources.data(), sources.size()};
       }
 

--- a/cpp/tests/mtmg/threaded_test.cpp
+++ b/cpp/tests/mtmg/threaded_test.cpp
@@ -176,12 +176,12 @@ class Tests_Multithreaded
                d_dst_v.begin(),
                d_dst_v.size(),
                handle.get_stream());
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(), d_unique_vertices.begin(), d_unique_vertices.end());
-    d_unique_vertices.resize(
-      cugraph::detail::unique_ints(
-        handle, raft::device_span<vertex_t>{d_unique_vertices.data(), d_unique_vertices.size()}),
-      handle.get_stream());
+    cugraph::sort(handle.get_thrust_policy(), d_unique_vertices.begin(), d_unique_vertices.end());
+    d_unique_vertices.resize(cuda::std::distance(d_unique_vertices.begin(),
+                                                 cugraph::unique(handle.get_thrust_policy(),
+                                                                 d_unique_vertices.begin(),
+                                                                 d_unique_vertices.end())),
+                             handle.get_stream());
 
     auto h_src_v         = cugraph::test::to_host(handle, d_src_v);
     auto h_dst_v         = cugraph::test::to_host(handle, d_dst_v);

--- a/cpp/tests/mtmg/threaded_test_jaccard.cpp
+++ b/cpp/tests/mtmg/threaded_test_jaccard.cpp
@@ -160,12 +160,12 @@ class Tests_Multithreaded
                d_dst_v.begin(),
                d_dst_v.size(),
                handle.get_stream());
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(), d_unique_vertices.begin(), d_unique_vertices.end());
-    d_unique_vertices.resize(
-      cugraph::detail::unique_ints(
-        handle, raft::device_span<vertex_t>{d_unique_vertices.data(), d_unique_vertices.size()}),
-      handle.get_stream());
+    cugraph::sort(handle.get_thrust_policy(), d_unique_vertices.begin(), d_unique_vertices.end());
+    d_unique_vertices.resize(cuda::std::distance(d_unique_vertices.begin(),
+                                                 cugraph::unique(handle.get_thrust_policy(),
+                                                                 d_unique_vertices.begin(),
+                                                                 d_unique_vertices.end())),
+                             handle.get_stream());
 
     auto h_src_v         = cugraph::test::to_host(handle, d_src_v);
     auto h_dst_v         = cugraph::test::to_host(handle, d_dst_v);

--- a/cpp/tests/mtmg/threaded_test_louvain.cpp
+++ b/cpp/tests/mtmg/threaded_test_louvain.cpp
@@ -173,12 +173,12 @@ class Tests_Multithreaded
                d_dst_v.begin(),
                d_dst_v.size(),
                handle.get_stream());
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(), d_unique_vertices.begin(), d_unique_vertices.end());
-    d_unique_vertices.resize(
-      cugraph::detail::unique_ints(
-        handle, raft::device_span<vertex_t>{d_unique_vertices.data(), d_unique_vertices.size()}),
-      handle.get_stream());
+    cugraph::sort(handle.get_thrust_policy(), d_unique_vertices.begin(), d_unique_vertices.end());
+    d_unique_vertices.resize(cuda::std::distance(d_unique_vertices.begin(),
+                                                 cugraph::unique(handle.get_thrust_policy(),
+                                                                 d_unique_vertices.begin(),
+                                                                 d_unique_vertices.end())),
+                             handle.get_stream());
 
     auto h_src_v         = cugraph::test::to_host(handle, d_src_v);
     auto h_dst_v         = cugraph::test::to_host(handle, d_dst_v);

--- a/cpp/tests/prims/mg_extract_transform_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_e.cu
@@ -201,7 +201,7 @@ class Tests_MGExtractTransformE
           false);
 
       if (handle_->get_comms().get_rank() == int{0}) {
-        cugraph::sort_wrapper(
+        cugraph::sort(
           handle_->get_thrust_policy(),
           cugraph::get_dataframe_buffer_begin(mg_aggregate_extract_transform_output_buffer),
           cugraph::get_dataframe_buffer_end(mg_aggregate_extract_transform_output_buffer));
@@ -216,10 +216,9 @@ class Tests_MGExtractTransformE
                                        cugraph::edge_dummy_property_t{}.view(),
                                        e_op_t<vertex_t, output_payload_t>{});
 
-        cugraph::sort_wrapper(
-          handle_->get_thrust_policy(),
-          cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
-          cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
+        cugraph::sort(handle_->get_thrust_policy(),
+                      cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
+                      cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
 
         bool e_op_result_passed = thrust::equal(
           handle_->get_thrust_policy(),

--- a/cpp/tests/prims/mg_extract_transform_if_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_if_e.cu
@@ -229,7 +229,7 @@ class Tests_MGExtractTransformIfE
           raft::device_span<result_t const>(mg_vertex_prop.data(), mg_vertex_prop.size()));
 
       if (handle_->get_comms().get_rank() == int{0}) {
-        cugraph::sort_wrapper(
+        cugraph::sort(
           handle_->get_thrust_policy(),
           cugraph::get_dataframe_buffer_begin(mg_aggregate_extract_transform_output_buffer),
           cugraph::get_dataframe_buffer_end(mg_aggregate_extract_transform_output_buffer));
@@ -250,10 +250,9 @@ class Tests_MGExtractTransformIfE
                                           e_op_t<vertex_t, result_t, output_payload_t>{},
                                           pred_op_t<vertex_t, result_t>{});
 
-        cugraph::sort_wrapper(
-          handle_->get_thrust_policy(),
-          cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
-          cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
+        cugraph::sort(handle_->get_thrust_policy(),
+                      cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
+                      cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
 
         bool e_op_result_passed = thrust::equal(
           handle_->get_thrust_policy(),

--- a/cpp/tests/prims/mg_extract_transform_if_v_frontier_incoming_outgoing_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_if_v_frontier_incoming_outgoing_e.cu
@@ -244,10 +244,10 @@ class Tests_MGExtractTransformIfVFrontierIncomingOutgoingE
     auto mg_key_buffer = cugraph::allocate_dataframe_buffer<key_t>(
       mg_graph_view.local_vertex_partition_range_size(), handle_->get_stream());
     if constexpr (std::is_same_v<tag_t, void>) {
-      thrust::sequence(handle_->get_thrust_policy(),
-                       cugraph::get_dataframe_buffer_begin(mg_key_buffer),
-                       cugraph::get_dataframe_buffer_end(mg_key_buffer),
-                       mg_graph_view.local_vertex_partition_range_first());
+      cugraph::sequence(handle_->get_thrust_policy(),
+                        cugraph::get_dataframe_buffer_begin(mg_key_buffer),
+                        cugraph::get_dataframe_buffer_end(mg_key_buffer),
+                        mg_graph_view.local_vertex_partition_range_first());
     } else {
       thrust::tabulate(handle_->get_thrust_policy(),
                        cugraph::get_dataframe_buffer_begin(mg_key_buffer),
@@ -362,7 +362,7 @@ class Tests_MGExtractTransformIfVFrontierIncomingOutgoingE
           raft::device_span<result_t const>(mg_vertex_prop.data(), mg_vertex_prop.size()));
 
       if (handle_->get_comms().get_rank() == int{0}) {
-        cugraph::sort_wrapper(
+        cugraph::sort(
           handle_->get_thrust_policy(),
           cugraph::get_dataframe_buffer_begin(mg_aggregate_extract_transform_output_buffer),
           cugraph::get_dataframe_buffer_end(mg_aggregate_extract_transform_output_buffer));
@@ -377,10 +377,10 @@ class Tests_MGExtractTransformIfVFrontierIncomingOutgoingE
         auto sg_key_buffer = cugraph::allocate_dataframe_buffer<key_t>(
           sg_graph_view.local_vertex_partition_range_size(), handle_->get_stream());
         if constexpr (std::is_same_v<tag_t, void>) {
-          thrust::sequence(handle_->get_thrust_policy(),
-                           cugraph::get_dataframe_buffer_begin(sg_key_buffer),
-                           cugraph::get_dataframe_buffer_end(sg_key_buffer),
-                           sg_graph_view.local_vertex_partition_range_first());
+          cugraph::sequence(handle_->get_thrust_policy(),
+                            cugraph::get_dataframe_buffer_begin(sg_key_buffer),
+                            cugraph::get_dataframe_buffer_end(sg_key_buffer),
+                            sg_graph_view.local_vertex_partition_range_first());
         } else {
           thrust::tabulate(handle_->get_thrust_policy(),
                            cugraph::get_dataframe_buffer_begin(sg_key_buffer),
@@ -423,10 +423,9 @@ class Tests_MGExtractTransformIfVFrontierIncomingOutgoingE
             pred_op_t<key_t, vertex_t, result_t, store_transposed>{});
         }
 
-        cugraph::sort_wrapper(
-          handle_->get_thrust_policy(),
-          cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
-          cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
+        cugraph::sort(handle_->get_thrust_policy(),
+                      cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
+                      cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
 
         bool e_op_result_passed = thrust::equal(
           handle_->get_thrust_policy(),

--- a/cpp/tests/prims/mg_extract_transform_v_frontier_incoming_outgoing_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_v_frontier_incoming_outgoing_e.cu
@@ -207,10 +207,10 @@ class Tests_MGExtractTransformVFrontierIncomingOutgoingE
     auto mg_key_buffer = cugraph::allocate_dataframe_buffer<key_t>(
       mg_graph_view.local_vertex_partition_range_size(), handle_->get_stream());
     if constexpr (std::is_same_v<tag_t, void>) {
-      thrust::sequence(handle_->get_thrust_policy(),
-                       cugraph::get_dataframe_buffer_begin(mg_key_buffer),
-                       cugraph::get_dataframe_buffer_end(mg_key_buffer),
-                       mg_graph_view.local_vertex_partition_range_first());
+      cugraph::sequence(handle_->get_thrust_policy(),
+                        cugraph::get_dataframe_buffer_begin(mg_key_buffer),
+                        cugraph::get_dataframe_buffer_end(mg_key_buffer),
+                        mg_graph_view.local_vertex_partition_range_first());
     } else {
       thrust::tabulate(handle_->get_thrust_policy(),
                        cugraph::get_dataframe_buffer_begin(mg_key_buffer),
@@ -313,7 +313,7 @@ class Tests_MGExtractTransformVFrontierIncomingOutgoingE
           false);
 
       if (handle_->get_comms().get_rank() == int{0}) {
-        cugraph::sort_wrapper(
+        cugraph::sort(
           handle_->get_thrust_policy(),
           cugraph::get_dataframe_buffer_begin(mg_aggregate_extract_transform_output_buffer),
           cugraph::get_dataframe_buffer_end(mg_aggregate_extract_transform_output_buffer));
@@ -323,10 +323,10 @@ class Tests_MGExtractTransformVFrontierIncomingOutgoingE
         auto sg_key_buffer = cugraph::allocate_dataframe_buffer<key_t>(
           sg_graph_view.local_vertex_partition_range_size(), handle_->get_stream());
         if constexpr (std::is_same_v<tag_t, void>) {
-          thrust::sequence(handle_->get_thrust_policy(),
-                           cugraph::get_dataframe_buffer_begin(sg_key_buffer),
-                           cugraph::get_dataframe_buffer_end(sg_key_buffer),
-                           sg_graph_view.local_vertex_partition_range_first());
+          cugraph::sequence(handle_->get_thrust_policy(),
+                            cugraph::get_dataframe_buffer_begin(sg_key_buffer),
+                            cugraph::get_dataframe_buffer_end(sg_key_buffer),
+                            sg_graph_view.local_vertex_partition_range_first());
         } else {
           thrust::tabulate(handle_->get_thrust_policy(),
                            cugraph::get_dataframe_buffer_begin(sg_key_buffer),
@@ -367,10 +367,9 @@ class Tests_MGExtractTransformVFrontierIncomingOutgoingE
             e_op_t<key_t, vertex_t, output_payload_t, store_transposed>{});
         }
 
-        cugraph::sort_wrapper(
-          handle_->get_thrust_policy(),
-          cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
-          cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
+        cugraph::sort(handle_->get_thrust_policy(),
+                      cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
+                      cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
 
         bool e_op_result_passed = thrust::equal(
           handle_->get_thrust_policy(),

--- a/cpp/tests/prims/mg_per_v_transform_reduce_dst_key_aggregated_outgoing_e.cu
+++ b/cpp/tests/prims/mg_per_v_transform_reduce_dst_key_aggregated_outgoing_e.cu
@@ -22,6 +22,7 @@
 #include <cugraph/utilities/dataframe_buffer.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
 #include <cugraph/utilities/thrust_tuple_utils.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -144,7 +145,7 @@ class Tests_MGPerVTransformReduceDstKeyAggregatedOutgoingE
 
     rmm::device_uvector<vertex_t> mg_kv_store_keys(comm_rank == 0 ? key_hash_bin_count : int{0},
                                                    handle_->get_stream());
-    thrust::sequence(
+    cugraph::sequence(
       handle_->get_thrust_policy(), mg_kv_store_keys.begin(), mg_kv_store_keys.end(), vertex_t{0});
     std::tie(mg_kv_store_keys, std::ignore) = cugraph::shuffle_ext_vertices(
       *handle_, std::move(mg_kv_store_keys), std::vector<cugraph::arithmetic_device_uvector_t>{});
@@ -361,10 +362,10 @@ class Tests_MGPerVTransformReduceDstKeyAggregatedOutgoingE
               *handle_, sg_graph_view, sg_vertex_key);
 
           rmm::device_uvector<vertex_t> sg_kv_store_keys(key_hash_bin_count, handle_->get_stream());
-          thrust::sequence(handle_->get_thrust_policy(),
-                           sg_kv_store_keys.begin(),
-                           sg_kv_store_keys.end(),
-                           vertex_t{0});
+          cugraph::sequence(handle_->get_thrust_policy(),
+                            sg_kv_store_keys.begin(),
+                            sg_kv_store_keys.end(),
+                            vertex_t{0});
           auto sg_kv_store_values =
             cugraph::test::generate<decltype(sg_graph_view), result_t>::vertex_property(
               *handle_, sg_kv_store_keys, key_prop_hash_bin_count);

--- a/cpp/tests/prims/mg_transform_e.cu
+++ b/cpp/tests/prims/mg_transform_e.cu
@@ -145,8 +145,7 @@ class Tests_MGTransformE
           thrust::make_zip_iterator(store_transposed ? dsts.begin() : srcs.begin(),
                                     store_transposed ? srcs.begin() : dsts.begin(),
                                     multi_edge_indices->begin());
-        cugraph::sort_wrapper(
-          handle_->get_thrust_policy(), triplet_first, triplet_first + srcs.size());
+        cugraph::sort(handle_->get_thrust_policy(), triplet_first, triplet_first + srcs.size());
       } else {
         auto ret = cugraph::extract_transform_if_e(
           *handle_,
@@ -165,7 +164,7 @@ class Tests_MGTransformE
         dsts            = std::move(std::get<1>(ret));
         auto pair_first = thrust::make_zip_iterator(store_transposed ? dsts.begin() : srcs.begin(),
                                                     store_transposed ? srcs.begin() : dsts.begin());
-        cugraph::sort_wrapper(handle_->get_thrust_policy(), pair_first, pair_first + srcs.size());
+        cugraph::sort(handle_->get_thrust_policy(), pair_first, pair_first + srcs.size());
       }
 
       edge_list.insert(

--- a/cpp/tests/prims/mg_transform_gather_e.cu
+++ b/cpp/tests/prims/mg_transform_gather_e.cu
@@ -159,8 +159,7 @@ class Tests_MGTransformGatherE
                                     multi_edge_indices->begin(),
                                     cugraph::get_dataframe_buffer_begin(should_be_gathered_values));
         if (prims_usecase.use_sorted_unique_edgelist) {
-          cugraph::sort_wrapper(
-            handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
+          cugraph::sort(handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
         } else {
           thrust::shuffle(handle_->get_thrust_policy(),
                           tuple_first,
@@ -203,8 +202,7 @@ class Tests_MGTransformGatherE
                                     store_transposed ? srcs.begin() : dsts.begin(),
                                     cugraph::get_dataframe_buffer_begin(should_be_gathered_values));
         if (prims_usecase.use_sorted_unique_edgelist) {
-          cugraph::sort_wrapper(
-            handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
+          cugraph::sort(handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
         } else {
           thrust::shuffle(handle_->get_thrust_policy(),
                           tuple_first,

--- a/cpp/tests/prims/mg_transform_gather_e_edge_ids.cu
+++ b/cpp/tests/prims/mg_transform_gather_e_edge_ids.cu
@@ -26,6 +26,7 @@
 #include <raft/core/handle.hpp>
 
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/std/iterator>
@@ -101,8 +102,10 @@ class Tests_MGTransformGatherE
 
     for (size_t i = 0; i < src_chunks.size(); ++i) {
       rmm::device_uvector<edge_t> tmp_ids(src_chunks[i].size(), handle_->get_stream());
-      cugraph::detail::sequence_fill(
-        handle_->get_stream(), tmp_ids.data(), tmp_ids.size(), base_edge_idx);
+      cugraph::sequence(rmm::exec_policy(handle_->get_stream()),
+                        tmp_ids.data(),
+                        tmp_ids.data() + tmp_ids.size(),
+                        base_edge_idx);
       base_edge_idx += src_chunks[i].size();
       edge_id_chunks.push_back(std::move(tmp_ids));
     }
@@ -202,7 +205,7 @@ class Tests_MGTransformGatherE
                                                    multi_edge_indices->begin(),
                                                    should_be_gathered_ids.begin());
       if (prims_usecase.use_sorted_unique_edgelist) {
-        cugraph::sort_wrapper(handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
+        cugraph::sort(handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
       } else {
         thrust::shuffle(handle_->get_thrust_policy(),
                         tuple_first,
@@ -214,7 +217,7 @@ class Tests_MGTransformGatherE
                                                    store_transposed ? srcs.begin() : dsts.begin(),
                                                    should_be_gathered_ids.begin());
       if (prims_usecase.use_sorted_unique_edgelist) {
-        cugraph::sort_wrapper(handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
+        cugraph::sort(handle_->get_thrust_policy(), tuple_first, tuple_first + srcs.size());
       } else {
         thrust::shuffle(handle_->get_thrust_policy(),
                         tuple_first,

--- a/cpp/tests/prims/mg_transform_reduce_if_v_frontier_outgoing_e_by_dst.cu
+++ b/cpp/tests/prims/mg_transform_reduce_if_v_frontier_outgoing_e_by_dst.cu
@@ -169,10 +169,10 @@ class Tests_MGTransformReduceIfVFrontierOutgoingEBySrcDst
     auto mg_key_buffer = cugraph::allocate_dataframe_buffer<key_t>(
       mg_graph_view.local_vertex_partition_range_size(), handle_->get_stream());
     if constexpr (std::is_same_v<tag_t, void>) {
-      thrust::sequence(handle_->get_thrust_policy(),
-                       cugraph::get_dataframe_buffer_begin(mg_key_buffer),
-                       cugraph::get_dataframe_buffer_end(mg_key_buffer),
-                       mg_graph_view.local_vertex_partition_range_first());
+      cugraph::sequence(handle_->get_thrust_policy(),
+                        cugraph::get_dataframe_buffer_begin(mg_key_buffer),
+                        cugraph::get_dataframe_buffer_end(mg_key_buffer),
+                        mg_graph_view.local_vertex_partition_range_first());
     } else {
       thrust::tabulate(handle_->get_thrust_policy(),
                        cugraph::get_dataframe_buffer_begin(mg_key_buffer),
@@ -309,7 +309,7 @@ class Tests_MGTransformReduceIfVFrontierOutgoingEBySrcDst
 
       if (handle_->get_comms().get_rank() == int{0}) {
         if constexpr (std::is_same_v<payload_t, void>) {
-          cugraph::sort_wrapper(
+          cugraph::sort(
             handle_->get_thrust_policy(),
             cugraph::get_dataframe_buffer_begin(mg_reduce_by_dst_aggregate_new_frontier_key_buffer),
             cugraph::get_dataframe_buffer_end(mg_reduce_by_dst_aggregate_new_frontier_key_buffer));
@@ -339,10 +339,10 @@ class Tests_MGTransformReduceIfVFrontierOutgoingEBySrcDst
         auto sg_key_buffer = cugraph::allocate_dataframe_buffer<key_t>(
           sg_graph_view.local_vertex_partition_range_size(), handle_->get_stream());
         if constexpr (std::is_same_v<tag_t, void>) {
-          thrust::sequence(handle_->get_thrust_policy(),
-                           cugraph::get_dataframe_buffer_begin(sg_key_buffer),
-                           cugraph::get_dataframe_buffer_end(sg_key_buffer),
-                           sg_graph_view.local_vertex_partition_range_first());
+          cugraph::sequence(handle_->get_thrust_policy(),
+                            cugraph::get_dataframe_buffer_begin(sg_key_buffer),
+                            cugraph::get_dataframe_buffer_end(sg_key_buffer),
+                            sg_graph_view.local_vertex_partition_range_first());
         } else {
           thrust::tabulate(handle_->get_thrust_policy(),
                            cugraph::get_dataframe_buffer_begin(sg_key_buffer),
@@ -391,7 +391,7 @@ class Tests_MGTransformReduceIfVFrontierOutgoingEBySrcDst
         }
 
         if constexpr (std::is_same_v<payload_t, void>) {
-          cugraph::sort_wrapper(
+          cugraph::sort(
             handle_->get_thrust_policy(),
             cugraph::get_dataframe_buffer_begin(sg_reduce_by_dst_new_frontier_key_buffer),
             cugraph::get_dataframe_buffer_end(sg_reduce_by_dst_new_frontier_key_buffer));

--- a/cpp/tests/prims/mg_transform_reduce_v_frontier_outgoing_e_by_dst.cu
+++ b/cpp/tests/prims/mg_transform_reduce_v_frontier_outgoing_e_by_dst.cu
@@ -149,10 +149,10 @@ class Tests_MGTransformReduceVFrontierOutgoingEBySrcDst
     auto mg_key_buffer = cugraph::allocate_dataframe_buffer<key_t>(
       mg_graph_view.local_vertex_partition_range_size(), handle_->get_stream());
     if constexpr (std::is_same_v<tag_t, void>) {
-      thrust::sequence(handle_->get_thrust_policy(),
-                       cugraph::get_dataframe_buffer_begin(mg_key_buffer),
-                       cugraph::get_dataframe_buffer_end(mg_key_buffer),
-                       mg_graph_view.local_vertex_partition_range_first());
+      cugraph::sequence(handle_->get_thrust_policy(),
+                        cugraph::get_dataframe_buffer_begin(mg_key_buffer),
+                        cugraph::get_dataframe_buffer_end(mg_key_buffer),
+                        mg_graph_view.local_vertex_partition_range_first());
     } else {
       thrust::tabulate(handle_->get_thrust_policy(),
                        cugraph::get_dataframe_buffer_begin(mg_key_buffer),
@@ -287,7 +287,7 @@ class Tests_MGTransformReduceVFrontierOutgoingEBySrcDst
 
       if (handle_->get_comms().get_rank() == int{0}) {
         if constexpr (std::is_same_v<payload_t, void>) {
-          cugraph::sort_wrapper(
+          cugraph::sort(
             handle_->get_thrust_policy(),
             cugraph::get_dataframe_buffer_begin(mg_reduce_by_dst_aggregate_new_frontier_key_buffer),
             cugraph::get_dataframe_buffer_end(mg_reduce_by_dst_aggregate_new_frontier_key_buffer));
@@ -304,10 +304,10 @@ class Tests_MGTransformReduceVFrontierOutgoingEBySrcDst
         auto sg_key_buffer = cugraph::allocate_dataframe_buffer<key_t>(
           sg_graph_view.local_vertex_partition_range_size(), handle_->get_stream());
         if constexpr (std::is_same_v<tag_t, void>) {
-          thrust::sequence(handle_->get_thrust_policy(),
-                           cugraph::get_dataframe_buffer_begin(sg_key_buffer),
-                           cugraph::get_dataframe_buffer_end(sg_key_buffer),
-                           sg_graph_view.local_vertex_partition_range_first());
+          cugraph::sequence(handle_->get_thrust_policy(),
+                            cugraph::get_dataframe_buffer_begin(sg_key_buffer),
+                            cugraph::get_dataframe_buffer_end(sg_key_buffer),
+                            sg_graph_view.local_vertex_partition_range_first());
         } else {
           thrust::tabulate(handle_->get_thrust_policy(),
                            cugraph::get_dataframe_buffer_begin(sg_key_buffer),
@@ -354,7 +354,7 @@ class Tests_MGTransformReduceVFrontierOutgoingEBySrcDst
         }
 
         if constexpr (std::is_same_v<payload_t, void>) {
-          cugraph::sort_wrapper(
+          cugraph::sort(
             handle_->get_thrust_policy(),
             cugraph::get_dataframe_buffer_begin(sg_reduce_by_dst_new_frontier_key_buffer),
             cugraph::get_dataframe_buffer_end(sg_reduce_by_dst_new_frontier_key_buffer));

--- a/cpp/tests/sampling/detail/nbr_sampling_validate.cu
+++ b/cpp/tests/sampling/detail/nbr_sampling_validate.cu
@@ -115,9 +115,9 @@ bool validate_extracted_graph_is_subgraph(
     raft::copy(wgt_v.data(), wgt->data(), wgt->size(), handle.get_stream());
 
     auto graph_iter = thrust::make_zip_iterator(src_v.begin(), dst_v.begin(), wgt_v.begin());
-    cugraph::sort_wrapper(
+    cugraph::sort(
       handle.get_thrust_policy(), graph_iter, graph_iter + src_v.size(), ArithmeticZipLess{});
-    auto graph_iter_end = thrust::unique(
+    auto graph_iter_end = cugraph::unique(
       handle.get_thrust_policy(), graph_iter, graph_iter + src_v.size(), ArithmeticZipEqual{});
     auto new_size = cuda::std::distance(graph_iter, graph_iter_end);
 
@@ -137,9 +137,9 @@ bool validate_extracted_graph_is_subgraph(
                        });
   } else {
     auto graph_iter = thrust::make_zip_iterator(src_v.begin(), dst_v.begin());
-    cugraph::sort_wrapper(
+    cugraph::sort(
       handle.get_thrust_policy(), graph_iter, graph_iter + src_v.size(), ArithmeticZipLess{});
-    auto graph_iter_end = thrust::unique(
+    auto graph_iter_end = cugraph::unique(
       handle.get_thrust_policy(), graph_iter, graph_iter + src_v.size(), ArithmeticZipEqual{});
     auto new_size = cuda::std::distance(graph_iter, graph_iter_end);
 
@@ -229,7 +229,7 @@ bool validate_sampling_depth(raft::handle_t const& handle,
                                          graph_view.local_vertex_partition_range_last());
 
   rmm::device_uvector<vertex_t> d_distances(graph_view.number_of_vertices(), handle.get_stream());
-  thrust::fill(
+  cugraph::fill(
     handle.get_thrust_policy(), d_distances.begin(), d_distances.end(), vertex_t{max_depth + 1});
 
   rmm::device_uvector<vertex_t> d_local_distances(graph_view.number_of_vertices(),
@@ -310,9 +310,9 @@ bool validate_temporal_integrity(
   raft::copy(sorted_dsts.begin(), dsts.begin(), dsts.size(), handle.get_stream());
   raft::copy(sorted_dst_times.begin(), edge_times.begin(), edge_times.size(), handle.get_stream());
 
-  cugraph::sort_wrapper(handle.get_thrust_policy(),
-                        thrust::make_zip_iterator(sorted_dsts.begin(), sorted_dst_times.begin()),
-                        thrust::make_zip_iterator(sorted_dsts.end(), sorted_dst_times.end()));
+  cugraph::sort(handle.get_thrust_policy(),
+                thrust::make_zip_iterator(sorted_dsts.begin(), sorted_dst_times.begin()),
+                thrust::make_zip_iterator(sorted_dsts.end(), sorted_dst_times.end()));
 
   if ((temporal_sampling_comparison ==
        cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING) ||

--- a/cpp/tests/sampling/detail/sampling_post_processing_validate.cu
+++ b/cpp/tests/sampling/detail/sampling_post_processing_validate.cu
@@ -137,15 +137,15 @@ bool compare_edgelist(raft::handle_t const& handle,
         thrust::make_zip_iterator(this_label_sorted_org_edgelist_srcs.begin(),
                                   this_label_sorted_org_edgelist_dsts.begin(),
                                   (*this_label_sorted_org_edgelist_weights).begin());
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            sorted_org_edge_first,
-                            sorted_org_edge_first + this_label_sorted_org_edgelist_srcs.size());
+      cugraph::sort(handle.get_thrust_policy(),
+                    sorted_org_edge_first,
+                    sorted_org_edge_first + this_label_sorted_org_edgelist_srcs.size());
     } else {
       auto sorted_org_edge_first = thrust::make_zip_iterator(
         this_label_sorted_org_edgelist_srcs.begin(), this_label_sorted_org_edgelist_dsts.begin());
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            sorted_org_edge_first,
-                            sorted_org_edge_first + this_label_sorted_org_edgelist_srcs.size());
+      cugraph::sort(handle.get_thrust_policy(),
+                    sorted_org_edge_first,
+                    sorted_org_edge_first + this_label_sorted_org_edgelist_srcs.size());
     }
 
     rmm::device_uvector<vertex_t> this_label_sorted_unrenumbered_edgelist_srcs(
@@ -206,7 +206,7 @@ bool compare_edgelist(raft::handle_t const& handle,
         thrust::make_zip_iterator(this_label_sorted_unrenumbered_edgelist_srcs.begin(),
                                   this_label_sorted_unrenumbered_edgelist_dsts.begin(),
                                   (*this_label_sorted_unrenumbered_edgelist_weights).begin());
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(),
         sorted_unrenumbered_edge_first,
         sorted_unrenumbered_edge_first + this_label_sorted_unrenumbered_edgelist_srcs.size());
@@ -225,7 +225,7 @@ bool compare_edgelist(raft::handle_t const& handle,
       auto sorted_unrenumbered_edge_first =
         thrust::make_zip_iterator(this_label_sorted_unrenumbered_edgelist_srcs.begin(),
                                   this_label_sorted_unrenumbered_edgelist_dsts.begin());
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(),
         sorted_unrenumbered_edge_first,
         sorted_unrenumbered_edge_first + this_label_sorted_unrenumbered_edgelist_srcs.size());
@@ -364,12 +364,12 @@ bool compare_heterogeneous_edgelist(
 
     rmm::device_uvector<size_t> this_label_org_sorted_indices(label_end_offset - label_start_offset,
                                                               handle.get_stream());
-    thrust::sequence(handle.get_thrust_policy(),
-                     this_label_org_sorted_indices.begin(),
-                     this_label_org_sorted_indices.end(),
-                     size_t{0});
+    cugraph::sequence(handle.get_thrust_policy(),
+                      this_label_org_sorted_indices.begin(),
+                      this_label_org_sorted_indices.end(),
+                      size_t{0});
 
-    cugraph::sort_wrapper(
+    cugraph::sort(
       handle.get_thrust_policy(),
       this_label_org_sorted_indices.begin(),
       this_label_org_sorted_indices.end(),
@@ -630,10 +630,10 @@ bool compare_heterogeneous_edgelist(
 
       rmm::device_uvector<size_t> this_edge_type_unrenumbered_sorted_indices(
         edge_type_end_offset - edge_type_start_offset, handle.get_stream());
-      thrust::sequence(handle.get_thrust_policy(),
-                       this_edge_type_unrenumbered_sorted_indices.begin(),
-                       this_edge_type_unrenumbered_sorted_indices.end(),
-                       size_t{0});
+      cugraph::sequence(handle.get_thrust_policy(),
+                        this_edge_type_unrenumbered_sorted_indices.begin(),
+                        this_edge_type_unrenumbered_sorted_indices.end(),
+                        size_t{0});
 
       for (size_t k = 0; k < num_hops; ++k) {
         auto hop_start_offset = edge_type_start_offset;
@@ -654,7 +654,7 @@ bool compare_heterogeneous_edgelist(
 
         if (hop_start_offset == hop_end_offset) { continue; }
 
-        cugraph::sort_wrapper(
+        cugraph::sort(
           handle.get_thrust_policy(),
           this_edge_type_unrenumbered_sorted_indices.begin() +
             (hop_start_offset - edge_type_start_offset),
@@ -1008,15 +1008,15 @@ bool check_vertex_renumber_map_invariants(
         auto old_size = (*this_label_unique_major_hops).size();
         (*this_label_unique_major_hops)
           .resize(this_label_unique_majors.size(), handle.get_stream());
-        thrust::fill(handle.get_thrust_policy(),
-                     (*this_label_unique_major_hops).begin() + old_size,
-                     (*this_label_unique_major_hops).end(),
-                     int32_t{0});
+        cugraph::fill(handle.get_thrust_policy(),
+                      (*this_label_unique_major_hops).begin() + old_size,
+                      (*this_label_unique_major_hops).end(),
+                      int32_t{0});
       }
 
       auto pair_first = thrust::make_zip_iterator(this_label_unique_majors.begin(),
                                                   (*this_label_unique_major_hops).begin());
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(), pair_first, pair_first + this_label_unique_majors.size());
       this_label_unique_majors.resize(
         cuda::std::distance(
@@ -1028,14 +1028,14 @@ bool check_vertex_renumber_map_invariants(
         handle.get_stream());
       (*this_label_unique_major_hops).resize(this_label_unique_majors.size(), handle.get_stream());
     } else {
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            this_label_unique_majors.begin(),
-                            this_label_unique_majors.end());
+      cugraph::sort(handle.get_thrust_policy(),
+                    this_label_unique_majors.begin(),
+                    this_label_unique_majors.end());
       this_label_unique_majors.resize(
         cuda::std::distance(this_label_unique_majors.begin(),
-                            thrust::unique(handle.get_thrust_policy(),
-                                           this_label_unique_majors.begin(),
-                                           this_label_unique_majors.end())),
+                            cugraph::unique(handle.get_thrust_policy(),
+                                            this_label_unique_majors.begin(),
+                                            this_label_unique_majors.end())),
         handle.get_stream());
     }
 
@@ -1059,7 +1059,7 @@ bool check_vertex_renumber_map_invariants(
 
       auto pair_first = thrust::make_zip_iterator(this_label_unique_minors.begin(),
                                                   (*this_label_unique_minor_hops).begin());
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(), pair_first, pair_first + this_label_unique_minors.size());
       this_label_unique_minors.resize(
         cuda::std::distance(
@@ -1074,14 +1074,14 @@ bool check_vertex_renumber_map_invariants(
           .resize(this_label_unique_minors.size(), handle.get_stream());
       }
     } else {
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            this_label_unique_minors.begin(),
-                            this_label_unique_minors.end());
+      cugraph::sort(handle.get_thrust_policy(),
+                    this_label_unique_minors.begin(),
+                    this_label_unique_minors.end());
       this_label_unique_minors.resize(
         cuda::std::distance(this_label_unique_minors.begin(),
-                            thrust::unique(handle.get_thrust_policy(),
-                                           this_label_unique_minors.begin(),
-                                           this_label_unique_minors.end())),
+                            cugraph::unique(handle.get_thrust_policy(),
+                                            this_label_unique_minors.begin(),
+                                            this_label_unique_minors.end())),
         handle.get_stream());
     }
 
@@ -1108,10 +1108,10 @@ bool check_vertex_renumber_map_invariants(
                    renumber_map.begin() + renumber_map_type_start_offset,
                    renumber_map.begin() + renumber_map_type_end_offset,
                    this_type_sorted_org_vertices.begin());
-      thrust::sequence(handle.get_thrust_policy(),
-                       this_type_matching_renumbered_vertices.begin(),
-                       this_type_matching_renumbered_vertices.end(),
-                       vertex_t{0});
+      cugraph::sequence(handle.get_thrust_policy(),
+                        this_type_matching_renumbered_vertices.begin(),
+                        this_type_matching_renumbered_vertices.end(),
+                        vertex_t{0});
       thrust::sort_by_key(handle.get_thrust_policy(),
                           this_type_sorted_org_vertices.begin(),
                           this_type_sorted_org_vertices.end(),
@@ -1536,9 +1536,9 @@ bool check_edge_id_renumber_map_invariants(
         auto triplet_first = thrust::make_zip_iterator((*this_label_unique_key_edge_types).begin(),
                                                        this_label_unique_key_edge_ids.begin(),
                                                        (*this_label_unique_key_hops).begin());
-        cugraph::sort_wrapper(handle.get_thrust_policy(),
-                              triplet_first,
-                              triplet_first + this_label_unique_key_edge_ids.size());
+        cugraph::sort(handle.get_thrust_policy(),
+                      triplet_first,
+                      triplet_first + this_label_unique_key_edge_ids.size());
         auto key_first = thrust::make_zip_iterator((*this_label_unique_key_edge_types).begin(),
                                                    this_label_unique_key_edge_ids.begin());
         this_label_unique_key_edge_ids.resize(
@@ -1556,14 +1556,14 @@ bool check_edge_id_renumber_map_invariants(
       } else {
         auto pair_first = thrust::make_zip_iterator((*this_label_unique_key_edge_types).begin(),
                                                     this_label_unique_key_edge_ids.begin());
-        cugraph::sort_wrapper(handle.get_thrust_policy(),
-                              pair_first,
-                              pair_first + this_label_unique_key_edge_ids.size());
+        cugraph::sort(handle.get_thrust_policy(),
+                      pair_first,
+                      pair_first + this_label_unique_key_edge_ids.size());
         this_label_unique_key_edge_ids.resize(
           cuda::std::distance(pair_first,
-                              thrust::unique(handle.get_thrust_policy(),
-                                             pair_first,
-                                             pair_first + this_label_unique_key_edge_ids.size())),
+                              cugraph::unique(handle.get_thrust_policy(),
+                                              pair_first,
+                                              pair_first + this_label_unique_key_edge_ids.size())),
           handle.get_stream());
         (*this_label_unique_key_edge_types)
           .resize(this_label_unique_key_edge_ids.size(), handle.get_stream());
@@ -1572,9 +1572,9 @@ bool check_edge_id_renumber_map_invariants(
       if (org_edgelist_hops) {
         auto pair_first = thrust::make_zip_iterator(this_label_unique_key_edge_ids.begin(),
                                                     (*this_label_unique_key_hops).begin());
-        cugraph::sort_wrapper(handle.get_thrust_policy(),
-                              pair_first,
-                              pair_first + this_label_unique_key_edge_ids.size());
+        cugraph::sort(handle.get_thrust_policy(),
+                      pair_first,
+                      pair_first + this_label_unique_key_edge_ids.size());
         this_label_unique_key_edge_ids.resize(
           cuda::std::distance(
             this_label_unique_key_edge_ids.begin(),
@@ -1586,14 +1586,14 @@ bool check_edge_id_renumber_map_invariants(
         (*this_label_unique_key_hops)
           .resize(this_label_unique_key_edge_ids.size(), handle.get_stream());
       } else {
-        cugraph::sort_wrapper(handle.get_thrust_policy(),
-                              this_label_unique_key_edge_ids.begin(),
-                              this_label_unique_key_edge_ids.end());
+        cugraph::sort(handle.get_thrust_policy(),
+                      this_label_unique_key_edge_ids.begin(),
+                      this_label_unique_key_edge_ids.end());
         this_label_unique_key_edge_ids.resize(
           cuda::std::distance(this_label_unique_key_edge_ids.begin(),
-                              thrust::unique(handle.get_thrust_policy(),
-                                             this_label_unique_key_edge_ids.begin(),
-                                             this_label_unique_key_edge_ids.end())),
+                              cugraph::unique(handle.get_thrust_policy(),
+                                              this_label_unique_key_edge_ids.begin(),
+                                              this_label_unique_key_edge_ids.end())),
           handle.get_stream());
       }
     }
@@ -1621,10 +1621,10 @@ bool check_edge_id_renumber_map_invariants(
                    renumber_map.begin() + renumber_map_type_start_offset,
                    renumber_map.begin() + renumber_map_type_end_offset,
                    this_type_sorted_org_edge_ids.begin());
-      thrust::sequence(handle.get_thrust_policy(),
-                       this_type_matching_renumbered_edge_ids.begin(),
-                       this_type_matching_renumbered_edge_ids.end(),
-                       edge_id_t{0});
+      cugraph::sequence(handle.get_thrust_policy(),
+                        this_type_matching_renumbered_edge_ids.begin(),
+                        this_type_matching_renumbered_edge_ids.end(),
+                        edge_id_t{0});
       thrust::sort_by_key(handle.get_thrust_policy(),
                           this_type_sorted_org_edge_ids.begin(),
                           this_type_sorted_org_edge_ids.end(),

--- a/cpp/tests/sampling/mg_random_walks_test.cpp
+++ b/cpp/tests/sampling/mg_random_walks_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,9 +14,12 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/graph_view.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
+
+#include <rmm/exec_policy.hpp>
 
 #include <gtest/gtest.h>
 
@@ -143,10 +146,10 @@ class Tests_MGRandomWalks : public ::testing::TestWithParam<tuple_t> {
       d_start.resize(std::min(10, mg_graph_view.local_vertex_partition_range_size()),
                      handle_->get_stream());
 
-      cugraph::detail::sequence_fill(handle_->get_stream(),
-                                     d_start.begin(),
-                                     d_start.size(),
-                                     mg_graph_view.local_vertex_partition_range_first());
+      cugraph::sequence(rmm::exec_policy(handle_->get_stream()),
+                        d_start.begin(),
+                        d_start.begin() + d_start.size(),
+                        mg_graph_view.local_vertex_partition_range_first());
     }
 
     if (cugraph::test::g_perf) {

--- a/cpp/tests/sampling/random_walks_check.cuh
+++ b/cpp/tests/sampling/random_walks_check.cuh
@@ -63,9 +63,9 @@ void random_walks_validate(
     rmm::device_uvector<int> failures(d_start.size() * max_length, handle.get_stream());
 
     if (d_wgt) {
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            thrust::make_zip_iterator(d_src.begin(), d_dst.begin(), d_wgt->begin()),
-                            thrust::make_zip_iterator(d_src.end(), d_dst.end(), d_wgt->end()));
+      cugraph::sort(handle.get_thrust_policy(),
+                    thrust::make_zip_iterator(d_src.begin(), d_dst.begin(), d_wgt->begin()),
+                    thrust::make_zip_iterator(d_src.end(), d_dst.end(), d_wgt->end()));
 
       thrust::transform(
         handle.get_thrust_policy(),
@@ -110,9 +110,9 @@ void random_walks_validate(
           return 0;
         });
     } else {
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            thrust::make_zip_iterator(d_src.begin(), d_dst.begin()),
-                            thrust::make_zip_iterator(d_src.end(), d_dst.end()));
+      cugraph::sort(handle.get_thrust_policy(),
+                    thrust::make_zip_iterator(d_src.begin(), d_dst.begin()),
+                    thrust::make_zip_iterator(d_src.end(), d_dst.end()));
 
       thrust::transform(
         handle.get_thrust_policy(),

--- a/cpp/tests/sampling/sampling_heterogeneous_post_processing_test.cpp
+++ b/cpp/tests/sampling/sampling_heterogeneous_post_processing_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,10 +11,12 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/sampling_functions.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <gtest/gtest.h>
 
@@ -128,16 +130,18 @@ class Tests_SamplingHeterogeneousPostProcessing
     if (starting_vertex_labels) {
       auto num_seeds_per_label = sampling_heterogeneous_post_processing_usecase.num_seeds_per_label;
       for (size_t i = 0; i < sampling_heterogeneous_post_processing_usecase.num_labels; ++i) {
-        cugraph::detail::scalar_fill(handle.get_stream(),
-                                     (*starting_vertex_labels).data() + i * num_seeds_per_label,
-                                     num_seeds_per_label,
-                                     static_cast<label_t>(i));
+        cugraph::fill(
+          rmm::exec_policy(handle.get_stream()),
+          (*starting_vertex_labels).data() + i * num_seeds_per_label,
+          ((*starting_vertex_labels).data() + i * num_seeds_per_label) + (num_seeds_per_label),
+          static_cast<label_t>(i));
       }
-      cugraph::detail::stride_fill(handle.get_stream(),
-                                   (*starting_vertex_label_offsets).data(),
-                                   (*starting_vertex_label_offsets).size(),
-                                   size_t{0},
-                                   num_seeds_per_label);
+      cugraph::sequence(
+        rmm::exec_policy(handle.get_stream()),
+        (*starting_vertex_label_offsets).data(),
+        (*starting_vertex_label_offsets).data() + (*starting_vertex_label_offsets).size(),
+        size_t{0},
+        num_seeds_per_label);
     }
 
     // 4. generate edge IDs and types

--- a/cpp/tests/sampling/sampling_post_processing_test.cpp
+++ b/cpp/tests/sampling/sampling_post_processing_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,10 +9,12 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/sampling_functions.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <gtest/gtest.h>
 
@@ -106,16 +108,18 @@ class Tests_SamplingPostProcessing
     if (starting_vertex_labels) {
       auto num_seeds_per_label = sampling_post_processing_usecase.num_seeds_per_label;
       for (size_t i = 0; i < sampling_post_processing_usecase.num_labels; ++i) {
-        cugraph::detail::scalar_fill(handle.get_stream(),
-                                     (*starting_vertex_labels).data() + i * num_seeds_per_label,
-                                     num_seeds_per_label,
-                                     static_cast<label_t>(i));
+        cugraph::fill(
+          rmm::exec_policy(handle.get_stream()),
+          (*starting_vertex_labels).data() + i * num_seeds_per_label,
+          ((*starting_vertex_labels).data() + i * num_seeds_per_label) + (num_seeds_per_label),
+          static_cast<label_t>(i));
       }
-      cugraph::detail::stride_fill(handle.get_stream(),
-                                   (*starting_vertex_label_offsets).data(),
-                                   (*starting_vertex_label_offsets).size(),
-                                   size_t{0},
-                                   num_seeds_per_label);
+      cugraph::sequence(
+        rmm::exec_policy(handle.get_stream()),
+        (*starting_vertex_label_offsets).data(),
+        (*starting_vertex_label_offsets).data() + (*starting_vertex_label_offsets).size(),
+        size_t{0},
+        num_seeds_per_label);
     }
 
     // 3. sampling

--- a/cpp/tests/sampling/sg_random_walks_test.cpp
+++ b/cpp/tests/sampling/sg_random_walks_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,6 +13,9 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/graph_view.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
+
+#include <rmm/exec_policy.hpp>
 
 #include <gtest/gtest.h>
 
@@ -134,7 +137,8 @@ class Tests_RandomWalks : public ::testing::TestWithParam<tuple_t> {
     edge_t max_length = 10;
     rmm::device_uvector<vertex_t> d_start(num_paths, handle.get_stream());
 
-    cugraph::detail::sequence_fill(handle.get_stream(), d_start.begin(), d_start.size(), 0);
+    cugraph::sequence(
+      rmm::exec_policy(handle.get_stream()), d_start.begin(), d_start.begin() + d_start.size(), 0);
 
     if (cugraph::test::g_perf) {
       RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement

--- a/cpp/tests/structure/induced_subgraph_validate.cu
+++ b/cpp/tests/structure/induced_subgraph_validate.cu
@@ -98,20 +98,20 @@ void induced_subgraph_validate(
       << "Extracted subgraph edges do not match with the edges extracted by the reference "
          "implementation.";
   } else {
-    cugraph::sort_wrapper(handle.get_thrust_policy(),
-                          thrust::make_zip_iterator(d_subgraph_index.begin(),
-                                                    d_reference_subgraph_edgelist_majors.begin(),
-                                                    d_reference_subgraph_edgelist_minors.begin()),
-                          thrust::make_zip_iterator(d_subgraph_index.end(),
-                                                    d_reference_subgraph_edgelist_majors.end(),
-                                                    d_reference_subgraph_edgelist_minors.end()));
-    cugraph::sort_wrapper(handle.get_thrust_policy(),
-                          thrust::make_zip_iterator(d_subgraph_index.begin(),
-                                                    d_cugraph_subgraph_edgelist_majors.begin(),
-                                                    d_cugraph_subgraph_edgelist_minors.begin()),
-                          thrust::make_zip_iterator(d_subgraph_index.end(),
-                                                    d_cugraph_subgraph_edgelist_majors.end(),
-                                                    d_cugraph_subgraph_edgelist_minors.end()));
+    cugraph::sort(handle.get_thrust_policy(),
+                  thrust::make_zip_iterator(d_subgraph_index.begin(),
+                                            d_reference_subgraph_edgelist_majors.begin(),
+                                            d_reference_subgraph_edgelist_minors.begin()),
+                  thrust::make_zip_iterator(d_subgraph_index.end(),
+                                            d_reference_subgraph_edgelist_majors.end(),
+                                            d_reference_subgraph_edgelist_minors.end()));
+    cugraph::sort(handle.get_thrust_policy(),
+                  thrust::make_zip_iterator(d_subgraph_index.begin(),
+                                            d_cugraph_subgraph_edgelist_majors.begin(),
+                                            d_cugraph_subgraph_edgelist_minors.begin()),
+                  thrust::make_zip_iterator(d_subgraph_index.end(),
+                                            d_cugraph_subgraph_edgelist_majors.end(),
+                                            d_cugraph_subgraph_edgelist_minors.end()));
 
     ASSERT_TRUE(
       thrust::equal(handle.get_thrust_policy(),

--- a/cpp/tests/structure/mg_induced_subgraph_test.cu
+++ b/cpp/tests/structure/mg_induced_subgraph_test.cu
@@ -204,7 +204,7 @@ class Tests_MGInducedSubgraph
                             triplet_first + graph_ids_v.size(),
                             d_subgraph_edgelist_weights->begin());
       } else {
-        cugraph::sort_wrapper(
+        cugraph::sort(
           handle_->get_thrust_policy(), triplet_first, triplet_first + graph_ids_v.size());
       }
 

--- a/cpp/tests/traversal/detail/graph500_forest_pruning_utils.cuh
+++ b/cpp/tests/traversal/detail/graph500_forest_pruning_utils.cuh
@@ -72,11 +72,11 @@ find_trees_from_2cores(
 
   rmm::device_uvector<vertex_t> parents(mg_graph_view.local_vertex_partition_range_size(),
                                         handle.get_stream());
-  thrust::fill(handle.get_thrust_policy(), parents.begin(), parents.end(), invalid_vertex);
+  cugraph::fill(handle.get_thrust_policy(), parents.begin(), parents.end(), invalid_vertex);
   std::optional<rmm::device_uvector<weight_t>> w_to_parents{std::nullopt};
   if (mg_edge_weight_view) {
     w_to_parents = rmm::device_uvector<weight_t>(parents.size(), handle.get_stream());
-    thrust::fill(
+    cugraph::fill(
       handle.get_thrust_policy(), w_to_parents->begin(), w_to_parents->end(), *invalid_distance);
   }
 
@@ -247,7 +247,7 @@ find_trees_from_2cores(
       weights = std::nullopt;
 
       auto new_reachable_vertices = std::move(srcs);
-      cugraph::sort_wrapper(
+      cugraph::sort(
         handle.get_thrust_policy(), new_reachable_vertices.begin(), new_reachable_vertices.end());
       fill_edge_src_property(handle,
                              tmp_graph_view,
@@ -508,7 +508,7 @@ extract_forest_pruned_graph_and_isolated_trees(
                  mg_isolated_trees_renumber_map.end(),
                  sorted_vertices.begin());
     rmm::device_uvector<vertex_t> indices(sorted_vertices.size(), handle.get_stream());
-    thrust::sequence(handle.get_thrust_policy(), indices.begin(), indices.end(), vertex_t{0});
+    cugraph::sequence(handle.get_thrust_policy(), indices.begin(), indices.end(), vertex_t{0});
     thrust::sort_by_key(
       handle.get_thrust_policy(), sorted_vertices.begin(), sorted_vertices.end(), indices.begin());
     mg_graph_to_isolated_trees_map.resize(mg_renumber_map.size(), handle.get_stream());
@@ -537,7 +537,7 @@ extract_forest_pruned_graph_and_isolated_trees(
                  mg_renumber_map.end(),
                  sorted_vertices.begin());
     indices.resize(sorted_vertices.size(), handle.get_stream());
-    thrust::sequence(handle.get_thrust_policy(), indices.begin(), indices.end(), vertex_t{0});
+    cugraph::sequence(handle.get_thrust_policy(), indices.begin(), indices.end(), vertex_t{0});
     thrust::sort_by_key(
       handle.get_thrust_policy(), sorted_vertices.begin(), sorted_vertices.end(), indices.begin());
     mg_isolated_trees_to_graph_map.resize(mg_isolated_trees_renumber_map.size(),
@@ -570,7 +570,7 @@ extract_forest_pruned_graph_and_isolated_trees(
                  mg_pruned_graph_renumber_map.end(),
                  sorted_vertices.begin());
     rmm::device_uvector<vertex_t> indices(sorted_vertices.size(), handle.get_stream());
-    thrust::sequence(handle.get_thrust_policy(), indices.begin(), indices.end(), vertex_t{0});
+    cugraph::sequence(handle.get_thrust_policy(), indices.begin(), indices.end(), vertex_t{0});
     thrust::sort_by_key(
       handle.get_thrust_policy(), sorted_vertices.begin(), sorted_vertices.end(), indices.begin());
     mg_graph_to_pruned_graph_map.resize(mg_renumber_map.size(), handle.get_stream());
@@ -599,7 +599,7 @@ extract_forest_pruned_graph_and_isolated_trees(
                  mg_renumber_map.end(),
                  sorted_vertices.begin());
     indices.resize(sorted_vertices.size(), handle.get_stream());
-    thrust::sequence(handle.get_thrust_policy(), indices.begin(), indices.end(), vertex_t{0});
+    cugraph::sequence(handle.get_thrust_policy(), indices.begin(), indices.end(), vertex_t{0});
     thrust::sort_by_key(
       handle.get_thrust_policy(), sorted_vertices.begin(), sorted_vertices.end(), indices.begin());
     mg_pruned_graph_to_graph_map.resize(mg_pruned_graph_renumber_map.size(), handle.get_stream());

--- a/cpp/tests/traversal/detail/graph500_nbr_unrenumber_cache.cuh
+++ b/cpp/tests/traversal/detail/graph500_nbr_unrenumber_cache.cuh
@@ -159,10 +159,10 @@ class nbr_unrenumber_cache_t {
       consecutive_unrenumbered_sorted_unique_nbrs_.resize(
         consecutive_size_per_vertex_partition_ * vertex_partition_range_lasts_.size(),
         handle.get_stream());
-      thrust::fill(handle.get_thrust_policy(),
-                   consecutive_unrenumbered_sorted_unique_nbrs_.begin(),
-                   consecutive_unrenumbered_sorted_unique_nbrs_.end(),
-                   invalid_vertex_);
+      cugraph::fill(handle.get_thrust_policy(),
+                    consecutive_unrenumbered_sorted_unique_nbrs_.begin(),
+                    consecutive_unrenumbered_sorted_unique_nbrs_.end(),
+                    invalid_vertex_);
       thrust::for_each(
         handle.get_thrust_policy(),
         pair_first,
@@ -595,10 +595,10 @@ nbr_unrenumber_cache_t<vertex_t> build_nbr_unrenumber_cache(
   if (dense_size_per_vertex_partition) {
     dense_nbr_bitmap = rmm::device_uvector<uint32_t>(
       cugraph::packed_bool_size(*dense_size_per_vertex_partition * comm_size), handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(),
-                 dense_nbr_bitmap->begin(),
-                 dense_nbr_bitmap->end(),
-                 cugraph::packed_bool_empty_mask());
+    cugraph::fill(handle.get_thrust_policy(),
+                  dense_nbr_bitmap->begin(),
+                  dense_nbr_bitmap->end(),
+                  cugraph::packed_bool_empty_mask());
   }
   for (size_t r = 0; r < num_k_hop_rounds; ++r) {
     rmm::device_uvector<vertex_t> this_round_nbrs(0, handle.get_stream());
@@ -703,13 +703,12 @@ nbr_unrenumber_cache_t<vertex_t> build_nbr_unrenumber_cache(
                              handle.get_stream());
       this_round_nbrs.shrink_to_fit(handle.get_stream());
     }
-    cugraph::sort_wrapper(
-      handle.get_thrust_policy(), this_round_nbrs.begin(), this_round_nbrs.end());
-    this_round_nbrs.resize(
-      cuda::std::distance(
-        this_round_nbrs.begin(),
-        thrust::unique(handle.get_thrust_policy(), this_round_nbrs.begin(), this_round_nbrs.end())),
-      handle.get_stream());
+    cugraph::sort(handle.get_thrust_policy(), this_round_nbrs.begin(), this_round_nbrs.end());
+    this_round_nbrs.resize(cuda::std::distance(this_round_nbrs.begin(),
+                                               cugraph::unique(handle.get_thrust_policy(),
+                                                               this_round_nbrs.begin(),
+                                                               this_round_nbrs.end())),
+                           handle.get_stream());
     if ((nbrs.size() > 0) && (this_round_nbrs.size() > 0)) {
       auto tmp_buf_size = std::max(nbrs.size() / num_k_hop_rounds, this_round_nbrs.size());
       auto num_chunks   = (nbrs.size() + (tmp_buf_size - 1)) / tmp_buf_size;
@@ -742,10 +741,10 @@ nbr_unrenumber_cache_t<vertex_t> build_nbr_unrenumber_cache(
                      new_nbrs.begin(),
                      new_nbrs.end(),
                      this_round_nbrs.begin() + this_round_nbr_offset);
-        thrust::fill(handle.get_thrust_policy(),
-                     this_round_nbrs.begin() + this_round_nbr_offset + new_nbrs.size(),
-                     last,
-                     invalid_vertex);
+        cugraph::fill(handle.get_thrust_policy(),
+                      this_round_nbrs.begin() + this_round_nbr_offset + new_nbrs.size(),
+                      last,
+                      invalid_vertex);
         this_round_nbr_offset += static_cast<vertex_t>(
           cuda::std::distance(this_round_nbrs.begin() + this_round_nbr_offset, last));
       }

--- a/cpp/tests/traversal/detail/graph500_validation_utils.cuh
+++ b/cpp/tests/traversal/detail/graph500_validation_utils.cuh
@@ -522,8 +522,7 @@ bool check_edge_endpoint_distances(
         cuda::proclaim_return_type<vertex_t>(
           [v_first = mg_subgraph_view.local_vertex_partition_range_first()] __device__(
             auto v_offset) { return v_first + v_offset; }));
-      cugraph::sort_wrapper(
-        handle.get_thrust_policy(), subgraph_level_vs.begin(), subgraph_level_vs.end());
+      cugraph::sort(handle.get_thrust_policy(), subgraph_level_vs.begin(), subgraph_level_vs.end());
       cugraph::fill_edge_src_property(
         handle, mg_subgraph_view, edge_src_flags.mutable_view(), false);
       cugraph::fill_edge_src_property(handle,
@@ -541,9 +540,9 @@ bool check_edge_endpoint_distances(
         cuda::proclaim_return_type<vertex_t>(
           [v_first = mg_subgraph_view.local_vertex_partition_range_first()] __device__(
             auto v_offset) { return v_first + v_offset; }));
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            subgraph_adjacent_level_vs.begin(),
-                            subgraph_adjacent_level_vs.end());
+      cugraph::sort(handle.get_thrust_policy(),
+                    subgraph_adjacent_level_vs.begin(),
+                    subgraph_adjacent_level_vs.end());
       cugraph::fill_edge_dst_property(
         handle, mg_subgraph_view, edge_dst_flags.mutable_view(), false);
       cugraph::fill_edge_dst_property(handle,
@@ -907,9 +906,9 @@ bool check_has_edge_from_parents(
       }
       auto forest_edge_first =
         thrust::make_zip_iterator(forest_edge_vertices.begin(), forest_edge_parents.begin());
-      cugraph::sort_wrapper(handle.get_thrust_policy(),
-                            forest_edge_first,
-                            forest_edge_first + forest_edge_vertices.size());
+      cugraph::sort(handle.get_thrust_policy(),
+                    forest_edge_first,
+                    forest_edge_first + forest_edge_vertices.size());
       query_edge_first = thrust::make_zip_iterator(query_preds.begin(), query_vertices.begin());
       query_preds.resize(
         cuda::std::distance(

--- a/cpp/tests/traversal/extract_bfs_paths_test.cu
+++ b/cpp/tests/traversal/extract_bfs_paths_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,12 +14,14 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/graph_view.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/util/cudart_utils.hpp>
 
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 
 #include <cuda/std/iterator>
@@ -120,8 +122,10 @@ class Tests_ExtractBfsPaths
     {
       constexpr vertex_t invalid_vertex = cugraph::invalid_vertex_id<vertex_t>::value;
       auto local_vertex_first           = vertex_t{0};
-      cugraph::detail::sequence_fill(
-        handle.get_stream(), d_vertices.begin(), d_vertices.size(), local_vertex_first);
+      cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                        d_vertices.begin(),
+                        d_vertices.begin() + d_vertices.size(),
+                        local_vertex_first);
       auto end_iter = thrust::remove_if(
         handle.get_thrust_policy(),
         d_vertices.begin(),

--- a/cpp/tests/traversal/mg_extract_bfs_paths_test.cu
+++ b/cpp/tests/traversal/mg_extract_bfs_paths_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,6 +16,7 @@
 #include <cugraph/graph_functions.hpp>
 #include <cugraph/graph_view.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -23,6 +24,7 @@
 
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 
 #include <cuda/std/iterator>
@@ -124,8 +126,10 @@ class Tests_MGExtractBFSPaths
     {
       constexpr vertex_t invalid_vertex = cugraph::invalid_vertex_id<vertex_t>::value;
       auto local_vertex_first           = mg_graph_view.local_vertex_partition_range_first();
-      cugraph::detail::sequence_fill(
-        handle_->get_stream(), d_vertices.begin(), d_vertices.size(), local_vertex_first);
+      cugraph::sequence(rmm::exec_policy(handle_->get_stream()),
+                        d_vertices.begin(),
+                        d_vertices.begin() + d_vertices.size(),
+                        local_vertex_first);
       auto end_iter = thrust::remove_if(
         handle_->get_thrust_policy(),
         d_vertices.begin(),

--- a/cpp/tests/traversal/mg_graph500_bfs_test.cu
+++ b/cpp/tests/traversal/mg_graph500_bfs_test.cu
@@ -30,6 +30,7 @@
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/misc_utils.cuh>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/comms/mpi_comms.hpp>
 #include <raft/core/comms.hpp>
@@ -481,10 +482,10 @@ class Tests_GRAPH500_MGBFS
     for (size_t i = 0; i < (num_warmup_starting_vertices + num_timed_starting_vertices); ++i) {
       double elapsed{0.0};
 
-      thrust::fill(handle_->get_thrust_policy(),
-                   d_mg_distances.begin(),
-                   d_mg_distances.end(),
-                   invalid_distance);
+      cugraph::fill(handle_->get_thrust_policy(),
+                    d_mg_distances.begin(),
+                    d_mg_distances.end(),
+                    invalid_distance);
 
       if (cugraph::test::g_perf) {
         RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
@@ -572,10 +573,10 @@ class Tests_GRAPH500_MGBFS
                                        : invalid_vertex;
                             }));
       } else {
-        thrust::fill(handle_->get_thrust_policy(),
-                     d_mg_unrenumbered_predecessors.begin(),
-                     d_mg_unrenumbered_predecessors.end(),
-                     invalid_vertex);
+        cugraph::fill(handle_->get_thrust_policy(),
+                      d_mg_unrenumbered_predecessors.begin(),
+                      d_mg_unrenumbered_predecessors.end(),
+                      invalid_vertex);
       }
 
       vertex_t subgraph_starting_vertex{starting_vertex};

--- a/cpp/tests/traversal/mg_graph500_sssp_test.cu
+++ b/cpp/tests/traversal/mg_graph500_sssp_test.cu
@@ -477,10 +477,10 @@ class Tests_GRAPH500_MGSSSP
     for (size_t i = 0; i < (num_warmup_starting_vertices + num_timed_starting_vertices); ++i) {
       double elapsed{0.0};
 
-      thrust::fill(handle_->get_thrust_policy(),
-                   d_mg_w_to_predecessors.begin(),
-                   d_mg_w_to_predecessors.end(),
-                   invalid_distance);
+      cugraph::fill(handle_->get_thrust_policy(),
+                    d_mg_w_to_predecessors.begin(),
+                    d_mg_w_to_predecessors.end(),
+                    invalid_distance);
 
       if (cugraph::test::g_perf) {
         RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement
@@ -488,10 +488,10 @@ class Tests_GRAPH500_MGSSSP
         hr_timer.start("MG SSSP (Kernel 2)");
       }
 
-      thrust::fill(handle_->get_thrust_policy(),
-                   d_mg_distances.begin(),
-                   d_mg_distances.end(),
-                   invalid_distance);
+      cugraph::fill(handle_->get_thrust_policy(),
+                    d_mg_distances.begin(),
+                    d_mg_distances.end(),
+                    invalid_distance);
 
       auto starting_vertex = starting_vertices[i];
       auto starting_vertex_vertex_partition_id =
@@ -545,10 +545,10 @@ class Tests_GRAPH500_MGSSSP
                                        : invalid_vertex;
                             }));
       } else {
-        thrust::fill(handle_->get_thrust_policy(),
-                     d_mg_unrenumbered_predecessors.begin(),
-                     d_mg_unrenumbered_predecessors.end(),
-                     invalid_vertex);
+        cugraph::fill(handle_->get_thrust_policy(),
+                      d_mg_unrenumbered_predecessors.begin(),
+                      d_mg_unrenumbered_predecessors.end(),
+                      invalid_vertex);
       }
 
       vertex_t subgraph_starting_vertex{starting_vertex};
@@ -904,7 +904,7 @@ class Tests_GRAPH500_MGSSSP
             cugraph::edge_bucket_t<vertex_t, edge_t, !store_transposed, multi_gpu, true> edge_list(
               *handle_, false);
             auto edge_pair_first = thrust::make_zip_iterator(tree_srcs.begin(), tree_dsts.begin());
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle_->get_thrust_policy(), edge_pair_first, edge_pair_first + tree_srcs.size());
             edge_list.insert(tree_srcs.begin(),
                              tree_srcs.end(),

--- a/cpp/tests/utilities/conversion_utilities_impl.cuh
+++ b/cpp/tests/utilities/conversion_utilities_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -14,8 +14,11 @@
 #include <cugraph/partition_manager.hpp>
 #include <cugraph/utilities/host_scalar_comm.hpp>
 #include <cugraph/utilities/shuffle_comm.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/device_span.hpp>
+
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/sort.h>
 
@@ -320,8 +323,10 @@ mg_graph_to_sg_graph(
   if (handle.get_comms().get_rank() == 0) {
     if (!renumber_map) {
       vertices.resize(graph_view.number_of_vertices(), handle.get_stream());
-      cugraph::detail::sequence_fill(
-        handle.get_stream(), vertices.data(), vertices.size(), vertex_t{0});
+      cugraph::sequence(rmm::exec_policy(handle.get_stream()),
+                        vertices.data(),
+                        vertices.data() + vertices.size(),
+                        vertex_t{0});
     }
 
     std::vector<cugraph::edge_arithmetic_property_t<edge_t>> sg_edge_properties{};
@@ -414,10 +419,10 @@ mg_vertex_property_values_to_sg_vertex_property_values(
       rmm::device_uvector<vertex_t> local_vertices(
         std::get<1>(mg_local_vertex_partition_range) - std::get<0>(mg_local_vertex_partition_range),
         handle.get_stream());
-      thrust::sequence(handle.get_thrust_policy(),
-                       local_vertices.begin(),
-                       local_vertices.end(),
-                       std::get<0>(mg_local_vertex_partition_range));
+      cugraph::sequence(handle.get_thrust_policy(),
+                        local_vertices.begin(),
+                        local_vertices.end(),
+                        std::get<0>(mg_local_vertex_partition_range));
       mg_aggregate_vertices = cugraph::test::device_gatherv(
         handle, raft::device_span<vertex_t const>(local_vertices.data(), local_vertices.size()));
     }

--- a/cpp/tests/utilities/csv_file_utilities_impl.cuh
+++ b/cpp/tests/utilities/csv_file_utilities_impl.cuh
@@ -113,20 +113,20 @@ bool check_symmetric(raft::handle_t const& handle,
   if (edgelist_weights) {
     auto org_first = thrust::make_zip_iterator(
       cuda::std::make_tuple(org_srcs.begin(), org_dsts.begin(), (*org_weights).begin()));
-    cugraph::sort_wrapper(handle.get_thrust_policy(), org_first, org_first + org_srcs.size());
+    cugraph::sort(handle.get_thrust_policy(), org_first, org_first + org_srcs.size());
     auto symmetrized_first = thrust::make_zip_iterator(cuda::std::make_tuple(
       symmetrized_srcs.begin(), symmetrized_dsts.begin(), (*symmetrized_weights).begin()));
-    cugraph::sort_wrapper(
+    cugraph::sort(
       handle.get_thrust_policy(), symmetrized_first, symmetrized_first + symmetrized_srcs.size());
     return thrust::equal(
       handle.get_thrust_policy(), org_first, org_first + org_srcs.size(), symmetrized_first);
   } else {
     auto org_first =
       thrust::make_zip_iterator(cuda::std::make_tuple(org_srcs.begin(), org_dsts.begin()));
-    cugraph::sort_wrapper(handle.get_thrust_policy(), org_first, org_first + org_srcs.size());
+    cugraph::sort(handle.get_thrust_policy(), org_first, org_first + org_srcs.size());
     auto symmetrized_first = thrust::make_zip_iterator(
       cuda::std::make_tuple(symmetrized_srcs.begin(), symmetrized_dsts.begin()));
-    cugraph::sort_wrapper(
+    cugraph::sort(
       handle.get_thrust_policy(), symmetrized_first, symmetrized_first + symmetrized_srcs.size());
     return thrust::equal(
       handle.get_thrust_policy(), org_first, org_first + org_srcs.size(), symmetrized_first);

--- a/cpp/tests/utilities/matrix_market_file_utilities_impl.cuh
+++ b/cpp/tests/utilities/matrix_market_file_utilities_impl.cuh
@@ -11,6 +11,7 @@
 #include <cugraph/legacy/functions.hpp>
 #include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/graph_partition_utils.cuh>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/util/cudart_utils.hpp>
 
@@ -287,7 +288,7 @@ read_edgelist_from_matrix_market_file(raft::handle_t const& handle,
       (*d_edgelist_weights).data(), h_weights.data(), h_weights.size(), handle.get_stream());
   }
 
-  thrust::sequence(handle.get_thrust_policy(), d_vertices.begin(), d_vertices.end(), vertex_t{0});
+  cugraph::sequence(handle.get_thrust_policy(), d_vertices.begin(), d_vertices.end(), vertex_t{0});
 
   if (multi_gpu) {
     auto& comm                 = handle.get_comms();

--- a/cpp/tests/utilities/property_generator_utilities_impl.cuh
+++ b/cpp/tests/utilities/property_generator_utilities_impl.cuh
@@ -12,6 +12,7 @@
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
 #include <cugraph/utilities/dataframe_buffer.hpp>
 #include <cugraph/utilities/thrust_tuple_utils.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/core/handle.hpp>
 
@@ -200,7 +201,7 @@ generate<GraphViewType, property_t>::unique_edge_property_per_type(
       graph_view.compute_number_of_edges(handle) <= std::numeric_limits<property_t>::max(),
       "std::numeric_limits<property_t>::max() is smaller than the number of edges.");
     rmm::device_uvector<property_t> counters(num_edge_types, handle.get_stream());
-    thrust::fill(handle.get_thrust_policy(), counters.begin(), counters.end(), property_t{0});
+    cugraph::fill(handle.get_thrust_policy(), counters.begin(), counters.end(), property_t{0});
     cugraph::transform_e(
       handle,
       graph_view,

--- a/cpp/tests/utilities/test_graphs.hpp
+++ b/cpp/tests/utilities/test_graphs.hpp
@@ -15,8 +15,11 @@
 #include <cugraph/large_buffer_manager.hpp>
 #include <cugraph/shuffle_functions.hpp>
 #include <cugraph/utilities/host_scalar_comm.hpp>
+#include <cugraph/utilities/thrust_wrappers.hpp>
 
 #include <raft/random/rng_state.hpp>
+
+#include <rmm/exec_policy.hpp>
 
 #include <memory>
 #include <numeric>
@@ -493,10 +496,11 @@ class Rmat_Usecase : public detail::TranslateGraph_Usecase {
                       : rmm::device_uvector<vertex_t>(tot_vertex_counts, handle.get_stream());
     size_t v_offset{0};
     for (size_t i = 0; i < partition_vertex_firsts.size(); ++i) {
-      cugraph::detail::sequence_fill(handle.get_stream(),
-                                     vertex_v.begin() + v_offset,
-                                     partition_vertex_lasts[i] - partition_vertex_firsts[i],
-                                     partition_vertex_firsts[i]);
+      cugraph::sequence(
+        rmm::exec_policy(handle.get_stream()),
+        vertex_v.begin() + v_offset,
+        vertex_v.begin() + v_offset + partition_vertex_lasts[i] - partition_vertex_firsts[i],
+        partition_vertex_firsts[i]);
       v_offset += partition_vertex_lasts[i] - partition_vertex_firsts[i];
     }
     if (scramble_vertex_ids_) {

--- a/cpp/tests/utilities/thrust_wrapper.cu
+++ b/cpp/tests/utilities/thrust_wrapper.cu
@@ -45,9 +45,9 @@ cugraph::dataframe_buffer_type_t<value_t> sort(
                cugraph::get_dataframe_buffer_end(values),
                cugraph::get_dataframe_buffer_begin(sorted_values));
 
-  cugraph::sort_wrapper(handle.get_thrust_policy(),
-                        cugraph::get_dataframe_buffer_begin(sorted_values),
-                        cugraph::get_dataframe_buffer_end(sorted_values));
+  cugraph::sort(handle.get_thrust_policy(),
+                cugraph::get_dataframe_buffer_begin(sorted_values),
+                cugraph::get_dataframe_buffer_end(sorted_values));
 
   return sorted_values;
 }
@@ -64,9 +64,9 @@ cugraph::dataframe_buffer_type_t<value_t> sort(raft::handle_t const& handle,
 {
   auto sorted_values = std::move(values);
 
-  cugraph::sort_wrapper(handle.get_thrust_policy(),
-                        cugraph::get_dataframe_buffer_begin(sorted_values),
-                        cugraph::get_dataframe_buffer_end(sorted_values));
+  cugraph::sort(handle.get_thrust_policy(),
+                cugraph::get_dataframe_buffer_begin(sorted_values),
+                cugraph::get_dataframe_buffer_end(sorted_values));
 
   return sorted_values;
 }
@@ -96,7 +96,7 @@ sort(raft::handle_t const& handle,
                input_first,
                input_first + size_dataframe_buffer(first),
                output_first);
-  cugraph::sort_wrapper(
+  cugraph::sort(
     handle.get_thrust_policy(), output_first, output_first + size_dataframe_buffer(sorted_first));
 
   return std::make_tuple(std::move(sorted_first), std::move(sorted_second));
@@ -348,9 +348,9 @@ template <typename value_t>
 cugraph::dataframe_buffer_type_t<value_t> unique(raft::handle_t const& handle,
                                                  cugraph::dataframe_buffer_type_t<value_t>&& values)
 {
-  auto last = thrust::unique(handle.get_thrust_policy(),
-                             cugraph::get_dataframe_buffer_begin(values),
-                             cugraph::get_dataframe_buffer_end(values));
+  auto last = cugraph::unique(handle.get_thrust_policy(),
+                              cugraph::get_dataframe_buffer_begin(values),
+                              cugraph::get_dataframe_buffer_end(values));
   cugraph::resize_dataframe_buffer(
     values,
     cuda::std::distance(cugraph::get_dataframe_buffer_begin(values), last),
@@ -516,7 +516,7 @@ cugraph::dataframe_buffer_type_t<value_t> sequence(raft::handle_t const& handle,
 {
   auto values = cugraph::allocate_dataframe_buffer<value_t>(length, handle.get_stream());
   if (repeat_count == 1) {
-    thrust::sequence(handle.get_thrust_policy(), values.begin(), values.end(), init);
+    cugraph::sequence(handle.get_thrust_policy(), values.begin(), values.end(), init);
   } else {
     thrust::tabulate(handle.get_thrust_policy(),
                      values.begin(),
@@ -616,7 +616,7 @@ void populate_vertex_ids(raft::handle_t const& handle,
                          rmm::device_uvector<vertex_t>& d_vertices_v,
                          vertex_t vertex_id_offset)
 {
-  thrust::sequence(
+  cugraph::sequence(
     handle.get_thrust_policy(), d_vertices_v.begin(), d_vertices_v.end(), vertex_id_offset);
 }
 

--- a/cpp/tests/utilities/validation_utilities.cu
+++ b/cpp/tests/utilities/validation_utilities.cu
@@ -54,9 +54,9 @@ void sort(raft::handle_t const& handle,
           raft::device_span<vertex_t> srcs,
           raft::device_span<vertex_t> dsts)
 {
-  cugraph::sort_wrapper(handle.get_thrust_policy(),
-                        thrust::make_zip_iterator(srcs.begin(), dsts.begin()),
-                        thrust::make_zip_iterator(srcs.end(), dsts.end()));
+  cugraph::sort(handle.get_thrust_policy(),
+                thrust::make_zip_iterator(srcs.begin(), dsts.begin()),
+                thrust::make_zip_iterator(srcs.end(), dsts.end()));
 }
 
 template <typename vertex_t,
@@ -78,23 +78,23 @@ void sort(raft::handle_t const& handle,
       if (types) {
         if (start_times) {
           if (end_times) {
-            cugraph::sort_wrapper(handle.get_thrust_policy(),
-                                  thrust::make_zip_iterator(srcs.begin(),
-                                                            dsts.begin(),
-                                                            wgts->begin(),
-                                                            ids->begin(),
-                                                            types->begin(),
-                                                            start_times->begin(),
-                                                            end_times->begin()),
-                                  thrust::make_zip_iterator(srcs.end(),
-                                                            dsts.end(),
-                                                            wgts->end(),
-                                                            ids->end(),
-                                                            types->end(),
-                                                            start_times->end(),
-                                                            end_times->end()));
+            cugraph::sort(handle.get_thrust_policy(),
+                          thrust::make_zip_iterator(srcs.begin(),
+                                                    dsts.begin(),
+                                                    wgts->begin(),
+                                                    ids->begin(),
+                                                    types->begin(),
+                                                    start_times->begin(),
+                                                    end_times->begin()),
+                          thrust::make_zip_iterator(srcs.end(),
+                                                    dsts.end(),
+                                                    wgts->end(),
+                                                    ids->end(),
+                                                    types->end(),
+                                                    start_times->end(),
+                                                    end_times->end()));
           } else {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(),
                                         dsts.begin(),
@@ -107,7 +107,7 @@ void sort(raft::handle_t const& handle,
           }
         } else {
           if (end_times) {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(),
                                         dsts.begin(),
@@ -118,7 +118,7 @@ void sort(raft::handle_t const& handle,
               thrust::make_zip_iterator(
                 srcs.end(), dsts.end(), wgts->end(), ids->end(), types->end(), end_times->end()));
           } else {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), wgts->begin(), ids->begin(), types->begin()),
@@ -129,21 +129,21 @@ void sort(raft::handle_t const& handle,
       } else {
         if (start_times) {
           if (end_times) {
-            cugraph::sort_wrapper(handle.get_thrust_policy(),
-                                  thrust::make_zip_iterator(srcs.begin(),
-                                                            dsts.begin(),
-                                                            wgts->begin(),
-                                                            ids->begin(),
-                                                            start_times->begin(),
-                                                            end_times->begin()),
-                                  thrust::make_zip_iterator(srcs.end(),
-                                                            dsts.end(),
-                                                            wgts->end(),
-                                                            ids->end(),
-                                                            start_times->end(),
-                                                            end_times->end()));
+            cugraph::sort(handle.get_thrust_policy(),
+                          thrust::make_zip_iterator(srcs.begin(),
+                                                    dsts.begin(),
+                                                    wgts->begin(),
+                                                    ids->begin(),
+                                                    start_times->begin(),
+                                                    end_times->begin()),
+                          thrust::make_zip_iterator(srcs.end(),
+                                                    dsts.end(),
+                                                    wgts->end(),
+                                                    ids->end(),
+                                                    start_times->end(),
+                                                    end_times->end()));
           } else {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), wgts->begin(), ids->begin(), start_times->begin()),
@@ -152,14 +152,14 @@ void sort(raft::handle_t const& handle,
           }
         } else {
           if (end_times) {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), wgts->begin(), ids->begin(), end_times->begin()),
               thrust::make_zip_iterator(
                 srcs.end(), dsts.end(), wgts->end(), ids->end(), end_times->end()));
           } else {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(), dsts.begin(), wgts->begin(), ids->begin()),
               thrust::make_zip_iterator(srcs.end(), dsts.end(), wgts->end(), ids->end()));
@@ -170,21 +170,21 @@ void sort(raft::handle_t const& handle,
       if (types) {
         if (start_times) {
           if (end_times) {
-            cugraph::sort_wrapper(handle.get_thrust_policy(),
-                                  thrust::make_zip_iterator(srcs.begin(),
-                                                            dsts.begin(),
-                                                            wgts->begin(),
-                                                            types->begin(),
-                                                            start_times->begin(),
-                                                            end_times->begin()),
-                                  thrust::make_zip_iterator(srcs.end(),
-                                                            dsts.end(),
-                                                            wgts->end(),
-                                                            types->end(),
-                                                            start_times->end(),
-                                                            end_times->end()));
+            cugraph::sort(handle.get_thrust_policy(),
+                          thrust::make_zip_iterator(srcs.begin(),
+                                                    dsts.begin(),
+                                                    wgts->begin(),
+                                                    types->begin(),
+                                                    start_times->begin(),
+                                                    end_times->begin()),
+                          thrust::make_zip_iterator(srcs.end(),
+                                                    dsts.end(),
+                                                    wgts->end(),
+                                                    types->end(),
+                                                    start_times->end(),
+                                                    end_times->end()));
           } else {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), wgts->begin(), types->begin(), start_times->begin()),
@@ -193,14 +193,14 @@ void sort(raft::handle_t const& handle,
           }
         } else {
           if (end_times) {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), wgts->begin(), types->begin(), end_times->begin()),
               thrust::make_zip_iterator(
                 srcs.end(), dsts.end(), wgts->end(), types->end(), end_times->end()));
           } else {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(), dsts.begin(), wgts->begin(), types->begin()),
               thrust::make_zip_iterator(srcs.end(), dsts.end(), wgts->end(), types->end()));
@@ -209,7 +209,7 @@ void sort(raft::handle_t const& handle,
       } else {
         if (start_times) {
           if (end_times) {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(),
                                         dsts.begin(),
@@ -219,7 +219,7 @@ void sort(raft::handle_t const& handle,
               thrust::make_zip_iterator(
                 srcs.end(), dsts.end(), wgts->end(), start_times->end(), end_times->end()));
           } else {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), wgts->begin(), start_times->begin()),
@@ -227,16 +227,15 @@ void sort(raft::handle_t const& handle,
           }
         } else {
           if (end_times) {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), wgts->begin(), end_times->begin()),
               thrust::make_zip_iterator(srcs.end(), dsts.end(), wgts->end(), end_times->end()));
           } else {
-            cugraph::sort_wrapper(
-              handle.get_thrust_policy(),
-              thrust::make_zip_iterator(srcs.begin(), dsts.begin(), wgts->begin()),
-              thrust::make_zip_iterator(srcs.end(), dsts.end(), wgts->end()));
+            cugraph::sort(handle.get_thrust_policy(),
+                          thrust::make_zip_iterator(srcs.begin(), dsts.begin(), wgts->begin()),
+                          thrust::make_zip_iterator(srcs.end(), dsts.end(), wgts->end()));
           }
         }
       }
@@ -246,21 +245,21 @@ void sort(raft::handle_t const& handle,
       if (types) {
         if (start_times) {
           if (end_times) {
-            cugraph::sort_wrapper(handle.get_thrust_policy(),
-                                  thrust::make_zip_iterator(srcs.begin(),
-                                                            dsts.begin(),
-                                                            ids->begin(),
-                                                            types->begin(),
-                                                            start_times->begin(),
-                                                            end_times->begin()),
-                                  thrust::make_zip_iterator(srcs.end(),
-                                                            dsts.end(),
-                                                            ids->end(),
-                                                            types->end(),
-                                                            start_times->end(),
-                                                            end_times->end()));
+            cugraph::sort(handle.get_thrust_policy(),
+                          thrust::make_zip_iterator(srcs.begin(),
+                                                    dsts.begin(),
+                                                    ids->begin(),
+                                                    types->begin(),
+                                                    start_times->begin(),
+                                                    end_times->begin()),
+                          thrust::make_zip_iterator(srcs.end(),
+                                                    dsts.end(),
+                                                    ids->end(),
+                                                    types->end(),
+                                                    start_times->end(),
+                                                    end_times->end()));
           } else {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), ids->begin(), types->begin(), start_times->begin()),
@@ -269,14 +268,14 @@ void sort(raft::handle_t const& handle,
           }
         } else {
           if (end_times) {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), ids->begin(), types->begin(), end_times->begin()),
               thrust::make_zip_iterator(
                 srcs.end(), dsts.end(), ids->end(), types->end(), end_times->end()));
           } else {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(), dsts.begin(), ids->begin(), types->begin()),
               thrust::make_zip_iterator(srcs.end(), dsts.end(), ids->end(), types->end()));
@@ -285,14 +284,14 @@ void sort(raft::handle_t const& handle,
       } else {
         if (start_times) {
           if (end_times) {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), ids->begin(), start_times->begin(), end_times->begin()),
               thrust::make_zip_iterator(
                 srcs.end(), dsts.end(), ids->end(), start_times->end(), end_times->end()));
           } else {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), ids->begin(), start_times->begin()),
@@ -300,16 +299,15 @@ void sort(raft::handle_t const& handle,
           }
         } else {
           if (end_times) {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), ids->begin(), end_times->begin()),
               thrust::make_zip_iterator(srcs.end(), dsts.end(), ids->end(), end_times->end()));
           } else {
-            cugraph::sort_wrapper(
-              handle.get_thrust_policy(),
-              thrust::make_zip_iterator(srcs.begin(), dsts.begin(), ids->begin()),
-              thrust::make_zip_iterator(srcs.end(), dsts.end(), ids->end()));
+            cugraph::sort(handle.get_thrust_policy(),
+                          thrust::make_zip_iterator(srcs.begin(), dsts.begin(), ids->begin()),
+                          thrust::make_zip_iterator(srcs.end(), dsts.end(), ids->end()));
           }
         }
       }
@@ -317,7 +315,7 @@ void sort(raft::handle_t const& handle,
       if (types) {
         if (start_times) {
           if (end_times) {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(),
                                         dsts.begin(),
@@ -327,7 +325,7 @@ void sort(raft::handle_t const& handle,
               thrust::make_zip_iterator(
                 srcs.end(), dsts.end(), types->end(), start_times->end(), end_times->end()));
           } else {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), types->begin(), start_times->begin()),
@@ -335,43 +333,40 @@ void sort(raft::handle_t const& handle,
           }
         } else {
           if (end_times) {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(
                 srcs.begin(), dsts.begin(), types->begin(), end_times->begin()),
               thrust::make_zip_iterator(srcs.end(), dsts.end(), types->end(), end_times->end()));
           } else {
-            cugraph::sort_wrapper(
-              handle.get_thrust_policy(),
-              thrust::make_zip_iterator(srcs.begin(), dsts.begin(), types->begin()),
-              thrust::make_zip_iterator(srcs.end(), dsts.end(), types->end()));
+            cugraph::sort(handle.get_thrust_policy(),
+                          thrust::make_zip_iterator(srcs.begin(), dsts.begin(), types->begin()),
+                          thrust::make_zip_iterator(srcs.end(), dsts.end(), types->end()));
           }
         }
       } else {
         if (start_times) {
           if (end_times) {
-            cugraph::sort_wrapper(
-              handle.get_thrust_policy(),
-              thrust::make_zip_iterator(
-                srcs.begin(), dsts.begin(), start_times->begin(), end_times->begin()),
-              thrust::make_zip_iterator(
-                srcs.end(), dsts.end(), start_times->end(), end_times->end()));
+            cugraph::sort(handle.get_thrust_policy(),
+                          thrust::make_zip_iterator(
+                            srcs.begin(), dsts.begin(), start_times->begin(), end_times->begin()),
+                          thrust::make_zip_iterator(
+                            srcs.end(), dsts.end(), start_times->end(), end_times->end()));
           } else {
-            cugraph::sort_wrapper(
+            cugraph::sort(
               handle.get_thrust_policy(),
               thrust::make_zip_iterator(srcs.begin(), dsts.begin(), start_times->begin()),
               thrust::make_zip_iterator(srcs.end(), dsts.end(), start_times->end()));
           }
         } else {
           if (end_times) {
-            cugraph::sort_wrapper(
-              handle.get_thrust_policy(),
-              thrust::make_zip_iterator(srcs.begin(), dsts.begin(), end_times->begin()),
-              thrust::make_zip_iterator(srcs.end(), dsts.end(), end_times->end()));
+            cugraph::sort(handle.get_thrust_policy(),
+                          thrust::make_zip_iterator(srcs.begin(), dsts.begin(), end_times->begin()),
+                          thrust::make_zip_iterator(srcs.end(), dsts.end(), end_times->end()));
           } else {
-            cugraph::sort_wrapper(handle.get_thrust_policy(),
-                                  thrust::make_zip_iterator(srcs.begin(), dsts.begin()),
-                                  thrust::make_zip_iterator(srcs.end(), dsts.end()));
+            cugraph::sort(handle.get_thrust_policy(),
+                          thrust::make_zip_iterator(srcs.begin(), dsts.begin()),
+                          thrust::make_zip_iterator(srcs.end(), dsts.end()));
           }
         }
       }


### PR DESCRIPTION
Next effort in binary size reduction.

This PR:
* Renames the sort_wrapper back to sort using the workaround we tried for scan
* Creates wrappers for thrust::unique, thrust::sequence, thrust::fill

| Stage | `libcugraph_common.so` | `libcugraph.so` | `libcugraph_mg.so` | Combined |
|---|---|---|---|---|
| CUDA 12 Before | 98 MB | 752 MB |  935 MB | 1785 MB |
| CUDA 12 After |  99 MB (+1, +1.2%) | 736 MB (-16, -2.1%) | 919 MB (-16, -1.8%) | 1754 MB (-31, -1.8%) |
|---|---|---|---|---|
| CUDA 13 Before | 50 MB | 382 MB | 469 MB | 901 MB |
| CUDA 13 After |  50 MB (+0.5, +0.96%)| 374 MB (-8, -2.1%)| 461  MB (-8, -1.8%) | 885 MB (-16, -1.8%)|
