### PR TITLE
Update arithmetic_device_uvector_t (device_span_t) to support int8_t and int16_t types.

### DIFF
--- a/cpp/include/cugraph/arithmetic_variant_types.hpp
+++ b/cpp/include/cugraph/arithmetic_variant_types.hpp
@@ -13,28 +13,36 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <cstdint>
 #include <variant>
 #include <vector>
 
 namespace CUGRAPH_EXPORT cugraph {
 
-using arithmetic_type_t = std::variant<std::monostate, float, double, int32_t, int64_t, size_t>;
+using arithmetic_type_t =
+  std::variant<std::monostate, float, double, int8_t, int16_t, int32_t, int64_t, size_t>;
 
 using arithmetic_device_uvector_t    = std::variant<std::monostate,
                                                     rmm::device_uvector<float>,
                                                     rmm::device_uvector<double>,
+                                                    rmm::device_uvector<int8_t>,
+                                                    rmm::device_uvector<int16_t>,
                                                     rmm::device_uvector<int32_t>,
                                                     rmm::device_uvector<int64_t>,
                                                     rmm::device_uvector<size_t>>;
 using arithmetic_device_span_t       = std::variant<std::monostate,
                                                     raft::device_span<float>,
                                                     raft::device_span<double>,
+                                                    raft::device_span<int8_t>,
+                                                    raft::device_span<int16_t>,
                                                     raft::device_span<int32_t>,
                                                     raft::device_span<int64_t>,
                                                     raft::device_span<size_t>>;
 using const_arithmetic_device_span_t = std::variant<std::monostate,
                                                     raft::device_span<float const>,
                                                     raft::device_span<double const>,
+                                                    raft::device_span<int8_t const>,
+                                                    raft::device_span<int16_t const>,
                                                     raft::device_span<int32_t const>,
                                                     raft::device_span<int64_t const>,
                                                     raft::device_span<size_t const>>;
@@ -43,6 +51,8 @@ template <typename edge_t>
 using edge_arithmetic_property_t = std::variant<std::monostate,
                                                 cugraph::edge_property_t<edge_t, float>,
                                                 cugraph::edge_property_t<edge_t, double>,
+                                                cugraph::edge_property_t<edge_t, int8_t>,
+                                                cugraph::edge_property_t<edge_t, int16_t>,
                                                 cugraph::edge_property_t<edge_t, int32_t>,
                                                 cugraph::edge_property_t<edge_t, int64_t>,
                                                 cugraph::edge_property_t<edge_t, size_t>>;
@@ -52,6 +62,8 @@ using edge_arithmetic_property_view_t =
   std::variant<std::monostate,
                cugraph::edge_property_view_t<edge_t, float const*>,
                cugraph::edge_property_view_t<edge_t, double const*>,
+               cugraph::edge_property_view_t<edge_t, int8_t const*>,
+               cugraph::edge_property_view_t<edge_t, int16_t const*>,
                cugraph::edge_property_view_t<edge_t, int32_t const*>,
                cugraph::edge_property_view_t<edge_t, int64_t const*>,
                cugraph::edge_property_view_t<edge_t, size_t const*>>;
@@ -61,6 +73,8 @@ using edge_arithmetic_property_mutable_view_t =
   std::variant<std::monostate,
                cugraph::edge_property_view_t<edge_t, float*>,
                cugraph::edge_property_view_t<edge_t, double*>,
+               cugraph::edge_property_view_t<edge_t, int8_t*>,
+               cugraph::edge_property_view_t<edge_t, int16_t*>,
                cugraph::edge_property_view_t<edge_t, int32_t*>,
                cugraph::edge_property_view_t<edge_t, int64_t*>,
                cugraph::edge_property_view_t<edge_t, size_t*>>;
@@ -74,6 +88,8 @@ auto variant_type_dispatch(dispatched_type_t& property, func_t func)
     case 3: return func(std::get<3>(property));
     case 4: return func(std::get<4>(property));
     case 5: return func(std::get<5>(property));
+    case 6: return func(std::get<6>(property));
+    case 7: return func(std::get<7>(property));
     default: CUGRAPH_FAIL("Variant not initialized");
   }
 }

