### PR TITLE
Use new `verify-dependencies` hook from pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,8 +34,9 @@ repos:
         types_or: [c, c++, cuda]
         args: ["-fallback-style=none", "-style=file", "-i"]
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.6.0
+    rev: v1.7.0
     hooks:
+      - id: verify-dependencies
       - id: verify-copyright
         name: verify-copyright-cugraph
         args: [--fix, --spdx]

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # cugraph build script
@@ -79,6 +79,12 @@ BUILD_DIRS="${LIBCUGRAPH_BUILD_DIR}
             ${LIBCUGRAPH_ETL_BUILD_DIR}
 "
 
+CUDA_VERSION="${RAPIDS_CUDA_VERSION:-$(nvcc --version | sed -E -n 's/^.*release ([0-9]+\.[0-9]+).*$/\1/p')}"
+if [[ -z "$CUDA_VERSION" ]]; then
+    echo "Could not determine CUDA version. Please set RAPIDS_CUDA_VERSION or make sure your \$PATH contains a valid nvcc."
+    exit 1
+fi
+
 # Set defaults for vars modified by flags to this script
 VERBOSE_FLAG=""
 CMAKE_VERBOSE_OPTION=()
@@ -93,6 +99,7 @@ PYTHON_ARGS_FOR_INSTALL=(
    --no-build-isolation
    --no-deps
    --config-settings="rapidsai.disable-cuda=true"
+   --config-settings="rapidsai.matrix-entry=cuda=${CUDA_VERSION};cuda_suffixed=false;use_cuda_wheels=false"
 )
 
 # Set defaults for vars that may not have been defined externally

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -584,7 +584,8 @@ dependencies:
               - cugraph-cu13==26.12.*,>=0.0.0a0
           - matrix:
               cuda_suffixed: "false"
-            packages: [*cugraph_unsuffixed]
+            packages:
+              - *cugraph_unsuffixed
   depends_on_libcugraph_etl:
     common:
       - output_types: conda
@@ -624,7 +625,8 @@ dependencies:
               - libraft-cu13==26.12.*,>=0.0.0a0
           - matrix:
               cuda_suffixed: "false"
-            packages: [*libraft_unsuffixed]
+            packages:
+              - *libraft_unsuffixed
   depends_on_libcuvs:
     common:
       - output_types: conda
@@ -649,7 +651,8 @@ dependencies:
               - libcuvs-cu13==26.12.*,>=0.0.0a0
           - matrix:
               cuda_suffixed: "false"
-            packages: [*libcuvs_unsuffixed]
+            packages:
+              - *libcuvs_unsuffixed
   depends_on_librmm:
     common:
       - output_types: conda
@@ -674,7 +677,8 @@ dependencies:
               - librmm-cu13==26.12.*,>=0.0.0a0
           - matrix:
               cuda_suffixed: "false"
-            packages: [*librmm_unsuffixed]
+            packages:
+              - *librmm_unsuffixed
   depends_on_rmm:
     common:
       - output_types: conda
@@ -699,7 +703,8 @@ dependencies:
               - rmm-cu13==26.12.*,>=0.0.0a0
           - matrix:
               cuda_suffixed: "false"
-            packages: [*rmm_unsuffixed]
+            packages:
+              - *rmm_unsuffixed
   depends_on_pylibcudf:
     common:
       - output_types: conda
@@ -724,7 +729,8 @@ dependencies:
               - pylibcudf-cu13==26.12.*,>=0.0.0a0
           - matrix:
               cuda_suffixed: "false"
-            packages: [*pylibcudf_unsuffixed]
+            packages:
+              - *pylibcudf_unsuffixed
   depends_on_cudf:
     common:
       - output_types: conda
@@ -749,7 +755,8 @@ dependencies:
               - cudf-cu13==26.12.*,>=0.0.0a0
           - matrix:
               cuda_suffixed: "false"
-            packages: [*cudf_unsuffixed]
+            packages:
+              - *cudf_unsuffixed
   depends_on_dask_cuda:
     common:
       - output_types: conda
@@ -799,7 +806,8 @@ dependencies:
               - dask-cudf-cu13==26.12.*,>=0.0.0a0
           - matrix:
               cuda_suffixed: "false"
