### PR TITLE
Fix flaky MG ZeroDivisionError in symmetrize_ddf

### DIFF
--- a/python/cugraph/cugraph/structure/symmetrize.py
+++ b/python/cugraph/cugraph/structure/symmetrize.py
@@ -160,9 +160,7 @@ def symmetrize_ddf(
         return result
     else:
         vertex_col_name = src_name + dst_name
-        result = _memory_efficient_drop_duplicates(
-            result, vertex_col_name, num_workers
-        )
+        result = _memory_efficient_drop_duplicates(result, vertex_col_name, num_workers)
         return result
 
 

--- a/python/cugraph/cugraph/structure/symmetrize.py
+++ b/python/cugraph/cugraph/structure/symmetrize.py
@@ -136,11 +136,10 @@ def symmetrize_ddf(
 
     """
     # FIXME: Uncomment out the above (broken) example
-    # Size partitioning from the race-free worker count (scheduler_info()
-    # ["n_workers"]) rather than len(scheduler_info()["workers"]): the latter
-    # dict is periodically emptied by dask's scheduler-info poll (n_workers=0),
-    # which can make npartitions=0 and raise ZeroDivisionError in dask's
-    # repartition.
+    # Size from get_n_workers() (scheduler_info()["n_workers"]) rather
+    # than len(scheduler_info()["workers"]): the latter is periodically
+    # overwritten with an empty dict by dask's scheduler-info poll, which can
+    # make npartitions=0 and raise ZeroDivisionError in dask's repartition.
     from cugraph.dask.common.read_utils import get_n_workers
 
     num_workers = get_n_workers()

--- a/python/cugraph/cugraph/structure/symmetrize.py
+++ b/python/cugraph/cugraph/structure/symmetrize.py
@@ -1,10 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from cugraph.structure import graph_classes as csg
 import cudf
 import dask_cudf
-from dask.distributed import default_client
 
 
 def symmetrize_df(
@@ -137,8 +136,14 @@ def symmetrize_ddf(
 
     """
     # FIXME: Uncomment out the above (broken) example
-    _client = default_client()
-    workers = _client.scheduler_info(n_workers=-1)["workers"]
+    # Size partitioning from the race-free worker count (scheduler_info()
+    # ["n_workers"]) rather than len(scheduler_info()["workers"]): the latter
+    # dict is periodically emptied by dask's scheduler-info poll (n_workers=0),
+    # which can make npartitions=0 and raise ZeroDivisionError in dask's
+    # repartition.
+    from cugraph.dask.common.read_utils import get_n_workers
+
+    num_workers = get_n_workers()
 
     if not isinstance(src_name, list):
         src_name = [src_name]
@@ -152,12 +157,12 @@ def symmetrize_ddf(
     else:
         result = ddf
     if multi:
-        result = result.reset_index(drop=True).repartition(npartitions=len(workers) * 2)
+        result = result.reset_index(drop=True).repartition(npartitions=num_workers * 2)
         return result
     else:
         vertex_col_name = src_name + dst_name
         result = _memory_efficient_drop_duplicates(
-            result, vertex_col_name, len(workers)
+            result, vertex_col_name, num_workers
         )
         return result
 


### PR DESCRIPTION
Dask single-GPU tests were still intermittently failing on CI with a ZeroDivisionError in dask's _repartition.py. PR #5599  fixed this in the graph-build path by sizing the repartition from a race-free worker count, but one path was left unguarded: `symmetrize_ddf` in `symmetrize.py` still set `npartitions = len(scheduler_info()["workers"]) * 2`.

This PR resolves it by sizing the repartition (and drop-duplicates) from `get_n_workers() (scheduler_info()["n_workers"])`, the race-free worker count that is never emptied, matching the approach already used elsewhere