### PR TITLE
[BUG] Fix Segfault Caused by Incorrect Dereferencing of Renumber Map

### DIFF
--- a/cpp/src/c_api/sampling_result.cpp
+++ b/cpp/src/c_api/sampling_result.cpp
@@ -285,7 +285,7 @@ extern "C" cugraph_type_erased_device_array_view_t* cugraph_sample_result_get_ed
   const cugraph_sample_result_t* result)
 {
   auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_sample_result_t const*>(result);
-  return internal_pointer->renumber_map_ == nullptr
+  return internal_pointer->edge_renumber_map_ == nullptr
            ? NULL
            : reinterpret_cast<cugraph_type_erased_device_array_view_t*>(
                internal_pointer->edge_renumber_map_->view());
@@ -295,7 +295,7 @@ extern "C" cugraph_type_erased_device_array_view_t*
 cugraph_sample_result_get_edge_renumber_map_offsets(const cugraph_sample_result_t* result)
 {
   auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_sample_result_t const*>(result);
-  return internal_pointer->renumber_map_ == nullptr
+  return internal_pointer->edge_renumber_map_offsets_ == nullptr
            ? NULL
            : reinterpret_cast<cugraph_type_erased_device_array_view_t*>(
                internal_pointer->edge_renumber_map_offsets_->view());

--- a/cpp/tests/c_api/uniform_neighbor_sample_test.c
+++ b/cpp/tests/c_api/uniform_neighbor_sample_test.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -150,6 +150,15 @@ int generic_uniform_neighbor_sample_test(const cugraph_resource_handle_t* handle
                                           sampling_options,
                                           FALSE);
   TEST_ASSERT(test_ret_value, test_ret_value == 0, "validate_sample_result failed.");
+
+  if (renumber_results) {
+    TEST_ASSERT(test_ret_value,
+                cugraph_sample_result_get_edge_renumber_map(result) == NULL,
+                "homogeneous sample should not have an edge renumber map.");
+    TEST_ASSERT(test_ret_value,
+                cugraph_sample_result_get_edge_renumber_map_offsets(result) == NULL,
+                "homogeneous sample should not have edge renumber map offsets.");
+  }
 
   cugraph_sampling_options_free(sampling_options);
   cugraph_rng_state_free(rng_state);


### PR DESCRIPTION
## Summary

- check the optional edge renumber map pointers before dereferencing them in
  the sampling-result C API accessors
- add regression coverage for accessing absent edge renumber maps on a
  renumbered homogeneous sampling result

## Problem

`cugraph_sample_result_get_edge_renumber_map()` and
`cugraph_sample_result_get_edge_renumber_map_offsets()` currently check whether
the vertex `renumber_map_` is null, then dereference the corresponding optional
edge renumber map pointer.

A sampling result can validly contain a vertex renumber map without an edge
renumber map. In particular, heterogeneous sampling with one edge type returns
that layout. Calling either accessor then dereferences a null pointer and
segfaults while pylibcugraph marshals an otherwise completed sampling result.

## Fix

Each accessor now checks the pointer it actually dereferences:

- `edge_renumber_map_`
- `edge_renumber_map_offsets_`

The accessors return null for absent optional results, matching the behavior of
the other sampling-result accessors and the existing pylibcugraph null handling.

## Validation

- repository pre-commit hooks pass for both changed files
- the cuGraph-GNN heterogeneous disjoint neighbor-loader reproducer passes
  end-to-end against an exact-baseline libcugraph build containing only this
  accessor fix
- the same reproducer still segfaults with cuGraph PR #5629 alone, confirming
  that the empty-frontier fix is independent
