### PR TITLE
Fix dask cudf failure

### DIFF
--- a/python/cugraph/cugraph/dask/centrality/betweenness_centrality.py
+++ b/python/cugraph/cugraph/dask/centrality/betweenness_centrality.py
@@ -81,6 +81,16 @@ def _mg_call_plc_betweenness_centrality(
     endpoints: bool = False,
     edge_bc: bool = False,
 ) -> dask_cudf.DataFrame:
+    comms_workers = list(Comms.get_workers())
+    plc_keys = list(input_graph._plc_graph.keys())
+    missing = set(comms_workers) - set(plc_keys)
+    extra = set(plc_keys) - set(comms_workers)
+    print(
+        f"[cugraph_mg_persist_debug] betweenness_plc_lookup "
+        f"comms_workers={comms_workers!r} plc_keys={plc_keys!r} "
+        f"missing={missing!r} extra={extra!r}",
+        flush=True,
+    )
     result = [
         client.submit(
             _call_plc_betweenness_centrality,

--- a/python/cugraph/cugraph/dask/centrality/betweenness_centrality.py
+++ b/python/cugraph/cugraph/dask/centrality/betweenness_centrality.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -81,16 +81,6 @@ def _mg_call_plc_betweenness_centrality(
     endpoints: bool = False,
     edge_bc: bool = False,
 ) -> dask_cudf.DataFrame:
-    comms_workers = list(Comms.get_workers())
-    plc_keys = list(input_graph._plc_graph.keys())
-    missing = set(comms_workers) - set(plc_keys)
-    extra = set(plc_keys) - set(comms_workers)
-    print(
-        f"[cugraph_mg_persist_debug] betweenness_plc_lookup "
-        f"comms_workers={comms_workers!r} plc_keys={plc_keys!r} "
-        f"missing={missing!r} extra={extra!r}",
-        flush=True,
-    )
     result = [
         client.submit(
             _call_plc_betweenness_centrality,

--- a/python/cugraph/cugraph/dask/centrality/betweenness_centrality.py
+++ b/python/cugraph/cugraph/dask/centrality/betweenness_centrality.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -96,7 +96,7 @@ def _mg_call_plc_betweenness_centrality(
             allow_other_workers=False,
             pure=False,
         )
-        for i, w in enumerate(Comms.get_workers())
+        for i, w in enumerate(input_graph._plc_graph)
     ]
 
     wait(result)
@@ -220,8 +220,8 @@ def betweenness_centrality(
                 k = cudf.Series(k, dtype=k_dtype)
 
         if isinstance(k, (cudf.Series, cudf.DataFrame)):
-            splits = cp.array_split(cp.arange(len(k)), len(Comms.get_workers()))
-            k = {w: [k.iloc[splits[i]]] for i, w in enumerate(Comms.get_workers())}
+            splits = cp.array_split(cp.arange(len(k)), len(input_graph._plc_graph))
+            k = {w: [k.iloc[splits[i]]] for i, w in enumerate(input_graph._plc_graph)}
 
     else:
         if k is not None:
@@ -378,8 +378,8 @@ def edge_betweenness_centrality(
                 k = cudf.Series(k, dtype=k_dtype)
 
         if isinstance(k, (cudf.Series, cudf.DataFrame)):
-            splits = cp.array_split(cp.arange(len(k)), len(Comms.get_workers()))
-            k = {w: [k.iloc[splits[i]]] for i, w in enumerate(Comms.get_workers())}
+            splits = cp.array_split(cp.arange(len(k)), len(input_graph._plc_graph))
+            k = {w: [k.iloc[splits[i]]] for i, w in enumerate(input_graph._plc_graph)}
 
     else:
         if k is not None:

--- a/python/cugraph/cugraph/dask/centrality/betweenness_centrality.py
+++ b/python/cugraph/cugraph/dask/centrality/betweenness_centrality.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/python/cugraph/cugraph/dask/centrality/eigenvector_centrality.py
+++ b/python/cugraph/cugraph/dask/centrality/eigenvector_centrality.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -125,7 +125,7 @@ def eigenvector_centrality(input_graph, max_iter=100, tol=1.0e-6):
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(cupy_result)

--- a/python/cugraph/cugraph/dask/centrality/katz_centrality.py
+++ b/python/cugraph/cugraph/dask/centrality/katz_centrality.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -177,7 +177,7 @@ def katz_centrality(
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(cupy_result)

--- a/python/cugraph/cugraph/dask/common/part_utils.py
+++ b/python/cugraph/cugraph/dask/common/part_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
@@ -88,12 +88,6 @@ def _chunk_lst(ls, num_parts):
     return [ls[i::num_parts] for i in range(num_parts)]
 
 
-def _debug_mg_persist(msg, **kwargs):
-    """CI debug logging for MG persist/partition issues (remove after root-cause found)."""
-    parts = " ".join(f"{k}={v!r}" for k, v in kwargs.items())
-    print(f"[cugraph_mg_persist_debug] {msg} {parts}", flush=True)
-
-
 def persist_dask_df_equal_parts_per_worker(
     dask_df, client, return_type="dask_cudf.DataFrame"
 ):
@@ -109,113 +103,31 @@ def persist_dask_df_equal_parts_per_worker(
     if return_type not in ["dask_cudf.DataFrame", "dict"]:
         raise ValueError("return_type must be either 'dask_cudf.DataFrame' or 'dict'")
 
+    ddf_keys = dask_df.to_delayed()
     rank_to_worker = Comms.rank_to_worker(client)
     # rank-worker mappings are in ascending order
-    workers = list(dict(sorted(rank_to_worker.items())).values())
-    n_workers = len(workers)
+    workers = dict(sorted(rank_to_worker.items())).values()
 
-    try:
-        input_npartitions = dask_df.npartitions
-    except Exception as exc:
-        input_npartitions = f"error:{exc!r}"
-
-    _debug_mg_persist(
-        "enter",
-        input_npartitions=input_npartitions,
-        n_workers=n_workers,
-        return_type=return_type,
-        comms_workers=workers,
-    )
-
-    if n_workers == 0:
-        _debug_mg_persist("zero_workers", comms_workers=workers)
-        raise RuntimeError(
-            "persist_dask_df_equal_parts_per_worker: no comms workers available"
+    ddf_keys_ls = _chunk_lst(ddf_keys, len(workers))
+    persisted_keys_d = {}
+    for w, ddf_k in zip(workers, ddf_keys_ls):
+        persisted_keys_d[w] = client.compute(
+            ddf_k,
+            workers=w,
+            allow_other_workers=False,
         )
-
-    # Fix: materialize with a stable, non-zero partition count before to_delayed().
-    # Avoids dask-expr repartition optimizer hitting n_new_partitions == 0.
-    target_npartitions = max(1, n_workers)
-    if isinstance(input_npartitions, int) and input_npartitions != target_npartitions:
-        _debug_mg_persist(
-            "repartition_before_to_delayed",
-            input_npartitions=input_npartitions,
-            target_npartitions=target_npartitions,
-        )
-        dask_df = dask_df.repartition(npartitions=target_npartitions).persist()
-    else:
-        dask_df = dask_df.persist()
-    wait(dask_df)
-    _debug_mg_persist("after_materialize", npartitions=dask_df.npartitions)
-
-    try:
-        ddf_keys = dask_df.to_delayed()
-    except Exception as exc:
-        _debug_mg_persist(
-            "to_delayed_failed",
-            error=repr(exc),
-            npartitions=dask_df.npartitions,
-        )
-        raise
-
-    _debug_mg_persist("after_to_delayed", n_delayed=len(ddf_keys))
-
-    if len(ddf_keys) == 0:
-        _debug_mg_persist("empty_delayed_keys_recover", workers=workers)
-        persisted_keys_d = {
-            w: _create_empty_dask_df_future(dask_df._meta, client, w) for w in workers
-        }
-    else:
-        ddf_keys_ls = _chunk_lst(ddf_keys, n_workers)
-        _debug_mg_persist(
-            "chunked_delayed_keys",
-            chunk_sizes=[len(chunk) for chunk in ddf_keys_ls],
-        )
-        persisted_keys_d = {}
-        for w, ddf_k in zip(workers, ddf_keys_ls):
-            if not ddf_k:
-                _debug_mg_persist("empty_chunk_for_worker_recover", worker=w)
-                persisted_keys_d[w] = _create_empty_dask_df_future(
-                    dask_df._meta, client, w
-                )
-            else:
-                persisted_keys_d[w] = client.compute(
-                    ddf_k,
-                    workers=w,
-                    allow_other_workers=False,
-                )
 
     persisted_keys_ls = [
         item for sublist in persisted_keys_d.values() for item in sublist
     ]
-    _debug_mg_persist(
-        "before_wait",
-        n_persisted_keys=len(persisted_keys_ls),
-        persisted_workers=list(persisted_keys_d.keys()),
-    )
     wait(persisted_keys_ls)
     if return_type == "dask_cudf.DataFrame":
-        if not persisted_keys_ls:
-            _debug_mg_persist("empty_persisted_keys_ls_recover", workers=workers)
-            persisted_keys_ls = [
-                item
-                for w in workers
-                for item in _create_empty_dask_df_future(dask_df._meta, client, w)
-            ]
         dask_df = dask_cudf.from_delayed(
             persisted_keys_ls, meta=dask_df._meta
         ).persist()
         wait(dask_df)
-        _debug_mg_persist(
-            "exit", return_type=return_type, npartitions=dask_df.npartitions
-        )
         return dask_df
 
-    _debug_mg_persist(
-        "exit",
-        return_type=return_type,
-        persisted_workers=list(persisted_keys_d.keys()),
-    )
     return persisted_keys_d
 
 

--- a/python/cugraph/cugraph/dask/common/part_utils.py
+++ b/python/cugraph/cugraph/dask/common/part_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
@@ -163,8 +163,7 @@ def persist_dask_df_equal_parts_per_worker(
     if len(ddf_keys) == 0:
         _debug_mg_persist("empty_delayed_keys_recover", workers=workers)
         persisted_keys_d = {
-            w: _create_empty_dask_df_future(dask_df._meta, client, w)
-            for w in workers
+            w: _create_empty_dask_df_future(dask_df._meta, client, w) for w in workers
         }
     else:
         ddf_keys_ls = _chunk_lst(ddf_keys, n_workers)
@@ -207,7 +206,9 @@ def persist_dask_df_equal_parts_per_worker(
             persisted_keys_ls, meta=dask_df._meta
         ).persist()
         wait(dask_df)
-        _debug_mg_persist("exit", return_type=return_type, npartitions=dask_df.npartitions)
+        _debug_mg_persist(
+            "exit", return_type=return_type, npartitions=dask_df.npartitions
+        )
         return dask_df
 
     _debug_mg_persist(

--- a/python/cugraph/cugraph/dask/common/part_utils.py
+++ b/python/cugraph/cugraph/dask/common/part_utils.py
@@ -88,6 +88,12 @@ def _chunk_lst(ls, num_parts):
     return [ls[i::num_parts] for i in range(num_parts)]
 
 
+def _debug_mg_persist(msg, **kwargs):
+    """CI debug logging for MG persist/partition issues (remove after root-cause found)."""
+    parts = " ".join(f"{k}={v!r}" for k, v in kwargs.items())
+    print(f"[cugraph_mg_persist_debug] {msg} {parts}", flush=True)
+
+
 def persist_dask_df_equal_parts_per_worker(
     dask_df, client, return_type="dask_cudf.DataFrame"
 ):
@@ -103,31 +109,112 @@ def persist_dask_df_equal_parts_per_worker(
     if return_type not in ["dask_cudf.DataFrame", "dict"]:
         raise ValueError("return_type must be either 'dask_cudf.DataFrame' or 'dict'")
 
-    ddf_keys = dask_df.to_delayed()
     rank_to_worker = Comms.rank_to_worker(client)
     # rank-worker mappings are in ascending order
-    workers = dict(sorted(rank_to_worker.items())).values()
+    workers = list(dict(sorted(rank_to_worker.items())).values())
+    n_workers = len(workers)
 
-    ddf_keys_ls = _chunk_lst(ddf_keys, len(workers))
-    persisted_keys_d = {}
-    for w, ddf_k in zip(workers, ddf_keys_ls):
-        persisted_keys_d[w] = client.compute(
-            ddf_k,
-            workers=w,
-            allow_other_workers=False,
+    try:
+        input_npartitions = dask_df.npartitions
+    except Exception as exc:
+        input_npartitions = f"error:{exc!r}"
+
+    _debug_mg_persist(
+        "enter",
+        input_npartitions=input_npartitions,
+        n_workers=n_workers,
+        return_type=return_type,
+        comms_workers=workers,
+    )
+
+    if n_workers == 0:
+        _debug_mg_persist("zero_workers", comms_workers=workers)
+        raise RuntimeError(
+            "persist_dask_df_equal_parts_per_worker: no comms workers available"
         )
+
+    # Fix: materialize with a stable, non-zero partition count before to_delayed().
+    # Avoids dask-expr repartition optimizer hitting n_new_partitions == 0.
+    target_npartitions = max(1, n_workers)
+    if isinstance(input_npartitions, int) and input_npartitions != target_npartitions:
+        _debug_mg_persist(
+            "repartition_before_to_delayed",
+            input_npartitions=input_npartitions,
+            target_npartitions=target_npartitions,
+        )
+        dask_df = dask_df.repartition(npartitions=target_npartitions).persist()
+    else:
+        dask_df = dask_df.persist()
+    wait(dask_df)
+    _debug_mg_persist("after_materialize", npartitions=dask_df.npartitions)
+
+    try:
+        ddf_keys = dask_df.to_delayed()
+    except Exception as exc:
+        _debug_mg_persist(
+            "to_delayed_failed",
+            error=repr(exc),
+            npartitions=dask_df.npartitions,
+        )
+        raise
+
+    _debug_mg_persist("after_to_delayed", n_delayed=len(ddf_keys))
+
+    if len(ddf_keys) == 0:
+        _debug_mg_persist("empty_delayed_keys_recover", workers=workers)
+        persisted_keys_d = {
+            w: _create_empty_dask_df_future(dask_df._meta, client, w)
+            for w in workers
+        }
+    else:
+        ddf_keys_ls = _chunk_lst(ddf_keys, n_workers)
+        _debug_mg_persist(
+            "chunked_delayed_keys",
+            chunk_sizes=[len(chunk) for chunk in ddf_keys_ls],
+        )
+        persisted_keys_d = {}
+        for w, ddf_k in zip(workers, ddf_keys_ls):
+            if not ddf_k:
+                _debug_mg_persist("empty_chunk_for_worker_recover", worker=w)
+                persisted_keys_d[w] = _create_empty_dask_df_future(
+                    dask_df._meta, client, w
+                )
+            else:
+                persisted_keys_d[w] = client.compute(
+                    ddf_k,
+                    workers=w,
+                    allow_other_workers=False,
+                )
 
     persisted_keys_ls = [
         item for sublist in persisted_keys_d.values() for item in sublist
     ]
+    _debug_mg_persist(
+        "before_wait",
+        n_persisted_keys=len(persisted_keys_ls),
+        persisted_workers=list(persisted_keys_d.keys()),
+    )
     wait(persisted_keys_ls)
     if return_type == "dask_cudf.DataFrame":
+        if not persisted_keys_ls:
+            _debug_mg_persist("empty_persisted_keys_ls_recover", workers=workers)
+            persisted_keys_ls = [
+                item
+                for w in workers
+                for item in _create_empty_dask_df_future(dask_df._meta, client, w)
+            ]
         dask_df = dask_cudf.from_delayed(
             persisted_keys_ls, meta=dask_df._meta
         ).persist()
         wait(dask_df)
+        _debug_mg_persist("exit", return_type=return_type, npartitions=dask_df.npartitions)
         return dask_df
 
+    _debug_mg_persist(
+        "exit",
+        return_type=return_type,
+        persisted_workers=list(persisted_keys_d.keys()),
+    )
     return persisted_keys_d
 
 

--- a/python/cugraph/cugraph/dask/comms/comms.py
+++ b/python/cugraph/cugraph/dask/comms/comms.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2018-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # This file contains various functions required for managing NCCL comms
@@ -262,7 +262,13 @@ def rank_to_worker(client):
     """
     Return a mapping of ranks to dask workers.
     """
-    workers = client.scheduler_info(n_workers=-1)["workers"].keys()
+    # Use the raft comms worker snapshot rather than
+    # client.scheduler_info(n_workers=-1)["workers"], whose "workers" dict is
+    # periodically overwritten with an empty dict by dask's scheduler-info poll
+    # (n_workers=0). Reading it during that window yields an empty mapping and
+    # builds an empty _plc_graph, later raising "Must supply at least one
+    # delayed object" in dask_cudf.from_delayed.
+    workers = get_workers()
     worker_info = __instance.worker_info(workers)
     rank_to_worker = {}
     for w in worker_info:

--- a/python/cugraph/cugraph/dask/community/ecg.py
+++ b/python/cugraph/cugraph/dask/community/ecg.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -166,7 +166,7 @@ def ecg(
             workers=[w],
             allow_other_workers=False,
         )
-        for i, w in enumerate(Comms.get_workers())
+        for i, w in enumerate(input_graph._plc_graph)
     ]
 
     wait(result)

--- a/python/cugraph/cugraph/dask/community/ktruss_subgraph.py
+++ b/python/cugraph/cugraph/dask/community/ktruss_subgraph.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -87,7 +87,7 @@ def ktruss_subgraph(input_graph, k: int) -> dask_cudf.DataFrame:
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
     wait(result)
 

--- a/python/cugraph/cugraph/dask/community/leiden.py
+++ b/python/cugraph/cugraph/dask/community/leiden.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -151,7 +151,7 @@ def leiden(
             workers=[w],
             allow_other_workers=False,
         )
-        for i, w in enumerate(Comms.get_workers())
+        for i, w in enumerate(input_graph._plc_graph)
     ]
 
     wait(result)

--- a/python/cugraph/cugraph/dask/community/louvain.py
+++ b/python/cugraph/cugraph/dask/community/louvain.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -172,7 +172,7 @@ def louvain(
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(result)

--- a/python/cugraph/cugraph/dask/community/triangle_count.py
+++ b/python/cugraph/cugraph/dask/community/triangle_count.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -116,7 +116,7 @@ def triangle_count(input_graph, start_list=None):
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
     wait(result)
 

--- a/python/cugraph/cugraph/dask/components/connectivity.py
+++ b/python/cugraph/cugraph/dask/components/connectivity.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -94,7 +94,7 @@ def weakly_connected_components(input_graph):
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(result)

--- a/python/cugraph/cugraph/dask/cores/core_number.py
+++ b/python/cugraph/cugraph/dask/cores/core_number.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -90,7 +90,7 @@ def core_number(input_graph, degree_type="bidirectional"):
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(result)

--- a/python/cugraph/cugraph/dask/cores/k_core.py
+++ b/python/cugraph/cugraph/dask/cores/k_core.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -158,7 +158,7 @@ def k_core(input_graph, k=None, core_number=None, degree_type="bidirectional"):
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(result)

--- a/python/cugraph/cugraph/dask/link_analysis/hits.py
+++ b/python/cugraph/cugraph/dask/link_analysis/hits.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -148,7 +148,7 @@ def hits(input_graph, tol=1.0e-5, max_iter=100, nstart=None, normalized=True):
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(cupy_result)

--- a/python/cugraph/cugraph/dask/link_analysis/pagerank.py
+++ b/python/cugraph/cugraph/dask/link_analysis/pagerank.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -390,7 +390,7 @@ def pagerank(
                 workers=[w],
                 allow_other_workers=False,
             )
-            for w in Comms.get_workers()
+            for w in input_graph._plc_graph
         ]
 
     wait(result)

--- a/python/cugraph/cugraph/dask/link_prediction/cosine.py
+++ b/python/cugraph/cugraph/dask/link_prediction/cosine.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -160,7 +160,7 @@ def cosine(input_graph, vertex_pair=None, use_weight=False):
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(result)
@@ -288,7 +288,7 @@ def all_pairs_cosine(
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(result)

--- a/python/cugraph/cugraph/dask/link_prediction/jaccard.py
+++ b/python/cugraph/cugraph/dask/link_prediction/jaccard.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -160,7 +160,7 @@ def jaccard(input_graph, vertex_pair=None, use_weight=False):
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(result)
@@ -288,7 +288,7 @@ def all_pairs_jaccard(
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(result)

--- a/python/cugraph/cugraph/dask/link_prediction/overlap.py
+++ b/python/cugraph/cugraph/dask/link_prediction/overlap.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -162,7 +162,7 @@ def overlap(input_graph, vertex_pair=None, use_weight=False):
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(result)
@@ -290,7 +290,7 @@ def all_pairs_overlap(
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(result)

--- a/python/cugraph/cugraph/dask/link_prediction/sorensen.py
+++ b/python/cugraph/cugraph/dask/link_prediction/sorensen.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -158,7 +158,7 @@ def sorensen(input_graph, vertex_pair=None, use_weight=False):
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(result)
@@ -286,7 +286,7 @@ def all_pairs_sorensen(
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(result)

--- a/python/cugraph/cugraph/dask/sampling/node2vec_random_walks.py
+++ b/python/cugraph/cugraph/dask/sampling/node2vec_random_walks.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from dask.distributed import wait, default_client

--- a/python/cugraph/cugraph/dask/sampling/node2vec_random_walks.py
+++ b/python/cugraph/cugraph/dask/sampling/node2vec_random_walks.py
@@ -151,6 +151,14 @@ def node2vec_random_walks(
     start_vertices = persist_dask_df_equal_parts_per_worker(
         start_vertices, client, return_type="dict"
     )
+    print(
+        f"[cugraph_mg_persist_debug] node2vec_after_persist "
+        f"start_vertex_workers={list(start_vertices.keys())!r} "
+        f"plc_keys={list(input_graph._plc_graph.keys())!r} "
+        f"comms_workers={list(Comms.get_workers())!r} "
+        f"plc_not_in_comms={set(input_graph._plc_graph.keys()) - set(Comms.get_workers())!r}",
+        flush=True,
+    )
 
     result = [
         client.submit(
@@ -184,6 +192,17 @@ def node2vec_random_walks(
     ]
 
     wait([cudf_vertex_paths, cudf_edge_wgt_paths])
+
+    print(
+        f"[cugraph_mg_persist_debug] node2vec_before_from_delayed "
+        f"n_cudf_vertex_paths={len(cudf_vertex_paths)} "
+        f"n_result={len(result)}",
+        flush=True,
+    )
+    if not cudf_vertex_paths:
+        raise RuntimeError(
+            "[cugraph_mg_persist_debug] node2vec: empty cudf_vertex_paths after persist/submit"
+        )
 
     ddf_vertex_paths = dask_cudf.from_delayed(cudf_vertex_paths).persist()
     ddf_edge_wgt_paths = dask_cudf.from_delayed(cudf_edge_wgt_paths).persist()

--- a/python/cugraph/cugraph/dask/sampling/node2vec_random_walks.py
+++ b/python/cugraph/cugraph/dask/sampling/node2vec_random_walks.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from dask.distributed import wait, default_client
@@ -151,14 +151,6 @@ def node2vec_random_walks(
     start_vertices = persist_dask_df_equal_parts_per_worker(
         start_vertices, client, return_type="dict"
     )
-    print(
-        f"[cugraph_mg_persist_debug] node2vec_after_persist "
-        f"start_vertex_workers={list(start_vertices.keys())!r} "
-        f"plc_keys={list(input_graph._plc_graph.keys())!r} "
-        f"comms_workers={list(Comms.get_workers())!r} "
-        f"plc_not_in_comms={set(input_graph._plc_graph.keys()) - set(Comms.get_workers())!r}",
-        flush=True,
-    )
 
     result = [
         client.submit(
@@ -192,17 +184,6 @@ def node2vec_random_walks(
     ]
 
     wait([cudf_vertex_paths, cudf_edge_wgt_paths])
-
-    print(
-        f"[cugraph_mg_persist_debug] node2vec_before_from_delayed "
-        f"n_cudf_vertex_paths={len(cudf_vertex_paths)} "
-        f"n_result={len(result)}",
-        flush=True,
-    )
-    if not cudf_vertex_paths:
-        raise RuntimeError(
-            "[cugraph_mg_persist_debug] node2vec: empty cudf_vertex_paths after persist/submit"
-        )
 
     ddf_vertex_paths = dask_cudf.from_delayed(cudf_vertex_paths).persist()
     ddf_edge_wgt_paths = dask_cudf.from_delayed(cudf_edge_wgt_paths).persist()

--- a/python/cugraph/cugraph/dask/traversal/sssp.py
+++ b/python/cugraph/cugraph/dask/traversal/sssp.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -124,7 +124,7 @@ def sssp(input_graph, source, cutoff=None, check_source=True):
             workers=[w],
             allow_other_workers=False,
         )
-        for w in Comms.get_workers()
+        for w in input_graph._plc_graph
     ]
 
     wait(result)

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
@@ -224,9 +224,30 @@ class simpleDistributedGraphImpl:
         ddf_columns = s_col + d_col
         self.vertex_columns = ddf_columns.copy()
         _client = default_client()
+
+        # Primary fix: block until at least one worker has registered so the
+        # scheduler_info() read below is not empty.
+        try:
+            _client.wait_for_workers(n_workers=1)
+        except Exception as e:
+            print(
+                f"[cugraph_mg_persist_debug] wait_for_workers(n_workers=1) failed: {e!r}",
+                flush=True,
+            )
+
         workers = _client.scheduler_info(n_workers=-1)["workers"]
+
+        # Fallback / safety net: if the worker list is still empty after waiting,
+        # log it and clamp so npartitions never becomes 0 (avoids ZeroDivisionError).
+        if len(workers) == 0:
+            print(
+                "[cugraph_mg_persist_debug] scheduler_info still reports 0 workers "
+                "after wait_for_workers; applying npartitions=max(1, len(workers)*2)",
+                flush=True,
+            )
+
         # Repartition to 2 partitions per GPU for memory efficient process
-        input_ddf = input_ddf.repartition(npartitions=len(workers) * 2)
+        input_ddf = input_ddf.repartition(npartitions=max(1, len(workers) * 2))
         # The dataframe will be symmetrized iff the graph is undirected
         # otherwise, the inital dataframe will be returned
         if edge_attr is not None:

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import gc

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
@@ -354,7 +354,15 @@ class simpleDistributedGraphImpl:
             is_multigraph=self.properties.multi_edge,
             is_symmetric=not self.properties.directed,
         )
-        ddf = ddf.repartition(npartitions=len(workers) * 2)
+        n_workers_before_repart = len(workers)
+        target_npartitions = max(1, n_workers_before_repart)
+        print(
+            f"[cugraph_mg_persist_debug] graph_from_edgelist_before_persist "
+            f"n_workers={n_workers_before_repart} input_npartitions={ddf.npartitions} "
+            f"target_npartitions={target_npartitions}",
+            flush=True,
+        )
+        ddf = ddf.repartition(npartitions=target_npartitions)
         workers = _client.scheduler_info(n_workers=-1)["workers"].keys()
         persisted_keys_d = persist_dask_df_equal_parts_per_worker(
             ddf, _client, return_type="dict"
@@ -387,6 +395,16 @@ class simpleDistributedGraphImpl:
             )
             for w, delayed_task in delayed_tasks_d.items()
         }
+        comms_workers = list(Comms.get_workers())
+        print(
+            f"[cugraph_mg_persist_debug] graph_plc_built "
+            f"plc_keys={list(self._plc_graph.keys())!r} "
+            f"comms_workers={comms_workers!r} "
+            f"scheduler_workers={list(workers)!r} "
+            f"plc_not_in_comms={set(self._plc_graph.keys()) - set(comms_workers)!r} "
+            f"comms_not_in_plc={set(comms_workers) - set(self._plc_graph.keys())!r}",
+            flush=True,
+        )
         del delayed_tasks_d
         run_gc_on_dask_cluster(_client)
         wait(list(self._plc_graph.values()))

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
@@ -224,30 +224,13 @@ class simpleDistributedGraphImpl:
         ddf_columns = s_col + d_col
         self.vertex_columns = ddf_columns.copy()
         _client = default_client()
-
-        # Primary fix: block until at least one worker has registered so the
-        # scheduler_info() read below is not empty.
-        try:
-            _client.wait_for_workers(n_workers=1)
-        except Exception as e:
-            print(
-                f"[cugraph_mg_persist_debug] wait_for_workers(n_workers=1) failed: {e!r}",
-                flush=True,
-            )
-
+        # Block until at least one worker has registered so that scheduler_info()
+        # below does not transiently return an empty worker list (which would make
+        # npartitions=0 and raise ZeroDivisionError in dask's repartition).
+        _client.wait_for_workers(n_workers=1)
         workers = _client.scheduler_info(n_workers=-1)["workers"]
-
-        # Fallback / safety net: if the worker list is still empty after waiting,
-        # log it and clamp so npartitions never becomes 0 (avoids ZeroDivisionError).
-        if len(workers) == 0:
-            print(
-                "[cugraph_mg_persist_debug] scheduler_info still reports 0 workers "
-                "after wait_for_workers; applying npartitions=max(1, len(workers)*2)",
-                flush=True,
-            )
-
         # Repartition to 2 partitions per GPU for memory efficient process
-        input_ddf = input_ddf.repartition(npartitions=max(1, len(workers) * 2))
+        input_ddf = input_ddf.repartition(npartitions=len(workers) * 2)
         # The dataframe will be symmetrized iff the graph is undirected
         # otherwise, the inital dataframe will be returned
         if edge_attr is not None:
@@ -375,15 +358,7 @@ class simpleDistributedGraphImpl:
             is_multigraph=self.properties.multi_edge,
             is_symmetric=not self.properties.directed,
         )
-        n_workers_before_repart = len(workers)
-        target_npartitions = max(1, n_workers_before_repart)
-        print(
-            f"[cugraph_mg_persist_debug] graph_from_edgelist_before_persist "
-            f"n_workers={n_workers_before_repart} input_npartitions={ddf.npartitions} "
-            f"target_npartitions={target_npartitions}",
-            flush=True,
-        )
-        ddf = ddf.repartition(npartitions=target_npartitions)
+        ddf = ddf.repartition(npartitions=len(workers) * 2)
         workers = _client.scheduler_info(n_workers=-1)["workers"].keys()
         persisted_keys_d = persist_dask_df_equal_parts_per_worker(
             ddf, _client, return_type="dict"
@@ -416,16 +391,6 @@ class simpleDistributedGraphImpl:
             )
             for w, delayed_task in delayed_tasks_d.items()
         }
-        comms_workers = list(Comms.get_workers())
-        print(
-            f"[cugraph_mg_persist_debug] graph_plc_built "
-            f"plc_keys={list(self._plc_graph.keys())!r} "
-            f"comms_workers={comms_workers!r} "
-            f"scheduler_workers={list(workers)!r} "
-            f"plc_not_in_comms={set(self._plc_graph.keys()) - set(comms_workers)!r} "
-            f"comms_not_in_plc={set(comms_workers) - set(self._plc_graph.keys())!r}",
-            flush=True,
-        )
         del delayed_tasks_d
         run_gc_on_dask_cluster(_client)
         wait(list(self._plc_graph.values()))

--- a/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
+++ b/python/cugraph/cugraph/structure/graph_implementation/simpleDistributedGraph.py
@@ -224,13 +224,12 @@ class simpleDistributedGraphImpl:
         ddf_columns = s_col + d_col
         self.vertex_columns = ddf_columns.copy()
         _client = default_client()
-        # Block until at least one worker has registered so that scheduler_info()
-        # below does not transiently return an empty worker list (which would make
-        # npartitions=0 and raise ZeroDivisionError in dask's repartition).
-        _client.wait_for_workers(n_workers=1)
-        workers = _client.scheduler_info(n_workers=-1)["workers"]
-        # Repartition to 2 partitions per GPU for memory efficient process
-        input_ddf = input_ddf.repartition(npartitions=len(workers) * 2)
+        # Repartition to 2 partitions per GPU for memory efficient process.
+        # Size from Comms.get_n_workers() (scheduler_info()["n_workers"]) rather
+        # than len(scheduler_info()["workers"]): the latter is periodically
+        # overwritten with an empty dict by dask's scheduler-info poll, which can
+        # make npartitions=0 and raise ZeroDivisionError in dask's repartition.
+        input_ddf = input_ddf.repartition(npartitions=Comms.get_n_workers() * 2)
         # The dataframe will be symmetrized iff the graph is undirected
         # otherwise, the inital dataframe will be returned
         if edge_attr is not None:
@@ -358,8 +357,7 @@ class simpleDistributedGraphImpl:
             is_multigraph=self.properties.multi_edge,
             is_symmetric=not self.properties.directed,
         )
-        ddf = ddf.repartition(npartitions=len(workers) * 2)
-        workers = _client.scheduler_info(n_workers=-1)["workers"].keys()
+        ddf = ddf.repartition(npartitions=Comms.get_n_workers() * 2)
         persisted_keys_d = persist_dask_df_equal_parts_per_worker(
             ddf, _client, return_type="dict"
         )
@@ -475,10 +473,8 @@ class simpleDistributedGraphImpl:
             if not self.properties.multi_edge:
                 # Drop parallel edges for non MultiGraph
                 # FIXME: Drop multi edges with the CAPI instead.
-                _client = default_client()
-                workers = _client.scheduler_info(n_workers=-1)["workers"]
                 edgelist_df = _memory_efficient_drop_duplicates(
-                    edgelist_df, [srcCol, dstCol], len(workers)
+                    edgelist_df, [srcCol, dstCol], Comms.get_n_workers()
                 )
 
             edgelist_df[srcCol], edgelist_df[dstCol] = (


### PR DESCRIPTION
Dask single-GPU tests were intermittently failing on CI with a `ZeroDivisionError` in dask's `_repartition.py`. The cause is a worker-registration race in `simpleDistributedGraphImpl.__from_edgelist`: the worker count is queried from `client.scheduler_info()` and used to set the repartition size `(npartitions = len(workers) * 2)`, but if the workers have not registered yet, that count is 0, so repartition receives `npartitions=0` and `das`k divides by zero.

This PR addresses this issue by waiting for at least one worker to register (`_client.wait_for_workers(n_workers=1)`) before querying `scheduler_info()`, so the worker count is never transiently zero.