### PR TITLE
switch from 'cuda-python' to specific components (e.g. 'cuda-bindings')

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -10,11 +10,11 @@ dependencies:
 - c-compiler
 - certifi
 - cmake>=4.0
+- cuda-bindings==12.*,>=12.9.2
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
 - cudf==26.8.*,>=0.0.0a0
 - cupy>=14.0.1,!=14.1.0

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - certifi
 - cmake>=4.0
-- cuda-bindings==12.*,>=12.9.2
+- cuda-bindings>=12.9.2,<13.0
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -10,11 +10,11 @@ dependencies:
 - c-compiler
 - certifi
 - cmake>=4.0
+- cuda-bindings==12.*,>=12.9.2
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
 - cudf==26.8.*,>=0.0.0a0
 - cupy>=14.0.1,!=14.1.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - certifi
 - cmake>=4.0
-- cuda-bindings==12.*,>=12.9.2
+- cuda-bindings>=12.9.2,<13.0
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - certifi
 - cmake>=4.0
-- cuda-bindings==13.*,>=13.0.1
+- cuda-bindings>=13.0.1,<14.0
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -10,11 +10,11 @@ dependencies:
 - c-compiler
 - certifi
 - cmake>=4.0
+- cuda-bindings==13.*,>=13.0.1
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-python>=13.0.1,<14.0
 - cuda-version=13.3
 - cudf==26.8.*,>=0.0.0a0
 - cupy>=14.0.1,!=14.1.0

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - certifi
 - cmake>=4.0
-- cuda-bindings==13.*,>=13.0.1
+- cuda-bindings>=13.0.1,<14.0
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -10,11 +10,11 @@ dependencies:
 - c-compiler
 - certifi
 - cmake>=4.0
+- cuda-bindings==13.*,>=13.0.1
 - cuda-nvcc
 - cuda-nvrtc-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-python>=13.0.1,<14.0
 - cuda-version=13.3
 - cudf==26.8.*,>=0.0.0a0
 - cupy>=14.0.1,!=14.1.0

--- a/conda/recipes/cugraph/recipe.yaml
+++ b/conda/recipes/cugraph/recipe.yaml
@@ -108,8 +108,8 @@ requirements:
     - requests
     - ucxx ${{ ucxx_version }}
     - if: cuda_major == "12"
-      then: cuda-python >=12.9.2,<13.0
-      else: cuda-python >=13.0.1,<14.0
+      then: cuda-bindings ==12.*,>=12.9.2
+      else: cuda-bindings ==13.*,>=13.0.1
   ignore_run_exports:
     from_package:
     by_name:

--- a/conda/recipes/cugraph/recipe.yaml
+++ b/conda/recipes/cugraph/recipe.yaml
@@ -108,8 +108,8 @@ requirements:
     - requests
     - ucxx ${{ ucxx_version }}
     - if: cuda_major == "12"
-      then: cuda-bindings ==12.*,>=12.9.2
-      else: cuda-bindings ==13.*,>=13.0.1
+      then: cuda-bindings >=12.9.2,<13.0
+      else: cuda-bindings >=13.0.1,<14.0
   ignore_run_exports:
     from_package:
     by_name:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -477,11 +477,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cuda-python>=12.9.2,<13.0
+              - cuda-bindings==12.*,>=12.9.2
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cuda-python>=13.0.1,<14.0
+              - cuda-bindings==13.*,>=13.0.1
   python_run_pylibcugraph:
     common:
       - output_types: [conda, pyproject, requirements]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -477,11 +477,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cuda-bindings==12.*,>=12.9.2
+              - cuda-bindings>=12.9.2,<13.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cuda-bindings==13.*,>=13.0.1
+              - cuda-bindings>=13.0.1,<14.0
   python_run_pylibcugraph:
     common:
       - output_types: [conda, pyproject, requirements]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -509,6 +509,21 @@ dependencies:
           - pytest-cov
           - pytest-xdist
           - &scipy scipy
+    specific:
+      - output_types: [conda, requirements, pyproject]
+        matrices:
+          - matrix:
+              dependencies: "oldest"
+              cuda: "12.*"
+            packages:
+              - cuda-bindings==12.9.2
+          - matrix:
+              dependencies: "oldest"
+              cuda: "13.*"
+            packages:
+              - cuda-bindings==13.0.1
+          - matrix:
+            packages:
   test_python_cugraph:
     common:
       - output_types: [conda, pyproject, requirements]

--- a/python/cugraph/pyproject.toml
+++ b/python/cugraph/pyproject.toml
@@ -24,7 +24,7 @@ authors = [
 license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
-    "cuda-python>=13.0.1,<14.0",
+    "cuda-bindings==13.*,>=13.0.1",
     "cudf==26.8.*,>=0.0.0a0",
     "cupy-cuda13x[ctk]>=14.0.1,!=14.1.0",
     "dask-cuda==26.8.*,>=0.0.0a0",

--- a/python/cugraph/pyproject.toml
+++ b/python/cugraph/pyproject.toml
@@ -24,7 +24,7 @@ authors = [
 license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
-    "cuda-bindings==13.*,>=13.0.1",
+    "cuda-bindings>=13.0.1,<14.0",
     "cudf==26.8.*,>=0.0.0a0",
     "cupy-cuda13x[ctk]>=14.0.1,!=14.1.0",
     "dask-cuda==26.8.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/285

`cuda-python` is a metapackage and sometimes pulls in components that RAPIDS libraries don't need. This PR is part of a series dropping direct use of `cuda-python` in favor of depending only on those specific components.

* drops dependency on `cuda-python`
* adds explicit dependencies on components:
  - `cuda-bindings >=12.9.2,<13.0` (CUDA 12), `cuda-bindings >=13.0.1,<14.0` (CUDA 13)
* adds explicit testing of oldest `cuda-bindings` in CI

## Notes for Reviewers

### Why these specific bounds?

* these roughly match what we were getting with `cuda-python`
* worked through finding compatible ranges in https://github.com/rapidsai/rmm/pull/2460#discussion_r3514148466
* `cuda-bindings` major version follows the CTK major version, so kept a ceiling just like we currently have for `cuda-python`