-            packages: [*dask_cudf_unsuffixed]
+            packages:
+              - *dask_cudf_unsuffixed
   depends_on_pylibraft:
     common:
       - output_types: conda
@@ -824,7 +832,8 @@ dependencies:
               - pylibraft-cu13==26.12.*,>=0.0.0a0
           - matrix:
               cuda_suffixed: "false"
-            packages: [*pylibraft_unsuffixed]
+            packages:
+              - *pylibraft_unsuffixed
   depends_on_raft_dask:
     common:
       - output_types: conda
@@ -849,7 +858,8 @@ dependencies:
               - raft-dask-cu13==26.12.*,>=0.0.0a0
           - matrix:
               cuda_suffixed: "false"
-            packages: [*raft_dask_unsuffixed]
+            packages:
+              - *raft_dask_unsuffixed
   depends_on_libcugraph:
     common:
       - output_types: conda
@@ -875,7 +885,8 @@ dependencies:
               - libcugraph-cu13==26.12.*,>=0.0.0a0
           - matrix:
               cuda_suffixed: "false"
-            packages: [*libcugraph_unsuffixed]
+            packages:
+              - *libcugraph_unsuffixed
   depends_on_pylibcugraph:
     common:
       - output_types: conda
@@ -901,7 +912,8 @@ dependencies:
               - pylibcugraph-cu13==26.12.*,>=0.0.0a0
           - matrix:
               cuda_suffixed: "false"
-            packages: [*pylibcugraph_unsuffixed]
+            packages:
+              - *pylibcugraph_unsuffixed
   depends_on_cupy:
     common:
       - output_types: conda
@@ -967,4 +979,5 @@ dependencies:
               - ucxx-cu13==0.53.*,>=0.0.0a0
           - matrix:
               cuda_suffixed: "false"
-            packages: [*ucxx_unsuffixed]
+            packages:
+              - *ucxx_unsuffixed

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -105,6 +105,9 @@ files:
   py_rapids_build_cugraph:
     output: pyproject
     pyproject_dir: python/cugraph
+    matrix:
+      cuda_suffixed: ["false"]
+      use_cuda_wheels: ["true"]
     extras:
       table: tool.rapids-build-backend
       key: requires
@@ -119,6 +122,9 @@ files:
   py_run_cugraph:
     output: pyproject
     pyproject_dir: python/cugraph
+    matrix:
+      cuda_suffixed: ["false"]
+      use_cuda_wheels: ["true"]
     extras:
       table: project
     includes:
@@ -154,6 +160,9 @@ files:
   py_rapids_build_libcugraph:
     output: pyproject
     pyproject_dir: python/libcugraph
+    matrix:
+      cuda_suffixed: ["false"]
+      use_cuda_wheels: ["true"]
     extras:
       table: tool.rapids-build-backend
       key: requires
@@ -165,6 +174,9 @@ files:
   py_run_libcugraph:
     output: pyproject
     pyproject_dir: python/libcugraph
+    matrix:
+      cuda_suffixed: ["false"]
+      use_cuda_wheels: ["true"]
     extras:
       table: project
     includes:
@@ -183,6 +195,9 @@ files:
   py_rapids_build_pylibcugraph:
     output: pyproject
     pyproject_dir: python/pylibcugraph
+    matrix:
+      cuda_suffixed: ["false"]
+      use_cuda_wheels: ["true"]
     extras:
       table: tool.rapids-build-backend
       key: requires
@@ -197,6 +212,9 @@ files:
   py_run_pylibcugraph:
     output: pyproject
     pyproject_dir: python/pylibcugraph
+    matrix:
+      cuda_suffixed: ["false"]
+      use_cuda_wheels: ["true"]
     extras:
       table: project
     includes:
@@ -208,6 +226,9 @@ files:
   py_test_pylibcugraph:
     output: pyproject
     pyproject_dir: python/pylibcugraph
+    matrix:
+      cuda_suffixed: ["false"]
+      use_cuda_wheels: ["true"]
     extras:
       table: project.optional-dependencies
       key: test