--- a/cpp/include/cugraph/mtmg/detail/per_device_edgelist.hpp
+++ b/cpp/include/cugraph/mtmg/detail/per_device_edgelist.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/include/cugraph/mtmg/detail/per_device_edgelist.hpp
+++ b/cpp/include/cugraph/mtmg/detail/per_device_edgelist.hpp
@@ -21,6 +21,8 @@ namespace mtmg {
 using arithmetic_host_vector_t = std::variant<std::monostate,
                                               std::vector<float>,
                                               std::vector<double>,
+                                              std::vector<int8_t>,
+                                              std::vector<int16_t>,
                                               std::vector<int32_t>,
                                               std::vector<int64_t>,
                                               std::vector<size_t>>;
@@ -28,6 +30,8 @@ using arithmetic_host_vector_t = std::variant<std::monostate,
 using arithmetic_const_host_span_t = std::variant<std::monostate,
                                                   raft::host_span<float const>,
                                                   raft::host_span<double const>,
+                                                  raft::host_span<int8_t const>,
+                                                  raft::host_span<int16_t const>,
                                                   raft::host_span<int32_t const>,
                                                   raft::host_span<int64_t const>,
                                                   raft::host_span<size_t const>>;

--- a/cpp/src/c_api/generic_cascaded_dispatch.hpp
+++ b/cpp/src/c_api/generic_cascaded_dispatch.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/src/c_api/generic_cascaded_dispatch.hpp
+++ b/cpp/src/c_api/generic_cascaded_dispatch.hpp
@@ -73,6 +73,14 @@ auto edge_time_type_dispatcher(cugraph_data_type_id_t edge_time_type,
                                functor_t& functor)
 {
   switch (edge_time_type) {
+    case cugraph_data_type_id_t::INT8: {
+      throw std::runtime_error(
+        "ERROR: Data type INT8 not allowed for edge time type (valid types: INT32, INT64).");
+    }
+    case cugraph_data_type_id_t::INT16: {
+      throw std::runtime_error(
+        "ERROR: Data type INT16 not allowed for edge time type (valid types: INT32, INT64).");
+    }
     case cugraph_data_type_id_t::INT32: {
       using time_stamp_t = int32_t;
       return transpose_dispatcher<vertex_t, edge_t, weight_t, edge_type_t, time_stamp_t>(
@@ -82,19 +90,19 @@ auto edge_time_type_dispatcher(cugraph_data_type_id_t edge_time_type,
       using time_stamp_t = int64_t;
       return transpose_dispatcher<vertex_t, edge_t, weight_t, edge_type_t, time_stamp_t>(
         store_transposed, multi_gpu, functor);
-      break;
     }
     case cugraph_data_type_id_t::FLOAT32: {
       throw std::runtime_error(
-        "ERROR: Data type FLOAT32 not allowed for edge type (valid types: INT32).");
-      break;
+        "ERROR: Data type FLOAT32 not allowed for edge time type (valid types: INT32, INT64).");
     }
     case cugraph_data_type_id_t::FLOAT64: {
       throw std::runtime_error(
-        "ERROR: Data type FLOAT64 not allowed for edge type (valid types: INT32).");
-      break;
+        "ERROR: Data type FLOAT64 not allowed for edge time type (valid types: INT32, INT64).");
     }
-
+    case cugraph_data_type_id_t::SIZE_T: {
+      throw std::runtime_error(
+        "ERROR: Data type SIZE_T not allowed for edge time type (valid types: INT32, INT64).");
+    }
     default: {
       std::stringstream ss;
       ss << "ERROR: Unknown type enum:" << static_cast<int>(edge_time_type);
@@ -115,6 +123,14 @@ auto edge_type_type_dispatcher(cugraph_data_type_id_t edge_type_type,
                                functor_t& functor)
 {
   switch (edge_type_type) {
+    case cugraph_data_type_id_t::INT8: {
+      throw std::runtime_error(
+        "ERROR: Data type INT8 not allowed for edge type (valid types: INT32).");
+    }
+    case cugraph_data_type_id_t::INT16: {
+      throw std::runtime_error(
+        "ERROR: Data type INT16 not allowed for edge type (valid types: INT32).");
+    }
     case cugraph_data_type_id_t::INT32: {
       using edge_type_t = int32_t;
       return edge_time_type_dispatcher<vertex_t, edge_t, weight_t, edge_type_t>(
@@ -123,19 +139,19 @@ auto edge_type_type_dispatcher(cugraph_data_type_id_t edge_type_type,
     case cugraph_data_type_id_t::INT64: {
       throw std::runtime_error(
         "ERROR: Data type INT64 not allowed for edge type (valid types: INT32).");
-      break;
     }
     case cugraph_data_type_id_t::FLOAT32: {
       throw std::runtime_error(
         "ERROR: Data type FLOAT32 not allowed for edge type (valid types: INT32).");
-      break;
     }
     case cugraph_data_type_id_t::FLOAT64: {
       throw std::runtime_error(
         "ERROR: Data type FLOAT64 not allowed for edge type (valid types: INT32).");
-      break;
     }
-
+    case cugraph_data_type_id_t::SIZE_T: {
+      throw std::runtime_error(
+        "ERROR: Data type SIZE_T not allowed for edge type (valid types: INT32).");
+    }
     default: {
       std::stringstream ss;
       ss << "ERROR: Unknown type enum:" << static_cast<int>(edge_type_type);
@@ -159,26 +175,36 @@ auto weight_dispatcher(cugraph_data_type_id_t weight_type,
                        functor_t& functor)
 {
   switch (weight_type) {
+    case cugraph_data_type_id_t::INT8: {
+      throw std::runtime_error(
+        "ERROR: Data type INT8 not allowed for weight type (valid types: FLOAT32, FLOAT64).");
+    }
+    case cugraph_data_type_id_t::INT16: {
+      throw std::runtime_error(
+        "ERROR: Data type INT16 not allowed for weight type (valid types: FLOAT32, FLOAT64).");
+    }
     case cugraph_data_type_id_t::INT32: {
-      using weight_t = int32_t;
-      return edge_type_type_dispatcher<vertex_t, edge_t, weight_t>(
-        edge_type_type, edge_time_type, store_transposed, multi_gpu, functor);
-    } break;
+      throw std::runtime_error(
+        "ERROR: Data type INT32 not allowed for weight type (valid types: FLOAT32, FLOAT64).");
+    }
     case cugraph_data_type_id_t::INT64: {
-      using weight_t = int64_t;
-      return edge_type_type_dispatcher<vertex_t, edge_t, weight_t>(
-        edge_type_type, edge_time_type, store_transposed, multi_gpu, functor);
-    } break;
+      throw std::runtime_error(
+        "ERROR: Data type INT64 not allowed for weight type (valid types: FLOAT32, FLOAT64).");
+    }
     case cugraph_data_type_id_t::FLOAT32: {
       using weight_t = float;
       return edge_type_type_dispatcher<vertex_t, edge_t, weight_t>(
         edge_type_type, edge_time_type, store_transposed, multi_gpu, functor);
-    } break;
+    }
     case cugraph_data_type_id_t::FLOAT64: {
       using weight_t = double;
       return edge_type_type_dispatcher<vertex_t, edge_t, weight_t>(
         edge_type_type, edge_time_type, store_transposed, multi_gpu, functor);
-    } break;
+    }
+    case cugraph_data_type_id_t::SIZE_T: {
+      throw std::runtime_error(
+        "ERROR: Data type SIZE_T not allowed for weight type (valid types: FLOAT32, FLOAT64).");
+    }
     default: {
       std::stringstream ss;
       ss << "ERROR: Unknown type enum:" << static_cast<int>(weight_type);
@@ -203,22 +229,36 @@ auto edge_dispatcher(cugraph_data_type_id_t edge_type,
                      functor_t& functor)
 {
   switch (edge_type) {
+    case cugraph_data_type_id_t::INT8: {
+      throw std::runtime_error(
+        "ERROR: Data type INT8 not allowed for edge type (valid types: INT32, INT64).");
+    }
+    case cugraph_data_type_id_t::INT16: {
+      throw std::runtime_error(
+        "ERROR: Data type INT16 not allowed for edge type (valid types: INT32, INT64).");
+    }
     case cugraph_data_type_id_t::INT32: {
       using edge_t = int32_t;
       return weight_dispatcher<vertex_t, edge_t>(
         weight_type, edge_type_type, edge_time_type, store_transposed, multi_gpu, functor);
-    } break;
+    }
     case cugraph_data_type_id_t::INT64: {
       using edge_t = int64_t;
       return weight_dispatcher<vertex_t, edge_t>(
         weight_type, edge_type_type, edge_time_type, store_transposed, multi_gpu, functor);
-    } break;
+    }
     case cugraph_data_type_id_t::FLOAT32: {
-      throw std::runtime_error("ERROR: FLOAT32 not supported for a vertex type");
-    } break;
+      throw std::runtime_error(
+        "ERROR: Data type FLOAT32 not allowed for edge type (valid types: INT32, INT64).");
+    }
     case cugraph_data_type_id_t::FLOAT64: {
-      throw std::runtime_error("ERROR: FLOAT64 not supported for a vertex type");
-    } break;
+      throw std::runtime_error(
+        "ERROR: Data type FLOAT64 not allowed for edge type (valid types: INT32, INT64).");
+    }
+    case cugraph_data_type_id_t::SIZE_T: {
+      throw std::runtime_error(
+        "ERROR: Data type SIZE_T not allowed for edge type (valid types: INT32, INT64).");
+    }
     default: {
       std::stringstream ss;
       ss << "ERROR: Unknown type enum:" << static_cast<int>(edge_type);
@@ -244,6 +284,14 @@ auto vertex_dispatcher(cugraph_data_type_id_t vertex_type,
                        functor_t& functor)
 {
   switch (vertex_type) {
+    case cugraph_data_type_id_t::INT8: {
+      throw std::runtime_error(
+        "ERROR: Data type INT8 not allowed for vertex type (valid types: INT32, INT64).");
+    }
+    case cugraph_data_type_id_t::INT16: {
+      throw std::runtime_error(
+        "ERROR: Data type INT16 not allowed for vertex type (valid types: INT32, INT64).");
+    }
     case cugraph_data_type_id_t::INT32: {
       using vertex_t = int32_t;
       return edge_dispatcher<vertex_t>(edge_type,
@@ -253,7 +301,7 @@ auto vertex_dispatcher(cugraph_data_type_id_t vertex_type,
                                        store_transposed,
                                        multi_gpu,
                                        functor);
-    } break;
+    }
     case cugraph_data_type_id_t::INT64: {
       using vertex_t = int64_t;
       return edge_dispatcher<vertex_t>(edge_type,
@@ -263,13 +311,19 @@ auto vertex_dispatcher(cugraph_data_type_id_t vertex_type,
                                        store_transposed,
                                        multi_gpu,
                                        functor);
-    } break;
+    }
     case cugraph_data_type_id_t::FLOAT32: {
-      throw std::runtime_error("ERROR: FLOAT32 not supported for a vertex type");
-    } break;
+      throw std::runtime_error(
+        "ERROR: Data type FLOAT32 not allowed for vertex type (valid types: INT32, INT64).");
+    }
     case cugraph_data_type_id_t::FLOAT64: {
-      throw std::runtime_error("ERROR: FLOAT64 not supported for a vertex type");
-    } break;
+      throw std::runtime_error(
+        "ERROR: Data type FLOAT64 not allowed for vertex type (valid types: INT32, INT64).");
+    }
+    case cugraph_data_type_id_t::SIZE_T: {
+      throw std::runtime_error(
+        "ERROR: Data type SIZE_T not allowed for vertex type (valid types: INT32, INT64).");
+    }
     default: {
       std::stringstream ss;
       ss << "ERROR: Unknown type enum:" << static_cast<int>(vertex_type);

--- a/cpp/src/c_api/graph.hpp
+++ b/cpp/src/c_api/graph.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/src/c_api/graph.hpp
+++ b/cpp/src/c_api/graph.hpp
@@ -24,6 +24,16 @@ struct data_type_id {
 };
 
 template <>
+struct data_type_id<int8_t> {
+  static const cugraph_data_type_id_t id{INT8};
+};
+
+template <>
+struct data_type_id<int16_t> {
+  static const cugraph_data_type_id_t id{INT16};
+};
+
+template <>
 struct data_type_id<int32_t> {
   static const cugraph_data_type_id_t id{INT32};
 };
@@ -41,6 +51,11 @@ struct data_type_id<float> {
 template <>
 struct data_type_id<double> {
   static const cugraph_data_type_id_t id{FLOAT64};
+};
+
+template <>
+struct data_type_id<size_t> {
+  static const cugraph_data_type_id_t id{SIZE_T};
 };
 
 struct cugraph_graph_t {

--- a/cpp/src/c_api/graph_helper.hpp
+++ b/cpp/src/c_api/graph_helper.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/src/c_api/graph_helper.hpp
+++ b/cpp/src/c_api/graph_helper.hpp
@@ -23,7 +23,8 @@ edge_property_t<typename GraphViewType::edge_type, T> create_constant_edge_prope
  * @ingroup utility_wrappers_cpp
  * @brief    Cast the values of a cugraph_type_erased_device_array_view_t to the new type
  *
- * @tparam      new_type_t     type of the value to operate on. Must be either int32_t or int64_t.
+ * @tparam      new_type_t     type of the value to operate on. Must be an arithmetic type
+ *                             (int8_t, int16_t, int32_t, int64_t, float, double, or size_t).
  *
  * @param[out]  output      device span to update with new data type
  * @param[in]   input       cugraph_type_erased_device_array_view_t with initial data type

--- a/cpp/src/c_api/graph_helper_impl.cuh
+++ b/cpp/src/c_api/graph_helper_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/src/c_api/graph_helper_impl.cuh
+++ b/cpp/src/c_api/graph_helper_impl.cuh
@@ -38,17 +38,34 @@ void copy_or_transform(raft::device_span<new_type_t> output,
                        cugraph_type_erased_device_array_view_t const* input,
                        rmm::cuda_stream_view const& stream_view)
 {
-  if (((input->type_ == cugraph_data_type_id_t::INT32) && (std::is_same_v<new_type_t, int32_t>)) ||
+  if (((input->type_ == cugraph_data_type_id_t::INT8) && (std::is_same_v<new_type_t, int8_t>)) ||
+      ((input->type_ == cugraph_data_type_id_t::INT16) && (std::is_same_v<new_type_t, int16_t>)) ||
+      ((input->type_ == cugraph_data_type_id_t::INT32) && (std::is_same_v<new_type_t, int32_t>)) ||
       ((input->type_ == cugraph_data_type_id_t::INT64) && (std::is_same_v<new_type_t, int64_t>)) ||
       ((input->type_ == cugraph_data_type_id_t::FLOAT32) && (std::is_same_v<new_type_t, float>)) ||
-      ((input->type_ == cugraph_data_type_id_t::FLOAT64) && (std::is_same_v<new_type_t, double>))) {
+      ((input->type_ == cugraph_data_type_id_t::FLOAT64) && (std::is_same_v<new_type_t, double>)) ||
+      ((input->type_ == cugraph_data_type_id_t::SIZE_T) && (std::is_same_v<new_type_t, size_t>))) {
     // dtype match so just perform a copy
     raft::copy<new_type_t>(output.data(), input->as_type<new_type_t>(), input->size_, stream_view);
   }
 
   else {
     // There is a dtype mismatch
-    if (input->type_ == cugraph_data_type_id_t::INT32) {
+    if (input->type_ == cugraph_data_type_id_t::INT8) {
+      thrust::transform(rmm::exec_policy(stream_view),
+                        input->as_type<int8_t>(),
+                        input->as_type<int8_t>() + input->size_,
+                        output.begin(),
+                        cuda::proclaim_return_type<new_type_t>(
+                          [] __device__(auto value) { return static_cast<new_type_t>(value); }));
+    } else if (input->type_ == cugraph_data_type_id_t::INT16) {
+      thrust::transform(rmm::exec_policy(stream_view),
+                        input->as_type<int16_t>(),
+                        input->as_type<int16_t>() + input->size_,
+                        output.begin(),
+                        cuda::proclaim_return_type<new_type_t>(
+                          [] __device__(auto value) { return static_cast<new_type_t>(value); }));
+    } else if (input->type_ == cugraph_data_type_id_t::INT32) {
       thrust::transform(rmm::exec_policy(stream_view),
                         input->as_type<int32_t>(),
                         input->as_type<int32_t>() + input->size_,
@@ -73,6 +90,13 @@ void copy_or_transform(raft::device_span<new_type_t> output,
       thrust::transform(rmm::exec_policy(stream_view),
                         input->as_type<double>(),
                         input->as_type<double>() + input->size_,
+                        output.begin(),
+                        cuda::proclaim_return_type<new_type_t>(
+                          [] __device__(auto value) { return static_cast<new_type_t>(value); }));
+    } else if (input->type_ == cugraph_data_type_id_t::SIZE_T) {
+      thrust::transform(rmm::exec_policy(stream_view),
+                        input->as_type<size_t>(),
+                        input->as_type<size_t>() + input->size_,
                         output.begin(),
                         cuda::proclaim_return_type<new_type_t>(
                           [] __device__(auto value) { return static_cast<new_type_t>(value); }));

--- a/cpp/src/c_api/graph_helper_sg.cu
+++ b/cpp/src/c_api/graph_helper_sg.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/src/c_api/graph_helper_sg.cu
+++ b/cpp/src/c_api/graph_helper_sg.cu
@@ -35,6 +35,14 @@ template CUGRAPH_EXPORT rmm::device_uvector<int64_t> expand_sparse_offsets(
   int64_t base_vertex_id,
   rmm::cuda_stream_view const& stream);
 
+template CUGRAPH_EXPORT void copy_or_transform(raft::device_span<int8_t> output,
+                                               cugraph_type_erased_device_array_view_t const* input,
+                                               rmm::cuda_stream_view const& stream_view);
+
+template CUGRAPH_EXPORT void copy_or_transform(raft::device_span<int16_t> output,
+                                               cugraph_type_erased_device_array_view_t const* input,
+                                               rmm::cuda_stream_view const& stream_view);
+
 template CUGRAPH_EXPORT void copy_or_transform(raft::device_span<int32_t> output,
                                                cugraph_type_erased_device_array_view_t const* input,
                                                rmm::cuda_stream_view const& stream_view);
@@ -48,6 +56,10 @@ template CUGRAPH_EXPORT void copy_or_transform(raft::device_span<float> output,
                                                rmm::cuda_stream_view const& stream_view);
 
 template CUGRAPH_EXPORT void copy_or_transform(raft::device_span<double> output,
+                                               cugraph_type_erased_device_array_view_t const* input,
+                                               rmm::cuda_stream_view const& stream_view);
+
+template CUGRAPH_EXPORT void copy_or_transform(raft::device_span<size_t> output,
                                                cugraph_type_erased_device_array_view_t const* input,
                                                rmm::cuda_stream_view const& stream_view);
 

--- a/cpp/tests/c_api/mg_test_utils.cpp
+++ b/cpp/tests/c_api/mg_test_utils.cpp
@@ -792,6 +792,22 @@ extern "C" cugraph_error_code_t cugraph_test_host_gatherv_fill(
   auto& comm = raft_handle->get_comms();
 
   switch (input_type) {
+    case cugraph_data_type_id_t::INT8: {
+      auto tmp = cugraph::test::to_device(
+        *raft_handle,
+        raft::host_span<int8_t const>{reinterpret_cast<int8_t const*>(input), input_size});
+      tmp = cugraph::test::device_gatherv(*raft_handle, tmp.data(), tmp.size());
+      raft::update_host(
+        reinterpret_cast<int8_t*>(output), tmp.data(), tmp.size(), raft_handle->get_stream());
+    } break;
+    case cugraph_data_type_id_t::INT16: {
+      auto tmp = cugraph::test::to_device(
+        *raft_handle,
+        raft::host_span<int16_t const>{reinterpret_cast<int16_t const*>(input), input_size});
+      tmp = cugraph::test::device_gatherv(*raft_handle, tmp.data(), tmp.size());
+      raft::update_host(
+        reinterpret_cast<int16_t*>(output), tmp.data(), tmp.size(), raft_handle->get_stream());
+    } break;
     case cugraph_data_type_id_t::INT32: {
       auto tmp = cugraph::test::to_device(
         *raft_handle,
@@ -852,6 +868,22 @@ extern "C" cugraph_error_code_t cugraph_test_device_gatherv_fill(
   auto& comm = raft_handle->get_comms();
 
   switch (internal_array->type_) {
+    case cugraph_data_type_id_t::INT8: {
+      auto tmp = cugraph::test::device_gatherv(
+        *raft_handle,
+        raft::device_span<int8_t const>{internal_array->as_type<int8_t const>(),
+                                        internal_array->size_});
+      raft::update_host(
+        reinterpret_cast<int8_t*>(output), tmp.data(), tmp.size(), raft_handle->get_stream());
+    } break;
+    case cugraph_data_type_id_t::INT16: {
+      auto tmp = cugraph::test::device_gatherv(
+        *raft_handle,
+        raft::device_span<int16_t const>{internal_array->as_type<int16_t const>(),
+                                         internal_array->size_});
+      raft::update_host(
+        reinterpret_cast<int16_t*>(output), tmp.data(), tmp.size(), raft_handle->get_stream());
+    } break;
     case cugraph_data_type_id_t::INT32: {
       auto tmp = cugraph::test::device_gatherv(
         *raft_handle,

--- a/cpp/tests/utilities/device_comm_wrapper.cu
+++ b/cpp/tests/utilities/device_comm_wrapper.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/utilities/device_comm_wrapper.cu
+++ b/cpp/tests/utilities/device_comm_wrapper.cu
@@ -1,44 +1,100 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "device_comm_wrapper.hpp"
 
 #include <cugraph/utilities/device_comm.hpp>
+#include <cugraph/utilities/error.hpp>
 #include <cugraph/utilities/host_scalar_comm.hpp>
 
+#include <cstddef>
 #include <numeric>
 #include <vector>
 
 namespace cugraph {
 namespace test {
+namespace detail {
+
+// RAFT comms only supports a fixed set of datatypes. gatherv only copy bytes, so transfer as
+// uint8_t regardless of the caller's logical element type.
+void device_gatherv(raft::handle_t const& handle,
+                    raft::device_span<std::byte const> d_input,
+                    raft::device_span<std::byte> d_output,
+                    raft::host_span<size_t const> rx_sizes)
+{
+  bool is_root = handle.get_comms().get_rank() == int{0};
+
+  std::vector<size_t> rx_displs{};
+  if (is_root) {
+    rx_displs.resize(rx_sizes.size());
+    if (rx_sizes.size() > 0) {
+      std::partial_sum(rx_sizes.begin(), rx_sizes.end() - 1, rx_displs.begin() + 1);
+    }
+  }
+
+  auto const expected_output_size =
+    is_root ? std::reduce(rx_sizes.begin(), rx_sizes.end()) : size_t{0};
+  CUGRAPH_EXPECTS(d_output.size() == expected_output_size,
+                  "device_gatherv: output span size must match the gathered byte count.");
+
+  cugraph::device_gatherv(handle.get_comms(),
+                          reinterpret_cast<uint8_t const*>(d_input.data()),
+                          reinterpret_cast<uint8_t*>(d_output.data()),
+                          d_input.size(),
+                          rx_sizes,
+                          raft::host_span<size_t const>(rx_displs.data(), rx_displs.size()),
+                          int{0},
+                          handle.get_stream());
+}
+
+// RAFT comms only supports a fixed set of datatypes. allgatherv only copy bytes, so transfer as
+// uint8_t regardless of the caller's logical element type.
+void device_allgatherv(raft::handle_t const& handle,
+                       raft::device_span<std::byte const> d_input,
+                       raft::device_span<std::byte> d_output,
+                       raft::host_span<size_t const> rx_sizes)
+{
+  std::vector<size_t> rx_displs(rx_sizes.size());
+  if (rx_sizes.size() > 0) {
+    std::partial_sum(rx_sizes.begin(), rx_sizes.end() - 1, rx_displs.begin() + 1);
+  }
+
+  auto const expected_output_size = std::reduce(rx_sizes.begin(), rx_sizes.end());
+  CUGRAPH_EXPECTS(d_output.size() == expected_output_size,
+                  "device_allgatherv: output span size must match the gathered byte count.");
+
+  cugraph::device_allgatherv(handle.get_comms(),
+                             reinterpret_cast<uint8_t const*>(d_input.data()),
+                             reinterpret_cast<uint8_t*>(d_output.data()),
+                             rx_sizes,
+                             raft::host_span<size_t const>(rx_displs.data(), rx_displs.size()),
+                             handle.get_stream());
+}
+
+}  // namespace detail
 
 template <typename T>
 rmm::device_uvector<T> device_gatherv(raft::handle_t const& handle,
                                       raft::device_span<T const> d_input)
-
 {
-  bool is_root = handle.get_comms().get_rank() == int{0};
-  auto rx_sizes =
-    cugraph::host_scalar_gather(handle.get_comms(), d_input.size(), int{0}, handle.get_stream());
-  std::vector<size_t> rx_displs(is_root ? static_cast<size_t>(handle.get_comms().get_size())
-                                        : size_t{0});
-  if (is_root) { std::partial_sum(rx_sizes.begin(), rx_sizes.end() - 1, rx_displs.begin() + 1); }
+  raft::device_span<std::byte const> d_input_bytes{
+    reinterpret_cast<std::byte const*>(d_input.data()), d_input.size() * sizeof(T)};
 
-  rmm::device_uvector<T> gathered_v(
-    is_root ? std::reduce(rx_sizes.begin(), rx_sizes.end()) : size_t{0}, handle.get_stream());
+  bool is_root       = handle.get_comms().get_rank() == int{0};
+  auto rx_byte_sizes = cugraph::host_scalar_gather(
+    handle.get_comms(), d_input_bytes.size(), int{0}, handle.get_stream());
+  auto const output_bytes =
+    is_root ? std::reduce(rx_byte_sizes.begin(), rx_byte_sizes.end()) : size_t{0};
 
-  using comm_datatype_t = std::conditional_t<std::is_same_v<T, bool>, uint8_t, T>;
-  cugraph::device_gatherv(handle.get_comms(),
-                          reinterpret_cast<comm_datatype_t const*>(d_input.data()),
-                          reinterpret_cast<comm_datatype_t*>(gathered_v.data()),
-                          d_input.size(),
-                          raft::host_span<size_t const>(rx_sizes.data(), rx_sizes.size()),
-                          raft::host_span<size_t const>(rx_displs.data(), rx_displs.size()),
-                          int{0},
-                          handle.get_stream());
-
+  rmm::device_uvector<T> gathered_v(output_bytes / sizeof(T), handle.get_stream());
+  detail::device_gatherv(
+    handle,
+    d_input_bytes,
+    raft::device_span<std::byte>{reinterpret_cast<std::byte*>(gathered_v.data()),
+                                 gathered_v.size() * sizeof(T)},
+    raft::host_span<size_t const>(rx_byte_sizes.data(), rx_byte_sizes.size()));
   return gathered_v;
 }
 
@@ -46,22 +102,20 @@ template <typename T>
 rmm::device_uvector<T> device_allgatherv(raft::handle_t const& handle,
                                          raft::device_span<T const> d_input)
 {
-  auto rx_sizes =
-    cugraph::host_scalar_allgather(handle.get_comms(), d_input.size(), handle.get_stream());
-  std::vector<size_t> rx_displs(static_cast<size_t>(handle.get_comms().get_size()));
-  std::partial_sum(rx_sizes.begin(), rx_sizes.end() - 1, rx_displs.begin() + 1);
+  raft::device_span<std::byte const> d_input_bytes{
+    reinterpret_cast<std::byte const*>(d_input.data()), d_input.size() * sizeof(T)};
 
-  rmm::device_uvector<T> gathered_v(std::reduce(rx_sizes.begin(), rx_sizes.end()),
-                                    handle.get_stream());
+  auto rx_byte_sizes =
+    cugraph::host_scalar_allgather(handle.get_comms(), d_input_bytes.size(), handle.get_stream());
+  auto const output_bytes = std::reduce(rx_byte_sizes.begin(), rx_byte_sizes.end());
 
-  using comm_datatype_t = std::conditional_t<std::is_same_v<T, bool>, uint8_t, T>;
-  cugraph::device_allgatherv(handle.get_comms(),
-                             reinterpret_cast<comm_datatype_t const*>(d_input.data()),
-                             reinterpret_cast<comm_datatype_t*>(gathered_v.data()),
-                             raft::host_span<size_t const>(rx_sizes.data(), rx_sizes.size()),
-                             raft::host_span<size_t const>(rx_displs.data(), rx_displs.size()),
-                             handle.get_stream());
-
+  rmm::device_uvector<T> gathered_v(output_bytes / sizeof(T), handle.get_stream());
+  detail::device_allgatherv(
+    handle,
+    d_input_bytes,
+    raft::device_span<std::byte>{reinterpret_cast<std::byte*>(gathered_v.data()),
+                                 gathered_v.size() * sizeof(T)},
+    raft::host_span<size_t const>(rx_byte_sizes.data(), rx_byte_sizes.size()));
   return gathered_v;
 }
 
@@ -69,6 +123,12 @@ rmm::device_uvector<T> device_allgatherv(raft::handle_t const& handle,
 
 template rmm::device_uvector<bool> device_gatherv(raft::handle_t const& handle,
                                                   raft::device_span<bool const> d_input);
+
+template rmm::device_uvector<int8_t> device_gatherv(raft::handle_t const& handle,
+                                                    raft::device_span<int8_t const> d_input);
+
+template rmm::device_uvector<int16_t> device_gatherv(raft::handle_t const& handle,
+                                                     raft::device_span<int16_t const> d_input);
 
 template rmm::device_uvector<int32_t> device_gatherv(raft::handle_t const& handle,
                                                      raft::device_span<int32_t const> d_input);
@@ -87,6 +147,12 @@ template rmm::device_uvector<double> device_gatherv(raft::handle_t const& handle
 
 template rmm::device_uvector<bool> device_allgatherv(raft::handle_t const& handle,
                                                      raft::device_span<bool const> d_input);
+
+template rmm::device_uvector<int8_t> device_allgatherv(raft::handle_t const& handle,
+                                                       raft::device_span<int8_t const> d_input);
+
+template rmm::device_uvector<int16_t> device_allgatherv(raft::handle_t const& handle,
+                                                        raft::device_span<int16_t const> d_input);
 
 template rmm::device_uvector<int32_t> device_allgatherv(raft::handle_t const& handle,
                                                         raft::device_span<int32_t const> d_input);

--- a/python/cugraph/cugraph/structure/replicate_edgelist.py
+++ b/python/cugraph/cugraph/structure/replicate_edgelist.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import dask_cudf

--- a/python/cugraph/cugraph/structure/replicate_edgelist.py
+++ b/python/cugraph/cugraph/structure/replicate_edgelist.py
@@ -48,9 +48,11 @@ def _call_plc_replicate_edgelist(
         resource_handle=ResourceHandle(Comms.get_handle(sID).getHandle()),
         src_array=edgelist_df[col_names[0]],
         dst_array=edgelist_df[col_names[1]],
-        weight_array=edgelist_df[col_names[2]] if len(col_names) > 2 else None,
-        edge_id_array=edgelist_df[col_names[3]] if len(col_names) > 3 else None,
-        edge_type_id_array=edgelist_df[col_names[4]] if len(col_names) > 4 else None,
+        weight_array=edgelist_df[col_names[2]] if col_names[2] is not None else None,
+        edge_id_array=edgelist_df[col_names[3]] if col_names[3] is not None else None,
+        edge_type_id_array=edgelist_df[col_names[4]]
+        if col_names[4] is not None
+        else None,
     )
     return _convert_to_cudf(cp_arrays, col_names)
 
@@ -201,16 +203,11 @@ def replicate_edgelist(
         edgelist_ddf = dask_cudf.from_cudf(
             edgelist_ddf, npartitions=len(Comms.get_workers())
         )
-    col_names = [source, destination]
+    col_names = [source, destination, weight, edge_id, edge_type]
 
-    if weight is not None:
-        col_names.append(weight)
-    if edge_id is not None:
-        col_names.append(edge_id)
-    if edge_type is not None:
-        col_names.append(edge_type)
-
-    if not (set(col_names).issubset(set(edgelist_ddf.columns))):
+    if not {name for name in col_names if name is not None}.issubset(
+        set(edgelist_ddf.columns)
+    ):
         raise ValueError(
             "Invalid column names were provided: valid columns names are "
             f"{edgelist_ddf.columns}"


### PR DESCRIPTION
This updates type erased vectors/spans (arithmetic_device_uvector_t and arithmetic_device_span_t) to support int8_t/int16_t.

This is a per-requisite to support int16_t edge type in graph creation.