### PR TITLE
Test rapids-cmake PR #1044

### DIFF
--- a/cmake/rapids_config.cmake
+++ b/cmake/rapids_config.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2018-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/cmake/rapids_config.cmake
+++ b/cmake/rapids_config.cmake
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
+
+# Test rapids-cmake PR #1044 (bump cuco for the new bloom filter)
+set(CPM_DOWNLOAD_cuco ON)
+set(rapids-cmake-repo PointKernel/rapids-cmake)
+set(rapids-cmake-branch cuco-new-filter)
+
 file(READ "${CMAKE_CURRENT_LIST_DIR}/../VERSION" _rapids_version)
 if(_rapids_version MATCHES [[^([0-9][0-9])\.([0-9][0-9])\.([0-9][0-9])]])
   set(RAPIDS_VERSION_MAJOR "${CMAKE_MATCH_1}")


### PR DESCRIPTION
## Description

DO NOT MERGE. CI-only PR to test [rapids-cmake#1044](https://github.com/rapidsai/rapids-cmake/pull/1044), which bumps the pinned cuco commit for the new bloom filter, against cugraph.

`cmake/rapids_config.cmake` is pointed at `PointKernel/rapids-cmake@cuco-new-filter` (with `CPM_DOWNLOAD_cuco ON`) for the duration of the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
