### PR TITLE
Primitive MG tests not actually validating results

### DIFF
--- a/cpp/tests/prims/mg_extract_transform_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_e.cu
@@ -1,6 +1,6 @@
 
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,6 +15,7 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/edge_partition_view.hpp>
 #include <cugraph/edge_src_dst_property.hpp>
+#include <cugraph/graph_functions.hpp>
 #include <cugraph/graph_view.hpp>
 #include <cugraph/prims/extract_transform_e.cuh>
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
@@ -167,6 +168,21 @@ class Tests_MGExtractTransformE
     // 3. compare SG & MG results
 
     if (prims_usecase.check_correctness) {
+      // the MG primitive returns renumbered (internal) vertex IDs while the SG reference graph
+      // below is created in the unrenumbered (external) vertex ID space, so unrenumber first
+      cugraph::unrenumber_int_vertices<vertex_t, true>(
+        *handle_,
+        std::get<0>(mg_extract_transform_output_buffer).data(),
+        std::get<0>(mg_extract_transform_output_buffer).size(),
+        (*d_mg_renumber_map_labels).data(),
+        mg_graph_view.vertex_partition_range_lasts());
+      cugraph::unrenumber_int_vertices<vertex_t, true>(
+        *handle_,
+        std::get<1>(mg_extract_transform_output_buffer).data(),
+        std::get<1>(mg_extract_transform_output_buffer).size(),
+        (*d_mg_renumber_map_labels).data(),
+        mg_graph_view.vertex_partition_range_lasts());
+
       auto mg_aggregate_extract_transform_output_buffer = cugraph::allocate_dataframe_buffer<
         typename e_op_t<vertex_t, output_payload_t>::return_type>(size_t{0}, handle_->get_stream());
       std::get<0>(mg_aggregate_extract_transform_output_buffer) =
@@ -220,11 +236,14 @@ class Tests_MGExtractTransformE
                       cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
                       cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
 
+        ASSERT_EQ(cugraph::size_dataframe_buffer(sg_extract_transform_output_buffer),
+                  cugraph::size_dataframe_buffer(mg_aggregate_extract_transform_output_buffer));
+
         bool e_op_result_passed = thrust::equal(
           handle_->get_thrust_policy(),
           cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
-          cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
-          cugraph::get_dataframe_buffer_end(mg_aggregate_extract_transform_output_buffer));
+          cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer),
+          cugraph::get_dataframe_buffer_begin(mg_aggregate_extract_transform_output_buffer));
         ASSERT_TRUE(e_op_result_passed);
       }
     }

--- a/cpp/tests/prims/mg_extract_transform_if_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_if_e.cu
@@ -1,6 +1,6 @@
 
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,6 +15,7 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/edge_partition_view.hpp>
 #include <cugraph/edge_src_dst_property.hpp>
+#include <cugraph/graph_functions.hpp>
 #include <cugraph/graph_view.hpp>
 #include <cugraph/prims/extract_transform_if_e.cuh>
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
@@ -184,6 +185,21 @@ class Tests_MGExtractTransformIfE
     // 3. compare SG & MG results
 
     if (prims_usecase.check_correctness) {
+      // the MG primitive returns renumbered (internal) vertex IDs while the SG reference graph
+      // below is created in the unrenumbered (external) vertex ID space, so unrenumber first
+      cugraph::unrenumber_int_vertices<vertex_t, true>(
+        *handle_,
+        std::get<0>(mg_extract_transform_output_buffer).data(),
+        std::get<0>(mg_extract_transform_output_buffer).size(),
+        (*d_mg_renumber_map_labels).data(),
+        mg_graph_view.vertex_partition_range_lasts());
+      cugraph::unrenumber_int_vertices<vertex_t, true>(
+        *handle_,
+        std::get<1>(mg_extract_transform_output_buffer).data(),
+        std::get<1>(mg_extract_transform_output_buffer).size(),
+        (*d_mg_renumber_map_labels).data(),
+        mg_graph_view.vertex_partition_range_lasts());
+
       auto mg_aggregate_extract_transform_output_buffer = cugraph::allocate_dataframe_buffer<
         typename e_op_t<vertex_t, result_t, output_payload_t>::return_type>(size_t{0},
                                                                             handle_->get_stream());
@@ -254,11 +270,14 @@ class Tests_MGExtractTransformIfE
                       cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
                       cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
 
+        ASSERT_EQ(cugraph::size_dataframe_buffer(sg_extract_transform_output_buffer),
+                  cugraph::size_dataframe_buffer(mg_aggregate_extract_transform_output_buffer));
+
         bool e_op_result_passed = thrust::equal(
           handle_->get_thrust_policy(),
           cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
-          cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
-          cugraph::get_dataframe_buffer_end(mg_aggregate_extract_transform_output_buffer));
+          cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer),
+          cugraph::get_dataframe_buffer_begin(mg_aggregate_extract_transform_output_buffer));
         ASSERT_TRUE(e_op_result_passed);
       }
     }

--- a/cpp/tests/prims/mg_extract_transform_if_v_frontier_incoming_outgoing_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_if_v_frontier_incoming_outgoing_e.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,6 +14,7 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/edge_partition_view.hpp>
 #include <cugraph/edge_src_dst_property.hpp>
