### PR TITLE
Fix flaky ForceAtlas2 test

### DIFF
--- a/python/cugraph/cugraph/tests/layout/test_force_atlas2.py
+++ b/python/cugraph/cugraph/tests/layout/test_force_atlas2.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import time
@@ -140,9 +140,7 @@ def compute_average_distance_from_center(
         vertices=vertices,
         random_state=random_state,
     )
-    return (
-        ((pos[["x", "y"]] - pos[["x", "y"]].mean()) ** 2).sum(axis=1) ** 0.5
-    ).mean()
+    return (((pos[["x", "y"]] - pos[["x", "y"]].mean()) ** 2).sum(axis=1) ** 0.5).mean()
 
 
 DATASETS = [

--- a/python/cugraph/cugraph/tests/layout/test_force_atlas2.py
+++ b/python/cugraph/cugraph/tests/layout/test_force_atlas2.py
@@ -110,6 +110,41 @@ def cugraph_call(
     return pos
 
 
+def compute_average_distance_from_center(
+    edgelist_df,
+    vertices,
+    max_iter,
+    barnes_hut_optimize,
+    gravity,
+    random_state,
+):
+    pos = cugraph_call(
+        edgelist_df,
+        max_iter=max_iter,
+        pos_list=None,
+        outbound_attraction_distribution=True,
+        lin_log_mode=False,
+        prevent_overlapping=False,
+        vertex_radius=None,
+        overlap_scaling_ratio=100.0,
+        edge_weight_influence=1.0,
+        jitter_tolerance=1.0,
+        barnes_hut_optimize=barnes_hut_optimize,
+        barnes_hut_theta=0.5,
+        scaling_ratio=2.0,
+        strong_gravity_mode=False,
+        gravity=gravity,
+        vertex_mobility=None,
+        vertex_mass=None,
+        callback=None,
+        vertices=vertices,
+        random_state=random_state,
+    )
+    return (
+        ((pos[["x", "y"]] - pos[["x", "y"]].mean()) ** 2).sum(axis=1) ** 0.5
+    ).mean()
+
+
 DATASETS = [
     (karate, 0.70),
     (polbooks, 0.75),
@@ -461,43 +496,28 @@ def test_force_atlas2_empty(max_iter, barnes_hut_optimize):
     edgelist_df = cudf.DataFrame({"src": [], "dst": [], "wgt": []}, dtype="int32")
     vertices = [0, 1, 2, 3]
 
-    def average_distance_from_center(gravity, random_state):
-        pos = cugraph_call(
-            edgelist_df,
-            max_iter=max_iter,
-            pos_list=None,
-            outbound_attraction_distribution=True,
-            lin_log_mode=False,
-            prevent_overlapping=False,
-            vertex_radius=None,
-            overlap_scaling_ratio=100.0,
-            edge_weight_influence=1.0,
-            jitter_tolerance=1.0,
-            barnes_hut_optimize=barnes_hut_optimize,
-            barnes_hut_theta=0.5,
-            scaling_ratio=2.0,
-            strong_gravity_mode=False,
-            gravity=gravity,
-            vertex_mobility=None,
-            vertex_mass=None,
-            callback=None,
-            vertices=vertices,
-            random_state=random_state,
-        )
-        # Changing gravity should change the distances apart.
-        # Compare average distance from center of mass.
-        return (
-            ((pos[["x", "y"]] - pos[["x", "y"]].mean()) ** 2).sum(axis=1) ** 0.5
-        ).mean()
-
     # FA2 is sensitive to random initialization. Use deterministic seeds and
     # retry a few starts to avoid failing only because of a bad local minimum.
     dist_1 = None
     dist_100 = None
     random_state = None
     for random_state in range(10):
-        dist_1 = average_distance_from_center(gravity=1.0, random_state=random_state)
-        dist_100 = average_distance_from_center(gravity=100.0, random_state=random_state)
+        dist_1 = compute_average_distance_from_center(
+            edgelist_df,
+            vertices,
+            max_iter,
+            barnes_hut_optimize,
+            gravity=1.0,
+            random_state=random_state,
+        )
+        dist_100 = compute_average_distance_from_center(
+            edgelist_df,
+            vertices,
+            max_iter,
+            barnes_hut_optimize,
+            gravity=100.0,
+            random_state=random_state,
+        )
         # Stronger gravity makes vertices closer together.
         if dist_1 > 4 * dist_100:
             break

--- a/python/cugraph/cugraph/tests/layout/test_force_atlas2.py
+++ b/python/cugraph/cugraph/tests/layout/test_force_atlas2.py
@@ -67,6 +67,7 @@ def cugraph_call(
     callback=None,
     renumber=False,
     vertices=None,
+    random_state=None,
 ):
     G = cugraph.Graph()
     if cu_M["src"] is not int or cu_M["dst"] is not int:
@@ -102,6 +103,7 @@ def cugraph_call(
         vertex_mobility=vertex_mobility,
         vertex_mass=vertex_mass,
         callback=callback,
+        random_state=random_state,
     )
     t2 = time.time() - t1
     print("Cugraph Time : " + str(t2))
@@ -458,58 +460,49 @@ def test_force_atlas2_empty(max_iter, barnes_hut_optimize):
     # Instead, this test simply tests whether gravity works as expected.
     edgelist_df = cudf.DataFrame({"src": [], "dst": [], "wgt": []}, dtype="int32")
     vertices = [0, 1, 2, 3]
-    gravity = 1.0
-    pos_1 = cugraph_call(
-        edgelist_df,
-        max_iter=max_iter,
-        pos_list=None,
-        outbound_attraction_distribution=True,
-        lin_log_mode=False,
-        prevent_overlapping=False,
-        vertex_radius=None,
-        overlap_scaling_ratio=100.0,
-        edge_weight_influence=1.0,
-        jitter_tolerance=1.0,
-        barnes_hut_optimize=barnes_hut_optimize,
-        barnes_hut_theta=0.5,
-        scaling_ratio=2.0,
-        strong_gravity_mode=False,
-        gravity=gravity,
-        vertex_mobility=None,
-        vertex_mass=None,
-        callback=None,
-        vertices=vertices,
-    )
-    # Changing gravity should change the distances apart.
-    # Compare average distance from center of mass.
-    dist_1 = (
-        ((pos_1[["x", "y"]] - pos_1[["x", "y"]].mean()) ** 2).sum(axis=1) ** 0.5
-    ).mean()
 
-    gravity = 100.0
-    pos_100 = cugraph_call(
-        edgelist_df,
-        max_iter=max_iter,
-        pos_list=None,
-        outbound_attraction_distribution=True,
-        lin_log_mode=False,
-        prevent_overlapping=False,
-        vertex_radius=None,
-        overlap_scaling_ratio=100.0,
-        edge_weight_influence=1.0,
-        jitter_tolerance=1.0,
-        barnes_hut_optimize=barnes_hut_optimize,
-        barnes_hut_theta=0.5,
-        scaling_ratio=2.0,
-        strong_gravity_mode=False,
-        gravity=gravity,
-        vertex_mobility=None,
-        vertex_mass=None,
-        callback=None,
-        vertices=vertices,
+    def average_distance_from_center(gravity, random_state):
+        pos = cugraph_call(
+            edgelist_df,
+            max_iter=max_iter,
+            pos_list=None,
+            outbound_attraction_distribution=True,
+            lin_log_mode=False,
+            prevent_overlapping=False,
+            vertex_radius=None,
+            overlap_scaling_ratio=100.0,
+            edge_weight_influence=1.0,
+            jitter_tolerance=1.0,
+            barnes_hut_optimize=barnes_hut_optimize,
+            barnes_hut_theta=0.5,
+            scaling_ratio=2.0,
+            strong_gravity_mode=False,
+            gravity=gravity,
+            vertex_mobility=None,
+            vertex_mass=None,
+            callback=None,
+            vertices=vertices,
+            random_state=random_state,
+        )
+        # Changing gravity should change the distances apart.
+        # Compare average distance from center of mass.
+        return (
+            ((pos[["x", "y"]] - pos[["x", "y"]].mean()) ** 2).sum(axis=1) ** 0.5
+        ).mean()
+
+    # FA2 is sensitive to random initialization. Use deterministic seeds and
+    # retry a few starts to avoid failing only because of a bad local minimum.
+    dist_1 = None
+    dist_100 = None
+    random_state = None
+    for random_state in range(10):
+        dist_1 = average_distance_from_center(gravity=1.0, random_state=random_state)
+        dist_100 = average_distance_from_center(gravity=100.0, random_state=random_state)
+        # Stronger gravity makes vertices closer together.
+        if dist_1 > 4 * dist_100:
+            break
+
+    assert dist_1 > 4 * dist_100, (
+        "Expected stronger gravity to make vertices closer together, "
+        f"but dist_1={dist_1}, dist_100={dist_100}, random_state={random_state}"
     )
-    dist_100 = (
-        ((pos_100[["x", "y"]] - pos_100[["x", "y"]].mean()) ** 2).sum(axis=1) ** 0.5
-    ).mean()
-    # Stronger gravity makes vertices closer together.
-    assert dist_1 > 4 * dist_100


### PR DESCRIPTION
This PR fixes the flaky `test_force_atlas2_empty` test from issue #5569. 

`ForceAtlas2` is a local-optimization algorithm, so most random starts give a good layout, but occasional start may land in a bad local minimum and produces a bad result. The fix makes the test deterministic by passing `random_state` through the test helper, and retries a few seeded runs before asserting.

closes #5569 