### PR TITLE
wheels: exclude libkvikio.so from 'auditwheel repair'

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -86,6 +86,7 @@ EXCLUDE_ARGS+=(
   --exclude "libcurand.so.*"
   --exclude "libcusolver.so.*"
   --exclude "libcusparse.so.*"
+  --exclude "libkvikio.so*"
   --exclude "libnvJitLink.so.*"
   --exclude "librapids_logger.so"
   --exclude "librmm.so"


### PR DESCRIPTION
As of https://github.com/NVIDIA/cuvs/pull/2565 (I think), `libcuvs.so` requires `libkvikio.so` at runtime.

```shell
mkdir -p ./delete-me
pip download \
  -d ./delete-me \
  --no-deps \
  --index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/ \
  'libcuvs-cu13>=26.10.0a0'
cd ./delete-me
unzip ./libcuvs*.whl
```

```console
$ ldd libcuvs/lib64/libcuvs.so
        ...
        libkvikio.so => not found
        ...
```

`auditwheel repair` sees that dependency when it resolves `libcugraph.so`'s dependency on `libcuvs.so`, and so CI is failing here like this:

> ValueError: Cannot repair wheel, because required library "libkvikio.so" could not be located

([build link](https://github.com/rapidsai/cugraph/actions/runs/34483969788/job/102894257002))

This fixes that by excluding `libkvikio.so` from `auditwheel repair`. This is safe to do because `libcuvs-cu13` has a runtime dependency on `libkvikio-cu13` to provide that.

## Notes for Reviewers

A similar change was needed in `cuml`: https://github.com/NVIDIA/cuml/pull/8604