+#include <cugraph/graph_functions.hpp>
 #include <cugraph/graph_view.hpp>
 #include <cugraph/prims/extract_transform_if_v_frontier_incoming_outgoing_e.cuh>
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
@@ -312,6 +313,26 @@ class Tests_MGExtractTransformIfVFrontierIncomingOutgoingE
     // 3. compare SG & MG results
 
     if (prims_usecase.check_correctness) {
+      // the MG primitive returns renumbered (internal) vertex IDs while the SG reference graph
+      // below is created in the unrenumbered (external) vertex ID space, so unrenumber first
+      {
+        constexpr size_t src_idx = 0;
+        constexpr size_t dst_idx =
+          (!std::is_same_v<key_t, vertex_t> && !store_transposed) ? size_t{2} : size_t{1};
+        cugraph::unrenumber_int_vertices<vertex_t, true>(
+          *handle_,
+          std::get<src_idx>(mg_extract_transform_output_buffer).data(),
+          std::get<src_idx>(mg_extract_transform_output_buffer).size(),
+          (*d_mg_renumber_map_labels).data(),
+          mg_graph_view.vertex_partition_range_lasts());
+        cugraph::unrenumber_int_vertices<vertex_t, true>(
+          *handle_,
+          std::get<dst_idx>(mg_extract_transform_output_buffer).data(),
+          std::get<dst_idx>(mg_extract_transform_output_buffer).size(),
+          (*d_mg_renumber_map_labels).data(),
+          mg_graph_view.vertex_partition_range_lasts());
+      }
+
       auto mg_aggregate_extract_transform_output_buffer = cugraph::allocate_dataframe_buffer<
         typename e_op_t<key_t, vertex_t, result_t, output_payload_t, store_transposed>::
           return_type>(size_t{0}, handle_->get_stream());
@@ -427,6 +448,9 @@ class Tests_MGExtractTransformIfVFrontierIncomingOutgoingE
         cugraph::sort(handle_->get_thrust_policy(),
                       cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
                       cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
+
+        ASSERT_EQ(cugraph::size_dataframe_buffer(sg_extract_transform_output_buffer),
+                  cugraph::size_dataframe_buffer(mg_aggregate_extract_transform_output_buffer));
 
         bool e_op_result_passed = thrust::equal(
           handle_->get_thrust_policy(),

--- a/cpp/tests/prims/mg_extract_transform_v_frontier_incoming_outgoing_e.cu
+++ b/cpp/tests/prims/mg_extract_transform_v_frontier_incoming_outgoing_e.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,6 +14,7 @@
 #include <cugraph/algorithms.hpp>
 #include <cugraph/edge_partition_view.hpp>
 #include <cugraph/edge_src_dst_property.hpp>
+#include <cugraph/graph_functions.hpp>
 #include <cugraph/graph_view.hpp>
 #include <cugraph/prims/extract_transform_v_frontier_incoming_outgoing_e.cuh>
 #include <cugraph/prims/update_edge_src_dst_property.cuh>
@@ -273,6 +274,26 @@ class Tests_MGExtractTransformVFrontierIncomingOutgoingE
     // 3. compare SG & MG results
 
     if (prims_usecase.check_correctness) {
+      // the MG primitive returns renumbered (internal) vertex IDs while the SG reference graph
+      // below is created in the unrenumbered (external) vertex ID space, so unrenumber first
+      {
+        constexpr size_t src_idx = 0;
+        constexpr size_t dst_idx =
+          (!std::is_same_v<key_t, vertex_t> && !store_transposed) ? size_t{2} : size_t{1};
+        cugraph::unrenumber_int_vertices<vertex_t, true>(
+          *handle_,
+          std::get<src_idx>(mg_extract_transform_output_buffer).data(),
+          std::get<src_idx>(mg_extract_transform_output_buffer).size(),
+          (*d_mg_renumber_map_labels).data(),
+          mg_graph_view.vertex_partition_range_lasts());
+        cugraph::unrenumber_int_vertices<vertex_t, true>(
+          *handle_,
+          std::get<dst_idx>(mg_extract_transform_output_buffer).data(),
+          std::get<dst_idx>(mg_extract_transform_output_buffer).size(),
+          (*d_mg_renumber_map_labels).data(),
+          mg_graph_view.vertex_partition_range_lasts());
+      }
+
       auto mg_aggregate_extract_transform_output_buffer = cugraph::allocate_dataframe_buffer<
         typename e_op_t<key_t, vertex_t, output_payload_t, store_transposed>::return_type>(
         size_t{0}, handle_->get_stream());
@@ -371,6 +392,9 @@ class Tests_MGExtractTransformVFrontierIncomingOutgoingE
         cugraph::sort(handle_->get_thrust_policy(),
                       cugraph::get_dataframe_buffer_begin(sg_extract_transform_output_buffer),
                       cugraph::get_dataframe_buffer_end(sg_extract_transform_output_buffer));
+
+        ASSERT_EQ(cugraph::size_dataframe_buffer(sg_extract_transform_output_buffer),
+                  cugraph::size_dataframe_buffer(mg_aggregate_extract_transform_output_buffer));
 
         bool e_op_result_passed = thrust::equal(
           handle_->get_thrust_policy(),


### PR DESCRIPTION
thrust::equal calls were not actually doing anything because *_begin was called for both the start and end iterator.

Correct iterator end call, then handle renumbering discrepancy that this fix reveals.