### PR TITLE
Update notebook code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,7 @@ dependencies.yaml        @rapidsai/packaging-codeowners
 pyproject.toml           @rapidsai/packaging-codeowners
 
 # notebooks code owners
-*.ipynb @rapidsai/cugraph-notebook-codeowners
+*.ipynb @rapidsai/cugraph-python-codeowners
 
 # Ops code owners
 /SECURITY.md             @rapidsai/ops-codeowners

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -464,7 +464,7 @@
 - Use CuPy for arrays &amp; CUDA Python for low-level CUDA functions ([#4958](https://github.com/rapidsai/cugraph/pull/4958)) [@jakirkham](https://github.com/jakirkham)
 - Reduce downloaded test data in CI ([#4951](https://github.com/rapidsai/cugraph/pull/4951)) [@ChuckHastings](https://github.com/ChuckHastings)
 - Use conda-build instead of conda-mambabuild ([#4950](https://github.com/rapidsai/cugraph/pull/4950)) [@bdice](https://github.com/bdice)
-- add cugraph-notebook-codeowners to CODEOWNERS ([#4949](https://github.com/rapidsai/cugraph/pull/4949)) [@AyodeAwe](https://github.com/AyodeAwe)
+- add notebook ownership to CODEOWNERS ([#4949](https://github.com/rapidsai/cugraph/pull/4949)) [@AyodeAwe](https://github.com/AyodeAwe)
 - Replace `cub::Min` with `cuda::minimum` ([#4948](https://github.com/rapidsai/cugraph/pull/4948)) [@miscco](https://github.com/miscco)
 - update handling of GNN dependencies ([#4947](https://github.com/rapidsai/cugraph/pull/4947)) [@jameslamb](https://github.com/jameslamb)
 - Update primitives to better follow STL/thrust conventions in supporting predicate operations ([#4946](https://github.com/rapidsai/cugraph/pull/4946)) [@seunghwak](https://github.com/seunghwak)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -464,7 +464,7 @@
 - Use CuPy for arrays &amp; CUDA Python for low-level CUDA functions ([#4958](https://github.com/rapidsai/cugraph/pull/4958)) [@jakirkham](https://github.com/jakirkham)
 - Reduce downloaded test data in CI ([#4951](https://github.com/rapidsai/cugraph/pull/4951)) [@ChuckHastings](https://github.com/ChuckHastings)
 - Use conda-build instead of conda-mambabuild ([#4950](https://github.com/rapidsai/cugraph/pull/4950)) [@bdice](https://github.com/bdice)
-- add notebook ownership to CODEOWNERS ([#4949](https://github.com/rapidsai/cugraph/pull/4949)) [@AyodeAwe](https://github.com/AyodeAwe)
+- add cugraph-notebook-codeowners to CODEOWNERS ([#4949](https://github.com/rapidsai/cugraph/pull/4949)) [@AyodeAwe](https://github.com/AyodeAwe)
 - Replace `cub::Min` with `cuda::minimum` ([#4948](https://github.com/rapidsai/cugraph/pull/4948)) [@miscco](https://github.com/miscco)
 - update handling of GNN dependencies ([#4947](https://github.com/rapidsai/cugraph/pull/4947)) [@jameslamb](https://github.com/jameslamb)
 - Update primitives to better follow STL/thrust conventions in supporting predicate operations ([#4946](https://github.com/rapidsai/cugraph/pull/4946)) [@seunghwak](https://github.com/seunghwak)


### PR DESCRIPTION
## Summary

- assign all `*.ipynb` files previously owned by `cugraph-notebook-codeowners` to `cugraph-python-codeowners`

## Impact

Python code owners will now be requested for notebook changes. The historical changelog entry remains unchanged.

## Validation

- `git diff --check`
- verified the live CODEOWNERS file no longer references `cugraph-notebook-codeowners`
- GitHub reports no CODEOWNERS errors for the PR branch
