### PR TITLE
Fix RAPIDS wheel discovery in pip builds

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -19,14 +19,13 @@ rapids_cuda_init_architectures(CUGRAPH)
 
 project(CUGRAPH VERSION "${RAPIDS_VERSION}" LANGUAGES C CXX CUDA)
 
-# Make libcuvs shipped in an installed wheel discoverable. This is needed for
-# direct C++ builds in pip environments, where scikit-build-core is not present
-# to add the wheel's `cmake.prefix` entry point to CMAKE_PREFIX_PATH.
+# Make CMake packages shipped in installed RAPIDS wheels discoverable. This is
+# needed for direct C++ builds in pip environments, where scikit-build-core is
+# not present to add the wheels' `cmake.prefix` entry points to CMAKE_PREFIX_PATH.
 find_package(Python COMPONENTS Interpreter)
 if(Python_FOUND)
   include(${rapids-cmake-dir}/cython-core/find_prefix_paths.cmake)
   rapids_cython_find_prefix_paths("${Python_EXECUTABLE}" wheel_prefix_paths)
-  list(FILTER wheel_prefix_paths INCLUDE REGEX "/libcuvs$")
   set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
   list(APPEND CMAKE_PREFIX_PATH ${wheel_prefix_paths})
 endif()

--- a/python/cugraph/CMakeLists.txt
+++ b/python/cugraph/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -19,6 +19,9 @@ project(
   VERSION "${RAPIDS_VERSION}"
   LANGUAGES CXX CUDA
 )
+
+# Find C++ libraries from RAPIDS wheels in site-packages.
+set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
 
 find_package(cugraph "${RAPIDS_VERSION}" REQUIRED)
 

--- a/python/libcugraph/CMakeLists.txt
+++ b/python/libcugraph/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -17,6 +17,9 @@ project(
   VERSION "${RAPIDS_VERSION}"
   LANGUAGES CXX CUDA
 )
+
+# Find C++ libraries from RAPIDS wheels in site-packages.
+set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
 
 # Check if cugraph is already available. If so, it is the user's responsibility to ensure that the
 # CMake package is also available at build time of Python packages that need libcugraph.

--- a/python/pylibcugraph/CMakeLists.txt
+++ b/python/pylibcugraph/CMakeLists.txt
@@ -20,6 +20,9 @@ project(
   LANGUAGES CXX CUDA
 )
 
+# Find C++ libraries from RAPIDS wheels in site-packages.
+set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
+
 find_package(cugraph "${RAPIDS_VERSION}" REQUIRED)
 
 # an installed version of libcugraph doesn't provide the dlpack headers so we


### PR DESCRIPTION
## Description

Follow-up to #5654.

The pip devcontainer already installs prebuilt `libcuvs`, `libraft`, `librmm`, and `rapids-logger` wheels. The C++ build should discover all of their CMake package prefixes rather than restricting discovery to `libcuvs` and falling back to source builds for RMM and RAFT.

Each Python package also starts an independent CMake process. On Debian-derived images, CMake disables `FIND_LIBRARY_USE_LIB64_PATHS` by default, so those processes do not search the wheels' `lib64/cmake` directories. This leaves transitive `nvtx3::nvtx3-cpp` and `rapids_logger::rapids_logger` targets unresolved even though the wheels are installed and their roots are present in `CMAKE_PREFIX_PATH`.

This PR:

- restores unfiltered discovery of all CMake prefixes exported by installed Python wheels in the C++ build;
- enables `FIND_LIBRARY_USE_LIB64_PATHS` before `find_package(cugraph)` in the `libcugraph`, `pylibcugraph`, and `cugraph` Python CMake projects.

This follows the same CMake ordering and wheel-discovery pattern used by cuDF.

## Validation

Using `rapids-dev cuda13.3-pip` at the previously failing #5654 commit:

- confirmed the C++ configure selected local wheel packages for RMM, RAFT, and cuVS;
- reproduced the downstream missing NVTX and RAPIDS Logger targets in the separate `pylibcugraph` configure;
- confirmed fresh configure/generate steps succeed for all three Python CMake entry points with the `lib64` search property enabled;
- confirmed the C++ configure continues to select local wheel packages for RMM, RAFT, and cuVS with unfiltered prefix discovery.

Targeted pre-commit hooks pass for all changed files.
