### PR TITLE
Last-n implementation using the new primitive

### DIFF
--- a/cpp/include/cugraph/prims/edge_bucket.cuh
+++ b/cpp/include/cugraph/prims/edge_bucket.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -73,6 +73,20 @@ class edge_bucket_t {
       minors_(std::move(src_major ? dsts : srcs)),
       multi_edge_indices_(std::move(multi_edge_indices))
   {
+  }
+
+  /**
+   * @brief Move the stored edgelist out of the bucket.
+   *
+   * Complements the r-value constructor: callers can construct with moved vectors, use the bucket
+   * for gather/transform, then recover ownership without an insert copy.
+   */
+  std::tuple<rmm::device_uvector<vertex_t>,
+             rmm::device_uvector<vertex_t>,
+             std::optional<rmm::device_uvector<edge_t>>>
+  take_edgelist()
+  {
+    return {std::move(majors_), std::move(minors_), std::move(multi_edge_indices_)};
   }
 
   /**

--- a/cpp/include/cugraph/sampling_functions.hpp
+++ b/cpp/include/cugraph/sampling_functions.hpp
@@ -60,8 +60,13 @@ enum class neighbor_selection_t {
                   times for STRICTLY_INCREASING and MONOTONICALLY_INCREASING (same as PyG);
                   earlier times for STRICTLY_DECREASING and MONOTONICALLY_DECREASING (the
                   last elements in decreasing time order). Does not accept edge biases or
-                  with_replacement. Equal timestamps (and 64-bit times that are not uniquely
-                  representable as double) may tie in arbitrary order. */
+                  with_replacement. Start times are ranked via double conversion: int32
+                  ranks exactly over the full signed range; int64 ranks exactly on
+                  [-2^52, 2^52 - 1] (typical unix seconds/milliseconds/microseconds).
+                  Beyond that, ordering is preserved but values may tie, so fanout edges
+                  are still returned yet the chosen set may be wrong when more than fanout
+                  K eligible edges on one source share the same rank. Equal timestamps
+                  always tie. */
 };
 
 /**
@@ -111,6 +116,9 @@ struct sampling_options_t {
    * LAST (PyG temporal_strategy='last') keeps fanout-K edges ranked by start time
    * along the walk implied by @p temporal_sampling_comparison: later times for
    * increasing modes, earlier times (last in decreasing order) for decreasing modes.
+   * int32 start times rank exactly over the full signed range; int64 ranks exactly
+   * on [-2^52, 2^52 - 1]. Outside that int64 range, ordering is preserved but ties
+   * are possible (see neighbor_selection_t::LAST).
    */
   neighbor_selection_t neighbor_selection{neighbor_selection_t::RANDOM};
 
@@ -958,7 +966,11 @@ heterogeneous_biased_temporal_neighbor_sample(
  * selects the last-n eligible edges along the temporal walk order (temporal only; no bias;
  * no with-replacement): later @p edge_start_time_view values for increasing comparisons,
  * earlier values for decreasing comparisons (last in decreasing time order, not latest
- * timestamp).
+ * timestamp). int32 start times rank exactly over the full signed range; int64 ranks exactly
+ * on [-2^52, 2^52 - 1] (typical unix seconds/milliseconds/microseconds). Beyond that, int64
+ * ordering is preserved but values may tie, so fanout edges are still returned yet the
+ * chosen set may be wrong when more than fanout K eligible edges on one source share the
+ * same rank. Equal timestamps always tie.
  *
  * Sampling is temporal when @p sampling_options.temporal_sampling_comparison is set; in that case
  * @p edge_start_time_view is required. When @p sampling_options.fixed_window is true, each seed's

--- a/cpp/include/cugraph/sampling_functions.hpp
+++ b/cpp/include/cugraph/sampling_functions.hpp
@@ -43,7 +43,6 @@ enum class temporal_sampling_comparison_t {
   STRICTLY_DECREASING,      /** Time strictly decreasing (each time is before the previous one) */
   MONOTONICALLY_DECREASING, /** Time monotonically decreasing (could have multiple edges with same
                                 time) */
-  FIXED_WINDOW,             /** Apply the original per-seed time window at every hop */
   LAST                      /** Deprecated Value, we moved last-n to a different parameter */
 };
 
@@ -52,8 +51,15 @@ enum class temporal_sampling_comparison_t {
  */
 enum class neighbor_selection_t {
   RANDOM = 0, /** Random selection. Uniform if no bias view is supplied, biased otherwise. */
-  LAST /** Deterministically select the latest edges based on the ordering criteria defined in
-          temporal_sampling_comparison. Not yet implemented. */
+  LAST        /** Deterministically select the last-n eligible edges (temporal only).
+                  Eligible edges are those that pass the temporal window and disjoint
+                  unvisited-destination filter. Among them, keep fanout K (per edge type
+                  when heterogeneous) ranked by edge start time: later times for
+                  STRICTLY_INCREASING and MONOTONICALLY_INCREASING; earlier
+                  times for STRICTLY_DECREASING and MONOTONICALLY_DECREASING. Does not
+                  accept edge biases or with_replacement. Equal timestamps (and 64-bit
+                  times that are not uniquely representable as double) may tie in
+                  arbitrary order. */
 };
 
 /**
@@ -100,8 +106,18 @@ struct sampling_options_t {
 
   /**
    * Specifies how neighbors are selected from the eligible set. Default is RANDOM.
+   * LAST ranks eligible temporal edges by start time (later for increasing, earlier
+   * for decreasing).
    */
   neighbor_selection_t neighbor_selection{neighbor_selection_t::RANDOM};
+
+  /**
+   * When true (temporal only), keep each seed's original time window at every hop
+   * instead of replacing the frontier bound with the sampled edge time.
+   * Orthogonal to temporal_sampling_comparison (increasing vs decreasing).
+   * Default is false.
+   */
+  bool fixed_window{false};
 };
 
 /** @deprecated Use sampling_options_t. */
