### PR TITLE
Add dlpack conversion to capi

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -22,6 +22,7 @@ dependencies:
 - cython>=3.2.2
 - dask-cuda==26.8.*,>=0.0.0a0
 - dask-cudf==26.8.*,>=0.0.0a0
+- dlpack
 - doxygen
 - fsspec>=0.6.0
 - gcc_linux-aarch64=14.*

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -22,6 +22,7 @@ dependencies:
 - cython>=3.2.2
 - dask-cuda==26.8.*,>=0.0.0a0
 - dask-cudf==26.8.*,>=0.0.0a0
+- dlpack
 - doxygen
 - fsspec>=0.6.0
 - gcc_linux-64=14.*

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -22,6 +22,7 @@ dependencies:
 - cython>=3.2.2
 - dask-cuda==26.8.*,>=0.0.0a0
 - dask-cudf==26.8.*,>=0.0.0a0
+- dlpack
 - doxygen
 - fsspec>=0.6.0
 - gcc_linux-aarch64=14.*

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -22,6 +22,7 @@ dependencies:
 - cython>=3.2.2
 - dask-cuda==26.8.*,>=0.0.0a0
 - dask-cudf==26.8.*,>=0.0.0a0
+- dlpack
 - doxygen
 - fsspec>=0.6.0
 - gcc_linux-64=14.*

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -756,7 +756,7 @@ target_link_libraries(cugraph_c PRIVATE cugraph::cugraph cugraph::cugraph_mg)
 # tests) only; installed consumers obtain dlpack.h from their own environment,
 # so it is intentionally not part of the install/export interface.
 target_include_directories(cugraph_c
-    PUBLIC "$<BUILD_INTERFACE:${DLPACK_INCLUDE_DIRS}>")
+    PUBLIC "$<BUILD_INTERFACE:${DLPACK_INCLUDE_DIR}>")
 
 ################################################################################
 # - generate tests -------------------------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -644,12 +644,18 @@ target_link_libraries(cugraph_mtmg PRIVATE cugraph_common)
 
 
 
