### PR TITLE
Don't use the r-value reference constructor for rmm::device_scalar

### DIFF
--- a/cpp/include/cugraph/edge_partition_device_view.cuh
+++ b/cpp/include/cugraph/edge_partition_device_view.cuh
@@ -557,8 +557,8 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                                     raft::device_span<T const> majors,
                                                     rmm::cuda_stream_view stream) const
   {
-    size_t initial_count{0};
-    rmm::device_scalar<size_t> count(initial_count, stream);
+    rmm::device_scalar<size_t> count(stream);
+    count.set_value_to_zero_async(stream);
     detail::compute_number_of_edges_with_mask_async_mg(
       cuda::std::optional<uint32_t const*>{edge_mask.data()},
       majors,
@@ -576,8 +576,8 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                     std::tuple<vertex_t, vertex_t> vertex_partition_range,
                                     rmm::cuda_stream_view stream) const
   {
-    size_t initial_count{0};
-    rmm::device_scalar<size_t> count(initial_count, stream);
+    rmm::device_scalar<size_t> count(stream);
+    count.set_value_to_zero_async(stream);
     detail::compute_number_of_edges_with_mask_async_mg(
       cuda::std::optional<uint32_t const*>{edge_mask.data()},
       vertex_partition_range,
@@ -595,8 +595,8 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                     majors_from_offsets_t<uint32_t, vertex_t> majors,
                                     rmm::cuda_stream_view stream) const
   {
-    size_t initial_count{0};
-    rmm::device_scalar<size_t> count(initial_count, stream);
+    rmm::device_scalar<size_t> count(stream);
+    count.set_value_to_zero_async(stream);
     detail::compute_number_of_edges_with_mask_async_mg(
       cuda::std::optional<uint32_t const*>{edge_mask.data()},
       majors,
@@ -616,8 +616,8 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                                     MajorIterator major_last,
                                                     rmm::cuda_stream_view stream) const
   {
-    size_t initial_count{0};
-    rmm::device_scalar<size_t> count(initial_count, stream);
+    rmm::device_scalar<size_t> count(stream);
+    count.set_value_to_zero_async(stream);
     detail::compute_number_of_edges_with_mask_async_mg(
       cuda::std::optional<uint32_t const*>{edge_mask.data()},
       major_first,
@@ -635,8 +635,8 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   __host__ size_t compute_number_of_edges(raft::device_span<T const> majors,
                                           rmm::cuda_stream_view stream) const
   {
-    size_t initial_count{0};
-    rmm::device_scalar<size_t> count(initial_count, stream);
+    rmm::device_scalar<size_t> count(stream);
+    count.set_value_to_zero_async(stream);
     compute_number_of_edges_async(majors, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
   }
@@ -644,8 +644,8 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   __host__ size_t compute_number_of_edges(std::tuple<vertex_t, vertex_t> vertex_partition_range,
                                           rmm::cuda_stream_view stream) const
   {
-    size_t initial_count{0};
-    rmm::device_scalar<size_t> count(initial_count, stream);
+    rmm::device_scalar<size_t> count(stream);
+    count.set_value_to_zero_async(stream);
     compute_number_of_edges_async(
       vertex_partition_range, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -654,8 +654,8 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   __host__ size_t compute_number_of_edges(majors_from_offsets_t<uint32_t, vertex_t> majors,
                                           rmm::cuda_stream_view stream) const
   {
-    size_t initial_count{0};
-    rmm::device_scalar<size_t> count(initial_count, stream);
+    rmm::device_scalar<size_t> count(stream);
+    count.set_value_to_zero_async(stream);
     detail::compute_number_of_edges_with_mask_async_mg(cuda::std::nullopt,
                                                        majors,
                                                        raft::device_span<size_t>{count.data(), 1},
@@ -673,8 +673,8 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                           MajorIterator major_last,
                                           rmm::cuda_stream_view stream) const
   {
-    size_t initial_count{0};
-    rmm::device_scalar<size_t> count(initial_count, stream);
+    rmm::device_scalar<size_t> count(stream);
+    count.set_value_to_zero_async(stream);
     compute_number_of_edges_async(
       major_first, major_last, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -1004,8 +1004,8 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                                     raft::device_span<T const> majors,
                                                     rmm::cuda_stream_view stream) const
   {
-    size_t initial_count{0};
-    rmm::device_scalar<size_t> count(initial_count, stream);
+    rmm::device_scalar<size_t> count(stream);
+    count.set_value_to_zero_async(stream);
     compute_number_of_edges_with_mask_async(
       edge_mask, majors, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -1016,8 +1016,8 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                     std::tuple<vertex_t, vertex_t> vertex_partition_range,
                                     rmm::cuda_stream_view stream) const
   {
-    size_t initial_count{0};
-    rmm::device_scalar<size_t> count(initial_count, stream);
+    rmm::device_scalar<size_t> count(stream);
+    count.set_value_to_zero_async(stream);
     compute_number_of_edges_with_mask_async(
       edge_mask, vertex_partition_range, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -1030,8 +1030,8 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                                     MajorIterator major_last,
                                                     rmm::cuda_stream_view stream) const
   {
-    size_t initial_count{0};
-    rmm::device_scalar<size_t> count(initial_count, stream);
+    rmm::device_scalar<size_t> count(stream);
+    count.set_value_to_zero_async(stream);
     compute_number_of_edges_with_mask_async(
       edge_mask, major_first, major_last, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -1041,8 +1041,8 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   __host__ size_t compute_number_of_edges(raft::device_span<T const> majors,
                                           rmm::cuda_stream_view stream) const
   {
-    size_t initial_count{0};
-    rmm::device_scalar<size_t> count(initial_count, stream);
+    rmm::device_scalar<size_t> count(stream);
+    count.set_value_to_zero_async(stream);
     compute_number_of_edges_async(majors, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
   }
@@ -1050,8 +1050,8 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   __host__ size_t compute_number_of_edges(std::tuple<vertex_t, vertex_t> vertex_partition_range,
                                           rmm::cuda_stream_view stream) const
   {
-    size_t initial_count{0};
-    rmm::device_scalar<size_t> count(initial_count, stream);
+    rmm::device_scalar<size_t> count(stream);
+    count.set_value_to_zero_async(stream);
     compute_number_of_edges_async(
       vertex_partition_range, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -1063,8 +1063,8 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                           MajorIterator major_last,
                                           rmm::cuda_stream_view stream) const
   {
-    size_t initial_count{0};
-    rmm::device_scalar<size_t> count(initial_count, stream);
+    rmm::device_scalar<size_t> count(stream);
+    count.set_value_to_zero_async(stream);
     compute_number_of_edges_async(
       major_first, major_last, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);

--- a/cpp/include/cugraph/edge_partition_device_view.cuh
+++ b/cpp/include/cugraph/edge_partition_device_view.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -557,7 +557,9 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                                     raft::device_span<T const> majors,
                                                     rmm::cuda_stream_view stream) const
   {
-    rmm::device_scalar<size_t> count(size_t{0}, stream);
+    size_t initial_count{0};
+    rmm::device_scalar<size_t> count(initial_count, stream);
+    stream.synchronize();
     detail::compute_number_of_edges_with_mask_async_mg(
       cuda::std::optional<uint32_t const*>{edge_mask.data()},
       majors,
@@ -575,7 +577,9 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                     std::tuple<vertex_t, vertex_t> vertex_partition_range,
                                     rmm::cuda_stream_view stream) const
   {
-    rmm::device_scalar<size_t> count(size_t{0}, stream);
+    size_t initial_count{0};
+    rmm::device_scalar<size_t> count(initial_count, stream);
+    stream.synchronize();
     detail::compute_number_of_edges_with_mask_async_mg(
       cuda::std::optional<uint32_t const*>{edge_mask.data()},
       vertex_partition_range,
@@ -593,7 +597,9 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                     majors_from_offsets_t<uint32_t, vertex_t> majors,
                                     rmm::cuda_stream_view stream) const
   {
-    rmm::device_scalar<size_t> count(size_t{0}, stream);
+    size_t initial_count{0};
+    rmm::device_scalar<size_t> count(initial_count, stream);
+    stream.synchronize();
     detail::compute_number_of_edges_with_mask_async_mg(
       cuda::std::optional<uint32_t const*>{edge_mask.data()},
       majors,
@@ -613,7 +619,9 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                                     MajorIterator major_last,
                                                     rmm::cuda_stream_view stream) const
   {
-    rmm::device_scalar<size_t> count(size_t{0}, stream);
+    size_t initial_count{0};
+    rmm::device_scalar<size_t> count(initial_count, stream);
+    stream.synchronize();
     detail::compute_number_of_edges_with_mask_async_mg(
       cuda::std::optional<uint32_t const*>{edge_mask.data()},
       major_first,
@@ -631,7 +639,9 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   __host__ size_t compute_number_of_edges(raft::device_span<T const> majors,
                                           rmm::cuda_stream_view stream) const
   {
-    rmm::device_scalar<size_t> count(size_t{0}, stream);
+    size_t initial_count{0};
+    rmm::device_scalar<size_t> count(initial_count, stream);
+    stream.synchronize();
     compute_number_of_edges_async(majors, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
   }
@@ -639,7 +649,9 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   __host__ size_t compute_number_of_edges(std::tuple<vertex_t, vertex_t> vertex_partition_range,
                                           rmm::cuda_stream_view stream) const
   {
-    rmm::device_scalar<size_t> count(size_t{0}, stream);
+    size_t initial_count{0};
+    rmm::device_scalar<size_t> count(initial_count, stream);
+    stream.synchronize();
     compute_number_of_edges_async(
       vertex_partition_range, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -648,7 +660,9 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   __host__ size_t compute_number_of_edges(majors_from_offsets_t<uint32_t, vertex_t> majors,
                                           rmm::cuda_stream_view stream) const
   {
-    rmm::device_scalar<size_t> count(size_t{0}, stream);
+    size_t initial_count{0};
+    rmm::device_scalar<size_t> count(initial_count, stream);
+    stream.synchronize();
     detail::compute_number_of_edges_with_mask_async_mg(cuda::std::nullopt,
                                                        majors,
                                                        raft::device_span<size_t>{count.data(), 1},
@@ -666,7 +680,9 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                           MajorIterator major_last,
                                           rmm::cuda_stream_view stream) const
   {
-    rmm::device_scalar<size_t> count(size_t{0}, stream);
+    size_t initial_count{0};
+    rmm::device_scalar<size_t> count(initial_count, stream);
+    stream.synchronize();
     compute_number_of_edges_async(
       major_first, major_last, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -996,7 +1012,9 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                                     raft::device_span<T const> majors,
                                                     rmm::cuda_stream_view stream) const
   {
-    rmm::device_scalar<size_t> count(size_t{0}, stream);
+    size_t initial_count{0};
+    rmm::device_scalar<size_t> count(initial_count, stream);
+    stream.synchronize();
     compute_number_of_edges_with_mask_async(
       edge_mask, majors, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -1007,7 +1025,9 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                     std::tuple<vertex_t, vertex_t> vertex_partition_range,
                                     rmm::cuda_stream_view stream) const
   {
-    rmm::device_scalar<size_t> count(size_t{0}, stream);
+    size_t initial_count{0};
+    rmm::device_scalar<size_t> count(initial_count, stream);
+    stream.synchronize();
     compute_number_of_edges_with_mask_async(
       edge_mask, vertex_partition_range, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -1020,7 +1040,9 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                                     MajorIterator major_last,
                                                     rmm::cuda_stream_view stream) const
   {
-    rmm::device_scalar<size_t> count(size_t{0}, stream);
+    size_t initial_count{0};
+    rmm::device_scalar<size_t> count(initial_count, stream);
+    stream.synchronize();
     compute_number_of_edges_with_mask_async(
       edge_mask, major_first, major_last, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -1030,7 +1052,9 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   __host__ size_t compute_number_of_edges(raft::device_span<T const> majors,
                                           rmm::cuda_stream_view stream) const
   {
-    rmm::device_scalar<size_t> count(size_t{0}, stream);
+    size_t initial_count{0};
+    rmm::device_scalar<size_t> count(initial_count, stream);
+    stream.synchronize();
     compute_number_of_edges_async(majors, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
   }
@@ -1038,7 +1062,9 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   __host__ size_t compute_number_of_edges(std::tuple<vertex_t, vertex_t> vertex_partition_range,
                                           rmm::cuda_stream_view stream) const
   {
-    rmm::device_scalar<size_t> count(size_t{0}, stream);
+    size_t initial_count{0};
+    rmm::device_scalar<size_t> count(initial_count, stream);
+    stream.synchronize();
     compute_number_of_edges_async(
       vertex_partition_range, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -1050,7 +1076,9 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
                                           MajorIterator major_last,
                                           rmm::cuda_stream_view stream) const
   {
-    rmm::device_scalar<size_t> count(size_t{0}, stream);
+    size_t initial_count{0};
+    rmm::device_scalar<size_t> count(initial_count, stream);
+    stream.synchronize();
     compute_number_of_edges_async(
       major_first, major_last, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);

--- a/cpp/include/cugraph/edge_partition_device_view.cuh
+++ b/cpp/include/cugraph/edge_partition_device_view.cuh
@@ -559,7 +559,6 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   {
     size_t initial_count{0};
     rmm::device_scalar<size_t> count(initial_count, stream);
-    stream.synchronize();
     detail::compute_number_of_edges_with_mask_async_mg(
       cuda::std::optional<uint32_t const*>{edge_mask.data()},
       majors,
@@ -579,7 +578,6 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   {
     size_t initial_count{0};
     rmm::device_scalar<size_t> count(initial_count, stream);
-    stream.synchronize();
     detail::compute_number_of_edges_with_mask_async_mg(
       cuda::std::optional<uint32_t const*>{edge_mask.data()},
       vertex_partition_range,
@@ -599,7 +597,6 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   {
     size_t initial_count{0};
     rmm::device_scalar<size_t> count(initial_count, stream);
-    stream.synchronize();
     detail::compute_number_of_edges_with_mask_async_mg(
       cuda::std::optional<uint32_t const*>{edge_mask.data()},
       majors,
@@ -621,7 +618,6 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   {
     size_t initial_count{0};
     rmm::device_scalar<size_t> count(initial_count, stream);
-    stream.synchronize();
     detail::compute_number_of_edges_with_mask_async_mg(
       cuda::std::optional<uint32_t const*>{edge_mask.data()},
       major_first,
@@ -641,7 +637,6 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   {
     size_t initial_count{0};
     rmm::device_scalar<size_t> count(initial_count, stream);
-    stream.synchronize();
     compute_number_of_edges_async(majors, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
   }
@@ -651,7 +646,6 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   {
     size_t initial_count{0};
     rmm::device_scalar<size_t> count(initial_count, stream);
-    stream.synchronize();
     compute_number_of_edges_async(
       vertex_partition_range, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -662,7 +656,6 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   {
     size_t initial_count{0};
     rmm::device_scalar<size_t> count(initial_count, stream);
-    stream.synchronize();
     detail::compute_number_of_edges_with_mask_async_mg(cuda::std::nullopt,
                                                        majors,
                                                        raft::device_span<size_t>{count.data(), 1},
@@ -682,7 +675,6 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   {
     size_t initial_count{0};
     rmm::device_scalar<size_t> count(initial_count, stream);
-    stream.synchronize();
     compute_number_of_edges_async(
       major_first, major_last, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -1014,7 +1006,6 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   {
     size_t initial_count{0};
     rmm::device_scalar<size_t> count(initial_count, stream);
-    stream.synchronize();
     compute_number_of_edges_with_mask_async(
       edge_mask, majors, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -1027,7 +1018,6 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   {
     size_t initial_count{0};
     rmm::device_scalar<size_t> count(initial_count, stream);
-    stream.synchronize();
     compute_number_of_edges_with_mask_async(
       edge_mask, vertex_partition_range, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -1042,7 +1032,6 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   {
     size_t initial_count{0};
     rmm::device_scalar<size_t> count(initial_count, stream);
-    stream.synchronize();
     compute_number_of_edges_with_mask_async(
       edge_mask, major_first, major_last, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -1054,7 +1043,6 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   {
     size_t initial_count{0};
     rmm::device_scalar<size_t> count(initial_count, stream);
-    stream.synchronize();
     compute_number_of_edges_async(majors, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
   }
@@ -1064,7 +1052,6 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   {
     size_t initial_count{0};
     rmm::device_scalar<size_t> count(initial_count, stream);
-    stream.synchronize();
     compute_number_of_edges_async(
       vertex_partition_range, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);
@@ -1078,7 +1065,6 @@ class edge_partition_device_view_t<vertex_t, edge_t, multi_gpu, std::enable_if_t
   {
     size_t initial_count{0};
     rmm::device_scalar<size_t> count(initial_count, stream);
-    stream.synchronize();
     compute_number_of_edges_async(
       major_first, major_last, raft::device_span<size_t>{count.data(), 1}, stream);
     return count.value(stream);

--- a/cpp/include/cugraph/prims/vertex_frontier.cuh
+++ b/cpp/include/cugraph/prims/vertex_frontier.cuh
@@ -187,9 +187,7 @@ void device_bcast_vertex_list(
     assert((comm.get_rank() != root) || (std::get<0>(v_list).size() == tmp_bitmap.size()));
     device_bcast(
       comm, std::get<0>(v_list).data(), tmp_bitmap.data(), tmp_bitmap.size(), root, stream_view);
-    size_t initial_dummy{0};
-    rmm::device_scalar<size_t> dummy(initial_dummy, stream_view);  // we already know the count
-    stream_view.synchronize();
+    rmm::device_scalar<size_t> dummy(stream_view);  // we already know the count
     detail::copy_if_nosync(
       thrust::make_counting_iterator(vertex_range_first),
       thrust::make_counting_iterator(vertex_range_last),

--- a/cpp/include/cugraph/prims/vertex_frontier.cuh
+++ b/cpp/include/cugraph/prims/vertex_frontier.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -187,7 +187,9 @@ void device_bcast_vertex_list(
     assert((comm.get_rank() != root) || (std::get<0>(v_list).size() == tmp_bitmap.size()));
     device_bcast(
       comm, std::get<0>(v_list).data(), tmp_bitmap.data(), tmp_bitmap.size(), root, stream_view);
-    rmm::device_scalar<size_t> dummy(size_t{0}, stream_view);  // we already know the count
+    size_t initial_dummy{0};
+    rmm::device_scalar<size_t> dummy(initial_dummy, stream_view);  // we already know the count
+    stream_view.synchronize();
     detail::copy_if_nosync(
       thrust::make_counting_iterator(vertex_range_first),
       thrust::make_counting_iterator(vertex_range_last),

--- a/cpp/src/components/weakly_connected_components_impl.cuh
+++ b/cpp/src/components/weakly_connected_components_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -415,7 +415,9 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
 
     auto edge_buffer =
       allocate_dataframe_buffer<cuda::std::tuple<vertex_t, vertex_t>>(0, handle.get_stream());
-    rmm::device_scalar<size_t> num_edge_inserts(size_t{0}, handle.get_stream());
+    size_t initial_num_edge_inserts{0};
+    rmm::device_scalar<size_t> num_edge_inserts(initial_num_edge_inserts, handle.get_stream());
+    handle.sync_stream();
 
     // 2-3. run BFS or multi-root expansion
 

--- a/cpp/src/components/weakly_connected_components_impl.cuh
+++ b/cpp/src/components/weakly_connected_components_impl.cuh
@@ -415,8 +415,8 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
 
     auto edge_buffer =
       allocate_dataframe_buffer<cuda::std::tuple<vertex_t, vertex_t>>(0, handle.get_stream());
-    size_t initial_num_edge_inserts{0};
-    rmm::device_scalar<size_t> num_edge_inserts(initial_num_edge_inserts, handle.get_stream());
+    rmm::device_scalar<size_t> num_edge_inserts(handle.get_stream());
+    num_edge_inserts.set_value_to_zero_async(handle.get_stream());
 
     // 2-3. run BFS or multi-root expansion
 

--- a/cpp/src/components/weakly_connected_components_impl.cuh
+++ b/cpp/src/components/weakly_connected_components_impl.cuh
@@ -417,7 +417,6 @@ void weakly_connected_components_impl(raft::handle_t const& handle,
       allocate_dataframe_buffer<cuda::std::tuple<vertex_t, vertex_t>>(0, handle.get_stream());
     size_t initial_num_edge_inserts{0};
     rmm::device_scalar<size_t> num_edge_inserts(initial_num_edge_inserts, handle.get_stream());
-    handle.sync_stream();
 
     // 2-3. run BFS or multi-root expansion
 

--- a/cpp/src/structure/graph_view_impl.cuh
+++ b/cpp/src/structure/graph_view_impl.cuh
@@ -314,8 +314,8 @@ edge_t count_edge_partition_multi_edges(
 {
   auto execution_policy = handle.get_thrust_policy();
   if (segment_offsets) {
-    edge_t initial_count{0};
-    rmm::device_scalar<edge_t> count(initial_count, handle.get_stream());
+    rmm::device_scalar<edge_t> count(handle.get_stream());
+    count.set_value_to_zero_async(handle.get_stream());
     // FIXME: we may further improve performance by 1) concurrently running kernels on different
     // segments; 2) individually tuning block sizes for different segments; and 3) adding one more
     // segment for very high degree vertices and running segmented reduction
@@ -698,8 +698,8 @@ edge_t graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu, std::enable_i
 {
   auto in_degrees = compute_in_degrees(handle);
   auto it = thrust::max_element(handle.get_thrust_policy(), in_degrees.begin(), in_degrees.end());
-  edge_t initial_value{0};
-  rmm::device_scalar<edge_t> ret(initial_value, handle.get_stream());
+  rmm::device_scalar<edge_t> ret(handle.get_stream());
+  ret.set_value_to_zero_async(handle.get_stream());
   device_allreduce(handle.get_comms(),
                    it != in_degrees.end() ? it : ret.data(),
                    ret.data(),
@@ -727,8 +727,8 @@ edge_t graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu, std::enable_i
 {
   auto out_degrees = compute_out_degrees(handle);
   auto it = thrust::max_element(handle.get_thrust_policy(), out_degrees.begin(), out_degrees.end());
-  edge_t initial_value{0};
-  rmm::device_scalar<edge_t> ret(initial_value, handle.get_stream());
+  rmm::device_scalar<edge_t> ret(handle.get_stream());
+  ret.set_value_to_zero_async(handle.get_stream());
   device_allreduce(handle.get_comms(),
                    it != out_degrees.end() ? it : ret.data(),
                    ret.data(),

--- a/cpp/src/structure/graph_view_impl.cuh
+++ b/cpp/src/structure/graph_view_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -314,7 +314,9 @@ edge_t count_edge_partition_multi_edges(
 {
   auto execution_policy = handle.get_thrust_policy();
   if (segment_offsets) {
-    rmm::device_scalar<edge_t> count(edge_t{0}, handle.get_stream());
+    edge_t initial_count{0};
+    rmm::device_scalar<edge_t> count(initial_count, handle.get_stream());
+    handle.sync_stream();
     // FIXME: we may further improve performance by 1) concurrently running kernels on different
     // segments; 2) individually tuning block sizes for different segments; and 3) adding one more
     // segment for very high degree vertices and running segmented reduction
@@ -697,7 +699,9 @@ edge_t graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu, std::enable_i
 {
   auto in_degrees = compute_in_degrees(handle);
   auto it = thrust::max_element(handle.get_thrust_policy(), in_degrees.begin(), in_degrees.end());
-  rmm::device_scalar<edge_t> ret(edge_t{0}, handle.get_stream());
+  edge_t initial_value{0};
+  rmm::device_scalar<edge_t> ret(initial_value, handle.get_stream());
+  handle.sync_stream();
   device_allreduce(handle.get_comms(),
                    it != in_degrees.end() ? it : ret.data(),
                    ret.data(),
@@ -725,7 +729,9 @@ edge_t graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu, std::enable_i
 {
   auto out_degrees = compute_out_degrees(handle);
   auto it = thrust::max_element(handle.get_thrust_policy(), out_degrees.begin(), out_degrees.end());
-  rmm::device_scalar<edge_t> ret(edge_t{0}, handle.get_stream());
+  edge_t initial_value{0};
+  rmm::device_scalar<edge_t> ret(initial_value, handle.get_stream());
+  handle.sync_stream();
   device_allreduce(handle.get_comms(),
                    it != out_degrees.end() ? it : ret.data(),
                    ret.data(),

--- a/cpp/src/structure/graph_view_impl.cuh
+++ b/cpp/src/structure/graph_view_impl.cuh
@@ -316,7 +316,6 @@ edge_t count_edge_partition_multi_edges(
   if (segment_offsets) {
     edge_t initial_count{0};
     rmm::device_scalar<edge_t> count(initial_count, handle.get_stream());
-    handle.sync_stream();
     // FIXME: we may further improve performance by 1) concurrently running kernels on different
     // segments; 2) individually tuning block sizes for different segments; and 3) adding one more
     // segment for very high degree vertices and running segmented reduction
@@ -701,7 +700,6 @@ edge_t graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu, std::enable_i
   auto it = thrust::max_element(handle.get_thrust_policy(), in_degrees.begin(), in_degrees.end());
   edge_t initial_value{0};
   rmm::device_scalar<edge_t> ret(initial_value, handle.get_stream());
-  handle.sync_stream();
   device_allreduce(handle.get_comms(),
                    it != in_degrees.end() ? it : ret.data(),
                    ret.data(),
@@ -731,7 +729,6 @@ edge_t graph_view_t<vertex_t, edge_t, store_transposed, multi_gpu, std::enable_i
   auto it = thrust::max_element(handle.get_thrust_policy(), out_degrees.begin(), out_degrees.end());
   edge_t initial_value{0};
   rmm::device_scalar<edge_t> ret(initial_value, handle.get_stream());
-  handle.sync_stream();
   device_allreduce(handle.get_comms(),
                    it != out_degrees.end() ? it : ret.data(),
                    ret.data(),

--- a/cpp/tests/traversal/bfs_test.cpp
+++ b/cpp/tests/traversal/bfs_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -138,7 +138,8 @@ class Tests_BFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, input_
       hr_timer.start("BFS");
     }
 
-    rmm::device_scalar<vertex_t> const d_source(bfs_usecase.source, handle.get_stream());
+    vertex_t const source{static_cast<vertex_t>(bfs_usecase.source)};
+    rmm::device_scalar<vertex_t> const d_source(source, handle.get_stream());
 
     cugraph::bfs(handle,
                  graph_view,

--- a/cpp/tests/traversal/bfs_test.cpp
+++ b/cpp/tests/traversal/bfs_test.cpp
@@ -140,6 +140,8 @@ class Tests_BFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, input_
 
     vertex_t const source{static_cast<vertex_t>(bfs_usecase.source)};
     rmm::device_scalar<vertex_t> const d_source(source, handle.get_stream());
+    handle
+      .sync_stream();  // before source goes out-of-scope (async H2D copy from device_scalar ctor)
 
     cugraph::bfs(handle,
                  graph_view,

--- a/cpp/tests/traversal/extract_bfs_paths_test.cu
+++ b/cpp/tests/traversal/extract_bfs_paths_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -104,8 +104,8 @@ class Tests_ExtractBfsPaths
     rmm::device_uvector<vertex_t> d_predecessors(graph_view.number_of_vertices(),
                                                  handle.get_stream());
 
-    rmm::device_scalar<vertex_t> const d_source(extract_bfs_paths_usecase.source,
-                                                handle.get_stream());
+    vertex_t const source{static_cast<vertex_t>(extract_bfs_paths_usecase.source)};
+    rmm::device_scalar<vertex_t> const d_source(source, handle.get_stream());
 
     cugraph::bfs(handle,
                  graph_view,

--- a/cpp/tests/traversal/mg_bfs_test.cpp
+++ b/cpp/tests/traversal/mg_bfs_test.cpp
@@ -107,6 +107,10 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
       mg_graph_view.in_local_vertex_partition_range_nocheck(source)
         ? std::make_optional<rmm::device_scalar<vertex_t>>(source, handle_->get_stream())
         : std::nullopt;
+    if (d_mg_source) {
+      handle_->sync_stream();  // before source goes out-of-scope (async H2D copy from device_scalar
+                               // ctor)
+    }
 
     if (cugraph::test::g_perf) {
       RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement

--- a/cpp/tests/traversal/mg_bfs_test.cpp
+++ b/cpp/tests/traversal/mg_bfs_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -102,10 +102,11 @@ class Tests_MGBFS : public ::testing::TestWithParam<std::tuple<BFS_Usecase, inpu
     rmm::device_uvector<vertex_t> d_mg_predecessors(
       mg_graph_view.local_vertex_partition_range_size(), handle_->get_stream());
 
-    auto d_mg_source = mg_graph_view.in_local_vertex_partition_range_nocheck(bfs_usecase.source)
-                         ? std::make_optional<rmm::device_scalar<vertex_t>>(bfs_usecase.source,
-                                                                            handle_->get_stream())
-                         : std::nullopt;
+    vertex_t const source{static_cast<vertex_t>(bfs_usecase.source)};
+    auto d_mg_source =
+      mg_graph_view.in_local_vertex_partition_range_nocheck(source)
+        ? std::make_optional<rmm::device_scalar<vertex_t>>(source, handle_->get_stream())
+        : std::nullopt;
 
     if (cugraph::test::g_perf) {
       RAFT_CUDA_TRY(cudaDeviceSynchronize());  // for consistent performance measurement

--- a/cpp/tests/traversal/mg_extract_bfs_paths_test.cu
+++ b/cpp/tests/traversal/mg_extract_bfs_paths_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -104,10 +104,10 @@ class Tests_MGExtractBFSPaths
     rmm::device_uvector<vertex_t> d_mg_predecessors(
       mg_graph_view.local_vertex_partition_range_size(), handle_->get_stream());
 
+    vertex_t const source{static_cast<vertex_t>(extract_bfs_paths_usecase.source)};
     auto const d_mg_source =
-      mg_graph_view.in_local_vertex_partition_range_nocheck(extract_bfs_paths_usecase.source)
-        ? std::make_optional<rmm::device_scalar<vertex_t>>(extract_bfs_paths_usecase.source,
-                                                           handle_->get_stream())
+      mg_graph_view.in_local_vertex_partition_range_nocheck(source)
+        ? std::make_optional<rmm::device_scalar<vertex_t>>(source, handle_->get_stream())
         : std::nullopt;
 
     cugraph::bfs(*handle_,

--- a/cpp/tests/traversal/mg_sssp_test.cpp
+++ b/cpp/tests/traversal/mg_sssp_test.cpp
@@ -131,7 +131,8 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
 
       vertex_t sg_source{static_cast<vertex_t>(sssp_usecase.source)};
       rmm::device_scalar<vertex_t> d_sg_source(sg_source, handle_->get_stream());
-      handle_->sync_stream();
+      handle_->sync_stream();  // before sg_source goes out-of-scope (async H2D copy from
+                               // device_scalar ctor)
 
       cugraph::unrenumber_int_vertices<vertex_t, true>(
         *handle_,

--- a/cpp/tests/traversal/mg_sssp_test.cpp
+++ b/cpp/tests/traversal/mg_sssp_test.cpp
@@ -131,6 +131,7 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
 
       vertex_t sg_source{static_cast<vertex_t>(sssp_usecase.source)};
       rmm::device_scalar<vertex_t> d_sg_source(sg_source, handle_->get_stream());
+      handle_->sync_stream();
 
       cugraph::unrenumber_int_vertices<vertex_t, true>(
         *handle_,

--- a/cpp/tests/traversal/mg_sssp_test.cpp
+++ b/cpp/tests/traversal/mg_sssp_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -129,8 +129,9 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
         (*mg_renumber_map).data(),
         mg_graph_view.vertex_partition_range_lasts());
 
-      rmm::device_scalar<vertex_t> d_sg_source(static_cast<vertex_t>(sssp_usecase.source),
-                                               handle_->get_stream());
+      vertex_t sg_source{static_cast<vertex_t>(sssp_usecase.source)};
+      rmm::device_scalar<vertex_t> d_sg_source(sg_source, handle_->get_stream());
+      handle_->sync_stream();
 
       cugraph::unrenumber_int_vertices<vertex_t, true>(
         *handle_,

--- a/cpp/tests/traversal/mg_sssp_test.cpp
+++ b/cpp/tests/traversal/mg_sssp_test.cpp
@@ -131,7 +131,6 @@ class Tests_MGSSSP : public ::testing::TestWithParam<std::tuple<SSSP_Usecase, in
 
       vertex_t sg_source{static_cast<vertex_t>(sssp_usecase.source)};
       rmm::device_scalar<vertex_t> d_sg_source(sg_source, handle_->get_stream());
-      handle_->sync_stream();
 
       cugraph::unrenumber_int_vertices<vertex_t, true>(
         *handle_,

--- a/cpp/tests/utilities/property_generator_utilities_impl.cuh
+++ b/cpp/tests/utilities/property_generator_utilities_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -167,7 +167,9 @@ generate<GraphViewType, property_t>::unique_edge_property(raft::handle_t const& 
     CUGRAPH_EXPECTS(
       graph_view.compute_number_of_edges(handle) <= std::numeric_limits<property_t>::max(),
       "std::numeric_limits<property_t>::max() is smaller than the number of edges.");
-    rmm::device_scalar<property_t> counter(property_t{0}, handle.get_stream());
+    property_t initial_counter{0};
+    rmm::device_scalar<property_t> counter(initial_counter, handle.get_stream());
+    handle.sync_stream();
     cugraph::transform_e(
       handle,
       graph_view,

--- a/cpp/tests/utilities/property_generator_utilities_impl.cuh
+++ b/cpp/tests/utilities/property_generator_utilities_impl.cuh
@@ -167,9 +167,8 @@ generate<GraphViewType, property_t>::unique_edge_property(raft::handle_t const& 
     CUGRAPH_EXPECTS(
       graph_view.compute_number_of_edges(handle) <= std::numeric_limits<property_t>::max(),
       "std::numeric_limits<property_t>::max() is smaller than the number of edges.");
-    property_t initial_counter{0};
-    rmm::device_scalar<property_t> counter(initial_counter, handle.get_stream());
-    handle.sync_stream();
+    rmm::device_scalar<property_t> counter(handle.get_stream());
+    counter.set_value_to_zero_async(handle.get_stream());
     cugraph::transform_e(
       handle,
       graph_view,


### PR DESCRIPTION
https://github.com/rapidsai/rmm/pull/2527 eliminated the r-value reference constructors for rmm::device_scalar, since it did asynchronous updates and could have issues if the r-value went out of scope.

This PR removes all references to that constructor.