### PR TITLE
fix(clang-format): preserve SPDX comments

### DIFF
--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -56,7 +56,7 @@ BreakConstructorInitializers: BeforeColon
 BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
 ColumnLimit: 100
-CommentPragmas: '^ IWYU pragma:'
+CommentPragmas: '^ ?[*]? ?(IWYU pragma:|SPDX-)'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 # Kept the below 2 to be the same as `IndentWidth` to keep everything uniform

--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -56,7 +56,7 @@ BreakConstructorInitializers: BeforeColon
 BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
 ColumnLimit: 100
-CommentPragmas: '^ ?[*]? ?(IWYU pragma:|SPDX-)'
+CommentPragmas: '(IWYU pragma:|SPDX-)'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 # Kept the below 2 to be the same as `IndentWidth` to keep everything uniform


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/303.

This updates clang-format's `CommentPragmas` to preserve SPDX copyright and license lines. Without this, clang-format reflows the canonical notice produced by `verify-copyright`, so consecutive pre-commit runs keep modifying the same block comment. Where a header was already corrupted, this also restores its canonical two-line form.
