### PR TITLE
Deprecate MTMG graph and result APIs for removal in 27.02

### DIFF
--- a/cpp/include/cugraph/mtmg/edge_property.hpp
+++ b/cpp/include/cugraph/mtmg/edge_property.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,6 +14,8 @@ namespace mtmg {
 
 /**
  * @brief Edge property object for each GPU
+ *
+ * @deprecated This API is deprecated and will be removed in release 27.02.
  */
 template <typename edge_t>
 class edge_property_t

--- a/cpp/include/cugraph/mtmg/edge_property_view.hpp
+++ b/cpp/include/cugraph/mtmg/edge_property_view.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,6 +13,8 @@ namespace mtmg {
 
 /**
  * @brief Edge property object for each GPU
+ *
+ * @deprecated This API is deprecated and will be removed in release 27.02.
  */
 template <typename edge_t>
 using edge_property_view_t =

--- a/cpp/include/cugraph/mtmg/edgelist.hpp
+++ b/cpp/include/cugraph/mtmg/edgelist.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,6 +16,8 @@ namespace mtmg {
 
 /**
  * @brief Edgelist object for each GPU
+ *
+ * @deprecated This API is deprecated and will be removed in release 27.02.
  */
 template <typename vertex_t>
 class edgelist_t : public detail::device_shared_wrapper_t<detail::per_device_edgelist_t<vertex_t>> {

--- a/cpp/include/cugraph/mtmg/graph.hpp
+++ b/cpp/include/cugraph/mtmg/graph.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,6 +17,8 @@ namespace mtmg {
 
 /**
  * @brief Graph object for each GPU
+ *
+ * @deprecated This API is deprecated and will be removed in release 27.02.
  */
 template <typename vertex_t, typename edge_t, bool store_transposed, bool multi_gpu>
 class graph_t : public detail::device_shared_wrapper_t<
@@ -44,6 +46,8 @@ class graph_t : public detail::device_shared_wrapper_t<
 
 /**
  * @brief Create an MTMG graph from an edgelist
+ *
+ * @deprecated This API is deprecated and will be removed in release 27.02.
  *
  * @param[in]  handle             Resource handle
  * @param[in]  edgelist           Edgelist

--- a/cpp/include/cugraph/mtmg/graph_view.hpp
+++ b/cpp/include/cugraph/mtmg/graph_view.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,6 +15,8 @@ namespace mtmg {
 
 /**
  * @brief Graph view for each GPU
+ *
+ * @deprecated This API is deprecated and will be removed in release 27.02.
  */
 template <typename vertex_t, typename edge_t, bool store_transposed, bool multi_gpu>
 class graph_view_t : public detail::device_shared_wrapper_t<

--- a/cpp/include/cugraph/mtmg/per_thread_edgelist.hpp
+++ b/cpp/include/cugraph/mtmg/per_thread_edgelist.hpp
@@ -15,6 +15,8 @@ namespace mtmg {
 /**
  * @brief Supports creating an edgelist from individual host threads
  *
+ * @deprecated This API is deprecated and will be removed in release 27.02.
+ *
  * A cugraph edgelist needs to contain all of the edges necessary to create the graph
  * stored in GPU memory (distributed across multiple GPUs in a multi-GPU configuration).
  *

--- a/cpp/include/cugraph/mtmg/renumber_map.hpp
+++ b/cpp/include/cugraph/mtmg/renumber_map.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,6 +14,8 @@ namespace mtmg {
 
 /**
  * @brief An MTMG device vector for storing a renumber map
+ *
+ * @deprecated This API is deprecated and will be removed in release 27.02.
  */
 template <typename vertex_t>
 class renumber_map_t : public detail::device_shared_device_vector_t<vertex_t> {

--- a/cpp/include/cugraph/mtmg/renumber_map_view.hpp
+++ b/cpp/include/cugraph/mtmg/renumber_map_view.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,6 +14,8 @@ namespace mtmg {
 
 /**
  * @brief An MTMG device span for storing a renumber map
+ *
+ * @deprecated This API is deprecated and will be removed in release 27.02.
  */
 template <typename vertex_t>
 using renumber_map_view_t = detail::device_shared_device_span_t<vertex_t const>;

--- a/cpp/include/cugraph/mtmg/vertex_pair_result.hpp
+++ b/cpp/include/cugraph/mtmg/vertex_pair_result.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,9 @@ namespace CUGRAPH_EXPORT cugraph {
 namespace mtmg {
 
 /**
- * @brief An MTMG device vector for storing vertex results
+ * @brief An MTMG device vector for storing vertex pair results
+ *
+ * @deprecated This API is deprecated and will be removed in release 27.02.
  */
 template <typename vertex_t, typename result_t>
 class vertex_pair_result_t

--- a/cpp/include/cugraph/mtmg/vertex_pair_result_view.hpp
+++ b/cpp/include/cugraph/mtmg/vertex_pair_result_view.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,6 +18,8 @@ namespace mtmg {
 
 /**
  * @brief An MTMG device span for referencing a vertex pair result
+ *
+ * @deprecated This API is deprecated and will be removed in release 27.02.
  */
 template <typename vertex_t, typename result_t>
 class vertex_pair_result_view_t
@@ -29,6 +31,8 @@ class vertex_pair_result_view_t
 
   /**
    * @brief Gather results from specified vertices
+   *
+   * @deprecated This API is deprecated and will be removed in release 27.02.
    */
   template <bool multi_gpu>
   std::tuple<rmm::device_uvector<vertex_t>,

--- a/cpp/include/cugraph/mtmg/vertex_result.hpp
+++ b/cpp/include/cugraph/mtmg/vertex_result.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,6 +14,8 @@ namespace mtmg {
 
 /**
  * @brief An MTMG device vector for storing vertex results
+ *
+ * @deprecated This API is deprecated and will be removed in release 27.02.
  */
 template <typename result_t>
 class vertex_result_t : public detail::device_shared_device_vector_t<result_t> {

--- a/cpp/include/cugraph/mtmg/vertex_result_view.hpp
+++ b/cpp/include/cugraph/mtmg/vertex_result_view.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,6 +18,8 @@ namespace mtmg {
 
 /**
  * @brief An MTMG device span for referencing a vertex result
+ *
+ * @deprecated This API is deprecated and will be removed in release 27.02.
  */
 template <typename result_t>
 class vertex_result_view_t : public detail::device_shared_device_span_t<result_t const> {
@@ -28,6 +30,8 @@ class vertex_result_view_t : public detail::device_shared_device_span_t<result_t
 
   /**
    * @brief Gather results from specified vertices into a device vector
+   *
+   * @deprecated This API is deprecated and will be removed in release 27.02.
    */
   template <typename vertex_t, bool multi_gpu>
   rmm::device_uvector<result_t> gather(


### PR DESCRIPTION
Mark documented public MTMG edgelist, graph, property, renumber, and result types for removal while keeping resource manager and handle APIs.