### PR TITLE
bump cuda-bindings floors to 12.9.3 (CUDA 12) and 13.0.2 (CUDA 13)

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - certifi
 - cmake>=4.0
-- cuda-bindings>=12.9.2,<13.0
+- cuda-bindings>=12.9.3,<13.0
 - cuda-nvcc
 - cuda-nvtx-dev
 - cuda-profiler-api

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - certifi
 - cmake>=4.0
-- cuda-bindings>=12.9.2,<13.0
+- cuda-bindings>=12.9.3,<13.0
 - cuda-nvcc
 - cuda-nvtx-dev
 - cuda-profiler-api

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - certifi
 - cmake>=4.0
-- cuda-bindings>=13.0.1,<14.0
+- cuda-bindings>=13.0.2,<14.0
 - cuda-nvcc
 - cuda-nvtx-dev
 - cuda-profiler-api

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - certifi
 - cmake>=4.0
-- cuda-bindings>=13.0.1,<14.0
+- cuda-bindings>=13.0.2,<14.0
 - cuda-nvcc
 - cuda-nvtx-dev
 - cuda-profiler-api

--- a/conda/recipes/cugraph/recipe.yaml
+++ b/conda/recipes/cugraph/recipe.yaml
@@ -108,8 +108,8 @@ requirements:
     - requests
     - ucxx ${{ ucxx_version }}
     - if: cuda_major == "12"
-      then: cuda-bindings >=12.9.2,<13.0
-      else: cuda-bindings >=13.0.1,<14.0
+      then: cuda-bindings >=12.9.3,<13.0
+      else: cuda-bindings >=13.0.2,<14.0
   ignore_run_exports:
     from_package:
     by_name:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -464,11 +464,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cuda-bindings>=12.9.2,<13.0
+              - cuda-bindings>=12.9.3,<13.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cuda-bindings>=13.0.1,<14.0
+              - cuda-bindings>=13.0.2,<14.0
   python_run_pylibcugraph:
     common:
       - output_types: [conda, pyproject, requirements]
@@ -503,12 +503,12 @@ dependencies:
               dependencies: "oldest"
               cuda: "12.*"
             packages:
-              - cuda-bindings==12.9.2
+              - cuda-bindings==12.9.3
           - matrix:
               dependencies: "oldest"
               cuda: "13.*"
             packages:
-              - cuda-bindings==13.0.1
+              - cuda-bindings==13.0.2
           - matrix:
             packages:
   test_python_cugraph:

--- a/python/cugraph/pyproject.toml
+++ b/python/cugraph/pyproject.toml
@@ -24,7 +24,7 @@ authors = [
 license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
-    "cuda-bindings>=13.0.1,<14.0",
+    "cuda-bindings>=13.0.2,<14.0",
     "cudf==26.12.*,>=0.0.0a0",
     "cupy-cuda13x[ctk]>=14.0.1,!=14.1.0",
     "dask-cuda==26.12.*,>=0.0.0a0",


### PR DESCRIPTION
https://github.com/NVIDIA/cudf/pull/21928 bumped `cudf`'s `cuda-bindings` floors, and as a result CI is breaking on `main` here for "oldest-deps" jobs

```text
error    libmamba Could not solve for environment specs
    The following packages are incompatible
    ├─ cuda-bindings ==12.9.2 * is requested and can be installed;
    └─ cugraph =26.12,>=0.0.0a0 * is not installable because there are no viable options
       ├─ cugraph 26.12.00a15 would require
       │  └─ pylibcudf =26.12 * but there are no viable options
       │     ├─ pylibcudf [26.12.00a0|26.12.00a10|...|26.12.00a9] would require
       │     │  └─ cuda-bindings >=12.9.3,<13.0 *, which conflicts with any installable versions previously reported;
       │     └─ pylibcudf [26.12.00a0|26.12.00a10|...|26.12.00a9] would require
       │        └─ cuda-bindings >=13.0.2,<14.0 *, which conflicts with any installable versions previously reported;
       └─ cugraph [26.12.00a0|26.12.00a11|26.12.00a4|26.12.00a9] conflicts with any installable versions previously reported.
critical libmamba Could not solve for environment specs
```

([build link](https://github.com/rapidsai/cugraph/actions/runs/34551642334/job/103120899608?pr=5662))

This fixes that by bumping `cugraph`'s floors to match.