### PR TITLE
Update to rapids-logger 0.3

### DIFF
--- a/conda/recipes/libcugraph/recipe.yaml
+++ b/conda/recipes/libcugraph/recipe.yaml
@@ -116,7 +116,7 @@ outputs:
         - cuda-version =${{ cuda_version }}
         - librmm =${{ minor_version }}
         - libcuvs =${{ minor_version }}
-        - rapids-logger =0.2
+        - rapids-logger =0.3
         - cuda-cudart-dev
         - cuda-nvrtc-dev
         - libcublas-dev
@@ -232,7 +232,7 @@ outputs:
         - cuda-nvrtc-dev
         - nccl ${{ nccl_version }}
         - openmpi <5.0.3 # Required for building cpp-mgtests (multi-GPU tests)
-        - rapids-logger =0.2
+        - rapids-logger =0.3
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - ${{ pin_subpackage("libcugraph", exact=True) }}

--- a/conda/recipes/libcugraph/recipe.yaml
+++ b/conda/recipes/libcugraph/recipe.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 schema_version: 1
 
@@ -116,7 +116,7 @@ outputs:
         - cuda-version =${{ cuda_version }}
         - librmm =${{ minor_version }}
         - libcuvs =${{ minor_version }}
-        - rapids-logger =0.2
+        - rapids-logger =0.3
         - cuda-cudart-dev
         - cuda-nvrtc-dev
         - libcublas-dev
@@ -232,7 +232,7 @@ outputs:
         - cuda-nvrtc-dev
         - nccl ${{ nccl_version }}
         - openmpi <5.0.3 # Required for building cpp-mgtests (multi-GPU tests)
-        - rapids-logger =0.2
+        - rapids-logger =0.3
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - ${{ pin_subpackage("libcugraph", exact=True) }}


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/313.

Updates rapids-logger to version 0.3.
