### PR TITLE
Fix doctest parametrization for pytest 9.1

### DIFF
--- a/python/cugraph/cugraph/tests/docs/test_doctests.py
+++ b/python/cugraph/cugraph/tests/docs/test_doctests.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
@@ -97,6 +97,9 @@ def _fetch_doctests():
     )
 
 
+DOCTESTS = tuple(_fetch_doctests())
+
+
 def skip_docstring(docstring_obj):
     """
     Returns a string indicating why the doctest example string should not be
@@ -127,7 +130,7 @@ class TestDoctests:
 
     @pytest.mark.sg
     @pytest.mark.parametrize(
-        "docstring", _fetch_doctests(), ids=lambda docstring: docstring.name
+        "docstring", DOCTESTS, ids=lambda docstring: docstring.name
     )
     @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_docstring(self, docstring):


### PR DESCRIPTION
## Summary
- Materialize the doctest generator before passing it to `pytest.mark.parametrize`.
- Update the copyright year for the touched test file.

## Details
Pytest 9.1 deprecated passing non-`Collection` iterables, such as generators and iterators, as `argvalues` to `pytest.mark.parametrize` / `metafunc.parametrize`.
The pytest docs recommend converting generators and iterators to a `list` or `tuple` because they can otherwise be exhausted after one collection pass.

This repo also promotes `DeprecationWarning` to errors in `python/cugraph/pytest.ini`, so the new pytest warning can fail collection in pytest 9.1.x.
The doctest set is small, so eagerly materializing it is cheap and matches pytest's documented migration path.

References:
- https://docs.pytest.org/en/stable/changelog.html#pytest-9-1-0-2026-06-13
- https://docs.pytest.org/en/stable/deprecations.html#non-collection-iterables-in-pytest-mark-parametrize

## Testing
- `git diff --check upstream/main..HEAD`
- `docker exec 8cf097001d69 python -m pytest /Projects/cugraph/python/cugraph/cugraph/tests/docs/test_doctests.py --collect-only -q`

Full doctest execution was also attempted in the provided container and failed due to missing local dataset files, for example `karate.csv`, unrelated to this collection-time change.
