### PR TITLE
Add synchronization to coo_to_csr

### DIFF
--- a/cpp/include/cugraph/legacy/functions.hpp
+++ b/cpp/include/cugraph/legacy/functions.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -34,6 +34,9 @@ namespace CUGRAPH_EXPORT cugraph {
  *
  * @param[in]  graph          cuGraph graph in coordinate format
  * @param[in]  mr             Memory resource used to allocate the returned graph
+ *
+ * @note Synchronizes the internal CUDA stream before returning so callers may use the
+ *       returned CSR on a different stream without additional ordering.
  *
  * @return                    Unique pointer to generate Compressed Sparse Row graph
  *

--- a/cpp/src/converters/legacy/COOtoCSR.cuh
+++ b/cpp/src/converters/legacy/COOtoCSR.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /*
@@ -153,6 +153,11 @@ std::unique_ptr<legacy::GraphCSR<VT, ET, WT>> coo_to_csr(
     std::make_unique<rmm::device_buffer>(std::move(offsets)),
     std::move(coo_contents.dst_indices),
     std::move(coo_contents.edge_data)};
+
+  // All conversion work runs on stream_view, which callers do not share (for example
+  // raft::handle_t defaults to cudaStreamPerThread). Synchronize before returning so
+  // downstream algorithms can safely consume the CSR buffers on any stream.
+  stream_view.synchronize();
 
   return std::make_unique<legacy::GraphCSR<VT, ET, WT>>(std::move(csr_contents));
 }


### PR DESCRIPTION
This legacy code is only used in MST and in some legacy python code.  Performance is not critical.

We could add a handle so that we can all use the same stream, but that has breaking API implications.  Simplest is to just add a synchronization call before leaving the function.