+rapids_find_package(dlpack REQUIRED
+    BUILD_EXPORT_SET    cugraph-exports
+    INSTALL_EXPORT_SET  cugraph-exports
+    )
+
 ################################################################################
 # - C-API library --------------------------------------------------------------
 
 add_library(cugraph_c
         src/c_api/resource_handle.cpp
         src/c_api/array.cpp
+        src/c_api/dlpack_interop.cpp
         src/c_api/degrees.cu
         src/c_api/degrees_result.cpp
         src/c_api/error.cpp
@@ -746,7 +752,9 @@ target_include_directories(cugraph_c
 
 ################################################################################
 # - C-API link libraries -------------------------------------------------------
-target_link_libraries(cugraph_c PRIVATE cugraph::cugraph cugraph::cugraph_mg)
+target_link_libraries(cugraph_c
+    PUBLIC dlpack::dlpack
+    PRIVATE cugraph::cugraph cugraph::cugraph_mg)
 
 ################################################################################
 # - generate tests -------------------------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -644,10 +644,7 @@ target_link_libraries(cugraph_mtmg PRIVATE cugraph_common)
 
 
 
-rapids_find_package(dlpack REQUIRED
-    BUILD_EXPORT_SET    cugraph-exports
-    INSTALL_EXPORT_SET  cugraph-exports
-    )
+include(cmake/thirdparty/get_dlpack.cmake)
 
 ################################################################################
 # - C-API library --------------------------------------------------------------
@@ -752,9 +749,14 @@ target_include_directories(cugraph_c
 
 ################################################################################
 # - C-API link libraries -------------------------------------------------------
-target_link_libraries(cugraph_c
-    PUBLIC dlpack::dlpack
-    PRIVATE cugraph::cugraph cugraph::cugraph_mg)
+target_link_libraries(cugraph_c PRIVATE cugraph::cugraph cugraph::cugraph_mg)
+
+# dlpack is a header-only dependency of the public cugraph_c/dlpack_interop.h
+# header. Expose its include directory to build-tree consumers (e.g. the C API
+# tests) only; installed consumers obtain dlpack.h from their own environment,
+# so it is intentionally not part of the install/export interface.
+target_include_directories(cugraph_c
+    PUBLIC "$<BUILD_INTERFACE:${DLPACK_INCLUDE_DIRS}>")
 
 ################################################################################
 # - generate tests -------------------------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 #=============================================================================

--- a/cpp/cmake/thirdparty/get_dlpack.cmake
+++ b/cpp/cmake/thirdparty/get_dlpack.cmake
@@ -1,6 +1,6 @@
 #=============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 #=============================================================================

--- a/cpp/cmake/thirdparty/get_dlpack.cmake
+++ b/cpp/cmake/thirdparty/get_dlpack.cmake
@@ -5,38 +5,26 @@
 # cmake-format: on
 #=============================================================================
 
-# dlpack is a header-only library used by the cugraph_c DLPack interop API.
-# In conda environments it is provided as an installed CMake package; in other
-# environments (e.g. pip / devcontainer builds) it may not be installed, so we
-# fall back to downloading the headers via CPM.
+# dlpack is a header-only library used by the cugraph_c DLPack interop API
+# (cugraph_c/dlpack_interop.h). In conda environments it is provided as an
+# installed package; in other environments (e.g. pip / devcontainer / wheel
+# builds) it may not be installed, so we fall back to downloading the headers.
 function(find_and_configure_dlpack VERSION)
 
+    include(${rapids-cmake-dir}/find/generate_module.cmake)
+    rapids_find_generate_module(DLPACK HEADER_NAMES dlpack.h)
+
     rapids_cpm_find(dlpack ${VERSION}
-        GLOBAL_TARGETS  dlpack::dlpack
-        CPM_ARGS
-            GIT_REPOSITORY  https://github.com/dmlc/dlpack.git
-            GIT_TAG         v${VERSION}
-            GIT_SHALLOW     TRUE
-            DOWNLOAD_ONLY   TRUE
-            OPTIONS         "BUILD_MOCK OFF"
+        GIT_REPOSITORY  https://github.com/dmlc/dlpack.git
+        GIT_TAG         v${VERSION}
+        GIT_SHALLOW     TRUE
+        DOWNLOAD_ONLY   TRUE
+        OPTIONS         "BUILD_MOCK OFF"
     )
 
     if(DEFINED dlpack_SOURCE_DIR)
-        # dlpack was downloaded from source (no installed CMake package was
-        # found). It ships no usable CMake config in DOWNLOAD_ONLY mode, so
-        # expose an interface target matching the one from an installed
-        # dlpackConfig.cmake. The include directory is build-tree only; installed
-        # consumers obtain dlpack.h from their own environment (e.g. conda).
-        set(DLPACK_INCLUDE_DIRS "${dlpack_SOURCE_DIR}/include" PARENT_SCOPE)
-        if(NOT TARGET dlpack::dlpack)
-            add_library(dlpack::dlpack INTERFACE IMPORTED GLOBAL)
-            target_include_directories(dlpack::dlpack INTERFACE
-                "$<BUILD_INTERFACE:${dlpack_SOURCE_DIR}/include>")
-        endif()
-    elseif(TARGET dlpack::dlpack)
-        get_target_property(_dlpack_include_dirs dlpack::dlpack
-            INTERFACE_INCLUDE_DIRECTORIES)
-        set(DLPACK_INCLUDE_DIRS "${_dlpack_include_dirs}" PARENT_SCOPE)
+        # otherwise find_package(DLPACK) will set this variable
+        set(DLPACK_INCLUDE_DIR "${dlpack_SOURCE_DIR}/include" PARENT_SCOPE)
     endif()
 
 endfunction()

--- a/cpp/cmake/thirdparty/get_dlpack.cmake
+++ b/cpp/cmake/thirdparty/get_dlpack.cmake
@@ -1,0 +1,46 @@
+#=============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+#=============================================================================
+
+# dlpack is a header-only library used by the cugraph_c DLPack interop API.
+# In conda environments it is provided as an installed CMake package; in other
+# environments (e.g. pip / devcontainer builds) it may not be installed, so we
+# fall back to downloading the headers via CPM.
+function(find_and_configure_dlpack VERSION)
+
+    rapids_cpm_find(dlpack ${VERSION}
+        GLOBAL_TARGETS  dlpack::dlpack
+        CPM_ARGS
+            GIT_REPOSITORY  https://github.com/dmlc/dlpack.git
+            GIT_TAG         v${VERSION}
+            GIT_SHALLOW     TRUE
+            DOWNLOAD_ONLY   TRUE
+            OPTIONS         "BUILD_MOCK OFF"
+    )
+
+    if(DEFINED dlpack_SOURCE_DIR)
+        # dlpack was downloaded from source (no installed CMake package was
+        # found). It ships no usable CMake config in DOWNLOAD_ONLY mode, so
+        # expose an interface target matching the one from an installed
+        # dlpackConfig.cmake. The include directory is build-tree only; installed
+        # consumers obtain dlpack.h from their own environment (e.g. conda).
+        set(DLPACK_INCLUDE_DIRS "${dlpack_SOURCE_DIR}/include" PARENT_SCOPE)
+        if(NOT TARGET dlpack::dlpack)
+            add_library(dlpack::dlpack INTERFACE IMPORTED GLOBAL)
+            target_include_directories(dlpack::dlpack INTERFACE
+                "$<BUILD_INTERFACE:${dlpack_SOURCE_DIR}/include>")
+        endif()
+    elseif(TARGET dlpack::dlpack)
+        get_target_property(_dlpack_include_dirs dlpack::dlpack
+            INTERFACE_INCLUDE_DIRECTORIES)
+        set(DLPACK_INCLUDE_DIRS "${_dlpack_include_dirs}" PARENT_SCOPE)
+    endif()
+
+endfunction()
+
+set(CUGRAPH_MIN_VERSION_dlpack 0.8)
+
+find_and_configure_dlpack(${CUGRAPH_MIN_VERSION_dlpack})

--- a/cpp/cmake/thirdparty/get_dlpack.cmake
+++ b/cpp/cmake/thirdparty/get_dlpack.cmake
@@ -12,7 +12,7 @@
 function(find_and_configure_dlpack VERSION)
 
     include(${rapids-cmake-dir}/find/generate_module.cmake)
-    rapids_find_generate_module(DLPACK HEADER_NAMES dlpack.h)
+    rapids_find_generate_module(dlpack HEADER_NAMES dlpack.h)
 
     rapids_cpm_find(dlpack ${VERSION}
         GIT_REPOSITORY  https://github.com/dmlc/dlpack.git

--- a/cpp/include/cugraph_c/dlpack_interop.h
+++ b/cpp/include/cugraph_c/dlpack_interop.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/include/cugraph_c/dlpack_interop.h
+++ b/cpp/include/cugraph_c/dlpack_interop.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cugraph_c/error.h>
+#include <cugraph_c/export.h>
+#include <cugraph_c/types.h>
+
+#include <dlpack/dlpack.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Convert a DLPack DLDataType to a cugraph_data_type_id_t.
+ *
+ * Converts the dtype field from a DLPack tensor (e.g. DLTensor::dtype or
+ * __dlpack__ metadata) into the cugraph_data_type_id_t required by
+ * cugraph_type_erased_device_array_view_create() and related array APIs.
+ *
+ * Only scalar types (lanes == 1) are supported. Vectorized DLPack types,
+ * bfloat16, complex, and opaque handle types are rejected.
+ *
+ * @param [in]  dlpack_dtype  Pointer to the DLPack data type to convert.
+ *                             Must not be NULL.
+ * @param [out] dtype         Pointer to store the resulting cuGraph data type.
+ *                             Must not be NULL.
+ * @param [out] error         Pointer to an error object storing details of any
+ *                             error. Will be populated if the return code is
+ *                             not CUGRAPH_SUCCESS. Must not be NULL.
+ * @return CUGRAPH_SUCCESS on success, or an error code on failure.
+ */
+CUGRAPH_EXPORT cugraph_error_code_t cugraph_data_type_id_from_dlpack(const DLDataType* dlpack_dtype,
+                                                                     cugraph_data_type_id_t* dtype,
+                                                                     cugraph_error_t** error);
+
+#ifdef __cplusplus
+}
+#endif

--- a/cpp/src/c_api/dlpack_interop.cpp
+++ b/cpp/src/c_api/dlpack_interop.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/src/c_api/dlpack_interop.cpp
+++ b/cpp/src/c_api/dlpack_interop.cpp
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "c_api/error.hpp"
+
+#include <cugraph_c/dlpack_interop.h>
+
+namespace {
+
+bool is_supported_dlpack_type_code(DLDataTypeCode code)
+{
+  switch (code) {
+    case kDLInt:
+    case kDLUInt:
+    case kDLFloat:
+    case kDLBool: return true;
+    default: return false;
+  }
+}
+
+}  // namespace
+
+extern "C" cugraph_error_code_t cugraph_data_type_id_from_dlpack(const DLDataType* dlpack_dtype,
+                                                                 cugraph_data_type_id_t* dtype,
+                                                                 cugraph_error_t** error)
+{
+  *error = nullptr;
+
+  CAPI_EXPECTS(
+    dlpack_dtype != nullptr, CUGRAPH_INVALID_INPUT, "dlpack_dtype cannot be NULL", *error);
+  CAPI_EXPECTS(dtype != nullptr, CUGRAPH_INVALID_INPUT, "dtype cannot be NULL", *error);
+
+  if (dlpack_dtype->lanes != 1) {
+    CAPI_EXPECTS(false,
+                 CUGRAPH_UNSUPPORTED_TYPE_COMBINATION,
+                 "vectorized DLPack types (lanes > 1) are not supported",
+                 *error);
+  }
+
+  auto const code = static_cast<DLDataTypeCode>(dlpack_dtype->code);
+  if (!is_supported_dlpack_type_code(code)) {
+    CAPI_EXPECTS(
+      false, CUGRAPH_UNSUPPORTED_TYPE_COMBINATION, "unsupported DLPack type code", *error);
+  }
+
+  switch (code) {
+    case kDLInt:
+      switch (dlpack_dtype->bits) {
+        case 8: *dtype = INT8; return CUGRAPH_SUCCESS;
+        case 16: *dtype = INT16; return CUGRAPH_SUCCESS;
+        case 32: *dtype = INT32; return CUGRAPH_SUCCESS;
+        case 64: *dtype = INT64; return CUGRAPH_SUCCESS;
+        default: break;
+      }
+      break;
+    case kDLUInt:
+      switch (dlpack_dtype->bits) {
+        case 8: *dtype = UINT8; return CUGRAPH_SUCCESS;
+        case 16: *dtype = UINT16; return CUGRAPH_SUCCESS;
+        case 32: *dtype = UINT32; return CUGRAPH_SUCCESS;
+        case 64: *dtype = UINT64; return CUGRAPH_SUCCESS;
+        default: break;
+      }
+      break;
+    case kDLFloat:
+      switch (dlpack_dtype->bits) {
+        case 32: *dtype = FLOAT32; return CUGRAPH_SUCCESS;
+        case 64: *dtype = FLOAT64; return CUGRAPH_SUCCESS;
+        default: break;
+      }
+      break;
+    case kDLBool:
+      if (dlpack_dtype->bits == 8) {
+        *dtype = BOOL;
+        return CUGRAPH_SUCCESS;
+      }
+      break;
+    default: break;
+  }
+
+  CAPI_EXPECTS(false,
+               CUGRAPH_INVALID_INPUT,
+               "unsupported DLPack dtype bit width for the given type code",
+               *error);
+}

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -919,6 +919,7 @@ endif()
 ###################################################################################################
 # - C API tests -----------------------------------------------------------------------------------
 
+ConfigureCTest(CAPI_DLPACK_INTEROP_TEST c_api/dlpack_interop_test.c)
 ConfigureCTest(CAPI_CREATE_GRAPH_TEST c_api/create_graph_test.c)
 ConfigureCTest(CAPI_GENERATE_RMAT_TEST c_api/generate_rmat_test.c)
 ConfigureCTest(CAPI_PAGERANK_TEST c_api/pagerank_test.c)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 #

--- a/cpp/tests/c_api/dlpack_interop_test.c
+++ b/cpp/tests/c_api/dlpack_interop_test.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/c_api/dlpack_interop_test.c
+++ b/cpp/tests/c_api/dlpack_interop_test.c
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "c_test_utils.h"
+
+#include <cugraph_c/dlpack_interop.h>
+
+#include <stdio.h>
+
+static int check_conversion(DLDataType dlpack_dtype,
+                            cugraph_data_type_id_t expected_dtype,
+                            cugraph_error_code_t expected_code)
+{
+  cugraph_data_type_id_t dtype;
+  cugraph_error_t* error    = NULL;
+  cugraph_error_code_t code = cugraph_data_type_id_from_dlpack(&dlpack_dtype, &dtype, &error);
+
+  if (code != expected_code) {
+    printf("unexpected return code %d (expected %d)\n", code, expected_code);
+    cugraph_error_free(error);
+    return 1;
+  }
+
+  if (expected_code == CUGRAPH_SUCCESS) {
+    if (dtype != expected_dtype) {
+      printf("unexpected dtype %d (expected %d)\n", dtype, expected_dtype);
+      cugraph_error_free(error);
+      return 1;
+    }
+  } else if (error == NULL) {
+    printf("expected error object on failure\n");
+    return 1;
+  }
+
+  cugraph_error_free(error);
+  return 0;
+}
+
+int test_dlpack_interop_conversions()
+{
+  int test_ret_value = 0;
+
+  TEST_ASSERT(test_ret_value,
+              check_conversion((DLDataType){kDLInt, 8, 1}, INT8, CUGRAPH_SUCCESS) == 0,
+              "INT8 conversion failed");
+  TEST_ASSERT(test_ret_value,
+              check_conversion((DLDataType){kDLInt, 16, 1}, INT16, CUGRAPH_SUCCESS) == 0,
+              "INT16 conversion failed");
+  TEST_ASSERT(test_ret_value,
+              check_conversion((DLDataType){kDLInt, 32, 1}, INT32, CUGRAPH_SUCCESS) == 0,
+              "INT32 conversion failed");
+  TEST_ASSERT(test_ret_value,
+              check_conversion((DLDataType){kDLInt, 64, 1}, INT64, CUGRAPH_SUCCESS) == 0,
+              "INT64 conversion failed");
+  TEST_ASSERT(test_ret_value,
+              check_conversion((DLDataType){kDLUInt, 8, 1}, UINT8, CUGRAPH_SUCCESS) == 0,
+              "UINT8 conversion failed");
+  TEST_ASSERT(test_ret_value,
+              check_conversion((DLDataType){kDLUInt, 16, 1}, UINT16, CUGRAPH_SUCCESS) == 0,
+              "UINT16 conversion failed");
+  TEST_ASSERT(test_ret_value,
+              check_conversion((DLDataType){kDLUInt, 32, 1}, UINT32, CUGRAPH_SUCCESS) == 0,
+              "UINT32 conversion failed");
+  TEST_ASSERT(test_ret_value,
+              check_conversion((DLDataType){kDLUInt, 64, 1}, UINT64, CUGRAPH_SUCCESS) == 0,
+              "UINT64 conversion failed");
+  TEST_ASSERT(test_ret_value,
+              check_conversion((DLDataType){kDLFloat, 32, 1}, FLOAT32, CUGRAPH_SUCCESS) == 0,
+              "FLOAT32 conversion failed");
+  TEST_ASSERT(test_ret_value,
+              check_conversion((DLDataType){kDLFloat, 64, 1}, FLOAT64, CUGRAPH_SUCCESS) == 0,
+              "FLOAT64 conversion failed");
+  TEST_ASSERT(test_ret_value,
+              check_conversion((DLDataType){kDLBool, 8, 1}, BOOL, CUGRAPH_SUCCESS) == 0,
+              "BOOL conversion failed");
+
+  TEST_ASSERT(
+    test_ret_value,
+    check_conversion((DLDataType){kDLFloat, 32, 4}, 0, CUGRAPH_UNSUPPORTED_TYPE_COMBINATION) == 0,
+    "vectorized dtype should be rejected");
+  TEST_ASSERT(
+    test_ret_value,
+    check_conversion((DLDataType){kDLBfloat, 16, 1}, 0, CUGRAPH_UNSUPPORTED_TYPE_COMBINATION) == 0,
+    "bfloat16 should be rejected");
+  TEST_ASSERT(
+    test_ret_value,
+    check_conversion((DLDataType){kDLComplex, 64, 1}, 0, CUGRAPH_UNSUPPORTED_TYPE_COMBINATION) == 0,
+    "complex should be rejected");
+  TEST_ASSERT(test_ret_value,
+              check_conversion((DLDataType){kDLInt, 24, 1}, 0, CUGRAPH_INVALID_INPUT) == 0,
+              "unsupported bit width should be rejected");
+
+  return test_ret_value;
+}
+
+int main(int argc, char** argv)
+{
+  int result = 0;
+  result |= RUN_TEST(test_dlpack_interop_conversions);
+  return result;
+}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Dependency list for https://github.com/rapidsai/dependency-file-generator

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -378,6 +378,7 @@ dependencies:
           - c-compiler
           - cuda-nvcc
           - cxx-compiler
+          - dlpack
           - openmpi # Required for building cpp-mgtests (multi-GPU tests)
     specific:
       - output_types: [conda]

--- a/python/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/python/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/CMakeLists.txt
@@ -22,6 +22,12 @@ project(
 
 find_package(cugraph "${RAPIDS_VERSION}" REQUIRED)
 
+# an installed version of libcugraph doesn't provide the dlpack headers so we
+# need to download dlpack for the DLPack interop used by utils.pyx
+include(rapids-cpm)
+rapids_cpm_init()
+include(../../cpp/cmake/thirdparty/get_dlpack.cmake)
+
 include(rapids-cython-core)
 
 rapids_cython_init()

--- a/python/pylibcugraph/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/pylibcugraph/CMakeLists.txt
@@ -82,3 +82,8 @@ rapids_cython_create_modules(
   LINKED_LIBRARIES ${linked_libraries}
   ASSOCIATED_TARGETS cugraph
 )
+
+# utils.pyx uses the DLPack interop API and includes dlpack/dlpack.h, which is
+# not provided by an installed libcugraph. Provide the downloaded/located dlpack
+# headers to that module.
+target_include_directories(utils PUBLIC "$<BUILD_INTERFACE:${DLPACK_INCLUDE_DIR}>")

--- a/python/pylibcugraph/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/pylibcugraph/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/python/pylibcugraph/pylibcugraph/_cugraph_c/dlpack_interop.pxd
+++ b/python/pylibcugraph/pylibcugraph/_cugraph_c/dlpack_interop.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Have cython use python 3 syntax

--- a/python/pylibcugraph/pylibcugraph/_cugraph_c/dlpack_interop.pxd
+++ b/python/pylibcugraph/pylibcugraph/_cugraph_c/dlpack_interop.pxd
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+# Have cython use python 3 syntax
+# cython: language_level = 3
+
+from libc.stdint cimport uint8_t, uint16_t
+
+from pylibcugraph._cugraph_c.error cimport (
+    cugraph_error_code_t,
+    cugraph_error_t,
+)
+from pylibcugraph._cugraph_c.types cimport cugraph_data_type_id_t
+
+cdef extern from "dlpack/dlpack.h" nogil:
+    cdef enum DLDataTypeCode:
+        kDLInt
+        kDLUInt
+        kDLFloat
+        kDLBfloat
+        kDLComplex
+        kDLBool
+
+    ctypedef struct DLDataType:
+        uint8_t code
+        uint8_t bits
+        uint16_t lanes
+
+cdef extern from "cugraph_c/dlpack_interop.h":
+    cdef cugraph_error_code_t cugraph_data_type_id_from_dlpack(
+        const DLDataType* dlpack_dtype,
+        cugraph_data_type_id_t* dtype,
+        cugraph_error_t** error,
+    )

--- a/python/pylibcugraph/pylibcugraph/utils.pyx
+++ b/python/pylibcugraph/pylibcugraph/utils.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 # Have cython use python 3 syntax
@@ -21,6 +21,15 @@ from pylibcugraph._cugraph_c.array cimport (
 from pylibcugraph._cugraph_c.error cimport (
     cugraph_error_message,
     cugraph_error_free
+)
+
+from pylibcugraph._cugraph_c.dlpack_interop cimport (
+    DLDataType,
+    kDLBool,
+    kDLFloat,
+    kDLInt,
+    kDLUInt,
+    cugraph_data_type_id_from_dlpack,
 )
 
 # FIXME: add tests for this
@@ -115,6 +124,15 @@ cdef get_numpy_type_from_c_type(cugraph_data_type_id_t c_type):
                            f"from C: {c_type}")
 
 
+cdef cugraph_data_type_id_t get_c_type_from_dlpack_dtype(const DLDataType* dl_dtype):
+    cdef cugraph_data_type_id_t c_type
+    cdef cugraph_error_t* error = NULL
+    cdef cugraph_error_code_t code = \
+        cugraph_data_type_id_from_dlpack(dl_dtype, &c_type, &error)
+    assert_success(code, error, "cugraph_data_type_id_from_dlpack")
+    return c_type
+
+
 cdef get_c_type_from_numpy_type(numpy_type):
     dt = numpy.dtype(numpy_type)
     if dt == numpy.int32:
@@ -140,7 +158,6 @@ cdef get_numpy_edge_ids_type_from_c_weight_type(cugraph_data_type_id_t c_weight_
         return numpy.int32
     else:
         return numpy.int64
-
 
 cdef copy_to_cupy_array(
    cugraph_resource_handle_t* c_resource_handle_ptr,

--- a/python/pylibcugraph/pylibcugraph/utils.pyx
+++ b/python/pylibcugraph/pylibcugraph/utils.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Have cython use python 3 syntax


### PR DESCRIPTION
Closes #5567 

dlpack.h defines the structure for DLPack data types.  This function will convert the structure to the dtype we use in the C API.

I kept the changes minimal.