@@ -349,6 +370,7 @@ dependencies:
           # if no matching matrix selectors passed, list the CUDA 13 requirement
           # (just as a source of documentation, as this populates pyproject.toml in source control)
           - matrix:
+              use_cuda_wheels: "true"
             packages:
               - *ctk_cu13
   common_build:
@@ -560,7 +582,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - cugraph-cu13==26.12.*,>=0.0.0a0
-          - {matrix: null, packages: [*cugraph_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*cugraph_unsuffixed]
   depends_on_libcugraph_etl:
     common:
       - output_types: conda
@@ -598,7 +622,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - libraft-cu13==26.12.*,>=0.0.0a0
-          - {matrix: null, packages: [*libraft_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*libraft_unsuffixed]
   depends_on_libcuvs:
     common:
       - output_types: conda
@@ -621,7 +647,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - libcuvs-cu13==26.12.*,>=0.0.0a0
-          - {matrix: null, packages: [*libcuvs_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*libcuvs_unsuffixed]
   depends_on_librmm:
     common:
       - output_types: conda
@@ -644,7 +672,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - librmm-cu13==26.12.*,>=0.0.0a0
-          - {matrix: null, packages: [*librmm_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*librmm_unsuffixed]
   depends_on_rmm:
     common:
       - output_types: conda
@@ -667,7 +697,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - rmm-cu13==26.12.*,>=0.0.0a0
-          - {matrix: null, packages: [*rmm_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*rmm_unsuffixed]
   depends_on_pylibcudf:
     common:
       - output_types: conda
@@ -690,7 +722,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - pylibcudf-cu13==26.12.*,>=0.0.0a0
-          - {matrix: null, packages: [*pylibcudf_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*pylibcudf_unsuffixed]
   depends_on_cudf:
     common:
       - output_types: conda
@@ -713,7 +747,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - cudf-cu13==26.12.*,>=0.0.0a0
-          - {matrix: null, packages: [*cudf_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*cudf_unsuffixed]
   depends_on_dask_cuda:
     common:
       - output_types: conda
@@ -761,7 +797,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - dask-cudf-cu13==26.12.*,>=0.0.0a0
-          - {matrix: null, packages: [*dask_cudf_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*dask_cudf_unsuffixed]
   depends_on_pylibraft:
     common:
       - output_types: conda
@@ -784,7 +822,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - pylibraft-cu13==26.12.*,>=0.0.0a0
-          - {matrix: null, packages: [*pylibraft_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*pylibraft_unsuffixed]
   depends_on_raft_dask:
     common:
       - output_types: conda
@@ -807,7 +847,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - raft-dask-cu13==26.12.*,>=0.0.0a0
-          - {matrix: null, packages: [*raft_dask_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*raft_dask_unsuffixed]
   depends_on_libcugraph:
     common:
       - output_types: conda
@@ -831,7 +873,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - libcugraph-cu13==26.12.*,>=0.0.0a0
-          - {matrix: null, packages: [*libcugraph_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*libcugraph_unsuffixed]
   depends_on_pylibcugraph:
     common:
       - output_types: conda
@@ -855,7 +899,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - pylibcugraph-cu13==26.12.*,>=0.0.0a0
-          - {matrix: null, packages: [*pylibcugraph_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*pylibcugraph_unsuffixed]
   depends_on_cupy:
     common:
       - output_types: conda
@@ -889,10 +935,12 @@ dependencies:
               - *cupy_cu13
           - matrix:
               cuda: "12.*"
+              use_cuda_wheels: "true"
             packages:
               - cupy-cuda12x[ctk]>=14.0.1,!=14.1.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
+              use_cuda_wheels: "true"
             packages:
               - cupy-cuda13x[ctk]>=14.0.1,!=14.1.0
   depends_on_ucxx:
@@ -917,4 +965,6 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - ucxx-cu13==0.53.*,>=0.0.0a0
-          - {matrix: null, packages: [*ucxx_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*ucxx_unsuffixed]


### PR DESCRIPTION
This hook enforces `dependencies.yaml` conventions, starting with ensuring that the correct `cuda_suffixed` and `use_cuda_wheels` matrix entries are used.

Issue: https://github.com/rapidsai/pre-commit-hooks/issues/132