### PR TITLE
update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 ## https://pre-commit.com/
@@ -16,7 +16,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.3
+    rev: v0.15.20
     hooks:
       - id: ruff-check
         args: [--fix]
@@ -25,7 +25,7 @@ repos:
             ^notebooks/algorithms/layout/Force-Atlas2[.]ipynb$
       - id: ruff-format
   - repo: https://github.com/asottile/yesqa
-    rev: v1.3.0
+    rev: v1.5.0
     hooks:
       - id: yesqa
         additional_dependencies:
@@ -37,7 +37,7 @@ repos:
         types_or: [c, c++, cuda]
         args: ["-fallback-style=none", "-style=file", "-i"]
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.3.3
+    rev: v1.6.0
     hooks:
       - id: verify-copyright
         name: verify-copyright-cugraph
@@ -110,21 +110,21 @@ repos:
           (?x)
             ^pyproject[.]toml$
   - repo: https://github.com/sphinx-contrib/sphinx-lint
-    rev: v1.0.0
+    rev: v1.0.2
     hooks:
       - id: sphinx-lint
         args: ["--enable=all", "--disable=line-too-long"]
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.20.0
+    rev: v1.21.0
     hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean", "--warn-all", "--strict"]
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
         args: ["--severity=warning"]
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.24.1
+    rev: v1.26.1
     hooks:
       - id: zizmor


### PR DESCRIPTION
A new commit on `main` is needed to build new packages in response to this ABI break in RAFT: https://github.com/NVIDIA/raft/pull/3052

This PR has a small change just to accomplish that... updating all `pre-commit` hooks (except `clang-format`) to their latest version.

Chose to avoid `clang-format` because the update touches a lot of files, and I wanted this PR to be small and non-controversial.