@@ -935,13 +951,14 @@ heterogeneous_biased_temporal_neighbor_sample(
  * contains one value per hop.
  *
  * RANDOM selection samples uniformly when @p edge_bias_view is absent and samples according to
- * the supplied biases when it is present. LAST is reserved for deterministically selecting the
- * latest eligible edges (temporal only; no bias; no with-replacement), but is not yet implemented.
+ * the supplied biases when it is present. LAST deterministically selects the last-n eligible
+ * edges (temporal only; no bias; no with-replacement): later @p edge_start_time_view values for
+ * increasing comparisons, earlier values for decreasing comparisons.
  *
  * Sampling is temporal when @p sampling_options.temporal_sampling_comparison is set; in that case
- * @p edge_start_time_view is required. FIXED_WINDOW applies each seed's original closed time window
- * at every hop, while the increasing and decreasing modes propagate sampled edge times as the next
- * frontier bound.
+ * @p edge_start_time_view is required. When @p sampling_options.fixed_window is true, each seed's
+ * original time window is reapplied at every hop; otherwise increasing and decreasing modes
+ * propagate sampled edge times as the next frontier bound.
  */
 template <typename vertex_t,
           typename edge_t,

--- a/cpp/include/cugraph/sampling_functions.hpp
+++ b/cpp/include/cugraph/sampling_functions.hpp
@@ -52,14 +52,16 @@ enum class temporal_sampling_comparison_t {
 enum class neighbor_selection_t {
   RANDOM = 0, /** Random selection. Uniform if no bias view is supplied, biased otherwise. */
   LAST        /** Deterministically select the last-n eligible edges (temporal only).
-                  Eligible edges are those that pass the temporal window and disjoint
-                  unvisited-destination filter. Among them, keep fanout K (per edge type
-                  when heterogeneous) ranked by edge start time: later times for
-                  STRICTLY_INCREASING and MONOTONICALLY_INCREASING; earlier
-                  times for STRICTLY_DECREASING and MONOTONICALLY_DECREASING. Does not
-                  accept edge biases or with_replacement. Equal timestamps (and 64-bit
-                  times that are not uniquely representable as double) may tie in
-                  arbitrary order. */
+                  Named to match PyTorch Geometric's temporal_strategy='last'. "Last" is
+                  relative to the temporal walk order in @p temporal_sampling_comparison,
+                  not unconditionally the latest timestamp: among edges that pass the
+                  temporal window and disjoint unvisited-destination filter, keep fanout K
+                  (per edge type when heterogeneous) ranked by edge start time — later
+                  times for STRICTLY_INCREASING and MONOTONICALLY_INCREASING (same as PyG);
+                  earlier times for STRICTLY_DECREASING and MONOTONICALLY_DECREASING (the
+                  last elements in decreasing time order). Does not accept edge biases or
+                  with_replacement. Equal timestamps (and 64-bit times that are not uniquely
+                  representable as double) may tie in arbitrary order. */
 };
 
 /**
@@ -106,8 +108,9 @@ struct sampling_options_t {
 
   /**
    * Specifies how neighbors are selected from the eligible set. Default is RANDOM.
-   * LAST ranks eligible temporal edges by start time (later for increasing, earlier
-   * for decreasing).
+   * LAST (PyG temporal_strategy='last') keeps fanout-K edges ranked by start time
+   * along the walk implied by @p temporal_sampling_comparison: later times for
+   * increasing modes, earlier times (last in decreasing order) for decreasing modes.
    */
   neighbor_selection_t neighbor_selection{neighbor_selection_t::RANDOM};
 
@@ -951,9 +954,11 @@ heterogeneous_biased_temporal_neighbor_sample(
  * contains one value per hop.
  *
  * RANDOM selection samples uniformly when @p edge_bias_view is absent and samples according to
- * the supplied biases when it is present. LAST deterministically selects the last-n eligible
- * edges (temporal only; no bias; no with-replacement): later @p edge_start_time_view values for
- * increasing comparisons, earlier values for decreasing comparisons.
+ * the supplied biases when it is present. LAST (PyG temporal_strategy='last') deterministically
+ * selects the last-n eligible edges along the temporal walk order (temporal only; no bias;
+ * no with-replacement): later @p edge_start_time_view values for increasing comparisons,
+ * earlier values for decreasing comparisons (last in decreasing time order, not latest
+ * timestamp).
  *
  * Sampling is temporal when @p sampling_options.temporal_sampling_comparison is set; in that case
  * @p edge_start_time_view is required. When @p sampling_options.fixed_window is true, each seed's

--- a/cpp/include/cugraph_c/sampling_algorithms.h
+++ b/cpp/include/cugraph_c/sampling_algorithms.h
@@ -197,7 +197,6 @@ typedef enum {
   STRICTLY_DECREASING,      /** Time strictly decreasing (each time is before the previous one) */
   MONOTONICALLY_DECREASING, /** Time monotonically decreasing (could have multiple edges with same
                                 time) */
-  FIXED_WINDOW,             /** Apply the original per-seed time window at every hop */
   LAST                      /** Deprecated Value, we moved last-n to a different parameter */
 } cugraph_temporal_sampling_comparison_t;
 
@@ -206,9 +205,11 @@ typedef enum {
  */
 typedef enum {
   CUGRAPH_NEIGHBOR_SELECTION_RANDOM = 0, /** Uniform without biases, biased with biases */
-  CUGRAPH_NEIGHBOR_SELECTION_LAST        /** Deterministically select the last-n edges based on the
-                                            ordering criteria defined in temporal_sampling_comparison (not
-                                            yet        implemented) */
+  CUGRAPH_NEIGHBOR_SELECTION_LAST        /** Deterministically select the last-n eligible
+                                            edges (temporal only). Later edge times for
+                                            increasing comparisons, earlier times for
+                                            decreasing. No edge biases and no
+                                            with-replacement. */
 } cugraph_neighbor_selection_t;
 
 /**
@@ -321,7 +322,10 @@ CUGRAPH_EXPORT void cugraph_sampling_set_dedupe_sources(cugraph_sampling_options
 
 /**
  * @ingroup samplingC
- * @brief Set temporal sampling to use associated comparision.
+ * @brief Set temporal sampling comparison (increasing vs decreasing).
+ *
+ * Enables temporal sampling. Direction (strict vs monotonic, increasing vs decreasing)
+ * is independent of cugraph_sampling_set_fixed_window.
  *
  * @param options - opaque pointer to the sampling options
  * @param comparison - Comparison value to assign to the option
@@ -347,6 +351,20 @@ CUGRAPH_EXPORT void cugraph_sampling_clear_temporal_sampling_comparison(
  */
 CUGRAPH_EXPORT void cugraph_sampling_set_neighbor_selection(cugraph_sampling_options_t* options,
                                                             cugraph_neighbor_selection_t selection);
+
+/**
+ * @ingroup samplingC
+ * @brief Keep each seed's original time window at every hop (temporal only).
+ *
+ * When TRUE, sampled edge times are not used as the next hop's frontier bound.
+ * Orthogonal to cugraph_sampling_set_temporal_sampling_comparison (increasing vs
+ * decreasing). Default is FALSE.
+ *
+ * @param options - opaque pointer to the sampling options
+ * @param value - Boolean value to assign to the option
+ */
+CUGRAPH_EXPORT void cugraph_sampling_set_fixed_window(cugraph_sampling_options_t* options,
+                                                      bool_t value);
 
 /**
  * @ingroup samplingC
@@ -386,13 +404,16 @@ CUGRAPH_EXPORT void cugraph_sampling_options_free(cugraph_sampling_options_t* op
  *
  * RANDOM selection samples according to @p edge_biases when provided. If @p edge_biases is NULL,
  * sampling is uniform unless cugraph_sampling_set_use_edge_weights_as_biases has been set, in which
- * case graph edge weights are used as biases (the graph must be weighted). LAST is reserved for
- * deterministically selecting the latest temporally eligible edges (requiring temporal sampling),
- * but is not yet implemented.
+ * case graph edge weights are used as biases (the graph must be weighted). LAST deterministically
+ * selects the last-n temporally eligible edges (later times for increasing,
+ * earlier times for decreasing). LAST requires temporal sampling, rejects edge biases, and
+ * rejects with-replacement.
  *
  * Sampling is non-temporal unless cugraph_sampling_set_temporal_sampling_comparison has been
- * called on @p sampling_options; all temporal arguments must then be NULL. Sampling is
- * homogeneous when @p num_edge_types is 1; otherwise @p fan_out contains one value per
+ * called on @p sampling_options; all temporal arguments must then be NULL. When temporal,
+ * cugraph_sampling_set_fixed_window(TRUE) reapplies each seed's original window at every hop
+ * instead of propagating sampled edge times; it is orthogonal to increasing vs decreasing.
+ * Sampling is homogeneous when @p num_edge_types is 1; otherwise @p fan_out contains one value per
  * (hop, edge type). When @p vertex_type_offsets is NULL, all vertices are treated as a single
  * vertex type.
  *
@@ -411,7 +432,8 @@ CUGRAPH_EXPORT void cugraph_sampling_options_free(cugraph_sampling_options_t* op
  * @param [in] num_edge_types Number of edge types. Use 1 for homogeneous sampling.
  * @param [in] sampling_options Sampling options. Temporal sampling is enabled by
  * cugraph_sampling_set_temporal_sampling_comparison; neighbor selection defaults to RANDOM and may
- * be set with cugraph_sampling_set_neighbor_selection.
+ * be set with cugraph_sampling_set_neighbor_selection; fixed_window defaults to FALSE and may be
+ * set with cugraph_sampling_set_fixed_window.
  * @param [in] do_expensive_check Whether to perform expensive input validation.
  * @param [out] result Sampling result.
  * @param [out] error Error details on failure.

--- a/cpp/include/cugraph_c/sampling_algorithms.h
+++ b/cpp/include/cugraph_c/sampling_algorithms.h
@@ -212,7 +212,14 @@ typedef enum {
                                             temporal_sampling_comparison — later times for
                                             increasing modes, earlier times (last in
                                             decreasing order) for decreasing modes. No edge
-                                            biases and no with-replacement. */
+                                            biases and no with-replacement. int32 start times
+                                            rank exactly over the full signed range; int64
+                                            ranks exactly on [-2^52, 2^52 - 1]. Beyond that,
+                                            int64 ordering is preserved but values may tie,
+                                            so fanout edges are still returned yet the chosen
+                                            set may be wrong when more than fanout K eligible
+                                            edges on one source share the same rank. Equal
+                                            timestamps always tie. */
 } cugraph_neighbor_selection_t;
 
 /**
@@ -411,7 +418,12 @@ CUGRAPH_EXPORT void cugraph_sampling_options_free(cugraph_sampling_options_t* op
  * temporal_strategy='last') deterministically selects the last-n temporally eligible edges
  * along the walk order: later times for increasing comparisons, earlier times (last in
  * decreasing order) for decreasing comparisons. LAST requires temporal sampling, ignores
- * edge biases, and rejects with-replacement.
+ * edge biases, and rejects with-replacement. int32 start times rank exactly over the full
+ * signed range; int64 ranks exactly on [-2^52, 2^52 - 1] (typical unix
+ * seconds/milliseconds/microseconds). Beyond that, int64 ordering is preserved but values
+ * may tie, so fanout edges are still returned yet the chosen set may be wrong when more
+ * than fanout K eligible edges on one source share the same rank. Equal timestamps always
+ * tie.
  *
  * Sampling is non-temporal unless cugraph_sampling_set_temporal_sampling_comparison has been
  * called on @p sampling_options; all temporal arguments must then be NULL. When temporal,

--- a/cpp/include/cugraph_c/sampling_algorithms.h
+++ b/cpp/include/cugraph_c/sampling_algorithms.h
@@ -206,10 +206,13 @@ typedef enum {
 typedef enum {
   CUGRAPH_NEIGHBOR_SELECTION_RANDOM = 0, /** Uniform without biases, biased with biases */
   CUGRAPH_NEIGHBOR_SELECTION_LAST        /** Deterministically select the last-n eligible
-                                            edges (temporal only). Later edge times for
-                                            increasing comparisons, earlier times for
-                                            decreasing. No edge biases and no
-                                            with-replacement. */
+                                            edges (temporal only). Matches PyG
+                                            temporal_strategy='last': rank by edge start
+                                            time along the walk in
+                                            temporal_sampling_comparison — later times for
+                                            increasing modes, earlier times (last in
+                                            decreasing order) for decreasing modes. No edge
+                                            biases and no with-replacement. */
 } cugraph_neighbor_selection_t;
 
 /**
@@ -404,10 +407,11 @@ CUGRAPH_EXPORT void cugraph_sampling_options_free(cugraph_sampling_options_t* op
  *
  * RANDOM selection samples according to @p edge_biases when provided. If @p edge_biases is NULL,
  * sampling is uniform unless cugraph_sampling_set_use_edge_weights_as_biases has been set, in which
- * case graph edge weights are used as biases (the graph must be weighted). LAST deterministically
- * selects the last-n temporally eligible edges (later times for increasing,
- * earlier times for decreasing). LAST requires temporal sampling, rejects edge biases, and
- * rejects with-replacement.
+ * case graph edge weights are used as biases (the graph must be weighted). LAST (PyG
+ * temporal_strategy='last') deterministically selects the last-n temporally eligible edges
+ * along the walk order: later times for increasing comparisons, earlier times (last in
+ * decreasing order) for decreasing comparisons. LAST requires temporal sampling, ignores
+ * edge biases, and rejects with-replacement.
  *
  * Sampling is non-temporal unless cugraph_sampling_set_temporal_sampling_comparison has been
  * called on @p sampling_options; all temporal arguments must then be NULL. When temporal,

--- a/cpp/src/c_api/neighbor_sample.cpp
+++ b/cpp/src/c_api/neighbor_sample.cpp
@@ -339,9 +339,6 @@ struct neighbor_sampling_functor : public cugraph::c_api::abstract_functor {
             temporal_sampling_comparison =
               cugraph::temporal_sampling_comparison_t::MONOTONICALLY_DECREASING;
             break;
-          case cugraph_temporal_sampling_comparison_t::FIXED_WINDOW:
-            temporal_sampling_comparison = cugraph::temporal_sampling_comparison_t::FIXED_WINDOW;
-            break;
           default: CUGRAPH_FAIL("Invalid temporal sampling comparison type");
         }
       }
@@ -406,7 +403,8 @@ struct neighbor_sampling_functor : public cugraph::c_api::abstract_functor {
                                       options_.with_replacement_ == TRUE,
                                       temporal_sampling_comparison,
                                       options_.disjoint_sampling_ == TRUE,
-                                      options_.neighbor_selection_},
+                                      options_.neighbor_selection_,
+                                      options_.fixed_window_ == TRUE},
           do_expensive_check_);
 
       cugraph::unrenumber_int_vertices<vertex_t, multi_gpu>(

--- a/cpp/src/c_api/sampling_common.hpp
+++ b/cpp/src/c_api/sampling_common.hpp
@@ -27,6 +27,7 @@ struct cugraph_sampling_options_t {
   bool_t disjoint_sampling_{FALSE};
   bool_t use_edge_weights_as_biases_{FALSE};
   cugraph::neighbor_selection_t neighbor_selection_{cugraph::neighbor_selection_t::RANDOM};
+  bool_t fixed_window_{FALSE};
 };
 
 struct sampling_flags_t {

--- a/cpp/src/c_api/sampling_result.cpp
+++ b/cpp/src/c_api/sampling_result.cpp
@@ -119,6 +119,12 @@ extern "C" void cugraph_sampling_set_neighbor_selection(cugraph_sampling_options
   }
 }
 
+extern "C" void cugraph_sampling_set_fixed_window(cugraph_sampling_options_t* options, bool_t value)
+{
+  auto internal_pointer = reinterpret_cast<cugraph::c_api::cugraph_sampling_options_t*>(options);
+  internal_pointer->fixed_window_ = value;
+}
+
 extern "C" void cugraph_sampling_set_disjoint_sampling(cugraph_sampling_options_t* options,
                                                        bool_t value)
 {

--- a/cpp/src/sampling/detail/deduplicate_edges_by_minor_impl.cuh
+++ b/cpp/src/sampling/detail/deduplicate_edges_by_minor_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -50,12 +50,18 @@ deduplicate_edges_by_minor(raft::handle_t const& handle,
   bool const has_types         = !std::holds_alternative<std::monostate>(result_types);
   bool const has_labels        = result_labels.has_value();
   if (has_types) {
-    CUGRAPH_EXPECTS(std::holds_alternative<rmm::device_uvector<int32_t>>(result_types),
-                    "result_types must be rmm::device_uvector<int32_t> when present.");
+    CUGRAPH_EXPECTS(
+      std::holds_alternative<rmm::device_uvector<int32_t>>(result_types),
+      "deduplicate_edges_by_minor: result_types expected rmm::device_uvector<int32_t>, variant "
+      "index %zu",
+      result_types.index());
   }
   if (has_edge_property) {
-    CUGRAPH_EXPECTS(std::holds_alternative<rmm::device_uvector<edge_t>>(result_edge_property),
-                    "result_edge_property must be rmm::device_uvector<edge_t> when present.");
+    CUGRAPH_EXPECTS(
+      std::holds_alternative<rmm::device_uvector<edge_t>>(result_edge_property),
+      "deduplicate_edges_by_minor: result_edge_property expected rmm::device_uvector<edge_t>, "
+      "variant index %zu",
+      result_edge_property.index());
   }
 
   size_t total_edges = result_majors.size();
@@ -92,6 +98,10 @@ deduplicate_edges_by_minor(raft::handle_t const& handle,
                            graph_view.vertex_partition_range_lasts(),
                            std::nullopt);
 
+    CUGRAPH_EXPECTS(std::holds_alternative<rmm::device_uvector<vertex_t>>(shuffle_properties[0]),
+                    "deduplicate_edges_by_minor MG shuffle: shuffle_properties[0] expected "
+                    "rmm::device_uvector<vertex_t>, variant index %zu",
+                    shuffle_properties[0].index());
     result_majors = std::move(std::get<rmm::device_uvector<vertex_t>>(shuffle_properties[0]));
     size_t shuffle_prop_idx{1};
     if (has_edge_property) {
@@ -99,6 +109,18 @@ deduplicate_edges_by_minor(raft::handle_t const& handle,
     }
     if (has_types) { result_types = std::move(shuffle_properties[shuffle_prop_idx++]); }
     if (has_labels) {
+      CUGRAPH_EXPECTS(
+        shuffle_prop_idx < shuffle_properties.size(),
+        "deduplicate_edges_by_minor MG shuffle: label property index %zu out of range "
+        "(shuffle_properties.size()=%zu)",
+        shuffle_prop_idx,
+        shuffle_properties.size());
+      CUGRAPH_EXPECTS(
+        std::holds_alternative<rmm::device_uvector<int32_t>>(shuffle_properties[shuffle_prop_idx]),
+        "deduplicate_edges_by_minor MG shuffle: shuffle_properties[%zu] expected "
+        "rmm::device_uvector<int32_t>, variant index %zu",
+        shuffle_prop_idx,
+        shuffle_properties[shuffle_prop_idx].index());
       result_labels =
         std::move(std::get<rmm::device_uvector<int32_t>>(shuffle_properties[shuffle_prop_idx++]));
     }

--- a/cpp/src/sampling/detail/gather_one_hop_common_v32_e32.cu
+++ b/cpp/src/sampling/detail/gather_one_hop_common_v32_e32.cu
@@ -62,6 +62,7 @@ using edge_t   = int32_t;
     std::optional<raft::device_span<int32_t const>> active_major_labels,             \
     std::optional<raft::device_span<bool const>> gather_flags,                       \
     temporal_sampling_comparison_t temporal_sampling_comparison,                     \
+    bool fixed_window,                                                               \
     bool do_expensive_check);                                                        \
                                                                                      \
   template CUGRAPH_EXPORT std::tuple<rmm::device_uvector<vertex_t>,                  \
@@ -84,6 +85,7 @@ using edge_t   = int32_t;
     rmm::device_uvector<vertex_t>&& visited_minors,                                  \
     std::optional<rmm::device_uvector<int32_t>>&& visited_minor_labels,              \
     temporal_sampling_comparison_t temporal_sampling_comparison,                     \
+    bool fixed_window,                                                               \
     bool do_expensive_check)
 
 CUGRAPH_INSTANTIATE_GATHER_ONE_HOP(false);

--- a/cpp/src/sampling/detail/gather_one_hop_common_v64_e64.cu
+++ b/cpp/src/sampling/detail/gather_one_hop_common_v64_e64.cu
@@ -62,6 +62,7 @@ using edge_t   = int64_t;
     std::optional<raft::device_span<int32_t const>> active_major_labels,             \
     std::optional<raft::device_span<bool const>> gather_flags,                       \
     temporal_sampling_comparison_t temporal_sampling_comparison,                     \
+    bool fixed_window,                                                               \
     bool do_expensive_check);                                                        \
                                                                                      \
   template CUGRAPH_EXPORT std::tuple<rmm::device_uvector<vertex_t>,                  \
@@ -84,6 +85,7 @@ using edge_t   = int64_t;
     rmm::device_uvector<vertex_t>&& visited_minors,                                  \
     std::optional<rmm::device_uvector<int32_t>>&& visited_minor_labels,              \
     temporal_sampling_comparison_t temporal_sampling_comparison,                     \
+    bool fixed_window,                                                               \
     bool do_expensive_check)
 
 CUGRAPH_INSTANTIATE_GATHER_ONE_HOP(false);

--- a/cpp/src/sampling/detail/gather_one_hop_impl.cuh
+++ b/cpp/src/sampling/detail/gather_one_hop_impl.cuh
@@ -464,6 +464,7 @@ temporal_gather_one_hop_edgelist(
   std::optional<raft::device_span<int32_t const>> active_major_labels,
   std::optional<raft::device_span<bool const>> gather_flags,
   temporal_sampling_comparison_t temporal_sampling_comparison,
+  bool fixed_window,
   bool do_expensive_check)
 {
   constexpr bool store_transposed = false;
@@ -566,12 +567,10 @@ temporal_gather_one_hop_edgelist(
           temporal_sampling_comparison ==
             temporal_sampling_comparison_t::MONOTONICALLY_INCREASING ||
           temporal_sampling_comparison == temporal_sampling_comparison_t::STRICTLY_INCREASING;
-        // FIXED_WINDOW keeps every seed's original window bounds fixed, so duplicate entries for
+        // fixed_window keeps every seed's original window bounds fixed, so duplicate entries for
         // the same key are expected to be identical; simply keep the first rather than taking a
-        // max/min extremum (which is otherwise wrong since FIXED_WINDOW is neither increasing nor
-        // decreasing).
-        bool const fixed_window = is_fixed_window(temporal_sampling_comparison);
-        auto const n            = kv_majors->size();
+        // max/min extremum.
+        auto const n = kv_majors->size();
         rmm::device_uvector<vertex_t> out_majors(n, handle.get_stream());
         rmm::device_uvector<label_t> out_labels(n, handle.get_stream());
         rmm::device_uvector<time_stamp_t> out_window_starts(n, handle.get_stream());
@@ -827,6 +826,7 @@ temporal_gather_one_hop_edgelist_to_unvisited_neighbors(
   rmm::device_uvector<vertex_t>&& visited_minors,
   std::optional<rmm::device_uvector<int32_t>>&& visited_minor_labels,
   temporal_sampling_comparison_t temporal_sampling_comparison,
+  bool fixed_window,
   bool do_expensive_check)
 {
   CUGRAPH_EXPECTS(active_major_labels.has_value() == visited_minor_labels.has_value(),
@@ -847,6 +847,7 @@ temporal_gather_one_hop_edgelist_to_unvisited_neighbors(
       active_major_labels,
       gather_flags,
       temporal_sampling_comparison,
+      fixed_window,
       do_expensive_check);
 
   // Drop edges whose destination has already been visited. Keep multi-edge indices

--- a/cpp/src/sampling/detail/sample_edges_impl.cuh
+++ b/cpp/src/sampling/detail/sample_edges_impl.cuh
@@ -225,7 +225,8 @@ void dedupe_sorted_temporal_mg_side_table(
   rmm::device_uvector<time_stamp_t>& sorted_times,
   std::optional<rmm::device_uvector<time_stamp_t>>& sorted_window_ends,
   std::optional<rmm::device_uvector<int32_t>>& sorted_labels,
-  temporal_sampling_comparison_t temporal_sampling_comparison)
+  temporal_sampling_comparison_t temporal_sampling_comparison,
+  bool fixed_window)
 {
   auto const n = sorted_majors.size();
   if (n < 2) { return; }
@@ -233,7 +234,6 @@ void dedupe_sorted_temporal_mg_side_table(
   bool const increasing =
     temporal_sampling_comparison == temporal_sampling_comparison_t::MONOTONICALLY_INCREASING ||
     temporal_sampling_comparison == temporal_sampling_comparison_t::STRICTLY_INCREASING;
-  bool const fixed_window = is_fixed_window(temporal_sampling_comparison);
 
   if (sorted_labels && sorted_window_ends) {
     rmm::device_uvector<vertex_t> out_majors(n, handle.get_stream());
@@ -410,7 +410,8 @@ temporal_sample_edges_to_unvisited_neighbors(
   std::optional<rmm::device_uvector<int32_t>>&& visited_minor_labels,
   bool with_replacement,
   temporal_sampling_comparison_t temporal_sampling_comparison,
-  neighbor_selection_t neighbor_selection)
+  neighbor_selection_t neighbor_selection,
+  bool fixed_window)
 {
   CUGRAPH_EXPECTS(Ks.size() >= 1, "Must specify non-zero value for Ks");
   CUGRAPH_EXPECTS((Ks.size() == 1) || edge_type_view,
@@ -421,9 +422,9 @@ temporal_sample_edges_to_unvisited_neighbors(
                   "Active major labels and visited vertex labels must both be specified or both "
                   "be unspecified");
   CUGRAPH_EXPECTS((neighbor_selection == neighbor_selection_t::RANDOM) || !with_replacement,
-                  "FIRST and LAST neighbor selection do not support sampling with replacement.");
+                  "LAST neighbor selection does not support sampling with replacement.");
   CUGRAPH_EXPECTS((neighbor_selection == neighbor_selection_t::RANDOM) || !edge_bias_view,
-                  "FIRST and LAST neighbor selection do not accept edge biases.");
+                  "LAST neighbor selection does not accept edge biases.");
 
   // Build side spans sorted so the bias operator can recover (time, window_end) by (major[,
   // label]).  On MG, per_v_random_select_transform_outgoing_e allgathers frontier keys across
@@ -546,7 +547,8 @@ temporal_sample_edges_to_unvisited_neighbors(
                                                                    *sorted_times,
                                                                    sorted_window_ends,
                                                                    sorted_labels,
-                                                                   temporal_sampling_comparison);
+                                                                   temporal_sampling_comparison,
+                                                                   fixed_window);
     }
   }
 

--- a/cpp/src/sampling/detail/sample_edges_mg_v32_e32.cu
+++ b/cpp/src/sampling/detail/sample_edges_mg_v32_e32.cu
@@ -68,7 +68,8 @@ temporal_sample_edges_to_unvisited_neighbors(
   std::optional<rmm::device_uvector<int32_t>>&& visited_minor_labels,
   bool with_replacement,
   temporal_sampling_comparison_t temporal_sampling_comparison,
-  neighbor_selection_t neighbor_selection);
+  neighbor_selection_t neighbor_selection,
+  bool fixed_window);
 
 template CUGRAPH_EXPORT std::tuple<rmm::device_uvector<int32_t>,
                                    rmm::device_uvector<int32_t>,
@@ -93,7 +94,8 @@ temporal_sample_edges_to_unvisited_neighbors(
   std::optional<rmm::device_uvector<int32_t>>&& visited_minor_labels,
   bool with_replacement,
   temporal_sampling_comparison_t temporal_sampling_comparison,
-  neighbor_selection_t neighbor_selection);
+  neighbor_selection_t neighbor_selection,
+  bool fixed_window);
 
 }  // namespace detail
 }  // namespace cugraph

--- a/cpp/src/sampling/detail/sample_edges_mg_v64_e64.cu
+++ b/cpp/src/sampling/detail/sample_edges_mg_v64_e64.cu
@@ -68,7 +68,8 @@ temporal_sample_edges_to_unvisited_neighbors(
   std::optional<rmm::device_uvector<int32_t>>&& visited_minor_labels,
   bool with_replacement,
   temporal_sampling_comparison_t temporal_sampling_comparison,
-  neighbor_selection_t neighbor_selection);
+  neighbor_selection_t neighbor_selection,
+  bool fixed_window);
 
 template CUGRAPH_EXPORT std::tuple<rmm::device_uvector<int64_t>,
                                    rmm::device_uvector<int64_t>,
@@ -93,7 +94,8 @@ temporal_sample_edges_to_unvisited_neighbors(
   std::optional<rmm::device_uvector<int32_t>>&& visited_minor_labels,
   bool with_replacement,
   temporal_sampling_comparison_t temporal_sampling_comparison,
-  neighbor_selection_t neighbor_selection);
+  neighbor_selection_t neighbor_selection,
+  bool fixed_window);
 
 }  // namespace detail
 }  // namespace cugraph

--- a/cpp/src/sampling/detail/sample_edges_sg_v32_e32.cu
+++ b/cpp/src/sampling/detail/sample_edges_sg_v32_e32.cu
@@ -68,7 +68,8 @@ temporal_sample_edges_to_unvisited_neighbors(
   std::optional<rmm::device_uvector<int32_t>>&& visited_minor_labels,
   bool with_replacement,
   temporal_sampling_comparison_t temporal_sampling_comparison,
-  neighbor_selection_t neighbor_selection);
+  neighbor_selection_t neighbor_selection,
+  bool fixed_window);
 
 template CUGRAPH_EXPORT std::tuple<rmm::device_uvector<int32_t>,
                                    rmm::device_uvector<int32_t>,
@@ -93,7 +94,8 @@ temporal_sample_edges_to_unvisited_neighbors(
   std::optional<rmm::device_uvector<int32_t>>&& visited_minor_labels,
   bool with_replacement,
   temporal_sampling_comparison_t temporal_sampling_comparison,
-  neighbor_selection_t neighbor_selection);
+  neighbor_selection_t neighbor_selection,
+  bool fixed_window);
 
 }  // namespace detail
 }  // namespace cugraph

--- a/cpp/src/sampling/detail/sample_edges_sg_v64_e64.cu
+++ b/cpp/src/sampling/detail/sample_edges_sg_v64_e64.cu
@@ -68,7 +68,8 @@ temporal_sample_edges_to_unvisited_neighbors(
   std::optional<rmm::device_uvector<int32_t>>&& visited_minor_labels,
   bool with_replacement,
   temporal_sampling_comparison_t temporal_sampling_comparison,
-  neighbor_selection_t neighbor_selection);
+  neighbor_selection_t neighbor_selection,
+  bool fixed_window);
 
 template CUGRAPH_EXPORT std::tuple<rmm::device_uvector<int64_t>,
                                    rmm::device_uvector<int64_t>,
@@ -93,7 +94,8 @@ temporal_sample_edges_to_unvisited_neighbors(
   std::optional<rmm::device_uvector<int32_t>>&& visited_minor_labels,
   bool with_replacement,
   temporal_sampling_comparison_t temporal_sampling_comparison,
-  neighbor_selection_t neighbor_selection);
+  neighbor_selection_t neighbor_selection,
+  bool fixed_window);
 
 }  // namespace detail
 }  // namespace cugraph

--- a/cpp/src/sampling/detail/sample_outgoing_edges.hpp
+++ b/cpp/src/sampling/detail/sample_outgoing_edges.hpp
@@ -47,8 +47,9 @@ struct temporal_unvisited_params_t {
   cuda::std::optional<raft::device_span<time_stamp_t const>> active_major_window_ends;
   cuda::std::optional<raft::device_span<int32_t const>> active_major_labels;  // sorted parallel
   temporal_sampling_comparison_t temporal_sampling_comparison;
-  // RANDOM (default) reuses the existing per_v_random_select_transform_outgoing_e path below.
-  // FIRST/LAST are accepted at the API boundary but are not yet implemented.
+  // RANDOM (default) uses per_v_random_select_transform_outgoing_e.
+  // LAST uses per_v_top_k_select_transform_outgoing_e with last_n_time_bias
+  // (later edge times for increasing, earlier for decreasing).
   neighbor_selection_t neighbor_selection{neighbor_selection_t::RANDOM};
 };
 

--- a/cpp/src/sampling/detail/sample_outgoing_edges_impl.cuh
+++ b/cpp/src/sampling/detail/sample_outgoing_edges_impl.cuh
@@ -835,36 +835,32 @@ rmm::device_uvector<int32_t> gather_edge_types_for_sampled_edgelist(
 // Gathers a single scalar edge property (e.g. edge start time, edge type) for the given
 // (major, minor[, multi-edge index]) edge list.  Unlike gather_edge_types_for_sampled_edgelist,
 // this also accepts a monostate multi-edge index (i.e. a non-multigraph edge list), matching the
-// "Filter by time" pattern used by temporal_gather_one_hop_edgelist.
+// "Filter by time" pattern used by temporal_gather_one_hop_edgelist.  Takes ownership of the
+// edgelist vectors and returns them after gathering so callers avoid an insert copy.
 template <typename vertex_t, typename edge_t, typename T, bool multi_gpu>
-rmm::device_uvector<T> gather_scalar_edge_property_for_edgelist(
+std::tuple<rmm::device_uvector<T>,
+           rmm::device_uvector<vertex_t>,
+           rmm::device_uvector<vertex_t>,
+           arithmetic_device_uvector_t>
+gather_scalar_edge_property_for_edgelist(
   raft::handle_t const& handle,
   graph_view_t<vertex_t, edge_t, false, multi_gpu> const& graph_view,
-  raft::device_span<vertex_t const> majors,
-  raft::device_span<vertex_t const> minors,
-  arithmetic_device_uvector_t const& multi_edge_index,
+  rmm::device_uvector<vertex_t>&& majors,
+  rmm::device_uvector<vertex_t>&& minors,
+  arithmetic_device_uvector_t&& multi_edge_index,
   edge_property_view_t<edge_t, T const*> prop_view)
 {
   constexpr bool store_transposed = false;
 
   rmm::device_uvector<T> values(majors.size(), handle.get_stream());
 
-  cugraph::edge_bucket_t<vertex_t, edge_t, !store_transposed, multi_gpu, false> edge_list(
-    handle, graph_view.is_multigraph());
+  std::optional<rmm::device_uvector<edge_t>> multi_indices{std::nullopt};
+  if (std::holds_alternative<rmm::device_uvector<edge_t>>(multi_edge_index)) {
+    multi_indices = std::move(std::get<rmm::device_uvector<edge_t>>(multi_edge_index));
+  }
 
-  edge_list.insert(majors.begin(),
-                   majors.end(),
-                   minors.begin(),
-                   (std::holds_alternative<rmm::device_uvector<edge_t>>(multi_edge_index))
-                     ? std::make_optional([&]() {
-                         CUGRAPH_EXPECTS(
-                           std::holds_alternative<rmm::device_uvector<edge_t>>(multi_edge_index),
-                           "gather_scalar_edge_property_for_edgelist: multi_edge_index expected "
-                           "rmm::device_uvector<edge_t>, variant index %zu",
-                           multi_edge_index.index());
-                         return std::get<rmm::device_uvector<edge_t>>(multi_edge_index).begin();
-                       }())
-                     : std::nullopt);
+  cugraph::edge_bucket_t<vertex_t, edge_t, !store_transposed, multi_gpu, false> edge_list(
+    handle, std::move(majors), std::move(minors), std::move(multi_indices));
 
   cugraph::transform_gather_e(handle,
                               graph_view,
@@ -875,7 +871,16 @@ rmm::device_uvector<T> gather_scalar_edge_property_for_edgelist(
                               return_edge_property_t{},
                               values.begin());
 
-  return values;
+  std::optional<rmm::device_uvector<edge_t>> out_multi_indices;
+  std::tie(majors, minors, out_multi_indices) = edge_list.take_edgelist();
+
+  arithmetic_device_uvector_t out_multi_edge_index{std::monostate{}};
+  if (out_multi_indices) {
+    out_multi_edge_index = arithmetic_device_uvector_t{std::move(*out_multi_indices)};
+  }
+
+  return std::make_tuple(
+    std::move(values), std::move(majors), std::move(minors), std::move(out_multi_edge_index));
 }
 
 // Looks up, for each (major[, label]) in the current (possibly carryover-shrunk) frontier, the
@@ -1189,13 +1194,14 @@ sample_unvisited_outgoing_edges(
         last_n_order = temporal_params.neighbor_selection == neighbor_selection_t::LAST;
         if (last_n_order && (majors.size() > 0)) {
           using time_stamp_t = typename temporal_params_t::time_type;
-          auto times =
+          rmm::device_uvector<time_stamp_t> times(0, handle.get_stream());
+          std::tie(times, majors, minors, prop) =
             gather_scalar_edge_property_for_edgelist<vertex_t, edge_t, time_stamp_t, multi_gpu>(
               handle,
               graph_view,
-              raft::device_span<vertex_t const>{majors.data(), majors.size()},
-              raft::device_span<vertex_t const>{minors.data(), minors.size()},
-              prop,
+              std::move(majors),
+              std::move(minors),
+              std::move(prop),
               temporal_params.edge_time_view);
           auto const comparison = temporal_params.temporal_sampling_comparison;
           thrust::transform(handle.get_thrust_policy(),

--- a/cpp/src/sampling/detail/sample_outgoing_edges_impl.cuh
+++ b/cpp/src/sampling/detail/sample_outgoing_edges_impl.cuh
@@ -18,6 +18,7 @@
 #include <cugraph/graph_view.hpp>
 #include <cugraph/prims/edge_bucket.cuh>
 #include <cugraph/prims/per_v_random_select_transform_outgoing_e.cuh>
+#include <cugraph/prims/per_v_top_k_select_transform_outgoing_e.cuh>
 #include <cugraph/prims/transform_gather_e.cuh>
 #include <cugraph/prims/transform_reduce_e.cuh>
 #include <cugraph/prims/vertex_frontier.cuh>
@@ -149,14 +150,23 @@ struct sample_unvisited_edge_biases_op_t {
 
 // Combined temporal + unvisited bias operator.  Returns bias 0 (excluding the edge from selection)
 // when the destination minor has already been visited (per-label when labels are used) OR when the
-// edge fails the temporal window filter; otherwise returns the edge bias (1 when unbiased).
+// edge fails the temporal window filter.
+//
+// When last_n is false (RANDOM), an eligible edge returns the edge bias (1 when unbiased).
+// When last_n is true (LAST), an eligible edge returns last_n_time_bias so
+// per_v_top_k_select_transform_outgoing_e keeps the K latest edges in the
+// temporal_sampling_comparison rank order.  Instantiate with bias_t = last_n_bias_t.
 //
 // The per-source window bounds are looked up from spans keyed on the frontier entry.
 // Under always-disjoint sampling each vertex appears at most once per label in the frontier, so the
 // key is (major) when unlabeled and (major, label) when labeled; both are unique.  The side spans
 // must be sorted by that same key.
-template <typename vertex_t, typename bias_t, typename time_stamp_t>
+template <typename vertex_t, typename bias_t, typename time_stamp_t, bool last_n = false>
 struct sample_unvisited_temporal_edge_biases_op_t {
+  static_assert(!last_n || std::is_same_v<bias_t, last_n_bias_t>,
+                "LAST neighbor selection must use last_n_bias_t (double) so integer "
+                "timestamps up to 53 bits rank exactly.");
+
   temporal_sampling_comparison_t temporal_sampling_comparison{};
   raft::device_span<vertex_t const> active_majors{};  // sorted by (major[, label])
   // Parallel to active_majors when present. nullopt => unbounded via
@@ -255,7 +265,12 @@ struct sample_unvisited_temporal_edge_biases_op_t {
     auto const edge_time  = extract_edge_time(edge_property);
     auto const passes =
       passes_temporal_filter(temporal_sampling_comparison, major_time, window_end, edge_time);
-    return passes ? extract_edge_bias(edge_property) : bias_t{0};
+    if (!passes) { return bias_t{0}; }
+    if constexpr (last_n) {
+      return last_n_time_bias(edge_time, temporal_sampling_comparison);
+    } else {
+      return extract_edge_bias(edge_property);
+    }
   }
 
   // Labeled frontier (tag == int32 label): key is (major, label).
@@ -278,7 +293,12 @@ struct sample_unvisited_temporal_edge_biases_op_t {
     auto const edge_time  = extract_edge_time(edge_property);
     auto const passes =
       passes_temporal_filter(temporal_sampling_comparison, major_time, window_end, edge_time);
-    return passes ? extract_edge_bias(edge_property) : bias_t{0};
+    if (!passes) { return bias_t{0}; }
+    if constexpr (last_n) {
+      return last_n_time_bias(edge_time, temporal_sampling_comparison);
+    } else {
+      return extract_edge_bias(edge_property);
+    }
   }
 };
 
@@ -426,6 +446,131 @@ call_biased_per_v_random_select_transform_outgoing_e(
                            with_replacement,
                            std::optional<return_type>{std::nullopt},
                            false);
+  }
+
+  if (active_major_labels) {
+    labels =
+      rmm::device_uvector<int32_t>(offsets->back_element(handle.get_stream()), handle.get_stream());
+    auto num_segments = offsets->size() - size_t{1};
+    thrust::for_each(
+      handle.get_thrust_policy(),
+      thrust::make_counting_iterator(size_t{0}),
+      thrust::make_counting_iterator(num_segments),
+      segmented_fill_t{*active_major_labels,
+                       raft::device_span<size_t const>{offsets->data(), offsets->size()},
+                       raft::device_span<int32_t>{labels->data(), labels->size()}});
+  }
+
+  return std::make_tuple(
+    std::move(labels), std::move(majors), std::move(minors), std::move(sampled_properties));
+}
+
+/**
+ * LAST analog of call_biased_per_v_random_select_transform_outgoing_e.  Selects the K highest-bias
+ * outgoing edges per (tagged-)vertex via per_v_top_k_select_transform_outgoing_e (no RNG, no
+ * replacement).  @p biases_op must return last_n_bias_t.
+ */
+template <typename vertex_t,
+          typename edge_t,
+          typename tag_t,
+          typename biases_view_t,
+          typename edge_type_t,
+          typename biases_op_t,
+          bool multi_gpu>
+std::tuple<std::optional<rmm::device_uvector<int32_t>>,
+           rmm::device_uvector<vertex_t>,
+           rmm::device_uvector<vertex_t>,
+           arithmetic_device_uvector_t>
+call_biased_per_v_top_k_select_transform_outgoing_e(
+  raft::handle_t const& handle,
+  graph_view_t<vertex_t, edge_t, false, multi_gpu> const& graph_view,
+  cugraph::key_bucket_view_t<vertex_t, tag_t, multi_gpu, false> const& key_bucket_view,
+  biases_view_t edge_biases_view,
+  bool has_output_edge_properties,
+  biases_op_t biases_op,
+  std::optional<cugraph::edge_property_view_t<edge_t, edge_type_t const*>> edge_type_view,
+  raft::host_span<size_t const> Ks,
+  std::optional<raft::device_span<int32_t const>> active_major_labels)
+{
+  std::optional<rmm::device_uvector<size_t>> offsets{std::nullopt};
+  std::optional<rmm::device_uvector<int32_t>> labels{std::nullopt};
+  rmm::device_uvector<vertex_t> majors(0, handle.get_stream());
+  rmm::device_uvector<vertex_t> minors(0, handle.get_stream());
+  arithmetic_device_uvector_t sampled_properties{std::monostate{}};
+
+  if (has_output_edge_properties && graph_view.is_multigraph()) {
+    edge_multi_index_property_t<edge_t, vertex_t> multi_index_property(handle, graph_view);
+    using edges_op_t = sample_edges_op_t<vertex_t, edge_t>;
+    edges_op_t edges_op{};
+    using return_type = typename edges_op_t::return_type;
+
+    std::forward_as_tuple(offsets, std::tie(majors, minors, sampled_properties)) =
+      (Ks.size() == 1)
+        ? cugraph::per_v_top_k_select_transform_outgoing_e(handle,
+                                                           graph_view,
+                                                           key_bucket_view,
+                                                           edge_src_dummy_property_t{}.view(),
+                                                           edge_dst_dummy_property_t{}.view(),
+                                                           edge_biases_view,
+                                                           biases_op,
+                                                           edge_src_dummy_property_t{}.view(),
+                                                           edge_dst_dummy_property_t{}.view(),
+                                                           multi_index_property.view(),
+                                                           edges_op,
+                                                           Ks[0],
+                                                           std::optional<return_type>{std::nullopt},
+                                                           false)
+        : cugraph::per_v_top_k_select_transform_outgoing_e(handle,
+                                                           graph_view,
+                                                           key_bucket_view,
+                                                           edge_src_dummy_property_t{}.view(),
+                                                           edge_dst_dummy_property_t{}.view(),
+                                                           edge_biases_view,
+                                                           biases_op,
+                                                           edge_src_dummy_property_t{}.view(),
+                                                           edge_dst_dummy_property_t{}.view(),
+                                                           multi_index_property.view(),
+                                                           edges_op,
+                                                           *edge_type_view,
+                                                           Ks,
+                                                           std::optional<return_type>{std::nullopt},
+                                                           false);
+  } else {
+    using edges_op_t = sample_edges_op_t<vertex_t, cuda::std::nullopt_t>;
+    edges_op_t edges_op{};
+    using return_type = typename edges_op_t::return_type;
+
+    std::forward_as_tuple(offsets, std::tie(majors, minors)) =
+      (Ks.size() == 1)
+        ? cugraph::per_v_top_k_select_transform_outgoing_e(handle,
+                                                           graph_view,
+                                                           key_bucket_view,
+                                                           edge_src_dummy_property_t{}.view(),
+                                                           edge_dst_dummy_property_t{}.view(),
+                                                           edge_biases_view,
+                                                           biases_op,
+                                                           edge_src_dummy_property_t{}.view(),
+                                                           edge_dst_dummy_property_t{}.view(),
+                                                           cugraph::edge_dummy_property_view_t{},
+                                                           edges_op,
+                                                           Ks[0],
+                                                           std::optional<return_type>{std::nullopt},
+                                                           false)
+        : cugraph::per_v_top_k_select_transform_outgoing_e(handle,
+                                                           graph_view,
+                                                           key_bucket_view,
+                                                           edge_src_dummy_property_t{}.view(),
+                                                           edge_dst_dummy_property_t{}.view(),
+                                                           edge_biases_view,
+                                                           biases_op,
+                                                           edge_src_dummy_property_t{}.view(),
+                                                           edge_dst_dummy_property_t{}.view(),
+                                                           cugraph::edge_dummy_property_view_t{},
+                                                           edges_op,
+                                                           *edge_type_view,
+                                                           Ks,
+                                                           std::optional<return_type>{std::nullopt},
+                                                           false);
   }
 
   if (active_major_labels) {
@@ -808,10 +953,10 @@ sample_unvisited_outgoing_edges(
   if constexpr (is_temporal) {
     CUGRAPH_EXPECTS(
       (temporal_params.neighbor_selection == neighbor_selection_t::RANDOM) || !with_replacement,
-      "FIRST and LAST neighbor selection do not support sampling with replacement.");
+      "LAST neighbor selection does not support sampling with replacement.");
     CUGRAPH_EXPECTS(
       (temporal_params.neighbor_selection == neighbor_selection_t::RANDOM) || !edge_bias_view,
-      "FIRST and LAST neighbor selection do not accept edge biases.");
+      "LAST neighbor selection does not accept edge biases.");
   }
 
   rmm::device_uvector<vertex_t> result_majors(0, handle.get_stream());
@@ -965,7 +1110,29 @@ sample_unvisited_outgoing_edges(
               active_major_labels,
               with_replacement);
         } else {
-          CUGRAPH_FAIL("FIRST and LAST neighbor selection are not yet implemented.");
+          CUGRAPH_EXPECTS(temporal_params.neighbor_selection == neighbor_selection_t::LAST,
+                          "Unknown neighbor selection mode.");
+          std::tie(sampled_labels, sampled_majors, sampled_minors, sampled_property) =
+            call_biased_per_v_top_k_select_transform_outgoing_e(
+              handle,
+              graph_view,
+              active_bucket_view,
+              temporal_params.edge_time_view,
+              has_output_edge_properties,
+              sample_unvisited_temporal_edge_biases_op_t<vertex_t,
+                                                         last_n_bias_t,
+                                                         time_stamp_t,
+                                                         true>{
+                temporal_params.temporal_sampling_comparison,
+                temporal_params.active_majors,
+                temporal_params.active_major_window_starts,
+                temporal_params.active_major_window_ends,
+                temporal_params.active_major_labels,
+                visited_minors_span,
+                visited_minor_labels_span},
+              edge_type_filter,
+              Ks,
+              active_major_labels);
         }
       } else {
         std::tie(sampled_labels, sampled_majors, sampled_minors, sampled_property) =
@@ -1008,10 +1175,41 @@ sample_unvisited_outgoing_edges(
       arithmetic_device_uvector_t types                  = std::move(sampled_types);
       std::optional<rmm::device_uvector<int32_t>> labels = std::move(sampled_labels);
 
-      rmm::device_uvector<float> random_numbers =
-        rmm::device_uvector<float>(majors.size(), handle.get_stream());
-      uniform_random_fill(
-        handle.get_stream(), random_numbers.data(), random_numbers.size(), 0.0f, 1.0f, rng_state);
+      rmm::device_uvector<double> order_keys(majors.size(), handle.get_stream());
+      bool last_n_order{false};
+      if constexpr (is_temporal) {
+        last_n_order = temporal_params.neighbor_selection == neighbor_selection_t::LAST;
+        if (last_n_order && (majors.size() > 0)) {
+          using time_stamp_t = typename temporal_params_t::time_type;
+          auto times =
+            gather_scalar_edge_property_for_edgelist<vertex_t, edge_t, time_stamp_t, multi_gpu>(
+              handle,
+              graph_view,
+              raft::device_span<vertex_t const>{majors.data(), majors.size()},
+              raft::device_span<vertex_t const>{minors.data(), minors.size()},
+              prop,
+              temporal_params.edge_time_view);
+          auto const comparison = temporal_params.temporal_sampling_comparison;
+          thrust::transform(handle.get_thrust_policy(),
+                            times.begin(),
+                            times.end(),
+                            order_keys.begin(),
+                            [comparison] __device__(time_stamp_t edge_time) {
+                              // Ascending sort then keep the first needed_count, so negate rank.
+                              return -last_n_time_bias(edge_time, comparison);
+                            });
+        }
+      }
+      if (!last_n_order) {
+        rmm::device_uvector<float> rng_draw(majors.size(), handle.get_stream());
+        uniform_random_fill(
+          handle.get_stream(), rng_draw.data(), rng_draw.size(), 0.0f, 1.0f, rng_state);
+        thrust::transform(handle.get_thrust_policy(),
+                          rng_draw.begin(),
+                          rng_draw.end(),
+                          order_keys.begin(),
+                          [] __device__(float x) { return static_cast<double>(x); });
+      }
 
       size_t keep_count{0};
       rmm::device_uvector<uint32_t> keep_flags(0, handle.get_stream());
@@ -1023,13 +1221,13 @@ sample_unvisited_outgoing_edges(
           thrust::sort_by_key(
             handle.get_thrust_policy(),
             thrust::make_zip_iterator(
-              labels->begin(), majors.begin(), type_vec.begin(), random_numbers.begin()),
+              labels->begin(), majors.begin(), type_vec.begin(), order_keys.begin()),
             thrust::make_zip_iterator(
-              labels->end(), majors.end(), type_vec.end(), random_numbers.end()),
+              labels->end(), majors.end(), type_vec.end(), order_keys.end()),
             minors.begin());
 
-          random_numbers.resize(0, handle.get_stream());
-          random_numbers.shrink_to_fit(handle.get_stream());
+          order_keys.resize(0, handle.get_stream());
+          order_keys.shrink_to_fit(handle.get_stream());
 
           std::tie(keep_count, keep_flags) = mark_entries(
             majors.size(),
@@ -1069,12 +1267,12 @@ sample_unvisited_outgoing_edges(
         } else {
           thrust::sort_by_key(
             handle.get_thrust_policy(),
-            thrust::make_zip_iterator(majors.begin(), type_vec.begin(), random_numbers.begin()),
-            thrust::make_zip_iterator(majors.end(), type_vec.end(), random_numbers.end()),
+            thrust::make_zip_iterator(majors.begin(), type_vec.begin(), order_keys.begin()),
+            thrust::make_zip_iterator(majors.end(), type_vec.end(), order_keys.end()),
             minors.begin());
 
-          random_numbers.resize(0, handle.get_stream());
-          random_numbers.shrink_to_fit(handle.get_stream());
+          order_keys.resize(0, handle.get_stream());
+          order_keys.shrink_to_fit(handle.get_stream());
 
           std::tie(keep_count, keep_flags) = mark_entries(
             majors.size(),
@@ -1113,12 +1311,12 @@ sample_unvisited_outgoing_edges(
         if (labels) {
           thrust::sort_by_key(
             handle.get_thrust_policy(),
-            thrust::make_zip_iterator(labels->begin(), majors.begin(), random_numbers.begin()),
-            thrust::make_zip_iterator(labels->end(), majors.end(), random_numbers.end()),
+            thrust::make_zip_iterator(labels->begin(), majors.begin(), order_keys.begin()),
+            thrust::make_zip_iterator(labels->end(), majors.end(), order_keys.end()),
             minors.begin());
 
-          random_numbers.resize(0, handle.get_stream());
-          random_numbers.shrink_to_fit(handle.get_stream());
+          order_keys.resize(0, handle.get_stream());
+          order_keys.shrink_to_fit(handle.get_stream());
 
           std::tie(keep_count, keep_flags) = mark_entries(
             majors.size(),
@@ -1155,12 +1353,12 @@ sample_unvisited_outgoing_edges(
 
         } else {
           thrust::sort_by_key(handle.get_thrust_policy(),
-                              thrust::make_zip_iterator(majors.begin(), random_numbers.begin()),
-                              thrust::make_zip_iterator(majors.end(), random_numbers.end()),
+                              thrust::make_zip_iterator(majors.begin(), order_keys.begin()),
+                              thrust::make_zip_iterator(majors.end(), order_keys.end()),
                               minors.begin());
 
-          random_numbers.resize(0, handle.get_stream());
-          random_numbers.shrink_to_fit(handle.get_stream());
+          order_keys.resize(0, handle.get_stream());
+          order_keys.shrink_to_fit(handle.get_stream());
 
           std::tie(keep_count, keep_flags) = mark_entries(
             majors.size(),

--- a/cpp/src/sampling/detail/sample_outgoing_edges_impl.cuh
+++ b/cpp/src/sampling/detail/sample_outgoing_edges_impl.cuh
@@ -803,7 +803,9 @@ rmm::device_uvector<int32_t> gather_edge_types_for_sampled_edgelist(
   arithmetic_device_uvector_t& multi_edge_index)
 {
   CUGRAPH_EXPECTS(std::holds_alternative<rmm::device_uvector<edge_t>>(multi_edge_index),
-                  "Multi-edge indices must be of type edge_t");
+                  "gather_edge_types_for_sampled_edgelist: multi_edge_index expected "
+                  "rmm::device_uvector<edge_t>, variant index %zu",
+                  multi_edge_index.index());
 
   using edge_type_t = int32_t;
 
@@ -850,13 +852,19 @@ rmm::device_uvector<T> gather_scalar_edge_property_for_edgelist(
   cugraph::edge_bucket_t<vertex_t, edge_t, !store_transposed, multi_gpu, false> edge_list(
     handle, graph_view.is_multigraph());
 
-  edge_list.insert(
-    majors.begin(),
-    majors.end(),
-    minors.begin(),
-    std::holds_alternative<rmm::device_uvector<edge_t>>(multi_edge_index)
-      ? std::make_optional(std::get<rmm::device_uvector<edge_t>>(multi_edge_index).begin())
-      : std::nullopt);
+  edge_list.insert(majors.begin(),
+                   majors.end(),
+                   minors.begin(),
+                   (std::holds_alternative<rmm::device_uvector<edge_t>>(multi_edge_index))
+                     ? std::make_optional([&]() {
+                         CUGRAPH_EXPECTS(
+                           std::holds_alternative<rmm::device_uvector<edge_t>>(multi_edge_index),
+                           "gather_scalar_edge_property_for_edgelist: multi_edge_index expected "
+                           "rmm::device_uvector<edge_t>, variant index %zu",
+                           multi_edge_index.index());
+                         return std::get<rmm::device_uvector<edge_t>>(multi_edge_index).begin();
+                       }())
+                     : std::nullopt);
 
   cugraph::transform_gather_e(handle,
                               graph_view,
@@ -1215,6 +1223,10 @@ sample_unvisited_outgoing_edges(
       rmm::device_uvector<uint32_t> keep_flags(0, handle.get_stream());
 
       if (carryover_frontier_types) {
+        CUGRAPH_EXPECTS(
+          std::holds_alternative<rmm::device_uvector<edge_type_t>>(types),
+          "LAST carryover: types expected rmm::device_uvector<edge_type_t>, variant index %zu",
+          types.index());
         auto& type_vec = std::get<rmm::device_uvector<edge_type_t>>(types);
 
         if (labels) {
@@ -1394,6 +1406,10 @@ sample_unvisited_outgoing_edges(
       majors = keep_marked_entries(handle, std::move(majors), keep_mask, keep_count);
       minors = keep_marked_entries(handle, std::move(minors), keep_mask, keep_count);
       if (carryover_frontier_types) {
+        CUGRAPH_EXPECTS(
+          std::holds_alternative<rmm::device_uvector<int32_t>>(types),
+          "LAST carryover keep: types expected rmm::device_uvector<int32_t>, variant index %zu",
+          types.index());
         types = arithmetic_device_uvector_t{keep_marked_entries(
           handle, std::move(std::get<rmm::device_uvector<int32_t>>(types)), keep_mask, keep_count)};
       }
@@ -1490,6 +1506,11 @@ sample_unvisited_outgoing_edges(
         }
         carryover_frontier_capacity = std::move(agg_counts);
       } else {
+        CUGRAPH_EXPECTS(
+          std::holds_alternative<rmm::device_uvector<edge_type_t>>(discarded_types),
+          "LAST carryover het: discarded_types expected rmm::device_uvector<edge_type_t>, "
+          "variant index %zu",
+          discarded_types.index());
         rmm::device_uvector<edge_type_t> types =
           std::get<rmm::device_uvector<edge_type_t>>(std::move(discarded_types));
 
@@ -1611,6 +1632,14 @@ sample_unvisited_outgoing_edges(
       if (std::holds_alternative<std::monostate>(result_properties)) {
         result_properties = std::move(sampled_property);
       } else {
+        CUGRAPH_EXPECTS(
+          std::holds_alternative<rmm::device_uvector<edge_t>>(result_properties),
+          "LAST append: result_properties expected rmm::device_uvector<edge_t>, variant index %zu",
+          result_properties.index());
+        CUGRAPH_EXPECTS(
+          std::holds_alternative<rmm::device_uvector<edge_t>>(sampled_property),
+          "LAST append: sampled_property expected rmm::device_uvector<edge_t>, variant index %zu",
+          sampled_property.index());
         auto& result_properties_ref = std::get<rmm::device_uvector<edge_t>>(result_properties);
         auto& sampled_property_ref  = std::get<rmm::device_uvector<edge_t>>(sampled_property);
         result_properties_ref.resize(result_properties_ref.size() + sampled_property_ref.size(),

--- a/cpp/src/sampling/detail/sampling_utils.hpp
+++ b/cpp/src/sampling/detail/sampling_utils.hpp
@@ -154,6 +154,7 @@ temporal_gather_one_hop_edgelist(
   std::optional<raft::device_span<int32_t const>> active_major_labels,
   std::optional<raft::device_span<bool const>> gather_flags,
   temporal_sampling_comparison_t temporal_sampling_comparison,
+  bool fixed_window,
   bool do_expensive_check);
 
 /**
@@ -185,6 +186,7 @@ temporal_gather_one_hop_edgelist_to_unvisited_neighbors(
   rmm::device_uvector<vertex_t>&& visited_minors,
   std::optional<rmm::device_uvector<int32_t>>&& visited_minor_labels,
   temporal_sampling_comparison_t temporal_sampling_comparison,
+  bool fixed_window,
   bool do_expensive_check);
 
 /**
@@ -277,7 +279,8 @@ temporal_sample_edges_to_unvisited_neighbors(
   std::optional<rmm::device_uvector<int32_t>>&& visited_minor_labels,
   bool with_replacement,
   temporal_sampling_comparison_t temporal_sampling_comparison,
-  neighbor_selection_t neighbor_selection = neighbor_selection_t::RANDOM);
+  neighbor_selection_t neighbor_selection = neighbor_selection_t::RANDOM,
+  bool fixed_window                       = false);
 
 /**
  * @brief Use the sampling results from hop N to populate the new frontier for hop N+1.

--- a/cpp/src/sampling/detail/temporal_sampling_utils.cuh
+++ b/cpp/src/sampling/detail/temporal_sampling_utils.cuh
@@ -14,7 +14,9 @@
 #include <thrust/distance.h>
 #include <thrust/iterator/zip_iterator.h>
 
+#include <cstdint>
 #include <limits>
+#include <type_traits>
 
 namespace cugraph {
 namespace detail {
@@ -26,19 +28,12 @@ __host__ __device__ inline bool is_temporal_decreasing(
          temporal_sampling_comparison == temporal_sampling_comparison_t::MONOTONICALLY_DECREASING;
 }
 
-__host__ __device__ inline bool is_fixed_window(
-  temporal_sampling_comparison_t temporal_sampling_comparison)
-{
-  return temporal_sampling_comparison == temporal_sampling_comparison_t::FIXED_WINDOW;
-}
-
 // Increasing/decreasing walks tighten the frontier window-start to the most recently sampled
-// edge's time at every hop.  FIXED_WINDOW instead keeps applying each seed's original window-start
+// edge's time at every hop.  fixed_window instead keeps applying each seed's original window-start
 // at every hop, so it must never be replaced by a sampled edge time.
-__host__ __device__ inline bool propagates_sampled_edge_times_as_window_start(
-  temporal_sampling_comparison_t temporal_sampling_comparison)
+__host__ __device__ inline bool propagates_sampled_edge_times_as_window_start(bool fixed_window)
 {
-  return !is_fixed_window(temporal_sampling_comparison);
+  return !fixed_window;
 }
 
 // Sentinel for an absent / unbounded frontier time.
@@ -81,8 +76,7 @@ __host__ __device__ inline bool passes_temporal_filter(
       return (key_time > edge_time) && (edge_time >= window_end);
     case temporal_sampling_comparison_t::MONOTONICALLY_DECREASING:
       return (key_time >= edge_time) && (edge_time >= window_end);
-    case temporal_sampling_comparison_t::FIXED_WINDOW:
-      return (key_time <= edge_time) && (edge_time <= window_end);
+    case temporal_sampling_comparison_t::LAST: return false;
   }
   return false;
 }
@@ -115,6 +109,75 @@ __device__ inline bool try_find_temporal_key_index(raft::device_span<vertex_t co
   }
   idx = static_cast<size_t>(cuda::std::distance(begin, it));
   return true;
+}
+
+// ---------------------------------------------------------------------------
+// LAST (last-n) neighbor selection
+// ---------------------------------------------------------------------------
+// LAST keeps the same eligible set as RANDOM temporal sampling: the destination
+// must be unvisited (per label, when labels are used) and the edge time must
+// pass passes_temporal_filter.  Among those edges it deterministically keeps
+// fanout K (per edge type when heterogeneous) with the highest last-n rank:
+//
+//   STRICTLY_INCREASING / MONOTONICALLY_INCREASING
+//       later edge_start_time ranks higher
+//   STRICTLY_DECREASING / MONOTONICALLY_DECREASING
+//       earlier edge_start_time ranks higher
+//
+// Ties (equal timestamps, or 64-bit times that collapse under double rounding)
+// have arbitrary order; per_v_top_k_select_transform_outgoing_e does not
+// provide a secondary key.
+//
+// The top-k primitive selects the highest strictly-positive bias and treats
+// bias 0 as "not selectable".  last_n_time_bias therefore maps an eligible
+// timestamp to (0, +inf) with that rank order.  The return type is
+// last_n_bias_t (double): float cannot uniquely represent int32 times.
+//
+// Exactness of last_n_time_bias: integer times with |t| <= 2^53 rank exactly;
+// see the FIXME in temporal_sampling_impl.cuh for the int64 / unix-ns case.
+//
+// LAST does not use caller edge biases and does not support with_replacement.
+
+using last_n_bias_t = double;
+
+template <typename time_stamp_t>
+inline constexpr bool last_n_time_bias_is_exact_v =
+  std::is_integral_v<time_stamp_t> &&
+  (std::numeric_limits<time_stamp_t>::digits <= std::numeric_limits<double>::digits);
+
+// Strictly positive bias for an *eligible* edge.  Callers must still return
+// bias 0 when the edge is visited or outside the temporal window.
+//
+// Signed times are XOR'd onto unsigned so integer order is preserved, then
+// inverted for decreasing walks so earlier times rank higher.  +1 so a valid
+// edge never produces 0, which the top-k primitive excludes.
+template <typename time_stamp_t>
+__device__ inline last_n_bias_t last_n_time_bias(
+  time_stamp_t edge_time, temporal_sampling_comparison_t temporal_sampling_comparison)
+{
+  static_assert(std::is_integral_v<time_stamp_t> && !std::is_same_v<time_stamp_t, bool>,
+                "LAST neighbor selection requires an integral timestamp type.");
+
+  uint64_t rank{};
+  if constexpr (std::is_signed_v<time_stamp_t>) {
+    using unsigned_t = std::make_unsigned_t<time_stamp_t>;
+    auto const u     = static_cast<unsigned_t>(edge_time);
+    auto const sign  = static_cast<unsigned_t>(unsigned_t{1} << (sizeof(time_stamp_t) * 8 - 1));
+    rank             = static_cast<uint64_t>(u ^ sign);
+  } else {
+    rank = static_cast<uint64_t>(edge_time);
+  }
+
+  if (is_temporal_decreasing(temporal_sampling_comparison)) {
+    if constexpr (sizeof(time_stamp_t) < sizeof(uint64_t)) {
+      auto const mask = (uint64_t{1} << (sizeof(time_stamp_t) * 8)) - uint64_t{1};
+      rank            = (~rank) & mask;
+    } else {
+      rank = ~rank;
+    }
+  }
+
+  return static_cast<last_n_bias_t>(rank) + last_n_bias_t{1};
 }
 
 }  // namespace detail

--- a/cpp/src/sampling/detail/temporal_sampling_utils.cuh
+++ b/cpp/src/sampling/detail/temporal_sampling_utils.cuh
@@ -124,17 +124,22 @@ __device__ inline bool try_find_temporal_key_index(raft::device_span<vertex_t co
 //   STRICTLY_DECREASING / MONOTONICALLY_DECREASING
 //       earlier edge_start_time ranks higher
 //
-// Ties (equal timestamps, or 64-bit times that collapse under double rounding)
-// have arbitrary order; per_v_top_k_select_transform_outgoing_e does not
-// provide a secondary key.
+// Ties (equal timestamps, or int64 magnitudes outside the exact core that collapse
+// under double rounding) have arbitrary order; per_v_top_k_select_transform_outgoing_e
+// does not provide a secondary key.
 //
 // The top-k primitive selects the highest strictly-positive bias and treats
 // bias 0 as "not selectable".  last_n_time_bias therefore maps an eligible
 // timestamp to (0, +inf) with that rank order.  The return type is
 // last_n_bias_t (double): float cannot uniquely represent int32 times.
 //
-// Exactness of last_n_time_bias: integer times with |t| <= 2^53 rank exactly;
-// see the FIXME in temporal_sampling_impl.cuh for the int64 / unix-ns case.
+// Exactness of last_n_time_bias:
+//   int32: all values rank exactly (signed offset lands in [1, 2^32]).
+//   int64: t in [-2^52, 2^52 - 1] ranks exactly (~4.5e15; covers unix s/ms/us).
+//     Timestamps outside that core use monotonic outer bands that stay strictly
+//     positive (large negative t in (0, 1), large positive t above the core) so
+//     LAST still returns fanout edges, but ordering among colliding timestamps
+//     is arbitrary.  See temporal_sampling_impl.cuh.
 //
 // LAST does not use caller edge biases and does not support with_replacement.
 
@@ -148,9 +153,11 @@ inline constexpr bool last_n_time_bias_is_exact_v =
 // Strictly positive bias for an *eligible* edge.  Callers must still return
 // bias 0 when the edge is visited or outside the temporal window.
 //
-// Signed times are XOR'd onto unsigned so integer order is preserved, then
-// inverted for decreasing walks so earlier times rank higher.  +1 so a valid
-// edge never produces 0, which the top-k primitive excludes.
+// int32: cast, optional (max - t) for decreasing, 2^31 offset, +1.
+// int64: three bands on the (possibly inverted) rank key:
+//   core [-2^52, 2^52 - 1]: t + 2^52 + 1 (exact, bias in [1, 2^53])
+//   large t >= 2^52:        (t - 2^52 + 1) * 2^54 (monotonic, bias > 2^53)
+//   large t <= -2^52 - 1:   (t - INT64_MIN + 1) / 2^63 (monotonic, bias in (0, 1))
 template <typename time_stamp_t>
 __device__ inline last_n_bias_t last_n_time_bias(
   time_stamp_t edge_time, temporal_sampling_comparison_t temporal_sampling_comparison)
@@ -158,26 +165,35 @@ __device__ inline last_n_bias_t last_n_time_bias(
   static_assert(std::is_integral_v<time_stamp_t> && !std::is_same_v<time_stamp_t, bool>,
                 "LAST neighbor selection requires an integral timestamp type.");
 
-  uint64_t rank{};
-  if constexpr (std::is_signed_v<time_stamp_t>) {
-    using unsigned_t = std::make_unsigned_t<time_stamp_t>;
-    auto const u     = static_cast<unsigned_t>(edge_time);
-    auto const sign  = static_cast<unsigned_t>(unsigned_t{1} << (sizeof(time_stamp_t) * 8 - 1));
-    rank             = static_cast<uint64_t>(u ^ sign);
-  } else {
-    rank = static_cast<uint64_t>(edge_time);
-  }
-
-  if (is_temporal_decreasing(temporal_sampling_comparison)) {
-    if constexpr (sizeof(time_stamp_t) < sizeof(uint64_t)) {
-      auto const mask = (uint64_t{1} << (sizeof(time_stamp_t) * 8)) - uint64_t{1};
-      rank            = (~rank) & mask;
-    } else {
-      rank = ~rank;
+  if constexpr (sizeof(time_stamp_t) >= sizeof(int64_t) && std::is_signed_v<time_stamp_t>) {
+    int64_t rank_key = static_cast<int64_t>(edge_time);
+    if (is_temporal_decreasing(temporal_sampling_comparison)) {
+      rank_key = std::numeric_limits<int64_t>::max() - rank_key;
     }
-  }
 
-  return static_cast<last_n_bias_t>(rank) + last_n_bias_t{1};
+    constexpr int64_t k_exact_lo = -(int64_t{1} << 52);
+    constexpr int64_t k_exact_hi = (int64_t{1} << 52) - 1;
+
+    if (rank_key >= k_exact_lo && rank_key <= k_exact_hi) {
+      return static_cast<last_n_bias_t>(rank_key) + static_cast<last_n_bias_t>(uint64_t{1} << 52) +
+             last_n_bias_t{1};
+    }
+    if (rank_key >= (int64_t{1} << 52)) {
+      return (static_cast<last_n_bias_t>(rank_key - (int64_t{1} << 52)) + last_n_bias_t{1}) *
+             static_cast<last_n_bias_t>(uint64_t{1} << 54);
+    }
+    auto const idx = static_cast<last_n_bias_t>(rank_key - std::numeric_limits<int64_t>::min());
+    return (idx + last_n_bias_t{1}) / static_cast<last_n_bias_t>(uint64_t{1} << 63);
+  } else {
+    last_n_bias_t rank = static_cast<last_n_bias_t>(edge_time);
+    if (is_temporal_decreasing(temporal_sampling_comparison)) {
+      rank = static_cast<last_n_bias_t>(std::numeric_limits<time_stamp_t>::max() - edge_time);
+    }
+    if constexpr (std::is_signed_v<time_stamp_t>) {
+      rank += static_cast<last_n_bias_t>(uint64_t{1} << (sizeof(time_stamp_t) * 8 - 1));
+    }
+    return rank + last_n_bias_t{1};
+  }
 }
 
 }  // namespace detail

--- a/cpp/src/sampling/neighbor_sample_impl.cuh
+++ b/cpp/src/sampling/neighbor_sample_impl.cuh
@@ -70,9 +70,6 @@ neighbor_sample(
   CUGRAPH_EXPECTS(
     neighbor_selection == neighbor_selection_t::RANDOM || !sampling_options.with_replacement,
     "LAST neighbor selection does not support sampling with replacement.");
-  if (neighbor_selection != neighbor_selection_t::RANDOM) {
-    CUGRAPH_FAIL("LAST neighbor selection is not yet implemented.");
-  }
   CUGRAPH_EXPECTS(!(sampling_options.with_replacement && sampling_options.disjoint_sampling),
                   "Invalid input argument: disjoint sampling and sampling with replacement are "
                   "mutually exclusive.");

--- a/cpp/src/sampling/neighbor_sample_impl.cuh
+++ b/cpp/src/sampling/neighbor_sample_impl.cuh
@@ -8,7 +8,6 @@
 #include "neighbor_sampling_impl.cuh"
 #include "temporal_sampling_impl.cuh"
 
-#include <cugraph/export.hpp>
 #include <cugraph/sampling_functions.hpp>
 
 #include <optional>
@@ -23,15 +22,15 @@ template <typename vertex_t,
           typename time_stamp_t,
           bool store_transposed,
           bool multi_gpu>
-CUGRAPH_EXPORT std::tuple<rmm::device_uvector<vertex_t>,
-                          rmm::device_uvector<vertex_t>,
-                          std::optional<rmm::device_uvector<weight_t>>,
-                          std::optional<rmm::device_uvector<edge_t>>,
-                          std::optional<rmm::device_uvector<edge_type_t>>,
-                          std::optional<rmm::device_uvector<time_stamp_t>>,
-                          std::optional<rmm::device_uvector<time_stamp_t>>,
-                          std::optional<rmm::device_uvector<int32_t>>,
-                          std::optional<rmm::device_uvector<size_t>>>
+std::tuple<rmm::device_uvector<vertex_t>,
+           rmm::device_uvector<vertex_t>,
+           std::optional<rmm::device_uvector<weight_t>>,
+           std::optional<rmm::device_uvector<edge_t>>,
+           std::optional<rmm::device_uvector<edge_type_t>>,
+           std::optional<rmm::device_uvector<time_stamp_t>>,
+           std::optional<rmm::device_uvector<time_stamp_t>>,
+           std::optional<rmm::device_uvector<int32_t>>,
+           std::optional<rmm::device_uvector<size_t>>>
 neighbor_sample(
   raft::handle_t const& handle,
   raft::random::RngState& rng_state,

--- a/cpp/src/sampling/neighbor_sampling_impl.cuh
+++ b/cpp/src/sampling/neighbor_sampling_impl.cuh
@@ -474,23 +474,67 @@ neighbor_sample_impl(raft::handle_t const& handle,
                     : std::nullopt,
       label_to_output_comm_rank);
 
+  CUGRAPH_EXPECTS(
+    std::holds_alternative<rmm::device_uvector<vertex_t>>(property_edges[0]),
+    "neighbor_sample output: property_edges[0] expected rmm::device_uvector<vertex_t>, variant "
+    "index %zu",
+    property_edges[0].index());
+  CUGRAPH_EXPECTS(
+    std::holds_alternative<rmm::device_uvector<vertex_t>>(property_edges[1]),
+    "neighbor_sample output: property_edges[1] expected rmm::device_uvector<vertex_t>, variant "
+    "index %zu",
+    property_edges[1].index());
   result_srcs = std::move(std::get<rmm::device_uvector<vertex_t>>(property_edges[0]));
   result_dsts = std::move(std::get<rmm::device_uvector<vertex_t>>(property_edges[1]));
 
-  auto result_weights =
-    weight_prop_idx
-      ? std::make_optional(
-          std::move(std::get<rmm::device_uvector<weight_t>>(property_edges[2 + *weight_prop_idx])))
-      : std::nullopt;
-  auto result_edge_ids =
-    edge_id_prop_idx
-      ? std::make_optional(
-          std::move(std::get<rmm::device_uvector<edge_t>>(property_edges[2 + *edge_id_prop_idx])))
-      : std::nullopt;
-  auto result_edge_types =
-    edge_type_prop_idx ? std::make_optional(std::move(std::get<rmm::device_uvector<edge_type_t>>(
-                           property_edges[2 + *edge_type_prop_idx])))
-                       : std::nullopt;
+  auto result_weights    = weight_prop_idx ? std::make_optional([&]() {
+    auto const idx = 2 + *weight_prop_idx;
+    CUGRAPH_EXPECTS(
+      idx < property_edges.size(),
+      "neighbor_sample output: weight index %zu out of range (property_edges.size()=%zu)",
+      idx,
+      property_edges.size());
+    CUGRAPH_EXPECTS(
+      std::holds_alternative<rmm::device_uvector<weight_t>>(property_edges[idx]),
+      "neighbor_sample output: property_edges[%zu] expected rmm::device_uvector<weight_t>, "
+         "variant index %zu",
+      idx,
+      property_edges[idx].index());
+    return std::move(std::get<rmm::device_uvector<weight_t>>(property_edges[idx]));
+  }())
+                                           : std::nullopt;
+  auto result_edge_ids   = edge_id_prop_idx ? std::make_optional([&]() {
+    auto const idx = 2 + *edge_id_prop_idx;
+    CUGRAPH_EXPECTS(
+      idx < property_edges.size(),
+      "neighbor_sample output: edge_id index %zu out of range (property_edges.size()=%zu)",
+      idx,
+      property_edges.size());
+    CUGRAPH_EXPECTS(
+      std::holds_alternative<rmm::device_uvector<edge_t>>(property_edges[idx]),
+      "neighbor_sample output: property_edges[%zu] expected rmm::device_uvector<edge_t>, "
+        "variant index %zu",
+      idx,
+      property_edges[idx].index());
+    return std::move(std::get<rmm::device_uvector<edge_t>>(property_edges[idx]));
+  }())
+                                            : std::nullopt;
+  auto result_edge_types = edge_type_prop_idx ? std::make_optional([&]() {
+    auto const idx = 2 + *edge_type_prop_idx;
+    CUGRAPH_EXPECTS(
+      idx < property_edges.size(),
+      "neighbor_sample output: edge_type index %zu out of range (property_edges.size()=%zu)",
+      idx,
+      property_edges.size());
+    CUGRAPH_EXPECTS(
+      std::holds_alternative<rmm::device_uvector<edge_type_t>>(property_edges[idx]),
+      "neighbor_sample output: property_edges[%zu] expected rmm::device_uvector<edge_type_t>, "
+      "variant index %zu",
+      idx,
+      property_edges[idx].index());
+    return std::move(std::get<rmm::device_uvector<edge_type_t>>(property_edges[idx]));
+  }())
+                                              : std::nullopt;
 
   return std::make_tuple(std::move(result_srcs),
                          std::move(result_dsts),

--- a/cpp/src/sampling/temporal_sampling_impl.cuh
+++ b/cpp/src/sampling/temporal_sampling_impl.cuh
@@ -537,14 +537,14 @@ temporal_neighbor_sample_impl(
     "Invalid input argument: LAST neighbor selection does not accept edge "
     "biases.");
 
-  // FIXME: LAST ranks eligible edges by converting timestamps to double
-  // (detail::last_n_time_bias) so per_v_top_k_select_transform_outgoing_e can
-  // sort them. A double represents every integer in [-2^53, 2^53] exactly;
-  // larger magnitudes are monotonic but not strictly unique (unix-ns ~2^60 has
-  // ULP 128). int32_t and unix s/ms/us fall in the exact range. A wrong last-n
-  // SET is possible only when more than fanout K eligible times on one source
-  // sit in a non-unique double bucket at the end of the walk (latest times for
-  // increasing, earliest for decreasing).
+  // LAST ranks eligible edges by converting timestamps to double bias values
+  // (detail::last_n_time_bias) for per_v_top_k_select_transform_outgoing_e.
+  // int32 timestamps rank exactly over the full signed range. int64 timestamps
+  // rank exactly on [-2^52, 2^52 - 1] (typical unix seconds/milliseconds/microseconds);
+  // beyond that, biases remain strictly positive and order-preserving but may tie
+  // (e.g. nanosecond timestamps or very negative times), so LAST still returns
+  // fanout edges but the chosen set can be wrong when more than fanout K eligible
+  // edges on one source share the same bias bucket. Equal timestamps always tie.
 
   validate_no_duplicate_seeds<vertex_t, label_t>(handle, starting_vertices, starting_vertex_labels);
 

--- a/cpp/src/sampling/temporal_sampling_impl.cuh
+++ b/cpp/src/sampling/temporal_sampling_impl.cuh
@@ -160,13 +160,13 @@ void dedupe_temporal_frontier(
   std::optional<rmm::device_uvector<label_t>>& frontier_vertex_labels,
   std::optional<rmm::device_uvector<time_stamp_t>>& frontier_vertex_times,
   std::optional<rmm::device_uvector<time_stamp_t>>& frontier_vertex_window_ends,
-  temporal_sampling_comparison_t temporal_sampling_comparison)
+  temporal_sampling_comparison_t temporal_sampling_comparison,
+  bool fixed_window)
 {
   if (!frontier_vertex_times || frontier_vertices.size() < 2) { return; }
 
-  auto const n            = frontier_vertices.size();
-  bool const increasing   = !is_temporal_decreasing(temporal_sampling_comparison);
-  bool const fixed_window = is_fixed_window(temporal_sampling_comparison);
+  auto const n          = frontier_vertices.size();
+  bool const increasing = !is_temporal_decreasing(temporal_sampling_comparison);
 
   if (frontier_vertex_labels && frontier_vertex_window_ends) {
     rmm::device_uvector<vertex_t> out_vertices(n, handle.get_stream());
@@ -537,6 +537,15 @@ temporal_neighbor_sample_impl(
     "Invalid input argument: LAST neighbor selection does not accept edge "
     "biases.");
 
+  // FIXME: LAST ranks eligible edges by converting timestamps to double
+  // (detail::last_n_time_bias) so per_v_top_k_select_transform_outgoing_e can
+  // sort them. A double represents every integer in [-2^53, 2^53] exactly;
+  // larger magnitudes are monotonic but not strictly unique (unix-ns ~2^60 has
+  // ULP 128). int32_t and unix s/ms/us fall in the exact range. A wrong last-n
+  // SET is possible only when more than fanout K eligible times on one source
+  // sit in a non-unique double bucket at the end of the walk (latest times for
+  // increasing, earliest for decreasing).
+
   validate_no_duplicate_seeds<vertex_t, label_t>(handle, starting_vertices, starting_vertex_labels);
 
   // Get the number of hop.
@@ -696,7 +705,7 @@ temporal_neighbor_sample_impl(
     // bound (rather than the sampled edge's start time), so those lookups need storage of their
     // own; unlike the other modes' window starts, they are not spans into produced_edge_lists.
     bool const fixed_window_starts =
-      is_fixed_window(temporal_sampling_comparison) && frontier_vertex_times.has_value();
+      sampling_flags.fixed_window && frontier_vertex_times.has_value();
     std::vector<rmm::device_uvector<time_stamp_t>> next_frontier_window_start_vectors{};
     if (fixed_window_starts) { next_frontier_window_start_vectors.reserve(2); }
 
@@ -766,7 +775,8 @@ temporal_neighbor_sample_impl(
           std::move(visited_minor_labels),
           sampling_flags.with_replacement,
           temporal_sampling_comparison,
-          sampling_flags.neighbor_selection);
+          sampling_flags.neighbor_selection,
+          sampling_flags.fixed_window);
       if (n_edge_props > 0) {
         std::tie(srcs, dsts, props) = gather_sampled_properties(handle,
                                                                 graph_view,
@@ -865,6 +875,7 @@ temporal_neighbor_sample_impl(
           std::move(*visited_minors),
           std::move(visited_minor_labels),
           temporal_sampling_comparison,
+          sampling_flags.fixed_window,
           do_expensive_check);
 
       // See the level_Ks branch above: publish next-hop frontier spans, then store the edge list.
@@ -995,7 +1006,8 @@ temporal_neighbor_sample_impl(
                                                               frontier_vertex_labels,
                                                               frontier_vertex_times,
                                                               frontier_vertex_window_ends,
-                                                              temporal_sampling_comparison);
+                                                              temporal_sampling_comparison,
+                                                              sampling_flags.fixed_window);
   }
 
   // Assemble the output by concatenating every produced edge list, in order.

--- a/cpp/src/sampling/temporal_sampling_impl.cuh
+++ b/cpp/src/sampling/temporal_sampling_impl.cuh
@@ -809,6 +809,17 @@ temporal_neighbor_sample_impl(
           raft::device_span<time_stamp_t const>{next_frontier_window_start_vectors.back().data(),
                                                 next_frontier_window_start_vectors.back().size()});
       } else {
+        CUGRAPH_EXPECTS(
+          edge_start_time_prop_idx < props.size(),
+          "LAST/temporal level_Ks: edge_start_time_prop_idx %zu out of range (props.size()=%zu)",
+          edge_start_time_prop_idx,
+          props.size());
+        CUGRAPH_EXPECTS(std::holds_alternative<rmm::device_uvector<time_stamp_t>>(
+                          props[edge_start_time_prop_idx]),
+                        "LAST/temporal level_Ks: props[edge_start_time_prop_idx=%zu] expected "
+                        "rmm::device_uvector<time_stamp_t>, variant index %zu",
+                        edge_start_time_prop_idx,
+                        props[edge_start_time_prop_idx].index());
         auto const& edge_start_times =
           std::get<rmm::device_uvector<time_stamp_t>>(props[edge_start_time_prop_idx]);
         next_frontier_vertex_time_spans->push_back(
@@ -898,6 +909,17 @@ temporal_neighbor_sample_impl(
           raft::device_span<time_stamp_t const>{next_frontier_window_start_vectors.back().data(),
                                                 next_frontier_window_start_vectors.back().size()});
       } else {
+        CUGRAPH_EXPECTS(
+          edge_start_time_prop_idx < props.size(),
+          "LAST/temporal gather: edge_start_time_prop_idx %zu out of range (props.size()=%zu)",
+          edge_start_time_prop_idx,
+          props.size());
+        CUGRAPH_EXPECTS(std::holds_alternative<rmm::device_uvector<time_stamp_t>>(
+                          props[edge_start_time_prop_idx]),
+                        "LAST/temporal gather: props[edge_start_time_prop_idx=%zu] expected "
+                        "rmm::device_uvector<time_stamp_t>, variant index %zu",
+                        edge_start_time_prop_idx,
+                        props[edge_start_time_prop_idx].index());
         auto const& edge_start_times =
           std::get<rmm::device_uvector<time_stamp_t>>(props[edge_start_time_prop_idx]);
         next_frontier_vertex_time_spans->push_back(
@@ -1041,30 +1063,97 @@ temporal_neighbor_sample_impl(
                     : std::nullopt,
       label_to_output_comm_rank);
 
+  CUGRAPH_EXPECTS(std::holds_alternative<rmm::device_uvector<vertex_t>>(property_edges[0]),
+                  "LAST/temporal output: property_edges[0] expected rmm::device_uvector<vertex_t>, "
+                  "variant index %zu",
+                  property_edges[0].index());
+  CUGRAPH_EXPECTS(std::holds_alternative<rmm::device_uvector<vertex_t>>(property_edges[1]),
+                  "LAST/temporal output: property_edges[1] expected rmm::device_uvector<vertex_t>, "
+                  "variant index %zu",
+                  property_edges[1].index());
   result_srcs = std::move(std::get<rmm::device_uvector<vertex_t>>(property_edges[0]));
   result_dsts = std::move(std::get<rmm::device_uvector<vertex_t>>(property_edges[1]));
 
-  auto result_weights =
-    weight_prop_idx
-      ? std::make_optional(
-          std::move(std::get<rmm::device_uvector<weight_t>>(property_edges[2 + *weight_prop_idx])))
-      : std::nullopt;
-  auto result_edge_ids =
-    edge_id_prop_idx
-      ? std::make_optional(
-          std::move(std::get<rmm::device_uvector<edge_t>>(property_edges[2 + *edge_id_prop_idx])))
-      : std::nullopt;
-  auto result_edge_types =
-    edge_type_prop_idx ? std::make_optional(std::move(std::get<rmm::device_uvector<edge_type_t>>(
-                           property_edges[2 + *edge_type_prop_idx])))
-                       : std::nullopt;
+  auto result_weights    = weight_prop_idx ? std::make_optional([&]() {
+    auto const idx = 2 + *weight_prop_idx;
+    CUGRAPH_EXPECTS(
+      idx < property_edges.size(),
+      "LAST/temporal output: weight index %zu out of range (property_edges.size()=%zu)",
+      idx,
+      property_edges.size());
+    CUGRAPH_EXPECTS(
+      std::holds_alternative<rmm::device_uvector<weight_t>>(property_edges[idx]),
+      "LAST/temporal output: property_edges[%zu] expected rmm::device_uvector<weight_t>, "
+         "variant index %zu",
+      idx,
+      property_edges[idx].index());
+    return std::move(std::get<rmm::device_uvector<weight_t>>(property_edges[idx]));
+  }())
+                                           : std::nullopt;
+  auto result_edge_ids   = edge_id_prop_idx ? std::make_optional([&]() {
+    auto const idx = 2 + *edge_id_prop_idx;
+    CUGRAPH_EXPECTS(
+      idx < property_edges.size(),
+      "LAST/temporal output: edge_id index %zu out of range (property_edges.size()=%zu)",
+      idx,
+      property_edges.size());
+    CUGRAPH_EXPECTS(
+      std::holds_alternative<rmm::device_uvector<edge_t>>(property_edges[idx]),
+      "LAST/temporal output: property_edges[%zu] expected rmm::device_uvector<edge_t>, "
+        "variant index %zu",
+      idx,
+      property_edges[idx].index());
+    return std::move(std::get<rmm::device_uvector<edge_t>>(property_edges[idx]));
+  }())
+                                            : std::nullopt;
+  auto result_edge_types = edge_type_prop_idx ? std::make_optional([&]() {
+    auto const idx = 2 + *edge_type_prop_idx;
+    CUGRAPH_EXPECTS(
+      idx < property_edges.size(),
+      "LAST/temporal output: edge_type index %zu out of range (property_edges.size()=%zu)",
+      idx,
+      property_edges.size());
+    CUGRAPH_EXPECTS(
+      std::holds_alternative<rmm::device_uvector<edge_type_t>>(property_edges[idx]),
+      "LAST/temporal output: property_edges[%zu] expected rmm::device_uvector<edge_type_t>, "
+      "variant index %zu",
+      idx,
+      property_edges[idx].index());
+    return std::move(std::get<rmm::device_uvector<edge_type_t>>(property_edges[idx]));
+  }())
+                                              : std::nullopt;
+  {
+    auto const idx = 2 + edge_start_time_prop_idx;
+    CUGRAPH_EXPECTS(
+      idx < property_edges.size(),
+      "LAST/temporal output: edge_start_time index %zu out of range (property_edges.size()=%zu)",
+      idx,
+      property_edges.size());
+    CUGRAPH_EXPECTS(
+      std::holds_alternative<rmm::device_uvector<time_stamp_t>>(property_edges[idx]),
+      "LAST/temporal output: property_edges[%zu] expected rmm::device_uvector<time_stamp_t>, "
+      "variant index %zu",
+      idx,
+      property_edges[idx].index());
+  }
   auto result_edge_start_times = std::move(
     std::get<rmm::device_uvector<time_stamp_t>>(property_edges[2 + edge_start_time_prop_idx]));
-  auto result_edge_end_times =
-    edge_end_time_prop_idx
-      ? std::make_optional(std::move(
-          std::get<rmm::device_uvector<time_stamp_t>>(property_edges[2 + *edge_end_time_prop_idx])))
-      : std::nullopt;
+  auto result_edge_end_times = edge_end_time_prop_idx ? std::make_optional([&]() {
+    auto const idx = 2 + *edge_end_time_prop_idx;
+    CUGRAPH_EXPECTS(
+      idx < property_edges.size(),
+      "LAST/temporal output: edge_end_time index %zu out of range (property_edges.size()=%zu)",
+      idx,
+      property_edges.size());
+    CUGRAPH_EXPECTS(
+      std::holds_alternative<rmm::device_uvector<time_stamp_t>>(property_edges[idx]),
+      "LAST/temporal output: property_edges[%zu] expected rmm::device_uvector<time_stamp_t>, "
+      "variant index %zu",
+      idx,
+      property_edges[idx].index());
+    return std::move(std::get<rmm::device_uvector<time_stamp_t>>(property_edges[idx]));
+  }())
+                                                      : std::nullopt;
 
   return std::make_tuple(std::move(result_srcs),
                          std::move(result_dsts),

--- a/cpp/tests/c_api/mg_test_utils.cpp
+++ b/cpp/tests/c_api/mg_test_utils.cpp
@@ -1692,8 +1692,10 @@ int mg_validate_sample_result(const cugraph_resource_handle_t* handle,
           }
         }
 
-        if (validate_edge_times) {
-          // Check that the edge times are moving in the correct direction
+        if (validate_edge_times && internal_sampling_options->fixed_window_ != TRUE) {
+          // Check that the edge times are moving in the correct direction. fixed_window is
+          // excluded because it reuses the original seed window at every hop and does not impose
+          // path-wise monotonicity.
           time_stamp_t previous_vertex_times[num_vertices];
           for (size_t i = 0; i < num_vertices; ++i)
             if (temporal_sampling_comparison == STRICTLY_INCREASING) {

--- a/cpp/tests/c_api/mg_uniform_temporal_neighbor_sample_test.c
+++ b/cpp/tests/c_api/mg_uniform_temporal_neighbor_sample_test.c
@@ -796,6 +796,7 @@ int generic_neighbor_sample_expected_edges_test(
   size_t fan_out_size,
   cugraph_temporal_sampling_comparison_t temporal_sampling_comparison,
   cugraph_neighbor_selection_t neighbor_selection,
+  bool_t fixed_window,
   expected_temporal_sample_edge_t const* expected_edges,
   size_t num_expected_edges)
 {
@@ -902,6 +903,7 @@ int generic_neighbor_sample_expected_edges_test(
   cugraph_sampling_set_temporal_sampling_comparison(sampling_options, temporal_sampling_comparison);
   cugraph_sampling_set_disjoint_sampling(sampling_options, TRUE);
   cugraph_sampling_set_neighbor_selection(sampling_options, neighbor_selection);
+  cugraph_sampling_set_fixed_window(sampling_options, fixed_window);
 
   ret_code = cugraph_neighbor_sample(handle,
                                      rng_state,
@@ -960,7 +962,7 @@ int test_mg_neighbor_sample_fixed_window_multihop(const cugraph_resource_handle_
   size_t fan_out_size = 2;
   size_t num_starts   = 1;
 
-  // FIXED_WINDOW keeps seed window [10, 100] at hop 1, so both 1->2 (t=30) and 1->3 (t=80) remain
+  // fixed_window keeps seed window [10, 100] at hop 1, so both 1->2 (t=30) and 1->3 (t=80) remain
   // eligible.
   vertex_t src[]                          = {0, 1, 1};
   vertex_t dst[]                          = {1, 2, 3};
@@ -998,8 +1000,59 @@ int test_mg_neighbor_sample_fixed_window_multihop(const cugraph_resource_handle_
     num_starts,
     fan_out,
     fan_out_size,
-    FIXED_WINDOW,
+    MONOTONICALLY_INCREASING,
     CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+    TRUE,
+    expected_edges,
+    sizeof(expected_edges) / sizeof(expected_edges[0]));
+}
+
+int test_mg_neighbor_sample_last_increasing(const cugraph_resource_handle_t* handle)
+{
+  size_t num_edges    = 4;
+  size_t fan_out_size = 1;
+  size_t num_starts   = 1;
+
+  // The destination vertices span partitions. LAST must perform a distributed top-K and return
+  // the two latest eligible edges, independent of where those edges are stored.
+  vertex_t src[]                          = {0, 0, 0, 0};
+  vertex_t dst[]                          = {1, 2, 3, 4};
+  edge_t edge_ids[]                       = {0, 1, 2, 3};
+  weight_t weight[]                       = {0.1, 0.2, 0.3, 0.4};
+  int32_t edge_types[]                    = {0, 0, 0, 0};
+  time_stamp_t edge_start_times[]         = {10, 20, 30, 40};
+  time_stamp_t edge_end_times[]           = {11, 21, 31, 41};
+  vertex_t start[]                        = {0};
+  time_stamp_t start_vertex_start_times[] = {0};
+  time_stamp_t start_vertex_end_times[]   = {50};
+  size_t start_vertex_label_offsets[]     = {0, 1};
+  int fan_out[]                           = {2};
+
+  expected_temporal_sample_edge_t expected_edges[] = {
+    {0, 3, 30, 0},
+    {0, 4, 40, 0},
+  };
+
+  return generic_neighbor_sample_expected_edges_test(
+    handle,
+    src,
+    dst,
+    weight,
+    edge_ids,
+    edge_types,
+    edge_start_times,
+    edge_end_times,
+    num_edges,
+    start,
+    start_vertex_start_times,
+    start_vertex_end_times,
+    start_vertex_label_offsets,
+    num_starts,
+    fan_out,
+    fan_out_size,
+    MONOTONICALLY_INCREASING,
+    CUGRAPH_NEIGHBOR_SELECTION_LAST,
+    FALSE,
     expected_edges,
     sizeof(expected_edges) / sizeof(expected_edges[0]));
 }
@@ -1016,6 +1069,7 @@ int main(int argc, char** argv)
   result |= RUN_MG_TEST(test_uniform_temporal_neighbor_sample_time_window, handle);
   result |= RUN_MG_TEST(test_uniform_temporal_neighbor_from_alex, handle);
   result |= RUN_MG_TEST(test_mg_neighbor_sample_fixed_window_multihop, handle);
+  result |= RUN_MG_TEST(test_mg_neighbor_sample_last_increasing, handle);
   // result |= RUN_MG_TEST(test_uniform_temporal_neighbor_sample_dedupe_sources, handle);
   // result |= RUN_MG_TEST(test_uniform_temporal_neighbor_sample_unique_sources, handle);
   // result |= RUN_MG_TEST(test_uniform_temporal_neighbor_sample_carry_over_sources, handle);

--- a/cpp/tests/c_api/test_utils.cpp
+++ b/cpp/tests/c_api/test_utils.cpp
@@ -1012,8 +1012,8 @@ extern "C" int validate_sample_result(const cugraph_resource_handle_t* handle,
         }
       }
 
-      if (validate_edge_times && temporal_sampling_comparison != FIXED_WINDOW) {
-        // Check that the edge times are moving in the correct direction. FIXED_WINDOW is excluded
+      if (validate_edge_times && internal_sampling_options->fixed_window_ != TRUE) {
+        // Check that the edge times are moving in the correct direction. fixed_window is excluded
         // because it reuses the original seed window at every hop and does not impose path-wise
         // monotonicity.
         time_stamp_t previous_vertex_times[num_vertices];

--- a/cpp/tests/c_api/uniform_temporal_neighbor_sample_test.c
+++ b/cpp/tests/c_api/uniform_temporal_neighbor_sample_test.c
@@ -201,7 +201,7 @@ cleanup:
   return test_ret_value;
 }
 
-int generic_uniform_temporal_neighbor_sample_test(
+int generic_uniform_temporal_neighbor_sample_test_impl(
   const cugraph_resource_handle_t* handle,
   vertex_t* h_src,
   vertex_t* h_dst,
@@ -226,9 +226,11 @@ int generic_uniform_temporal_neighbor_sample_test(
   bool_t dedupe_sources,
   cugraph_temporal_sampling_comparison_t temporal_sampling_comparison,
   cugraph_neighbor_selection_t neighbor_selection,
+  bool_t fixed_window,
   bool_t renumber_results,
   expected_temporal_sample_edge_t const* expected_edges,
-  size_t num_expected_edges)
+  size_t num_expected_edges,
+  bool_t is_multigraph)
 {
   // Create graph
   int test_ret_value              = 0;
@@ -255,7 +257,7 @@ int generic_uniform_temporal_neighbor_sample_test(
                                   FALSE,
                                   TRUE,
                                   FALSE,
-                                  FALSE,
+                                  is_multigraph,
                                   &graph,
                                   &ret_error);
 
@@ -341,6 +343,7 @@ int generic_uniform_temporal_neighbor_sample_test(
   // Temporal neighbor sampling requires disjoint sampling.
   cugraph_sampling_set_disjoint_sampling(sampling_options, TRUE);
   cugraph_sampling_set_neighbor_selection(sampling_options, neighbor_selection);
+  cugraph_sampling_set_fixed_window(sampling_options, fixed_window);
 
   ret_code = cugraph_neighbor_sample(handle,
                                      rng_state,
@@ -404,6 +407,67 @@ int generic_uniform_temporal_neighbor_sample_test(
   cugraph_error_free(ret_error);
 
   return test_ret_value;
+}
+
+int generic_uniform_temporal_neighbor_sample_test(
+  const cugraph_resource_handle_t* handle,
+  vertex_t* h_src,
+  vertex_t* h_dst,
+  weight_t* h_wgt,
+  edge_t* h_edge_ids,
+  int32_t* h_edge_types,
+  time_stamp_t* h_edge_start_times,
+  time_stamp_t* h_edge_end_times,
+  size_t num_vertices,
+  size_t num_edges,
+  vertex_t* h_start,
+  time_stamp_t* h_start_vertex_start_times,
+  time_stamp_t* h_start_vertex_end_times,
+  size_t* h_start_vertex_label_offsets,
+  size_t num_start_vertices,
+  size_t num_start_labels,
+  int* fan_out,
+  size_t fan_out_size,
+  bool_t with_replacement,
+  bool_t return_hops,
+  cugraph_prior_sources_behavior_t prior_sources_behavior,
+  bool_t dedupe_sources,
+  cugraph_temporal_sampling_comparison_t temporal_sampling_comparison,
+  cugraph_neighbor_selection_t neighbor_selection,
+  bool_t fixed_window,
+  bool_t renumber_results,
+  expected_temporal_sample_edge_t const* expected_edges,
+  size_t num_expected_edges)
+{
+  return generic_uniform_temporal_neighbor_sample_test_impl(handle,
+                                                            h_src,
+                                                            h_dst,
+                                                            h_wgt,
+                                                            h_edge_ids,
+                                                            h_edge_types,
+                                                            h_edge_start_times,
+                                                            h_edge_end_times,
+                                                            num_vertices,
+                                                            num_edges,
+                                                            h_start,
+                                                            h_start_vertex_start_times,
+                                                            h_start_vertex_end_times,
+                                                            h_start_vertex_label_offsets,
+                                                            num_start_vertices,
+                                                            num_start_labels,
+                                                            fan_out,
+                                                            fan_out_size,
+                                                            with_replacement,
+                                                            return_hops,
+                                                            prior_sources_behavior,
+                                                            dedupe_sources,
+                                                            temporal_sampling_comparison,
+                                                            neighbor_selection,
+                                                            fixed_window,
+                                                            renumber_results,
+                                                            expected_edges,
+                                                            num_expected_edges,
+                                                            FALSE);
 }
 
 int test_uniform_temporal_neighbor_sample_with_labels(const cugraph_resource_handle_t* handle)
@@ -691,6 +755,7 @@ int test_uniform_temporal_neighbor_sample_clean(const cugraph_resource_handle_t*
                                                        dedupe_sources,
                                                        temporal_sampling_comparison,
                                                        CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+                                                       FALSE,
                                                        renumber_results,
                                                        NULL,
                                                        0);
@@ -756,6 +821,7 @@ int test_uniform_temporal_neighbor_sample_dedupe_sources(const cugraph_resource_
                                                        dedupe_sources,
                                                        temporal_sampling_comparison,
                                                        CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+                                                       FALSE,
                                                        renumber_results,
                                                        NULL,
                                                        0);
@@ -821,6 +887,7 @@ int test_uniform_temporal_neighbor_sample_unique_sources(const cugraph_resource_
                                                        dedupe_sources,
                                                        temporal_sampling_comparison,
                                                        CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+                                                       FALSE,
                                                        renumber_results,
                                                        NULL,
                                                        0);
@@ -887,6 +954,7 @@ int test_uniform_temporal_neighbor_sample_carry_over_sources(
                                                        dedupe_sources,
                                                        temporal_sampling_comparison,
                                                        CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+                                                       FALSE,
                                                        renumber_results,
                                                        NULL,
                                                        0);
@@ -952,6 +1020,7 @@ int test_uniform_temporal_neighbor_sample_renumber_results(const cugraph_resourc
                                                        dedupe_sources,
                                                        temporal_sampling_comparison,
                                                        CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+                                                       FALSE,
                                                        renumber_results,
                                                        NULL,
                                                        0);
@@ -1018,6 +1087,7 @@ int test_uniform_temporal_neighbor_sample_strictly_increasing(
                                                        dedupe_sources,
                                                        temporal_sampling_comparison,
                                                        CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+                                                       FALSE,
                                                        renumber_results,
                                                        NULL,
                                                        0);
@@ -1084,6 +1154,7 @@ int test_uniform_temporal_neighbor_sample_monotonically_decreasing(
                                                        dedupe_sources,
                                                        temporal_sampling_comparison,
                                                        CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+                                                       FALSE,
                                                        renumber_results,
                                                        NULL,
                                                        0);
@@ -1150,6 +1221,7 @@ int test_uniform_temporal_neighbor_sample_strictly_decreasing(
                                                        dedupe_sources,
                                                        temporal_sampling_comparison,
                                                        CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+                                                       FALSE,
                                                        renumber_results,
                                                        NULL,
                                                        0);
@@ -1218,6 +1290,7 @@ int test_uniform_temporal_neighbor_sample_with_vertex_start_times(
                                                        dedupe_sources,
                                                        temporal_sampling_comparison,
                                                        CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+                                                       FALSE,
                                                        renumber_results,
                                                        NULL,
                                                        0);
@@ -1284,6 +1357,7 @@ int test_uniform_temporal_neighbor_sample_with_vertex_end_times(
     dedupe_sources,
     temporal_sampling_comparison,
     CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+    FALSE,
     renumber_results,
     expected_edges,
     sizeof(expected_edges) / sizeof(expected_edges[0]));
@@ -1351,6 +1425,7 @@ int test_uniform_temporal_neighbor_sample_with_vertex_end_times_limits_multihop(
     dedupe_sources,
     temporal_sampling_comparison,
     CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+    FALSE,
     renumber_results,
     expected_edges,
     sizeof(expected_edges) / sizeof(expected_edges[0]));
@@ -1417,6 +1492,7 @@ int test_uniform_temporal_neighbor_sample_with_per_seed_time_windows(
     dedupe_sources,
     temporal_sampling_comparison,
     CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+    FALSE,
     renumber_results,
     expected_edges,
     sizeof(expected_edges) / sizeof(expected_edges[0]));
@@ -1484,6 +1560,7 @@ int test_uniform_temporal_neighbor_sample_with_vertex_end_times_monotonically_de
     dedupe_sources,
     temporal_sampling_comparison,
     CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+    FALSE,
     renumber_results,
     expected_edges,
     sizeof(expected_edges) / sizeof(expected_edges[0]));
@@ -1550,6 +1627,7 @@ int test_uniform_temporal_neighbor_sample_with_start_time_only_monotonically_dec
     dedupe_sources,
     temporal_sampling_comparison,
     CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+    FALSE,
     renumber_results,
     expected_edges,
     sizeof(expected_edges) / sizeof(expected_edges[0]));
@@ -1567,7 +1645,7 @@ int test_uniform_temporal_neighbor_sample_fixed_window_multihop(
   // Chain/fork: 0->1 (t=50), then from 1: 1->2 (t=30) and 1->3 (t=80).
   // Seed window [10, 100].
   // MONOTONICALLY_INCREASING would exclude 1->2 after sampling 0->1, because hop-2 would require
-  // edge_time >= 50. FIXED_WINDOW keeps applying [10, 100] at every hop, so both 1->2 and 1->3
+  // edge_time >= 50. fixed_window keeps applying [10, 100] at every hop, so both 1->2 and 1->3
   // remain eligible.
   vertex_t src[]                          = {0, 1, 1};
   vertex_t dst[]                          = {1, 2, 3};
@@ -1587,7 +1665,7 @@ int test_uniform_temporal_neighbor_sample_fixed_window_multihop(
   cugraph_prior_sources_behavior_t prior_sources_behavior             = DEFAULT;
   bool_t dedupe_sources                                               = FALSE;
   bool_t renumber_results                                             = FALSE;
-  cugraph_temporal_sampling_comparison_t temporal_sampling_comparison = FIXED_WINDOW;
+  cugraph_temporal_sampling_comparison_t temporal_sampling_comparison = MONOTONICALLY_INCREASING;
 
   expected_temporal_sample_edge_t expected_edges[] = {
     {0, 1, 50, 0},
@@ -1620,9 +1698,245 @@ int test_uniform_temporal_neighbor_sample_fixed_window_multihop(
     dedupe_sources,
     temporal_sampling_comparison,
     CUGRAPH_NEIGHBOR_SELECTION_RANDOM,
+    TRUE,
     renumber_results,
     expected_edges,
     sizeof(expected_edges) / sizeof(expected_edges[0]));
+}
+
+int test_uniform_temporal_neighbor_sample_last_increasing(const cugraph_resource_handle_t* handle)
+{
+  size_t num_edges        = 4;
+  size_t num_vertices     = 5;
+  size_t fan_out_size     = 1;
+  size_t num_starts       = 1;
+  size_t num_start_labels = 2;
+
+  // The seed window [-4, 9] first removes times -5 and 10. LAST with an increasing comparison
+  // then chooses the later of the remaining eligible times, 5.
+  vertex_t src[]                          = {0, 0, 0, 0};
+  vertex_t dst[]                          = {1, 2, 3, 4};
+  edge_t edge_ids[]                       = {0, 1, 2, 3};
+  weight_t weight[]                       = {0.1, 0.2, 0.3, 0.4};
+  int32_t edge_types[]                    = {0, 0, 0, 0};
+  time_stamp_t edge_start_times[]         = {-5, 0, 5, 10};
+  time_stamp_t edge_end_times[]           = {-4, 1, 6, 11};
+  vertex_t start[]                        = {0};
+  time_stamp_t start_vertex_start_times[] = {-4};
+  time_stamp_t start_vertex_end_times[]   = {9};
+  size_t start_vertex_label_offsets[]     = {0, 1};
+  int fan_out[]                           = {1};
+
+  expected_temporal_sample_edge_t expected_edges[] = {{0, 3, 5, 0}};
+
+  return generic_uniform_temporal_neighbor_sample_test(
+    handle,
+    src,
+    dst,
+    weight,
+    edge_ids,
+    edge_types,
+    edge_start_times,
+    edge_end_times,
+    num_vertices,
+    num_edges,
+    start,
+    start_vertex_start_times,
+    start_vertex_end_times,
+    start_vertex_label_offsets,
+    num_starts,
+    num_start_labels,
+    fan_out,
+    fan_out_size,
+    FALSE,
+    TRUE,
+    DEFAULT,
+    FALSE,
+    MONOTONICALLY_INCREASING,
+    CUGRAPH_NEIGHBOR_SELECTION_LAST,
+    FALSE,
+    FALSE,
+    expected_edges,
+    sizeof(expected_edges) / sizeof(expected_edges[0]));
+}
+
+int test_uniform_temporal_neighbor_sample_last_decreasing(const cugraph_resource_handle_t* handle)
+{
+  size_t num_edges        = 4;
+  size_t num_vertices     = 5;
+  size_t fan_out_size     = 1;
+  size_t num_starts       = 1;
+  size_t num_start_labels = 2;
+
+  // The same eligible set as the increasing test is ranked in the opposite direction:
+  // decreasing LAST chooses the earlier eligible time, 0.
+  vertex_t src[]                          = {0, 0, 0, 0};
+  vertex_t dst[]                          = {1, 2, 3, 4};
+  edge_t edge_ids[]                       = {0, 1, 2, 3};
+  weight_t weight[]                       = {0.1, 0.2, 0.3, 0.4};
+  int32_t edge_types[]                    = {0, 0, 0, 0};
+  time_stamp_t edge_start_times[]         = {-5, 0, 5, 10};
+  time_stamp_t edge_end_times[]           = {-4, 1, 6, 11};
+  vertex_t start[]                        = {0};
+  time_stamp_t start_vertex_start_times[] = {-4};
+  time_stamp_t start_vertex_end_times[]   = {9};
+  size_t start_vertex_label_offsets[]     = {0, 1};
+  int fan_out[]                           = {1};
+
+  expected_temporal_sample_edge_t expected_edges[] = {{0, 2, 0, 0}};
+
+  return generic_uniform_temporal_neighbor_sample_test(
+    handle,
+    src,
+    dst,
+    weight,
+    edge_ids,
+    edge_types,
+    edge_start_times,
+    edge_end_times,
+    num_vertices,
+    num_edges,
+    start,
+    start_vertex_start_times,
+    start_vertex_end_times,
+    start_vertex_label_offsets,
+    num_starts,
+    num_start_labels,
+    fan_out,
+    fan_out_size,
+    FALSE,
+    TRUE,
+    DEFAULT,
+    FALSE,
+    MONOTONICALLY_DECREASING,
+    CUGRAPH_NEIGHBOR_SELECTION_LAST,
+    FALSE,
+    FALSE,
+    expected_edges,
+    sizeof(expected_edges) / sizeof(expected_edges[0]));
+}
+
+int test_uniform_temporal_neighbor_sample_last_fixed_window_multihop(
+  const cugraph_resource_handle_t* handle)
+{
+  size_t num_edges        = 4;
+  size_t num_vertices     = 5;
+  size_t fan_out_size     = 2;
+  size_t num_starts       = 1;
+  size_t num_start_labels = 2;
+
+  // Hop 0 selects 0->1 at time 50. All of vertex 1's edges are earlier than 50, so they would be
+  // ineligible if the sampled time propagated. fixed_window reapplies [10, 100], and LAST picks
+  // the latest of them (time 40).
+  vertex_t src[]                          = {0, 1, 1, 1};
+  vertex_t dst[]                          = {1, 2, 3, 4};
+  edge_t edge_ids[]                       = {0, 1, 2, 3};
+  weight_t weight[]                       = {0.1, 0.2, 0.3, 0.4};
+  int32_t edge_types[]                    = {0, 0, 0, 0};
+  time_stamp_t edge_start_times[]         = {50, 20, 30, 40};
+  time_stamp_t edge_end_times[]           = {51, 21, 31, 41};
+  vertex_t start[]                        = {0};
+  time_stamp_t start_vertex_start_times[] = {10};
+  time_stamp_t start_vertex_end_times[]   = {100};
+  size_t start_vertex_label_offsets[]     = {0, 1};
+  int fan_out[]                           = {1, 1};
+
+  expected_temporal_sample_edge_t expected_edges[] = {
+    {0, 1, 50, 0},
+    {1, 4, 40, 1},
+  };
+
+  return generic_uniform_temporal_neighbor_sample_test(
+    handle,
+    src,
+    dst,
+    weight,
+    edge_ids,
+    edge_types,
+    edge_start_times,
+    edge_end_times,
+    num_vertices,
+    num_edges,
+    start,
+    start_vertex_start_times,
+    start_vertex_end_times,
+    start_vertex_label_offsets,
+    num_starts,
+    num_start_labels,
+    fan_out,
+    fan_out_size,
+    FALSE,
+    TRUE,
+    DEFAULT,
+    FALSE,
+    MONOTONICALLY_INCREASING,
+    CUGRAPH_NEIGHBOR_SELECTION_LAST,
+    TRUE,
+    FALSE,
+    expected_edges,
+    sizeof(expected_edges) / sizeof(expected_edges[0]));
+}
+
+int test_uniform_temporal_neighbor_sample_last_refills_after_duplicate_destination(
+  const cugraph_resource_handle_t* handle)
+{
+  size_t num_edges        = 4;
+  size_t num_vertices     = 4;
+  size_t fan_out_size     = 1;
+  size_t num_starts       = 1;
+  size_t num_start_labels = 2;
+
+  // The first top-2 edges both target vertex 1. Disjoint sampling keeps the time-100 edge, then
+  // refills the remaining slot. LAST must choose time 80 from the remaining destinations, not a
+  // random candidate (time 70).
+  vertex_t src[]                          = {0, 0, 0, 0};
+  vertex_t dst[]                          = {1, 1, 2, 3};
+  edge_t edge_ids[]                       = {0, 1, 2, 3};
+  weight_t weight[]                       = {0.1, 0.2, 0.3, 0.4};
+  int32_t edge_types[]                    = {0, 0, 0, 0};
+  time_stamp_t edge_start_times[]         = {100, 90, 80, 70};
+  time_stamp_t edge_end_times[]           = {101, 91, 81, 71};
+  vertex_t start[]                        = {0};
+  time_stamp_t start_vertex_start_times[] = {0};
+  time_stamp_t start_vertex_end_times[]   = {100};
+  size_t start_vertex_label_offsets[]     = {0, 1};
+  int fan_out[]                           = {2};
+
+  expected_temporal_sample_edge_t expected_edges[] = {
+    {0, 1, 100, 0},
+    {0, 2, 80, 0},
+  };
+
+  return generic_uniform_temporal_neighbor_sample_test_impl(
+    handle,
+    src,
+    dst,
+    weight,
+    edge_ids,
+    edge_types,
+    edge_start_times,
+    edge_end_times,
+    num_vertices,
+    num_edges,
+    start,
+    start_vertex_start_times,
+    start_vertex_end_times,
+    start_vertex_label_offsets,
+    num_starts,
+    num_start_labels,
+    fan_out,
+    fan_out_size,
+    FALSE,
+    TRUE,
+    DEFAULT,
+    FALSE,
+    MONOTONICALLY_INCREASING,
+    CUGRAPH_NEIGHBOR_SELECTION_LAST,
+    FALSE,
+    FALSE,
+    expected_edges,
+    sizeof(expected_edges) / sizeof(expected_edges[0]),
+    TRUE);
 }
 
 int main(int argc, char** argv)
@@ -1651,6 +1965,11 @@ int main(int argc, char** argv)
   result |= RUN_TEST_NEW(
     test_uniform_temporal_neighbor_sample_with_start_time_only_monotonically_decreasing, handle);
   result |= RUN_TEST_NEW(test_uniform_temporal_neighbor_sample_fixed_window_multihop, handle);
+  result |= RUN_TEST_NEW(test_uniform_temporal_neighbor_sample_last_increasing, handle);
+  result |= RUN_TEST_NEW(test_uniform_temporal_neighbor_sample_last_decreasing, handle);
+  result |= RUN_TEST_NEW(test_uniform_temporal_neighbor_sample_last_fixed_window_multihop, handle);
+  result |= RUN_TEST_NEW(
+    test_uniform_temporal_neighbor_sample_last_refills_after_duplicate_destination, handle);
 
   cugraph_free_resource_handle(handle);
 

--- a/cpp/tests/c_api/uniform_temporal_neighbor_sample_test.c
+++ b/cpp/tests/c_api/uniform_temporal_neighbor_sample_test.c
@@ -11,6 +11,7 @@
 
 #include <math.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -196,6 +197,350 @@ cleanup:
   free(h_hops);
   free(actual_edges);
   free(sorted_expected);
+  cugraph_error_free(ret_error);
+
+  return test_ret_value;
+}
+
+typedef struct {
+  vertex_t src;
+  vertex_t dst;
+  int64_t edge_start_time;
+  int32_t hop;
+} expected_temporal_sample_edge_i64_t;
+
+int expected_temporal_sample_edge_i64_compare(const void* a, const void* b)
+{
+  expected_temporal_sample_edge_i64_t const* lhs = (expected_temporal_sample_edge_i64_t const*)a;
+  expected_temporal_sample_edge_i64_t const* rhs = (expected_temporal_sample_edge_i64_t const*)b;
+
+  if (lhs->src != rhs->src) return (lhs->src < rhs->src) ? -1 : 1;
+  if (lhs->dst != rhs->dst) return (lhs->dst < rhs->dst) ? -1 : 1;
+  if (lhs->edge_start_time != rhs->edge_start_time) {
+    return (lhs->edge_start_time < rhs->edge_start_time) ? -1 : 1;
+  }
+  if (lhs->hop != rhs->hop) return (lhs->hop < rhs->hop) ? -1 : 1;
+  return 0;
+}
+
+int compare_uniform_temporal_neighbor_sample_i64_to_expected(
+  const cugraph_resource_handle_t* handle,
+  const cugraph_sample_result_t* result,
+  expected_temporal_sample_edge_i64_t const* expected_edges,
+  size_t num_expected_edges,
+  bool_t compare_hops,
+  size_t fan_out_size)
+{
+  int test_ret_value            = 0;
+  cugraph_error_code_t ret_code = CUGRAPH_SUCCESS;
+  cugraph_error_t* ret_error    = NULL;
+
+  cugraph_type_erased_device_array_view_t* result_srcs                   = NULL;
+  cugraph_type_erased_device_array_view_t* result_dsts                   = NULL;
+  cugraph_type_erased_device_array_view_t* result_edge_start_times       = NULL;
+  cugraph_type_erased_device_array_view_t* result_hops                   = NULL;
+  cugraph_type_erased_device_array_view_t* result_label_hop_offsets      = NULL;
+  cugraph_type_erased_device_array_view_t* result_label_type_hop_offsets = NULL;
+
+  result_srcs                   = cugraph_sample_result_get_majors(result);
+  result_dsts                   = cugraph_sample_result_get_destinations(result);
+  result_edge_start_times       = cugraph_sample_result_get_edge_start_time(result);
+  result_hops                   = cugraph_sample_result_get_hop(result);
+  result_label_hop_offsets      = cugraph_sample_result_get_label_hop_offsets(result);
+  result_label_type_hop_offsets = cugraph_sample_result_get_label_type_hop_offsets(result);
+
+  size_t result_size = cugraph_type_erased_device_array_view_size(result_srcs);
+
+  TEST_ASSERT(
+    test_ret_value, result_size == num_expected_edges, "unexpected number of sampled edges");
+
+  if (test_ret_value != 0) { return test_ret_value; }
+
+  vertex_t* h_srcs            = (vertex_t*)malloc(result_size * sizeof(vertex_t));
+  vertex_t* h_dsts            = (vertex_t*)malloc(result_size * sizeof(vertex_t));
+  int64_t* h_edge_start_times = (int64_t*)malloc(result_size * sizeof(int64_t));
+  int32_t* h_hops = compare_hops ? (int32_t*)malloc(result_size * sizeof(int32_t)) : NULL;
+  expected_temporal_sample_edge_i64_t* actual_edges = (expected_temporal_sample_edge_i64_t*)malloc(
+    result_size * sizeof(expected_temporal_sample_edge_i64_t));
+  expected_temporal_sample_edge_i64_t* sorted_expected =
+    (expected_temporal_sample_edge_i64_t*)malloc(num_expected_edges *
+                                                 sizeof(expected_temporal_sample_edge_i64_t));
+
+  if (!h_srcs || !h_dsts || !h_edge_start_times || !actual_edges || !sorted_expected ||
+      (compare_hops && !h_hops)) {
+    test_ret_value = 1;
+    goto cleanup;
+  }
+
+  ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+    handle, (byte_t*)h_srcs, result_srcs, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+  ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+    handle, (byte_t*)h_dsts, result_dsts, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+  ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+    handle, (byte_t*)h_edge_start_times, result_edge_start_times, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+  if (compare_hops) {
+    if (result_hops != NULL) {
+      ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+        handle, (byte_t*)h_hops, result_hops, &ret_error);
+      TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+    } else if ((result_label_type_hop_offsets != NULL) || (result_label_hop_offsets != NULL)) {
+      cugraph_type_erased_device_array_view_t* offsets_view =
+        (result_label_type_hop_offsets != NULL) ? result_label_type_hop_offsets
+                                                : result_label_hop_offsets;
+      size_t offsets_size = cugraph_type_erased_device_array_view_size(offsets_view);
+      size_t* h_offsets   = (size_t*)malloc(offsets_size * sizeof(size_t));
+      if (!h_offsets) {
+        test_ret_value = 1;
+        goto cleanup;
+      }
+      ret_code = cugraph_type_erased_device_array_view_copy_to_host(
+        handle, (byte_t*)h_offsets, offsets_view, &ret_error);
+      TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "copy_to_host failed.");
+
+      int32_t hop = 0;
+      for (size_t i = 0; i < offsets_size - 1; ++i) {
+        for (size_t j = h_offsets[i]; j < h_offsets[i + 1]; ++j) {
+          h_hops[j] = hop;
+        }
+        hop = (hop + 1) % (int32_t)fan_out_size;
+      }
+      free(h_offsets);
+    } else {
+      for (size_t i = 0; i < result_size; ++i) {
+        h_hops[i] = 0;
+      }
+    }
+  }
+
+  for (size_t i = 0; i < result_size; ++i) {
+    actual_edges[i].src             = h_srcs[i];
+    actual_edges[i].dst             = h_dsts[i];
+    actual_edges[i].edge_start_time = h_edge_start_times[i];
+    actual_edges[i].hop             = compare_hops ? h_hops[i] : 0;
+  }
+
+  memcpy(sorted_expected,
+         expected_edges,
+         num_expected_edges * sizeof(expected_temporal_sample_edge_i64_t));
+  qsort(sorted_expected,
+        num_expected_edges,
+        sizeof(expected_temporal_sample_edge_i64_t),
+        expected_temporal_sample_edge_i64_compare);
+  qsort(actual_edges,
+        result_size,
+        sizeof(expected_temporal_sample_edge_i64_t),
+        expected_temporal_sample_edge_i64_compare);
+
+  for (size_t i = 0; (i < result_size) && (test_ret_value == 0); ++i) {
+    TEST_ASSERT(test_ret_value,
+                actual_edges[i].src == sorted_expected[i].src,
+                "sampled edge source does not match expected");
+    TEST_ASSERT(test_ret_value,
+                actual_edges[i].dst == sorted_expected[i].dst,
+                "sampled edge destination does not match expected");
+    TEST_ASSERT(test_ret_value,
+                actual_edges[i].edge_start_time == sorted_expected[i].edge_start_time,
+                "sampled edge start time does not match expected");
+    if (compare_hops) {
+      TEST_ASSERT(test_ret_value,
+                  actual_edges[i].hop == sorted_expected[i].hop,
+                  "sampled edge hop does not match expected");
+    }
+  }
+
+cleanup:
+  free(h_srcs);
+  free(h_dsts);
+  free(h_edge_start_times);
+  free(h_hops);
+  free(actual_edges);
+  free(sorted_expected);
+  cugraph_error_free(ret_error);
+
+  return test_ret_value;
+}
+
+int generic_uniform_temporal_neighbor_sample_i64_test(
+  const cugraph_resource_handle_t* handle,
+  vertex_t* h_src,
+  vertex_t* h_dst,
+  weight_t* h_wgt,
+  edge_t* h_edge_ids,
+  int32_t* h_edge_types,
+  int64_t* h_edge_start_times,
+  int64_t* h_edge_end_times,
+  size_t num_vertices,
+  size_t num_edges,
+  vertex_t* h_start,
+  int64_t* h_start_vertex_start_times,
+  int64_t* h_start_vertex_end_times,
+  size_t* h_start_vertex_label_offsets,
+  size_t num_start_vertices,
+  size_t num_start_labels,
+  int* fan_out,
+  size_t fan_out_size,
+  bool_t with_replacement,
+  bool_t return_hops,
+  cugraph_prior_sources_behavior_t prior_sources_behavior,
+  bool_t dedupe_sources,
+  cugraph_temporal_sampling_comparison_t temporal_sampling_comparison,
+  cugraph_neighbor_selection_t neighbor_selection,
+  bool_t fixed_window,
+  bool_t renumber_results,
+  expected_temporal_sample_edge_i64_t const* expected_edges,
+  size_t num_expected_edges)
+{
+  int test_ret_value              = 0;
+  cugraph_error_code_t ret_code   = CUGRAPH_SUCCESS;
+  cugraph_error_t* ret_error      = NULL;
+  cugraph_graph_t* graph          = NULL;
+  cugraph_sample_result_t* result = NULL;
+
+  ret_code = create_sg_test_graph(handle,
+                                  vertex_tid,
+                                  edge_tid,
+                                  h_src,
+                                  h_dst,
+                                  weight_tid,
+                                  h_wgt,
+                                  edge_type_tid,
+                                  h_edge_types,
+                                  edge_id_tid,
+                                  h_edge_ids,
+                                  INT64,
+                                  h_edge_start_times,
+                                  h_edge_end_times,
+                                  num_edges,
+                                  FALSE,
+                                  TRUE,
+                                  FALSE,
+                                  FALSE,
+                                  &graph,
+                                  &ret_error);
+
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "graph creation failed.");
+
+  cugraph_type_erased_device_array_t* d_start                              = NULL;
+  cugraph_type_erased_device_array_view_t* d_start_view                    = NULL;
+  cugraph_type_erased_device_array_t* d_start_vertex_start_times           = NULL;
+  cugraph_type_erased_device_array_view_t* d_start_vertex_start_times_view = NULL;
+  cugraph_type_erased_device_array_t* d_start_vertex_end_times             = NULL;
+  cugraph_type_erased_device_array_view_t* d_start_vertex_end_times_view   = NULL;
+  cugraph_type_erased_device_array_t* d_start_label_offsets                = NULL;
+  cugraph_type_erased_device_array_view_t* d_start_label_offsets_view      = NULL;
+  cugraph_type_erased_host_array_view_t* h_fan_out_view                    = NULL;
+
+  ret_code = cugraph_type_erased_device_array_create(
+    handle, num_start_vertices, INT32, &d_start, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "d_start create failed.");
+
+  d_start_view = cugraph_type_erased_device_array_view(d_start);
+
+  ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+    handle, d_start_view, (byte_t*)h_start, &ret_error);
+
+  if (h_start_vertex_start_times != NULL) {
+    ret_code = cugraph_type_erased_device_array_create(
+      handle, num_start_vertices, INT64, &d_start_vertex_start_times, &ret_error);
+    TEST_ASSERT(
+      test_ret_value, ret_code == CUGRAPH_SUCCESS, "d_start_vertex_start_times create failed.");
+
+    d_start_vertex_start_times_view =
+      cugraph_type_erased_device_array_view(d_start_vertex_start_times);
+
+    ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+      handle, d_start_vertex_start_times_view, (byte_t*)h_start_vertex_start_times, &ret_error);
+  } else {
+    d_start_vertex_start_times_view = NULL;
+  }
+
+  if (h_start_vertex_end_times != NULL) {
+    ret_code = cugraph_type_erased_device_array_create(
+      handle, num_start_vertices, INT64, &d_start_vertex_end_times, &ret_error);
+    TEST_ASSERT(
+      test_ret_value, ret_code == CUGRAPH_SUCCESS, "d_start_vertex_end_times create failed.");
+
+    d_start_vertex_end_times_view = cugraph_type_erased_device_array_view(d_start_vertex_end_times);
+
+    ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+      handle, d_start_vertex_end_times_view, (byte_t*)h_start_vertex_end_times, &ret_error);
+  } else {
+    d_start_vertex_end_times_view = NULL;
+  }
+
+  ret_code = cugraph_type_erased_device_array_create(
+    handle, num_start_labels, SIZE_T, &d_start_label_offsets, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "d_start_labels create failed.");
+
+  d_start_label_offsets_view = cugraph_type_erased_device_array_view(d_start_label_offsets);
+
+  ret_code = cugraph_type_erased_device_array_view_copy_from_host(
+    handle, d_start_label_offsets_view, (byte_t*)h_start_vertex_label_offsets, &ret_error);
+
+  TEST_ASSERT(
+    test_ret_value, ret_code == CUGRAPH_SUCCESS, "start_labels_offsets copy_from_host failed.");
+
+  h_fan_out_view = cugraph_type_erased_host_array_view_create(fan_out, fan_out_size, INT32);
+
+  cugraph_rng_state_t* rng_state;
+  ret_code = cugraph_rng_state_create(handle, 0, &rng_state, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "rng_state create failed.");
+
+  cugraph_sampling_options_t* sampling_options;
+
+  ret_code = cugraph_sampling_options_create(&sampling_options, &ret_error);
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, "sampling_options create failed.");
+
+  cugraph_sampling_set_with_replacement(sampling_options, with_replacement);
+  cugraph_sampling_set_return_hops(sampling_options, return_hops);
+  cugraph_sampling_set_prior_sources_behavior(sampling_options, prior_sources_behavior);
+  cugraph_sampling_set_dedupe_sources(sampling_options, dedupe_sources);
+  cugraph_sampling_set_renumber_results(sampling_options, renumber_results);
+  cugraph_sampling_set_temporal_sampling_comparison(sampling_options, temporal_sampling_comparison);
+  cugraph_sampling_set_disjoint_sampling(sampling_options, TRUE);
+  cugraph_sampling_set_neighbor_selection(sampling_options, neighbor_selection);
+  cugraph_sampling_set_fixed_window(sampling_options, fixed_window);
+
+  ret_code = cugraph_neighbor_sample(handle,
+                                     rng_state,
+                                     graph,
+                                     NULL,
+                                     d_start_view,
+                                     d_start_vertex_start_times_view,
+                                     d_start_vertex_end_times_view,
+                                     d_start_label_offsets_view,
+                                     NULL,
+                                     h_fan_out_view,
+                                     1,
+                                     sampling_options,
+                                     FALSE,
+                                     &result,
+                                     &ret_error);
+
+  TEST_ASSERT(test_ret_value, ret_code == CUGRAPH_SUCCESS, cugraph_error_message(ret_error));
+  TEST_ASSERT(
+    test_ret_value, ret_code == CUGRAPH_SUCCESS, "uniform_temporal_neighbor_sample failed.");
+
+  test_ret_value = compare_uniform_temporal_neighbor_sample_i64_to_expected(
+    handle, result, expected_edges, num_expected_edges, return_hops, fan_out_size);
+  TEST_ASSERT(test_ret_value, test_ret_value == 0, "compare to expected failed.");
+
+  cugraph_sampling_options_free(sampling_options);
+  cugraph_sample_result_free(result);
+  cugraph_type_erased_device_array_view_free(d_start_view);
+  cugraph_type_erased_device_array_view_free(d_start_vertex_start_times_view);
+  cugraph_type_erased_device_array_view_free(d_start_vertex_end_times_view);
+  cugraph_type_erased_device_array_view_free(d_start_label_offsets_view);
+  cugraph_type_erased_host_array_view_free(h_fan_out_view);
+  cugraph_type_erased_device_array_free(d_start);
+  cugraph_type_erased_device_array_free(d_start_vertex_start_times);
+  cugraph_type_erased_device_array_free(d_start_vertex_end_times);
+  cugraph_type_erased_device_array_free(d_start_label_offsets);
+  cugraph_graph_free(graph);
   cugraph_error_free(ret_error);
 
   return test_ret_value;
@@ -1939,6 +2284,66 @@ int test_uniform_temporal_neighbor_sample_last_refills_after_duplicate_destinati
     TRUE);
 }
 
+int test_uniform_temporal_neighbor_sample_last_int64_increasing_small_times(
+  const cugraph_resource_handle_t* handle)
+{
+  size_t num_edges        = 3;
+  size_t num_vertices     = 4;
+  size_t fan_out_size     = 1;
+  size_t num_starts       = 1;
+  size_t num_start_labels = 2;
+
+  // Three parallel edges from vertex 0 with int64 start times 1, 3, and 2. With
+  // MONOTONICALLY_INCREASING LAST and seed window [0, 3], the latest eligible time
+  // is 3 on destination 2. The pre-fix last_n_time_bias XOR path mapped small int64
+  // timestamps near 2^63, collapsing their double biases so top-k kept the first
+  // edge (0 -> 1, time 1) instead.
+  vertex_t src[]                      = {0, 0, 0};
+  vertex_t dst[]                      = {1, 2, 3};
+  edge_t edge_ids[]                   = {0, 1, 2};
+  weight_t weight[]                   = {0.1, 0.2, 0.3};
+  int32_t edge_types[]                = {0, 0, 0};
+  int64_t edge_start_times[]          = {1, 3, 2};
+  int64_t edge_end_times[]            = {2, 4, 3};
+  vertex_t start[]                    = {0};
+  int64_t start_vertex_start_times[]  = {0};
+  int64_t start_vertex_end_times[]    = {3};
+  size_t start_vertex_label_offsets[] = {0, 1};
+  int fan_out[]                       = {1};
+
+  expected_temporal_sample_edge_i64_t expected_edges[] = {{0, 2, 3, 0}};
+
+  return generic_uniform_temporal_neighbor_sample_i64_test(
+    handle,
+    src,
+    dst,
+    weight,
+    edge_ids,
+    edge_types,
+    edge_start_times,
+    edge_end_times,
+    num_vertices,
+    num_edges,
+    start,
+    start_vertex_start_times,
+    start_vertex_end_times,
+    start_vertex_label_offsets,
+    num_starts,
+    num_start_labels,
+    fan_out,
+    fan_out_size,
+    FALSE,
+    TRUE,
+    DEFAULT,
+    FALSE,
+    MONOTONICALLY_INCREASING,
+    CUGRAPH_NEIGHBOR_SELECTION_LAST,
+    FALSE,
+    FALSE,
+    expected_edges,
+    sizeof(expected_edges) / sizeof(expected_edges[0]));
+}
+
 int main(int argc, char** argv)
 {
   cugraph_resource_handle_t* handle = NULL;
@@ -1970,6 +2375,8 @@ int main(int argc, char** argv)
   result |= RUN_TEST_NEW(test_uniform_temporal_neighbor_sample_last_fixed_window_multihop, handle);
   result |= RUN_TEST_NEW(
     test_uniform_temporal_neighbor_sample_last_refills_after_duplicate_destination, handle);
+  result |=
+    RUN_TEST_NEW(test_uniform_temporal_neighbor_sample_last_int64_increasing_small_times, handle);
 
   cugraph_free_resource_handle(handle);
 

--- a/cpp/tests/sampling/detail/nbr_sampling_validate.cu
+++ b/cpp/tests/sampling/detail/nbr_sampling_validate.cu
@@ -753,6 +753,9 @@ bool validate_last_n_selection(
         h_frontier_vertices.push_back(entry.first);
       }
 
+      // Match sampler semantics: an empty frontier ends the walk for this label.
+      if (h_frontier_vertices.empty()) { continue; }
+
       rmm::device_uvector<vertex_t> d_frontier_vertices(h_frontier_vertices.size(),
                                                         handle.get_stream());
       raft::update_device(d_frontier_vertices.data(),

--- a/cpp/tests/sampling/detail/nbr_sampling_validate.cu
+++ b/cpp/tests/sampling/detail/nbr_sampling_validate.cu
@@ -7,8 +7,8 @@
 
 #include <cugraph/algorithms.hpp>
 #include <cugraph/edge_partition_device_view.cuh>
-#include <cugraph/graph_functions.hpp>
 #include <cugraph/graph_view.hpp>
+#include <cugraph/prims/transform_e.cuh>
 #include <cugraph/sampling_functions.hpp>
 #include <cugraph/utilities/high_res_timer.hpp>
 #include <cugraph/utilities/thrust_wrappers/fill.hpp>
@@ -43,6 +43,7 @@
 #include <functional>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <numeric>
 #include <optional>
 #include <queue>
@@ -50,6 +51,7 @@
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 // utilities for testing / verification of Nbr Sampling functionality:
@@ -319,12 +321,6 @@ bool validate_temporal_integrity(
   cugraph::sort(handle.get_thrust_policy(),
                 thrust::make_zip_iterator(sorted_dsts.begin(), sorted_dst_times.begin()),
                 thrust::make_zip_iterator(sorted_dsts.end(), sorted_dst_times.end()));
-
-  // FIXED_WINDOW does not impose path-wise monotonicity; only seed-window bounds matter, and those
-  // are checked by validate_temporal_time_windows.
-  if (temporal_sampling_comparison == cugraph::temporal_sampling_comparison_t::FIXED_WINDOW) {
-    return true;
-  }
 
   if ((temporal_sampling_comparison ==
        cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING) ||
@@ -625,6 +621,300 @@ template bool validate_temporal_time_windows(raft::handle_t const&,
                                              std::optional<raft::device_span<int32_t const>>,
                                              cugraph::temporal_sampling_comparison_t);
 
+namespace {
+
+template <typename time_stamp_t>
+bool passes_temporal_window(cugraph::temporal_sampling_comparison_t comparison,
+                            time_stamp_t key_time,
+                            time_stamp_t window_end,
+                            time_stamp_t edge_time)
+{
+  switch (comparison) {
+    case cugraph::temporal_sampling_comparison_t::STRICTLY_INCREASING:
+      return key_time < edge_time && edge_time <= window_end;
+    case cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING:
+      return key_time <= edge_time && edge_time <= window_end;
+    case cugraph::temporal_sampling_comparison_t::STRICTLY_DECREASING:
+      return key_time > edge_time && edge_time >= window_end;
+    case cugraph::temporal_sampling_comparison_t::MONOTONICALLY_DECREASING:
+      return key_time >= edge_time && edge_time >= window_end;
+    case cugraph::temporal_sampling_comparison_t::LAST: return false;
+  }
+  return false;
+}
+
+}  // namespace
+
+template <typename vertex_t, typename edge_t, typename time_stamp_t>
+bool validate_last_n_selection(
+  raft::handle_t const& handle,
+  cugraph::graph_view_t<vertex_t, edge_t, false, false> const& graph_view,
+  cugraph::edge_property_view_t<edge_t, time_stamp_t const*> edge_start_time_view,
+  raft::device_span<vertex_t const> sampled_srcs,
+  raft::device_span<vertex_t const> sampled_dsts,
+  raft::device_span<time_stamp_t const> sampled_edge_times,
+  raft::device_span<int32_t const> sampled_hops,
+  raft::device_span<vertex_t const> starting_vertices,
+  std::optional<raft::device_span<time_stamp_t const>> starting_vertex_start_times,
+  std::optional<raft::device_span<time_stamp_t const>> starting_vertex_end_times,
+  raft::device_span<size_t const> label_offsets,
+  std::optional<raft::device_span<int32_t const>> starting_vertex_labels,
+  std::vector<int32_t> const& fanout,
+  cugraph::temporal_sampling_comparison_t temporal_sampling_comparison,
+  bool fixed_window)
+{
+  if ((sampled_srcs.size() != sampled_dsts.size()) ||
+      (sampled_srcs.size() != sampled_edge_times.size()) ||
+      (sampled_srcs.size() != sampled_hops.size()) || fanout.empty() ||
+      (starting_vertex_start_times &&
+       starting_vertex_start_times->size() != starting_vertices.size()) ||
+      (starting_vertex_end_times &&
+       starting_vertex_end_times->size() != starting_vertices.size()) ||
+      (starting_vertex_labels && starting_vertex_labels->size() != starting_vertices.size()) ||
+      label_offsets.empty()) {
+    return false;
+  }
+
+  auto h_offsets = cugraph::test::to_host(handle, label_offsets);
+  if (h_offsets.empty() || h_offsets.front() != size_t{0} ||
+      h_offsets.back() != sampled_srcs.size()) {
+    return false;
+  }
+
+  std::vector<int32_t> h_local_edge_labels(sampled_srcs.size());
+  for (size_t segment = 0; segment + 1 < h_offsets.size(); ++segment) {
+    auto const label = static_cast<int32_t>(segment);
+    std::fill(h_local_edge_labels.begin() + static_cast<std::ptrdiff_t>(h_offsets[segment]),
+              h_local_edge_labels.begin() + static_cast<std::ptrdiff_t>(h_offsets[segment + 1]),
+              label);
+  }
+
+  auto double_edge_times = cugraph::edge_property_t<edge_t, double>(handle, graph_view);
+  cugraph::transform_e(
+    handle,
+    graph_view,
+    cugraph::edge_src_dummy_property_t{}.view(),
+    cugraph::edge_dst_dummy_property_t{}.view(),
+    edge_start_time_view,
+    [] __device__(auto, auto, auto, auto, time_stamp_t edge_time) {
+      return static_cast<double>(edge_time);
+    },
+    double_edge_times.mutable_view());
+
+  auto h_sampled_srcs      = cugraph::test::to_host(handle, sampled_srcs);
+  auto h_sampled_dsts      = cugraph::test::to_host(handle, sampled_dsts);
+  auto h_sampled_times     = cugraph::test::to_host(handle, sampled_edge_times);
+  auto h_edge_hops         = cugraph::test::to_host(handle, sampled_hops);
+  auto h_starting_vertices = cugraph::test::to_host(handle, starting_vertices);
+  auto h_start_times       = starting_vertex_start_times
+                               ? cugraph::test::to_host(handle, *starting_vertex_start_times)
+                               : std::vector<time_stamp_t>{};
+  auto h_end_times         = starting_vertex_end_times
+                               ? cugraph::test::to_host(handle, *starting_vertex_end_times)
+                               : std::vector<time_stamp_t>{};
+  auto h_start_labels      = starting_vertex_labels
+                               ? cugraph::test::to_host(handle, *starting_vertex_labels)
+                               : std::vector<int32_t>{};
+
+  struct frontier_state_t {
+    time_stamp_t key_time;
+    time_stamp_t window_end;
+  };
+
+  auto const decreasing =
+    temporal_sampling_comparison == cugraph::temporal_sampling_comparison_t::STRICTLY_DECREASING ||
+    temporal_sampling_comparison ==
+      cugraph::temporal_sampling_comparison_t::MONOTONICALLY_DECREASING;
+  std::unordered_map<int32_t, std::unordered_map<vertex_t, frontier_state_t>> frontier_by_label;
+  std::unordered_map<int32_t, std::unordered_set<vertex_t>> visited_by_label;
+  for (size_t i = 0; i < h_starting_vertices.size(); ++i) {
+    auto const label = h_start_labels.empty() ? int32_t{0} : h_start_labels[i];
+    auto const lower =
+      h_start_times.empty() ? std::numeric_limits<time_stamp_t>::lowest() : h_start_times[i];
+    auto const upper =
+      h_end_times.empty() ? std::numeric_limits<time_stamp_t>::max() : h_end_times[i];
+    auto const state = decreasing ? frontier_state_t{upper, lower} : frontier_state_t{lower, upper};
+    if (!frontier_by_label[label].emplace(h_starting_vertices[i], state).second) { return false; }
+    visited_by_label[label].insert(h_starting_vertices[i]);
+  }
+
+  raft::random::RngState rng_state{0};
+  std::vector<int32_t> all_neighbors_fanout{-1};
+
+  for (size_t hop = 0; hop < fanout.size(); ++hop) {
+    for (auto& [label, frontier] : frontier_by_label) {
+      std::vector<vertex_t> h_frontier_vertices;
+      h_frontier_vertices.reserve(frontier.size());
+      for (auto const& entry : frontier) {
+        h_frontier_vertices.push_back(entry.first);
+      }
+
+      rmm::device_uvector<vertex_t> d_frontier_vertices(h_frontier_vertices.size(),
+                                                        handle.get_stream());
+      raft::update_device(d_frontier_vertices.data(),
+                          h_frontier_vertices.data(),
+                          h_frontier_vertices.size(),
+                          handle.get_stream());
+
+      rmm::device_uvector<vertex_t> candidate_srcs(0, handle.get_stream());
+      rmm::device_uvector<vertex_t> candidate_dsts(0, handle.get_stream());
+      std::optional<rmm::device_uvector<double>> candidate_times{std::nullopt};
+      std::tie(candidate_srcs,
+               candidate_dsts,
+               candidate_times,
+               std::ignore,
+               std::ignore,
+               std::ignore,
+               std::ignore,
+               std::ignore,
+               std::ignore) =
+        cugraph::neighbor_sample<vertex_t, edge_t, double, int32_t, time_stamp_t, false, false>(
+          handle,
+          rng_state,
+          graph_view,
+          std::make_optional(double_edge_times.view()),
+          std::optional<cugraph::edge_property_view_t<edge_t, edge_t const*>>{std::nullopt},
+          std::optional<cugraph::edge_property_view_t<edge_t, int32_t const*>>{std::nullopt},
+          std::optional<cugraph::edge_property_view_t<edge_t, time_stamp_t const*>>{std::nullopt},
+          std::optional<cugraph::edge_property_view_t<edge_t, time_stamp_t const*>>{std::nullopt},
+          std::optional<cugraph::edge_property_view_t<edge_t, double const*>>{std::nullopt},
+          raft::device_span<vertex_t const>{d_frontier_vertices.data(), d_frontier_vertices.size()},
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          raft::host_span<int32_t const>{all_neighbors_fanout.data(), all_neighbors_fanout.size()},
+          std::nullopt,
+          cugraph::sampling_options_t{},
+          false);
+
+      if (!candidate_times) { return false; }
+      cugraph::sort(handle.get_thrust_policy(),
+                    thrust::make_zip_iterator(
+                      candidate_srcs.begin(), candidate_times->begin(), candidate_dsts.begin()),
+                    thrust::make_zip_iterator(
+                      candidate_srcs.end(), candidate_times->end(), candidate_dsts.end()));
+
+      auto h_candidate_srcs    = cugraph::test::to_host(handle, candidate_srcs);
+      auto h_candidate_dsts    = cugraph::test::to_host(handle, candidate_dsts);
+      auto h_candidate_times_d = cugraph::test::to_host(handle, *candidate_times);
+
+      std::unordered_map<vertex_t, std::vector<size_t>> sampled_by_src;
+      std::unordered_map<vertex_t, vertex_t> chosen_dst_owner;
+      for (size_t i = 0; i < h_sampled_srcs.size(); ++i) {
+        if (h_local_edge_labels[i] != label || h_edge_hops[i] != static_cast<int32_t>(hop)) {
+          continue;
+        }
+        if (!frontier.contains(h_sampled_srcs[i])) { return false; }
+        chosen_dst_owner.emplace(h_sampled_dsts[i], h_sampled_srcs[i]);
+        sampled_by_src[h_sampled_srcs[i]].push_back(i);
+      }
+
+      std::unordered_map<vertex_t, frontier_state_t> next_frontier;
+      for (auto const& [src, state] : frontier) {
+        auto const src_begin =
+          std::lower_bound(h_candidate_srcs.begin(), h_candidate_srcs.end(), src);
+        auto const src_end = std::upper_bound(src_begin, h_candidate_srcs.end(), src);
+
+        std::vector<time_stamp_t> eligible_times;
+        eligible_times.reserve(static_cast<size_t>(std::distance(src_begin, src_end)));
+        for (auto candidate_it = src_begin; candidate_it != src_end; ++candidate_it) {
+          auto const candidate_index =
+            static_cast<size_t>(std::distance(h_candidate_srcs.begin(), candidate_it));
+          auto const dst       = h_candidate_dsts[candidate_index];
+          auto const edge_time = static_cast<time_stamp_t>(h_candidate_times_d[candidate_index]);
+          if (visited_by_label[label].contains(dst)) { continue; }
+          auto owner_it = chosen_dst_owner.find(dst);
+          if (owner_it != chosen_dst_owner.end() && owner_it->second != src) { continue; }
+          if (passes_temporal_window(
+                temporal_sampling_comparison, state.key_time, state.window_end, edge_time)) {
+            eligible_times.push_back(edge_time);
+          }
+        }
+
+        auto const expected_count =
+          fanout[hop] < 0 ? eligible_times.size()
+                          : std::min(eligible_times.size(), static_cast<size_t>(fanout[hop]));
+        // Times are already sorted ascending. Decreasing LAST keeps the earliest K
+        // (distance from the first eligible entry); increasing LAST keeps the latest K
+        // (distance from the last eligible entry).
+        auto expected_begin =
+          decreasing ? eligible_times.begin()
+                     : eligible_times.end() - static_cast<std::ptrdiff_t>(expected_count);
+        std::vector<time_stamp_t> expected_times(expected_begin, expected_begin + expected_count);
+
+        std::vector<time_stamp_t> actual_times;
+        auto sampled_it = sampled_by_src.find(src);
+        if (sampled_it != sampled_by_src.end()) {
+          actual_times.reserve(sampled_it->second.size());
+          for (auto index : sampled_it->second) {
+            actual_times.push_back(h_sampled_times[index]);
+            auto const next_state = frontier_state_t{
+              fixed_window ? state.key_time : h_sampled_times[index], state.window_end};
+            if (!next_frontier.emplace(h_sampled_dsts[index], next_state).second) { return false; }
+          }
+        }
+        std::sort(actual_times.begin(), actual_times.end());
+        std::sort(expected_times.begin(), expected_times.end());
+        if (actual_times != expected_times) {
+          std::cerr << "LAST validation mismatch for label " << label << ", hop " << hop
+                    << ", source " << src << ": expected times [";
+          for (size_t i = 0; i < expected_times.size(); ++i) {
+            std::cerr << (i == 0 ? "" : ",") << expected_times[i];
+          }
+          std::cerr << "], actual times [";
+          for (size_t i = 0; i < actual_times.size(); ++i) {
+            std::cerr << (i == 0 ? "" : ",") << actual_times[i];
+          }
+          std::cerr << "]\n";
+          return false;
+        }
+      }
+
+      for (auto const& [dst, state] : next_frontier) {
+        visited_by_label[label].insert(dst);
+      }
+      frontier = std::move(next_frontier);
+    }
+  }
+
+  return true;
+}
+
+template bool validate_last_n_selection(
+  raft::handle_t const&,
+  cugraph::graph_view_t<int32_t, int32_t, false, false> const&,
+  cugraph::edge_property_view_t<int32_t, int32_t const*>,
+  raft::device_span<int32_t const>,
+  raft::device_span<int32_t const>,
+  raft::device_span<int32_t const>,
+  raft::device_span<int32_t const>,
+  raft::device_span<int32_t const>,
+  std::optional<raft::device_span<int32_t const>>,
+  std::optional<raft::device_span<int32_t const>>,
+  raft::device_span<size_t const>,
+  std::optional<raft::device_span<int32_t const>>,
+  std::vector<int32_t> const&,
+  cugraph::temporal_sampling_comparison_t,
+  bool);
+
+template bool validate_last_n_selection(
+  raft::handle_t const&,
+  cugraph::graph_view_t<int64_t, int64_t, false, false> const&,
+  cugraph::edge_property_view_t<int64_t, int32_t const*>,
+  raft::device_span<int64_t const>,
+  raft::device_span<int64_t const>,
+  raft::device_span<int32_t const>,
+  raft::device_span<int32_t const>,
+  raft::device_span<int64_t const>,
+  std::optional<raft::device_span<int32_t const>>,
+  std::optional<raft::device_span<int32_t const>>,
+  raft::device_span<size_t const>,
+  std::optional<raft::device_span<int32_t const>>,
+  std::vector<int32_t> const&,
+  cugraph::temporal_sampling_comparison_t,
+  bool);
+
 template <typename vertex_t, typename time_stamp_t>
 bool validate_fixed_window_temporal_sampling(
   raft::handle_t const& handle,
@@ -638,17 +928,18 @@ bool validate_fixed_window_temporal_sampling(
   std::optional<raft::device_span<int32_t const>> starting_vertex_labels,
   std::optional<raft::device_span<int32_t const>> edge_labels)
 {
-  return validate_temporal_time_windows(handle,
-                                        srcs,
-                                        dsts,
-                                        edge_times,
-                                        starting_vertices,
-                                        starting_vertex_start_times,
-                                        starting_vertex_end_times,
-                                        label_offsets,
-                                        starting_vertex_labels,
-                                        edge_labels,
-                                        cugraph::temporal_sampling_comparison_t::FIXED_WINDOW);
+  return validate_temporal_time_windows(
+    handle,
+    srcs,
+    dsts,
+    edge_times,
+    starting_vertices,
+    starting_vertex_start_times,
+    starting_vertex_end_times,
+    label_offsets,
+    starting_vertex_labels,
+    edge_labels,
+    cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING);
 }
 
 template bool validate_fixed_window_temporal_sampling(

--- a/cpp/tests/sampling/detail/nbr_sampling_validate.cu
+++ b/cpp/tests/sampling/detail/nbr_sampling_validate.cu
@@ -663,6 +663,10 @@ bool validate_last_n_selection(
   cugraph::temporal_sampling_comparison_t temporal_sampling_comparison,
   bool fixed_window)
 {
+  std::cerr << "[LAST debug] validate_last_n_selection entered: sampled_edges="
+            << sampled_srcs.size() << " fanout_levels=" << fanout.size()
+            << " fixed_window=" << fixed_window << '\n';
+
   if ((sampled_srcs.size() != sampled_dsts.size()) ||
       (sampled_srcs.size() != sampled_edge_times.size()) ||
       (sampled_srcs.size() != sampled_hops.size()) || fanout.empty() ||
@@ -759,6 +763,8 @@ bool validate_last_n_selection(
       rmm::device_uvector<vertex_t> candidate_srcs(0, handle.get_stream());
       rmm::device_uvector<vertex_t> candidate_dsts(0, handle.get_stream());
       std::optional<rmm::device_uvector<double>> candidate_times{std::nullopt};
+      std::cerr << "[LAST debug] validate_last_n_selection: calling neighbor_sample for hop=" << hop
+                << " label=" << label << " frontier_size=" << h_frontier_vertices.size() << '\n';
       std::tie(candidate_srcs,
                candidate_dsts,
                candidate_times,
@@ -789,6 +795,9 @@ bool validate_last_n_selection(
           false);
 
       if (!candidate_times) { return false; }
+      std::cerr << "[LAST debug] validate_last_n_selection: neighbor_sample returned "
+                << candidate_srcs.size() << " candidate edges for hop=" << hop << " label=" << label
+                << '\n';
       cugraph::sort(handle.get_thrust_policy(),
                     thrust::make_zip_iterator(
                       candidate_srcs.begin(), candidate_times->begin(), candidate_dsts.begin()),

--- a/cpp/tests/sampling/detail/nbr_sampling_validate.hpp
+++ b/cpp/tests/sampling/detail/nbr_sampling_validate.hpp
@@ -15,6 +15,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <optional>
+#include <vector>
 
 // utilities for testing / verification of Nbr Sampling functionality:
 //
@@ -69,6 +70,39 @@ bool validate_temporal_time_windows(
   std::optional<raft::device_span<int32_t const>> starting_vertex_labels,
   std::optional<raft::device_span<int32_t const>> edge_labels,
   cugraph::temporal_sampling_comparison_t temporal_sampling_comparison);
+
+/**
+ * @brief Validate that LAST selected the highest-ranked eligible edges at every hop.
+ *
+ * This replays the sampled traversal one hop at a time. At each hop, a fanout of -1 gathers every
+ * outgoing edge from the current frontier and sorts those edges by (src, time, dst). For each
+ * source, LAST is the first K eligible times (decreasing) or last K eligible times (increasing) in
+ * that already-sorted range. Candidates whose destination was visited, or claimed at this hop by a
+ * different source, are not eligible; destination uniqueness itself is checked separately by
+ * validate_disjoint_sampling. Equal timestamps are interchangeable because the top-k primitive has
+ * no secondary tie-breaker.
+ *
+ * Like the other temporal validators, this inspects already-complete sampled arrays. MG tests
+ * gather results to rank 0 before calling those helpers; this one follows the same contract and
+ * expects an SG graph view so the original edgelist is available on the host.
+ */
+template <typename vertex_t, typename edge_t, typename time_stamp_t>
+bool validate_last_n_selection(
+  raft::handle_t const& handle,
+  cugraph::graph_view_t<vertex_t, edge_t, false, false> const& graph_view,
+  cugraph::edge_property_view_t<edge_t, time_stamp_t const*> edge_start_time_view,
+  raft::device_span<vertex_t const> sampled_srcs,
+  raft::device_span<vertex_t const> sampled_dsts,
+  raft::device_span<time_stamp_t const> sampled_edge_times,
+  raft::device_span<int32_t const> sampled_hops,
+  raft::device_span<vertex_t const> starting_vertices,
+  std::optional<raft::device_span<time_stamp_t const>> starting_vertex_start_times,
+  std::optional<raft::device_span<time_stamp_t const>> starting_vertex_end_times,
+  raft::device_span<size_t const> label_offsets,
+  std::optional<raft::device_span<int32_t const>> starting_vertex_labels,
+  std::vector<int32_t> const& fanout,
+  cugraph::temporal_sampling_comparison_t temporal_sampling_comparison,
+  bool fixed_window);
 
 /**
  * @brief Validate fixed-window temporal sampling against each seed's original window.

--- a/cpp/tests/sampling/mg_temporal_neighbor_sampling.cpp
+++ b/cpp/tests/sampling/mg_temporal_neighbor_sampling.cpp
@@ -28,6 +28,7 @@ struct Temporal_Neighbor_Sampling_Usecase {
   cugraph::temporal_sampling_comparison_t temporal_sampling_comparison{
     cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING};
   bool check_correctness{true};
+  cugraph::neighbor_selection_t neighbor_selection{cugraph::neighbor_selection_t::RANDOM};
 };
 
 template <typename input_usecase_t>
@@ -188,6 +189,7 @@ class Tests_MGTemporal_Neighbor_Sampling
     sampling_flags.disjoint_sampling = true;
     sampling_flags.temporal_sampling_comparison =
       temporal_neighbor_sampling_usecase.temporal_sampling_comparison;
+    sampling_flags.neighbor_selection = temporal_neighbor_sampling_usecase.neighbor_selection;
 
     rmm::device_uvector<vertex_t> src_out(0, handle_->get_stream());
     rmm::device_uvector<vertex_t> dst_out(0, handle_->get_stream());
@@ -670,6 +672,32 @@ INSTANTIATE_TEST_SUITE_P(
                          true,
                          false,
                          cugraph::temporal_sampling_comparison_t::MONOTONICALLY_DECREASING}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_test_last_selection,
+  Tests_MGTemporal_Neighbor_Sampling_File,
+  ::testing::Combine(::testing::Values(
+                       Temporal_Neighbor_Sampling_Usecase{
+                         {4, -1, 10},
+                         128,
+                         false,
+                         false,
+                         true,
+                         true,
+                         cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING,
+                         true,
+                         cugraph::neighbor_selection_t::LAST},
+                       Temporal_Neighbor_Sampling_Usecase{
+                         {4, -1, 10},
+                         128,
+                         false,
+                         false,
+                         true,
+                         true,
+                         cugraph::temporal_sampling_comparison_t::MONOTONICALLY_DECREASING,
+                         true,
+                         cugraph::neighbor_selection_t::LAST}),
                      ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/sampling/mg_temporal_neighbor_sampling_fixed_window.cpp
+++ b/cpp/tests/sampling/mg_temporal_neighbor_sampling_fixed_window.cpp
@@ -30,7 +30,6 @@ struct Fixed_Window_Temporal_Neighbor_Sampling_Usecase {
   cugraph::temporal_sampling_comparison_t temporal_sampling_comparison{
     cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING};
   bool check_correctness{true};
-  // LAST are expected to fast-fail until the selection primitive is implemented.
   cugraph::neighbor_selection_t neighbor_selection{cugraph::neighbor_selection_t::RANDOM};
 };
 
@@ -191,7 +190,9 @@ class Tests_MGFixed_Window_Temporal_Neighbor_Sampling
     sampling_flags.with_replacement  = false;
     sampling_flags.disjoint_sampling = true;
     sampling_flags.temporal_sampling_comparison =
-      cugraph::temporal_sampling_comparison_t::FIXED_WINDOW;
+      temporal_neighbor_sampling_usecase.temporal_sampling_comparison;
+    sampling_flags.fixed_window       = true;
+    sampling_flags.neighbor_selection = temporal_neighbor_sampling_usecase.neighbor_selection;
 
     rmm::device_uvector<vertex_t> src_out(0, handle_->get_stream());
     rmm::device_uvector<vertex_t> dst_out(0, handle_->get_stream());
@@ -249,47 +250,6 @@ class Tests_MGFixed_Window_Temporal_Neighbor_Sampling
         ? std::make_optional(raft::device_span<time_stamp_t const>{
             starting_vertex_end_times->data(), starting_vertex_end_times->size()})
         : std::nullopt;
-
-    if (temporal_neighbor_sampling_usecase.neighbor_selection !=
-        cugraph::neighbor_selection_t::RANDOM) {
-      sampling_flags.neighbor_selection = temporal_neighbor_sampling_usecase.neighbor_selection;
-      // LAST is declared in the public API but is not implemented yet.  The check is
-      // local to each rank and runs before any collective, so every rank throws here.
-      try {
-        cugraph::neighbor_sample<vertex_t,
-                                 edge_t,
-                                 weight_t,
-                                 edge_type_t,
-                                 time_stamp_t,
-                                 store_transposed,
-                                 true>(
-          *handle_,
-          rng_state,
-          graph_view,
-          std::nullopt,
-          std::nullopt,
-          std::nullopt,
-          edge_start_times_view,
-          edge_end_times_view,
-          std::nullopt,
-          raft::device_span<vertex_t const>{random_sources_copy.data(), random_sources.size()},
-          starting_vertex_start_times_span,
-          starting_vertex_end_times_span,
-          batch_number ? std::make_optional(raft::device_span<int32_t const>{batch_number->data(),
-                                                                             batch_number->size()})
-                       : std::nullopt,
-          label_to_output_comm_rank_mapping,
-          raft::host_span<int32_t const>(temporal_neighbor_sampling_usecase.fanout.data(),
-                                         temporal_neighbor_sampling_usecase.fanout.size()),
-          std::nullopt,
-          sampling_flags);
-        ADD_FAILURE() << "expected LAST neighbor selection to fail as not implemented";
-      } catch (cugraph::logic_error const& e) {
-        EXPECT_NE(std::string{e.what()}.find("not yet implemented"), std::string::npos)
-          << "expected a not-implemented failure, got: " << e.what();
-      }
-      return;
-    }
 
     if (temporal_neighbor_sampling_usecase.biased) {
       std::tie(src_out,
@@ -372,7 +332,7 @@ class Tests_MGFixed_Window_Temporal_Neighbor_Sampling
         starting_vertex_start_times_span,
         starting_vertex_end_times_span,
         num_sampled_edges,
-        cugraph::temporal_sampling_comparison_t::FIXED_WINDOW));
+        temporal_neighbor_sampling_usecase.temporal_sampling_comparison));
 
       ASSERT_TRUE(offsets.has_value());
       auto h_offsets = cugraph::test::to_host(*handle_, *offsets);
@@ -579,7 +539,7 @@ INSTANTIATE_TEST_SUITE_P(
                          false,
                          true,
                          true,
-                         cugraph::temporal_sampling_comparison_t::FIXED_WINDOW,
+                         cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING,
                          true},
                        Fixed_Window_Temporal_Neighbor_Sampling_Usecase{
                          {4, -1, 10},
@@ -588,7 +548,7 @@ INSTANTIATE_TEST_SUITE_P(
                          false,
                          true,
                          true,
-                         cugraph::temporal_sampling_comparison_t::FIXED_WINDOW,
+                         cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING,
                          true}),
                      ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
 
@@ -604,7 +564,7 @@ INSTANTIATE_TEST_SUITE_P(
         false,
         true,
         true,
-        cugraph::temporal_sampling_comparison_t::FIXED_WINDOW,
+        cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING,
         true},
       Fixed_Window_Temporal_Neighbor_Sampling_Usecase{
         {4, -1, 10},
@@ -613,14 +573,12 @@ INSTANTIATE_TEST_SUITE_P(
         false,
         true,
         true,
-        cugraph::temporal_sampling_comparison_t::FIXED_WINDOW,
+        cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING,
         true}),
     ::testing::Values(cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false, 0))));
 
-// The fast-fail is an argument check that runs before any graph traversal, so a single small
-// input is enough to cover it.
 INSTANTIATE_TEST_SUITE_P(
-  file_test_unimplemented_selection,
+  file_test_last_selection,
   Tests_MGFixed_Window_Temporal_Neighbor_Sampling_File,
   ::testing::Combine(::testing::Values(Fixed_Window_Temporal_Neighbor_Sampling_Usecase{
                        {4, -1, 10},
@@ -629,8 +587,8 @@ INSTANTIATE_TEST_SUITE_P(
                        false,
                        true,
                        true,
-                       cugraph::temporal_sampling_comparison_t::FIXED_WINDOW,
-                       false,
+                       cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING,
+                       true,
                        cugraph::neighbor_selection_t::LAST}),
                      ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
 

--- a/cpp/tests/sampling/temporal_neighbor_sampling.cpp
+++ b/cpp/tests/sampling/temporal_neighbor_sampling.cpp
@@ -25,6 +25,7 @@ struct Temporal_Neighbor_Sampling_Usecase {
   cugraph::temporal_sampling_comparison_t temporal_sampling_comparison{
     cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING};
   bool check_correctness{true};
+  cugraph::neighbor_selection_t neighbor_selection{cugraph::neighbor_selection_t::RANDOM};
 };
 
 // Without this, gtest reports a failing parameterized case as an opaque byte dump, which makes it
@@ -54,7 +55,12 @@ std::ostream& operator<<(std::ostream& os, Temporal_Neighbor_Sampling_Usecase co
       break;
     case cugraph::temporal_sampling_comparison_t::LAST: os << "LAST"; break;
   }
-  return os << " check_correctness=" << usecase.check_correctness << "}";
+  os << " check_correctness=" << usecase.check_correctness << " neighbor_selection=";
+  switch (usecase.neighbor_selection) {
+    case cugraph::neighbor_selection_t::RANDOM: os << "RANDOM"; break;
+    case cugraph::neighbor_selection_t::LAST: os << "LAST"; break;
+  }
+  return os << "}";
 }
 
 template <typename input_usecase_t>
@@ -220,6 +226,9 @@ class Tests_Temporal_Neighbor_Sampling
     sampling_flags.disjoint_sampling = true;
     sampling_flags.temporal_sampling_comparison =
       temporal_neighbor_sampling_usecase.temporal_sampling_comparison;
+    sampling_flags.neighbor_selection = temporal_neighbor_sampling_usecase.neighbor_selection;
+    sampling_flags.return_hops =
+      temporal_neighbor_sampling_usecase.neighbor_selection == cugraph::neighbor_selection_t::LAST;
 
     rmm::device_uvector<vertex_t> src_out(0, handle.get_stream());
     rmm::device_uvector<vertex_t> dst_out(0, handle.get_stream());
@@ -439,6 +448,30 @@ class Tests_Temporal_Neighbor_Sampling
         batch_number ? std::make_optional(raft::device_span<int32_t const>{batch_number->data(),
                                                                            batch_number->size()})
                      : std::nullopt));
+
+      if (temporal_neighbor_sampling_usecase.neighbor_selection ==
+          cugraph::neighbor_selection_t::LAST) {
+        ASSERT_TRUE(offsets.has_value());
+        ASSERT_TRUE(hop.has_value());
+        ASSERT_TRUE(cugraph::test::validate_last_n_selection(
+          handle,
+          graph_view,
+          *edge_start_times_view,
+          raft::device_span<vertex_t const>{src_out.data(), src_out.size()},
+          raft::device_span<vertex_t const>{dst_out.data(), dst_out.size()},
+          raft::device_span<time_stamp_t const>{edge_start_time->data(), edge_start_time->size()},
+          raft::device_span<int32_t const>{hop->data(), hop->size()},
+          raft::device_span<vertex_t const>{random_sources.data(), random_sources.size()},
+          starting_vertex_start_times_span,
+          starting_vertex_end_times_span,
+          raft::device_span<size_t const>{offsets->data(), offsets->size()},
+          batch_number ? std::make_optional(raft::device_span<int32_t const>{batch_number->data(),
+                                                                             batch_number->size()})
+                       : std::nullopt,
+          temporal_neighbor_sampling_usecase.fanout,
+          temporal_neighbor_sampling_usecase.temporal_sampling_comparison,
+          false));
+      }
 
       if (random_sources.size() < 100) {
         // This validation is too expensive for large number of vertices
@@ -709,6 +742,59 @@ INSTANTIATE_TEST_SUITE_P(
                          cugraph::temporal_sampling_comparison_t::MONOTONICALLY_DECREASING,
                          true}),
                      ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  file_test_last_selection,
+  Tests_Temporal_Neighbor_Sampling_File,
+  ::testing::Combine(::testing::Values(
+                       Temporal_Neighbor_Sampling_Usecase{
+                         {4, -1, 10},
+                         128,
+                         false,
+                         false,
+                         true,
+                         true,
+                         cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING,
+                         true,
+                         cugraph::neighbor_selection_t::LAST},
+                       Temporal_Neighbor_Sampling_Usecase{
+                         {4, -1, 10},
+                         128,
+                         false,
+                         false,
+                         true,
+                         true,
+                         cugraph::temporal_sampling_comparison_t::MONOTONICALLY_DECREASING,
+                         true,
+                         cugraph::neighbor_selection_t::LAST}),
+                     ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  rmat_small_test_last_selection,
+  Tests_Temporal_Neighbor_Sampling_Rmat,
+  ::testing::Combine(
+    ::testing::Values(
+      Temporal_Neighbor_Sampling_Usecase{
+        {4, -1, 10},
+        128,
+        false,
+        false,
+        true,
+        true,
+        cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING,
+        true,
+        cugraph::neighbor_selection_t::LAST},
+      Temporal_Neighbor_Sampling_Usecase{
+        {4, -1, 10},
+        128,
+        false,
+        false,
+        true,
+        true,
+        cugraph::temporal_sampling_comparison_t::MONOTONICALLY_DECREASING,
+        true,
+        cugraph::neighbor_selection_t::LAST}),
+    ::testing::Values(cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false, 0))));
 
 INSTANTIATE_TEST_SUITE_P(
   rmat_small_test_time_window,

--- a/cpp/tests/sampling/temporal_neighbor_sampling.cpp
+++ b/cpp/tests/sampling/temporal_neighbor_sampling.cpp
@@ -471,7 +471,9 @@ class Tests_Temporal_Neighbor_Sampling
                   << src_out.size()
                   << " fanout_levels=" << temporal_neighbor_sampling_usecase.fanout.size()
                   << " comparison="
-                  << temporal_neighbor_sampling_usecase.temporal_sampling_comparison << '\n';
+                  << static_cast<int>(
+                       temporal_neighbor_sampling_usecase.temporal_sampling_comparison)
+                  << '\n';
         ASSERT_TRUE(cugraph::test::validate_last_n_selection(
           handle,
           graph_view,

--- a/cpp/tests/sampling/temporal_neighbor_sampling.cpp
+++ b/cpp/tests/sampling/temporal_neighbor_sampling.cpp
@@ -13,6 +13,7 @@
 
 #include <gtest/gtest.h>
 
+#include <iostream>
 #include <ostream>
 
 struct Temporal_Neighbor_Sampling_Usecase {
@@ -355,7 +356,20 @@ class Tests_Temporal_Neighbor_Sampling
       hr_timer.display_and_clear(std::cout);
     }
 
+    if (temporal_neighbor_sampling_usecase.neighbor_selection ==
+        cugraph::neighbor_selection_t::LAST) {
+      std::cerr << "[LAST debug] temporal sampling returned: src_out.size()=" << src_out.size()
+                << " dst_out.size()=" << dst_out.size() << " edge_start_time="
+                << (edge_start_time ? std::to_string(edge_start_time->size()) : "nullopt")
+                << " hop=" << (hop ? std::to_string(hop->size()) : "nullopt")
+                << " offsets=" << (offsets ? std::to_string(offsets->size()) : "nullopt") << '\n';
+    }
+
     if (temporal_neighbor_sampling_usecase.check_correctness) {
+      if (temporal_neighbor_sampling_usecase.neighbor_selection ==
+          cugraph::neighbor_selection_t::LAST) {
+        std::cerr << "[LAST debug] starting check_correctness validations\n";
+      }
       //  Every check below only inspects the edges that came back, so they all pass trivially on an
       //  empty result.  Check first that an empty result was actually justified.
       ASSERT_TRUE(cugraph::test::validate_sampling_empty_result(
@@ -453,6 +467,11 @@ class Tests_Temporal_Neighbor_Sampling
           cugraph::neighbor_selection_t::LAST) {
         ASSERT_TRUE(offsets.has_value());
         ASSERT_TRUE(hop.has_value());
+        std::cerr << "[LAST debug] starting validate_last_n_selection: sampled_edges="
+                  << src_out.size()
+                  << " fanout_levels=" << temporal_neighbor_sampling_usecase.fanout.size()
+                  << " comparison="
+                  << temporal_neighbor_sampling_usecase.temporal_sampling_comparison << '\n';
         ASSERT_TRUE(cugraph::test::validate_last_n_selection(
           handle,
           graph_view,

--- a/cpp/tests/sampling/temporal_neighbor_sampling_fixed_window.cpp
+++ b/cpp/tests/sampling/temporal_neighbor_sampling_fixed_window.cpp
@@ -465,7 +465,9 @@ class Tests_Fixed_Window_Temporal_Neighbor_Sampling
                   << src_out.size()
                   << " fanout_levels=" << temporal_neighbor_sampling_usecase.fanout.size()
                   << " comparison="
-                  << temporal_neighbor_sampling_usecase.temporal_sampling_comparison << '\n';
+                  << static_cast<int>(
+                       temporal_neighbor_sampling_usecase.temporal_sampling_comparison)
+                  << '\n';
         ASSERT_TRUE(cugraph::test::validate_last_n_selection(
           handle,
           graph_view,

--- a/cpp/tests/sampling/temporal_neighbor_sampling_fixed_window.cpp
+++ b/cpp/tests/sampling/temporal_neighbor_sampling_fixed_window.cpp
@@ -26,7 +26,6 @@ struct Fixed_Window_Temporal_Neighbor_Sampling_Usecase {
   cugraph::temporal_sampling_comparison_t temporal_sampling_comparison{
     cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING};
   bool check_correctness{true};
-  // LAST are expected to fast-fail until the selection primitive is implemented.
   cugraph::neighbor_selection_t neighbor_selection{cugraph::neighbor_selection_t::RANDOM};
 };
 
@@ -56,7 +55,7 @@ std::ostream& operator<<(std::ostream& os,
     case cugraph::temporal_sampling_comparison_t::MONOTONICALLY_DECREASING:
       os << "MONOTONICALLY_DECREASING";
       break;
-    case cugraph::temporal_sampling_comparison_t::FIXED_WINDOW: os << "FIXED_WINDOW"; break;
+    case cugraph::temporal_sampling_comparison_t::LAST: os << "LAST"; break;
   }
   os << " check_correctness=" << usecase.check_correctness << " neighbor_selection=";
   switch (usecase.neighbor_selection) {
@@ -228,7 +227,11 @@ class Tests_Fixed_Window_Temporal_Neighbor_Sampling
     sampling_flags.with_replacement  = false;
     sampling_flags.disjoint_sampling = true;
     sampling_flags.temporal_sampling_comparison =
-      cugraph::temporal_sampling_comparison_t::FIXED_WINDOW;
+      temporal_neighbor_sampling_usecase.temporal_sampling_comparison;
+    sampling_flags.fixed_window       = true;
+    sampling_flags.neighbor_selection = temporal_neighbor_sampling_usecase.neighbor_selection;
+    sampling_flags.return_hops =
+      temporal_neighbor_sampling_usecase.neighbor_selection == cugraph::neighbor_selection_t::LAST;
 
     rmm::device_uvector<vertex_t> src_out(0, handle.get_stream());
     rmm::device_uvector<vertex_t> dst_out(0, handle.get_stream());
@@ -285,48 +288,6 @@ class Tests_Fixed_Window_Temporal_Neighbor_Sampling
         ? std::make_optional(raft::device_span<time_stamp_t const>{
             starting_vertex_end_times->data(), starting_vertex_end_times->size()})
         : std::nullopt;
-
-    if (temporal_neighbor_sampling_usecase.neighbor_selection !=
-        cugraph::neighbor_selection_t::RANDOM) {
-      sampling_flags.neighbor_selection = temporal_neighbor_sampling_usecase.neighbor_selection;
-      // LAST are declared in the public API but are not implemented yet.  Pin the
-      // fast-fail so the stub cannot start silently returning edges before the selection
-      // primitive replaces it.
-      try {
-        cugraph::neighbor_sample<vertex_t,
-                                 edge_t,
-                                 weight_t,
-                                 edge_type_t,
-                                 time_stamp_t,
-                                 store_transposed,
-                                 false>(
-          handle,
-          rng_state,
-          graph_view,
-          std::nullopt,
-          std::nullopt,
-          std::nullopt,
-          edge_start_times_view,
-          edge_end_times_view,
-          std::nullopt,
-          raft::device_span<vertex_t const>{random_sources_copy.data(), random_sources.size()},
-          starting_vertex_start_times_span,
-          starting_vertex_end_times_span,
-          batch_number ? std::make_optional(raft::device_span<int32_t const>{batch_number->data(),
-                                                                             batch_number->size()})
-                       : std::nullopt,
-          label_to_output_comm_rank_mapping,
-          raft::host_span<int32_t const>(temporal_neighbor_sampling_usecase.fanout.data(),
-                                         temporal_neighbor_sampling_usecase.fanout.size()),
-          std::nullopt,
-          sampling_flags);
-        ADD_FAILURE() << "expected LAST neighbor selection to fail as not implemented";
-      } catch (cugraph::logic_error const& e) {
-        EXPECT_NE(std::string{e.what()}.find("not yet implemented"), std::string::npos)
-          << "expected a not-implemented failure, got: " << e.what();
-      }
-      return;
-    }
 
     if (temporal_neighbor_sampling_usecase.biased) {
       ASSERT_TRUE(edge_weights_view.has_value());
@@ -408,7 +369,7 @@ class Tests_Fixed_Window_Temporal_Neighbor_Sampling
         starting_vertex_start_times_span,
         starting_vertex_end_times_span,
         src_out.size(),
-        cugraph::temporal_sampling_comparison_t::FIXED_WINDOW));
+        temporal_neighbor_sampling_usecase.temporal_sampling_comparison));
 
       //  Next validate that the extracted edges are actually a subset of the
       //  edges in the input graph
@@ -482,6 +443,30 @@ class Tests_Fixed_Window_Temporal_Neighbor_Sampling
                                                                            batch_number->size()})
                      : std::nullopt));
 
+      if (temporal_neighbor_sampling_usecase.neighbor_selection ==
+          cugraph::neighbor_selection_t::LAST) {
+        ASSERT_TRUE(offsets.has_value());
+        ASSERT_TRUE(hop.has_value());
+        ASSERT_TRUE(cugraph::test::validate_last_n_selection(
+          handle,
+          graph_view,
+          *edge_start_times_view,
+          raft::device_span<vertex_t const>{src_out.data(), src_out.size()},
+          raft::device_span<vertex_t const>{dst_out.data(), dst_out.size()},
+          raft::device_span<time_stamp_t const>{edge_start_time->data(), edge_start_time->size()},
+          raft::device_span<int32_t const>{hop->data(), hop->size()},
+          raft::device_span<vertex_t const>{random_sources.data(), random_sources.size()},
+          starting_vertex_start_times_span,
+          starting_vertex_end_times_span,
+          raft::device_span<size_t const>{offsets->data(), offsets->size()},
+          batch_number ? std::make_optional(raft::device_span<int32_t const>{batch_number->data(),
+                                                                             batch_number->size()})
+                       : std::nullopt,
+          temporal_neighbor_sampling_usecase.fanout,
+          temporal_neighbor_sampling_usecase.temporal_sampling_comparison,
+          true));
+      }
+
       if (random_sources.size() < 100) {
         // This validation is too expensive for large number of vertices
         ASSERT_TRUE(
@@ -536,7 +521,7 @@ INSTANTIATE_TEST_SUITE_P(
                          false,
                          true,
                          true,
-                         cugraph::temporal_sampling_comparison_t::FIXED_WINDOW,
+                         cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING,
                          true},
                        Fixed_Window_Temporal_Neighbor_Sampling_Usecase{
                          {4, -1, 10},
@@ -545,7 +530,7 @@ INSTANTIATE_TEST_SUITE_P(
                          false,
                          true,
                          true,
-                         cugraph::temporal_sampling_comparison_t::FIXED_WINDOW,
+                         cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING,
                          true}),
                      ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
 
@@ -561,7 +546,7 @@ INSTANTIATE_TEST_SUITE_P(
         false,
         true,
         true,
-        cugraph::temporal_sampling_comparison_t::FIXED_WINDOW,
+        cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING,
         true},
       Fixed_Window_Temporal_Neighbor_Sampling_Usecase{
         {4, -1, 10},
@@ -570,14 +555,12 @@ INSTANTIATE_TEST_SUITE_P(
         false,
         true,
         true,
-        cugraph::temporal_sampling_comparison_t::FIXED_WINDOW,
+        cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING,
         true}),
     ::testing::Values(cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false, 0))));
 
-// The fast-fail is an argument check that runs before any graph traversal, so a single small
-// input is enough to cover it.
 INSTANTIATE_TEST_SUITE_P(
-  file_test_unimplemented_selection,
+  file_test_last_selection,
   Tests_Fixed_Window_Temporal_Neighbor_Sampling_File,
   ::testing::Combine(::testing::Values(Fixed_Window_Temporal_Neighbor_Sampling_Usecase{
                        {4, -1, 10},
@@ -586,9 +569,25 @@ INSTANTIATE_TEST_SUITE_P(
                        false,
                        true,
                        true,
-                       cugraph::temporal_sampling_comparison_t::FIXED_WINDOW,
-                       false,
+                       cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING,
+                       true,
                        cugraph::neighbor_selection_t::LAST}),
                      ::testing::Values(cugraph::test::File_Usecase("test/datasets/karate.mtx"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  rmat_small_test_last_selection,
+  Tests_Fixed_Window_Temporal_Neighbor_Sampling_Rmat,
+  ::testing::Combine(
+    ::testing::Values(Fixed_Window_Temporal_Neighbor_Sampling_Usecase{
+      {4, -1, 10},
+      128,
+      false,
+      false,
+      true,
+      true,
+      cugraph::temporal_sampling_comparison_t::MONOTONICALLY_INCREASING,
+      true,
+      cugraph::neighbor_selection_t::LAST}),
+    ::testing::Values(cugraph::test::Rmat_Usecase(10, 16, 0.57, 0.19, 0.19, 0, false, false, 0))));
 
 CUGRAPH_TEST_PROGRAM_MAIN()

--- a/cpp/tests/sampling/temporal_neighbor_sampling_fixed_window.cpp
+++ b/cpp/tests/sampling/temporal_neighbor_sampling_fixed_window.cpp
@@ -13,6 +13,7 @@
 
 #include <gtest/gtest.h>
 
+#include <iostream>
 #include <ostream>
 #include <string>
 
@@ -358,7 +359,20 @@ class Tests_Fixed_Window_Temporal_Neighbor_Sampling
       hr_timer.display_and_clear(std::cout);
     }
 
+    if (temporal_neighbor_sampling_usecase.neighbor_selection ==
+        cugraph::neighbor_selection_t::LAST) {
+      std::cerr << "[LAST debug] temporal sampling returned: src_out.size()=" << src_out.size()
+                << " dst_out.size()=" << dst_out.size() << " edge_start_time="
+                << (edge_start_time ? std::to_string(edge_start_time->size()) : "nullopt")
+                << " hop=" << (hop ? std::to_string(hop->size()) : "nullopt")
+                << " offsets=" << (offsets ? std::to_string(offsets->size()) : "nullopt") << '\n';
+    }
+
     if (temporal_neighbor_sampling_usecase.check_correctness) {
+      if (temporal_neighbor_sampling_usecase.neighbor_selection ==
+          cugraph::neighbor_selection_t::LAST) {
+        std::cerr << "[LAST debug] starting check_correctness validations\n";
+      }
       //  Every check below only inspects the edges that came back, so they all pass trivially on an
       //  empty result.  Check first that an empty result was actually justified.
       ASSERT_TRUE(cugraph::test::validate_sampling_empty_result(
@@ -447,6 +461,11 @@ class Tests_Fixed_Window_Temporal_Neighbor_Sampling
           cugraph::neighbor_selection_t::LAST) {
         ASSERT_TRUE(offsets.has_value());
         ASSERT_TRUE(hop.has_value());
+        std::cerr << "[LAST debug] starting validate_last_n_selection: sampled_edges="
+                  << src_out.size()
+                  << " fanout_levels=" << temporal_neighbor_sampling_usecase.fanout.size()
+                  << " comparison="
+                  << temporal_neighbor_sampling_usecase.temporal_sampling_comparison << '\n';
         ASSERT_TRUE(cugraph::test::validate_last_n_selection(
           handle,
           graph_view,

--- a/python/pylibcugraph/pylibcugraph/_cugraph_c/algorithms.pxd
+++ b/python/pylibcugraph/pylibcugraph/_cugraph_c/algorithms.pxd
@@ -291,7 +291,6 @@ cdef extern from "cugraph_c/algorithms.h":
         MONOTONICALLY_INCREASING
         STRICTLY_DECREASING
         MONOTONICALLY_DECREASING
-        FIXED_WINDOW
         LAST
 
     ctypedef enum cugraph_neighbor_selection_t:
@@ -319,6 +318,12 @@ cdef extern from "cugraph_c/algorithms.h":
         cugraph_sampling_set_neighbor_selection(
             cugraph_sampling_options_t* options,
             cugraph_neighbor_selection_t selection,
+        )
+
+    cdef void \
+        cugraph_sampling_set_fixed_window(
+            cugraph_sampling_options_t* options,
+            bool_t value,
         )
 
     cdef void \

--- a/python/pylibcugraph/pylibcugraph/neighbor_sample.pyx
+++ b/python/pylibcugraph/pylibcugraph/neighbor_sample.pyx
@@ -187,7 +187,12 @@ def neighbor_sample(ResourceHandle resource_handle,
         temporally eligible edges, keep fanout-K ranked by start time along the walk
         implied by temporal_sampling_comparison — later times for increasing modes,
         earliest times for decreasing modes (last in decreasing time order). Requires
-        temporal sampling, no edge biases, and with_replacement=False.
+        temporal sampling, no edge biases, and with_replacement=False. int32 start
+        times rank exactly over the full signed range; int64 ranks exactly on
+        [-2^52, 2^52 - 1] (typical unix seconds/milliseconds/microseconds). Beyond
+        that, int64 ordering is preserved but values may tie, so fanout edges are still
+        returned yet the chosen set may be wrong when more than fanout K eligible edges
+        on one source share the same rank. Equal timestamps always tie.
 
     fixed_window: bool (Optional)
         If True (temporal only), keep each seed's original time window at

--- a/python/pylibcugraph/pylibcugraph/neighbor_sample.pyx
+++ b/python/pylibcugraph/pylibcugraph/neighbor_sample.pyx
@@ -51,6 +51,7 @@ from pylibcugraph._cugraph_c.algorithms cimport (
     cugraph_sampling_set_use_edge_weights_as_biases,
     cugraph_sampling_set_neighbor_selection,
     cugraph_neighbor_selection_t,
+    cugraph_sampling_set_fixed_window,
 )
 from pylibcugraph._cugraph_c.sampling_algorithms cimport (
     cugraph_neighbor_sample,
@@ -101,7 +102,8 @@ def neighbor_sample(ResourceHandle resource_handle,
                     random_state=None,
                     temporal_sampling_comparison=None,
                     use_edge_weights_as_biases=False,
-                    neighbor_selection='random'):
+                    neighbor_selection='random',
+                    fixed_window=False):
     """
     Unified neighborhood sampling for homogeneous/heterogeneous and
     temporal/non-temporal graphs.
@@ -173,8 +175,7 @@ def neighbor_sample(ResourceHandle resource_handle,
     temporal_sampling_comparison: str (Optional)
         If None (default), sampling is non-temporal. Otherwise one of
         'strictly_increasing', 'strictly_decreasing',
-        'monotonically_increasing', 'monotonically_decreasing',
-        or 'fixed_window'.
+        'monotonically_increasing', or 'monotonically_decreasing'.
 
     use_edge_weights_as_biases: bool (Optional)
         If True and no separate edge-bias property is provided, use graph
@@ -182,7 +183,16 @@ def neighbor_sample(ResourceHandle resource_handle,
         supported from pylibcugraph. Defaults to False (uniform).
 
     neighbor_selection: str (Optional)
-        'random' (default) or 'last'. 'last' is not yet implemented.
+        'random' (default) or 'last'. 'last' keeps the fanout-K eligible
+        edges with the latest start time for increasing comparisons, or
+        the earliest start time for decreasing comparisons. Requires
+        temporal sampling, no edge biases, and with_replacement=False.
+
+    fixed_window: bool (Optional)
+        If True (temporal only), keep each seed's original time window at
+        every hop instead of replacing the frontier bound with the sampled
+        edge time. Orthogonal to temporal_sampling_comparison. Defaults to
+        False.
 
     Returns
     -------
@@ -203,6 +213,7 @@ def neighbor_sample(ResourceHandle resource_handle,
     cdef bool_t c_renumber = renumber
     cdef bool_t c_compress_per_hop = compress_per_hop
     cdef bool_t c_use_edge_weights_as_biases = use_edge_weights_as_biases
+    cdef bool_t c_fixed_window = fixed_window
 
     cdef cugraph_error_code_t error_code
     cdef cugraph_error_t* error_ptr
@@ -365,6 +376,7 @@ def neighbor_sample(ResourceHandle resource_handle,
     cugraph_sampling_set_use_edge_weights_as_biases(
         sampling_options, c_use_edge_weights_as_biases)
     cugraph_sampling_set_neighbor_selection(sampling_options, neighbor_selection_e)
+    cugraph_sampling_set_fixed_window(sampling_options, c_fixed_window)
 
     cdef cugraph_temporal_sampling_comparison_t temporal_sampling_comparison_e
     if temporal_sampling_comparison is not None:
@@ -380,9 +392,6 @@ def neighbor_sample(ResourceHandle resource_handle,
         elif temporal_sampling_comparison == 'monotonically_decreasing':
             temporal_sampling_comparison_e = (
                 cugraph_temporal_sampling_comparison_t.MONOTONICALLY_DECREASING)
-        elif temporal_sampling_comparison == 'fixed_window':
-            temporal_sampling_comparison_e = (
-                cugraph_temporal_sampling_comparison_t.FIXED_WINDOW)
         elif temporal_sampling_comparison == 'last':
             raise NotImplementedError(
                 'The "last" temporal comparison type is currently unsupported.')

--- a/python/pylibcugraph/pylibcugraph/neighbor_sample.pyx
+++ b/python/pylibcugraph/pylibcugraph/neighbor_sample.pyx
@@ -183,9 +183,10 @@ def neighbor_sample(ResourceHandle resource_handle,
         supported from pylibcugraph. Defaults to False (uniform).
 
     neighbor_selection: str (Optional)
-        'random' (default) or 'last'. 'last' keeps the fanout-K eligible
-        edges with the latest start time for increasing comparisons, or
-        the earliest start time for decreasing comparisons. Requires
+        'random' (default) or 'last'. Matches PyG temporal_strategy='last': among
+        temporally eligible edges, keep fanout-K ranked by start time along the walk
+        implied by temporal_sampling_comparison — later times for increasing modes,
+        earliest times for decreasing modes (last in decreasing time order). Requires
         temporal sampling, no edge biases, and with_replacement=False.
 
     fixed_window: bool (Optional)

--- a/python/pylibcugraph/pylibcugraph/tests/test_neighbor_sample.py
+++ b/python/pylibcugraph/pylibcugraph/tests/test_neighbor_sample.py
@@ -93,6 +93,28 @@ def _build_temporal_sg(resource_handle: ResourceHandle) -> SGGraph:
     return G
 
 
+def _build_last_temporal_sg(resource_handle: ResourceHandle) -> SGGraph:
+    srcs = cp.asarray([0, 0, 0, 0], dtype=np.int32)
+    dsts = cp.asarray([1, 2, 3, 4], dtype=np.int32)
+    weights = cp.asarray([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+    edge_start_times = cp.asarray([-5, 0, 5, 10], dtype=np.int32)
+    edge_end_times = edge_start_times + 1
+
+    props = GraphProperties(is_symmetric=False, is_multigraph=False)
+    return SGGraph(
+        resource_handle,
+        props,
+        srcs,
+        dsts,
+        weight_array=weights,
+        edge_start_time_array=edge_start_times,
+        edge_end_time_array=edge_end_times,
+        store_transposed=True,
+        renumber=False,
+        do_expensive_check=False,
+    )
+
+
 def _build_temporal_sg_with_edge_types(resource_handle: ResourceHandle) -> SGGraph:
     srcs = cp.asarray([0, 1, 1, 2], dtype=np.int32)
     dsts = cp.asarray([1, 2, 3, 3], dtype=np.int32)
@@ -328,7 +350,6 @@ def test_starting_vertex_label_offsets_length_mismatch_raises():
         "strictly_decreasing",
         "monotonically_increasing",
         "monotonically_decreasing",
-        "fixed_window",
     ],
 )
 def test_homogeneous_uniform_temporal_none_times(temporal_sampling_comparison):
@@ -361,7 +382,6 @@ def test_homogeneous_uniform_temporal_none_times(temporal_sampling_comparison):
         "strictly_decreasing",
         "monotonically_increasing",
         "monotonically_decreasing",
-        "fixed_window",
     ],
 )
 def test_homogeneous_uniform_temporal_with_times_and_labels(
@@ -398,7 +418,6 @@ def test_homogeneous_uniform_temporal_with_times_and_labels(
         "strictly_decreasing",
         "monotonically_increasing",
         "monotonically_decreasing",
-        "fixed_window",
     ],
 )
 def test_homogeneous_biased_temporal_with_times(temporal_sampling_comparison):
@@ -442,11 +461,44 @@ def test_homogeneous_temporal_with_seed_time_window():
         with_replacement=False,
         do_expensive_check=True,
         disjoint_sampling=True,
-        temporal_sampling_comparison="fixed_window",
+        temporal_sampling_comparison="monotonically_increasing",
+        fixed_window=True,
     )
 
     assert isinstance(result["majors"], cp.ndarray)
     assert isinstance(result["minors"], cp.ndarray)
+
+
+@pytest.mark.parametrize(
+    ("temporal_sampling_comparison", "expected_dst", "expected_time"),
+    [
+        ("monotonically_increasing", 3, 5),
+        ("monotonically_decreasing", 2, 0),
+    ],
+)
+def test_homogeneous_temporal_last_selects_expected_edge(
+    temporal_sampling_comparison, expected_dst, expected_time
+):
+    rh = ResourceHandle()
+    G = _build_last_temporal_sg(rh)
+
+    result = neighbor_sample(
+        rh,
+        G,
+        cp.asarray([0], dtype=np.int32),
+        np.asarray([1], dtype=np.int32),
+        starting_vertex_start_times=cp.asarray([-4], dtype=np.int32),
+        starting_vertex_end_times=cp.asarray([9], dtype=np.int32),
+        with_replacement=False,
+        do_expensive_check=True,
+        disjoint_sampling=True,
+        temporal_sampling_comparison=temporal_sampling_comparison,
+        neighbor_selection="last",
+    )
+
+    assert result["majors"].get().tolist() == [0]
+    assert result["minors"].get().tolist() == [expected_dst]
+    assert result["edge_start_time"].get().tolist() == [expected_time]
 
 
 @pytest.mark.parametrize(
@@ -456,7 +508,6 @@ def test_homogeneous_temporal_with_seed_time_window():
         "strictly_decreasing",
         "monotonically_increasing",
         "monotonically_decreasing",
-        "fixed_window",
     ],
 )
 def test_heterogeneous_uniform_temporal_none_times(temporal_sampling_comparison):
@@ -487,7 +538,6 @@ def test_heterogeneous_uniform_temporal_none_times(temporal_sampling_comparison)
         "strictly_decreasing",
         "monotonically_increasing",
         "monotonically_decreasing",
-        "fixed_window",
     ],
 )
 def test_heterogeneous_biased_temporal_with_times(temporal_sampling_comparison):


### PR DESCRIPTION
Had to make a minor change to the API, last-n needs to be orthogonal to the direction (increasing/decreasing) in order to support first-n (which is basically free if we keep the parameters orthogonal).  I have marked this as non-breaking in spite of this change since we only defined the change within this release, so the only potential breakage would be developers using our nightlies.

Implements last-n using the new primitive.  For int64_t times, the result might be approximate if edge times exceed 2**53 due to the conversion of the time to a double.  If this becomes problematic we can explore alternative options.

