### PR TITLE
Pin CMake to < 4.4

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - breathe>=4.35.0
 - c-compiler
 - certifi
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=12.9.2,<13.0
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - breathe>=4.35.0
 - c-compiler
 - certifi
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=12.9.2,<13.0
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - breathe>=4.35.0
 - c-compiler
 - certifi
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=13.0.1,<14.0
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - breathe>=4.35.0
 - c-compiler
 - certifi
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=13.0.1,<14.0
 - cuda-nvcc
 - cuda-nvrtc-dev

--- a/conda/recipes/cugraph/conda_build_config.yaml
+++ b/conda/recipes/cugraph/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - cuda-nvcc
 
 cmake_version:
-  - ">=4.0"
+  - ">=4.0,<4.4"
 
 c_stdlib:
   - sysroot

--- a/conda/recipes/libcugraph/conda_build_config.yaml
+++ b/conda/recipes/libcugraph/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - cuda-nvcc
 
 cmake_version:
-  - ">=4.0"
+  - ">=4.0,<4.4"
 
 doxygen_version:
   - ">=1.8.11"

--- a/conda/recipes/pylibcugraph/conda_build_config.yaml
+++ b/conda/recipes/pylibcugraph/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - cuda-nvcc
 
 cmake_version:
-  - ">=4.0"
+  - ">=4.0,<4.4"
 
 c_stdlib:
   - sysroot

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Dependency list for https://github.com/rapidsai/dependency-file-generator
@@ -369,7 +369,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - &cmake_ver cmake>=4.0
+          - &cmake_ver cmake>=4.0,<4.4
           - ninja
   cpp_build:
     common:

--- a/python/cugraph/pyproject.toml
+++ b/python/cugraph/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
@@ -88,7 +88,7 @@ regex = "(?P<value>.*)"
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 requires = [
-    "cmake>=4.0",
+    "cmake>=4.0,<4.4",
     "libcugraph==26.8.*,>=0.0.0a0",
     "libraft==26.8.*,>=0.0.0a0",
     "librmm==26.8.*,>=0.0.0a0",

--- a/python/libcugraph/pyproject.toml
+++ b/python/libcugraph/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
@@ -66,7 +66,7 @@ build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
-    "cmake>=4.0",
+    "cmake>=4.0,<4.4",
     "libraft==26.8.*,>=0.0.0a0",
     "librmm==26.8.*,>=0.0.0a0",
     "ninja",

--- a/python/pylibcugraph/pyproject.toml
+++ b/python/pylibcugraph/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
@@ -73,7 +73,7 @@ regex = "(?P<value>.*)"
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 requires = [
-    "cmake>=4.0",
+    "cmake>=4.0,<4.4",
     "cython>=3.2.2",
     "libcugraph==26.8.*,>=0.0.0a0",
     "libraft==26.8.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

rapids-cmake is currently broken by CMake 4.4, so pin CMake until we have a fix.

Issue: https://github.com/rapidsai/build-planning/issues/302
